### PR TITLE
feat: implement entity-first migrations system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Rust web framework for micro-SaaS. Single binary, SQLite-only, maximum compile-t
 - "Full magic" — proc macros for everything, auto-discovery, zero runtime cost
 - SQLite only — WAL mode, no Postgres/Redis
 - Cron jobs: in-memory only (tokio timers), errors logged via tracing
-- Multi-tenancy: both per-DB and shared-DB strategies supported
+- Multi-tenancy: shared-DB strategy (Phase 3); per-DB deferred to Phase 5
 - Auth: layered traits with swappable defaults
 - Cookie-based flash (not session) — no DB dependency
 - CSRF via double-submit signed cookie — ~130 lines, no external crate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ Rust web framework for micro-SaaS. Single binary, SQLite-only, maximum compile-t
 
 ## Gotchas
 
+- Feature flags: optional deps use `dep:name` syntax; gate fields with `#[cfg(feature = "...")]` in struct, Default, and from_env()
+- Proc macros can't check `cfg` flags — emit both `#[cfg(feature = "x")]` / `#[cfg(not(feature = "x"))]` branches in generated code
 - `SignedCookieJar` needs explicit `Key` type: `SignedCookieJar::<Key>::from_request_parts(...)`
 - `cookie` crate needs `key-expansion` feature for `Key::derive_from()`
 - Always run `just fmt` before `just check` — format diffs fail the check early

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,42 @@
 # modo
 
-Rust web framework for micro-SaaS. Single binary, SQLite-only, maximum compile-time magic.
+Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB support.
+
+## NEXT SESSION: Major Refactor (2026-03-07)
+
+**IMPORTANT: Read `docs/plans/2026-03-06-crate-split-design.md` before doing anything.**
+
+Plan: Move ALL current code into `_legacy/` subfolder, then rebuild the framework feature-by-feature from that reference. Extract cleanly into separate crates instead of moving files around in-place. This avoids dragging old coupling into the new structure.
+
+Refactor strategy:
+1. `git mv modo/ _legacy/modo/` and `git mv modo-macros/ _legacy/modo-macros/`
+2. Create fresh `modo/` (core: HTTP, cookies, services — NO DB)
+3. Pull code feature-by-feature from `_legacy/` into new crates
+4. Follow implementation order in the ADR: modo-db → modo-session → modo-auth → modo-jobs → modo-templates → modo-csrf
+5. Build example apps after each extraction to validate
+6. Delete `_legacy/` when done
 
 ## Stack
 
 - axum 0.8 (HTTP)
 - SeaORM v2 RC (database) — use v2 only, not v1.x
-- Askama (templates, Phase 2)
+- Askama (templates)
 - inventory (auto-discovery, not linkme)
 - tokio (async runtime)
 
 ## Architecture
 
-- `modo/` — main library crate
-- `modo-macros/` — proc macro crate
-- `modo/src/middleware/` — middleware functions (csrf, etc.)
-- `modo/src/templates/` — HTMX, flash, BaseContext extractors
-- Design doc: `docs/plans/2026-03-04-modo-architecture-design.md`
-- Phase 1 plan: `docs/plans/2026-03-04-phase1-foundation.md`
+**Target structure (post-refactor):**
+- `modo/` — core crate (HTTP, cookies, services — no DB)
+- `modo-macros/` — core proc macros
+- `modo-db/` — database layer (features: sqlite, postgres)
+- `modo-session/` — session management
+- `modo-auth/` — authentication
+- `modo-jobs/` — background jobs
+- `modo-templates/` — Askama + HTMX + flash
+- `modo-csrf/` — CSRF protection
+- ADR: `docs/plans/2026-03-06-crate-split-design.md`
+- Original design doc: `docs/plans/2026-03-04-modo-architecture-design.md`
 
 ## Commands
 
@@ -54,7 +73,7 @@ Rust web framework for micro-SaaS. Single binary, SQLite-only, maximum compile-t
 ## Key Decisions
 
 - "Full magic" — proc macros for everything, auto-discovery, zero runtime cost
-- SQLite only — WAL mode, no Postgres/Redis
+- Multi-DB — SQLite (default, WAL mode) + Postgres via modo-db feature flags
 - Cron jobs: in-memory only (tokio timers), errors logged via tracing
 - Multi-tenancy: shared-DB strategy (Phase 3); per-DB deferred to Phase 5
 - Auth: layered traits with swappable defaults

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB support.
 
-## NEXT SESSION: Major Refactor (2026-03-07)
+## NEXT SESSION: Major Refactor (2026-03-06)
 
 **IMPORTANT: Read `docs/plans/2026-03-06-crate-split-design.md` before doing anything.**
 

--- a/docs/plans/2026-03-04-modo-architecture-design.md
+++ b/docs/plans/2026-03-04-modo-architecture-design.md
@@ -152,7 +152,7 @@ impl AppBuilder {
 
 1. `#[modo::main]` expands, collects all auto-discovered routes/jobs/modules via `inventory`
 2. User calls `.service()`, `.layer()`, etc.
-3. `.run()`: init DB (WAL mode) -> run migrations -> build Router from inventory -> apply middleware -> start job workers -> execute startup hooks -> serve with graceful shutdown
+3. `.run()`: init DB (WAL mode) -> schema sync (framework + user entities) -> run pending migrations -> build Router from inventory -> apply middleware -> start job workers -> execute startup hooks -> serve with graceful shutdown
 
 ### Configuration
 
@@ -348,9 +348,20 @@ where F: FnOnce(DatabaseTransaction) -> Fut, Fut: Future<Output = Result<T>>
 }
 ```
 
-### Migrations
+### Migrations — Entity-First with Auto-Sync
 
-SeaORM v2 auto-sync in development, explicit migrations in production.
+**Full design:** `docs/plans/2026-03-05-entity-first-migrations-design.md`
+
+**Approach:** Entity-first — define Rust structs with `#[modo::entity]`, framework auto-syncs schema on startup. Hybrid escape hatches via `#[modo::migration]` for destructive changes and data migrations.
+
+**Key points:**
+- `#[modo::entity]` replaces `DeriveEntityModel` — generates SeaORM derives, relations, indices, and `inventory` registration in one macro
+- Extended attributes beyond SeaORM: `on_delete`, `on_update`, composite `index(columns = [...])`, `renamed_from`
+- SeaORM v2 `schema-sync` runs on every startup (all environments) — addition-only, never drops tables/columns
+- Framework entities (`_modo_sessions`, `_modo_jobs`, etc.) merge with user entities in a single sync pass
+- Framework tables are `pub` and queryable but framework-owned
+- `#[modo::migration(version = N)]` for data migrations, auto-discovered via `inventory`
+- Migration history tracked in `_modo_migrations` table
 
 ---
 

--- a/docs/plans/2026-03-04-modo-architecture-design.md
+++ b/docs/plans/2026-03-04-modo-architecture-design.md
@@ -43,7 +43,7 @@ modo/
       extractors/
         mod.rs
         db.rs               # Db extractor
-        tenant_db.rs        # TenantDb extractor
+        tenant.rs           # TenantId, TenantResolver, TenantScoped
         auth.rs             # Auth<User>, OptionalAuth<User>
         service.rs          # Service<T> extractor
         htmx.rs             # HtmxRequest extractor
@@ -54,8 +54,7 @@ modo/
         migrations.rs       # Migration runner, auto-sync
         transaction.rs      # Transaction helpers
       tenancy/
-        mod.rs              # TenantStrategy enum, TenantResolver trait
-        per_database.rs     # PerDatabase LRU pool manager
+        mod.rs              # TenantResolver trait, TenantScoped extension
         shared.rs           # SharedDatabase tenant_id scoping
       auth/
         mod.rs              # Traits: Authenticator, SessionStore, UserProvider
@@ -107,8 +106,7 @@ templates = ["dep:askama"]
 jobs = []
 sessions = []
 db = ["dep:sea-orm"]
-tenancy-per-db = ["db"]
-tenancy-shared = ["db"]
+tenancy = ["db"]
 email = ["dep:lettre", "templates", "jobs"]
 sse = []
 webhooks = ["jobs"]
@@ -312,7 +310,6 @@ pub struct AppState {
     pub services: ServiceRegistry,
     pub job_queue: JobQueue,
     pub config: AppConfig,
-    pub tenant_pool: Option<Arc<dyn TenantPoolManager>>,
     pub session_store: Option<Arc<dyn SessionStore>>,
 }
 ```
@@ -357,20 +354,9 @@ SeaORM v2 auto-sync in development, explicit migrations in production.
 
 ---
 
-## 7. Multi-Tenancy
+## 7. Multi-Tenancy (Shared Database)
 
-Both strategies, user chooses:
-
-```rust
-pub enum TenantStrategy {
-    PerDatabase {
-        data_dir: PathBuf,
-        max_cached_connections: usize,
-        sharded_dirs: bool,           // /ab/cd/tenant_id.db
-    },
-    SharedDatabase,
-}
-```
+Shared-database strategy only. Per-database tenancy (LRU pool of separate SQLite files) deferred to Phase 5 as an advanced module.
 
 ### Tenant Resolution
 
@@ -381,22 +367,17 @@ pub trait TenantResolver: Send + Sync + 'static {
 // Built-in: SubdomainResolver, PathPrefixResolver, HeaderResolver, UserTenantResolver
 ```
 
-### PerDatabase Pool Manager
-
-LRU cache of `DatabaseConnection`. When at capacity, evicts least-recently-used. Lazy migration on first connect per tenant. Sharded directory structure optional (`/ab/cd/abcdef.db`).
-
 ### SharedDatabase Scoping
 
-Extension trait `TenantScoped` auto-adds `WHERE tenant_id = ?` to SeaORM queries.
+Extension trait `TenantScoped` auto-adds `WHERE tenant_id = ?` to SeaORM queries. Tenant ID injected into request extensions by middleware, accessible via `TenantId` extractor.
 
-### TenantDb Extractor
+### TenantId Extractor
 
 ```rust
-pub struct TenantDb(pub DatabaseConnection);
-// Resolves tenant from request, gets correct DB connection. Handlers don't know about tenancy.
+pub struct TenantId(pub String);
+// Extracted from request extensions (set by tenant resolution middleware).
+// Handlers use this to scope queries via TenantScoped trait.
 ```
-
-System DB always accessible via `SystemDb` extractor for tenant registry, jobs, global config.
 
 ---
 
@@ -659,15 +640,14 @@ Features: in-memory SQLite, fake auth, request builders, CSS selector assertions
 
 **Milestone:** Login/register flow with HTMX partial rendering and CSRF protection.
 
-### Phase 3: Jobs, Multi-Tenancy
+### Phase 3: Jobs, Shared-DB Multi-Tenancy
 
 - SQLite job queue: schema, polling, retries, cron, dedup, transactional enqueue
 - `#[job]` macro
-- `TenantStrategy::PerDatabase` + `TenantStrategy::SharedDatabase`
-- `TenantDb` extractor, tenant resolver
-- Cross-tenant migration runner
+- Shared-database multi-tenancy: `TenantResolver` trait, `TenantId` extractor, `TenantScoped` query extension
+- Tenant resolution middleware
 
-**Milestone:** Job enqueued in a transaction executes after commit. Tenant switching works with config change.
+**Milestone:** Job enqueued in a transaction executes after commit. Tenant-scoped queries work transparently.
 
 ### Phase 4: Email, Testing, DX
 
@@ -681,6 +661,7 @@ Features: in-memory SQLite, fake auth, request builders, CSS selector assertions
 ### Phase 5: Advanced Modules
 
 - SSE, webhooks, file storage, i18n, JWT, TOTP, OAuth client, HTML sanitization
+- Per-database multi-tenancy (LRU connection pool, sharded dirs, cross-tenant migrations)
 - Documentation and example apps
 - Optional CLI scaffolding tool
 
@@ -741,7 +722,7 @@ scraper = "0.21"         # test HTML assertions
 | Job queue         | Custom over Apalis            | Tighter transactional enqueue + multi-tenancy integration         |
 | Middleware model  | Plain async functions         | Much simpler than Tower Layer+Service for 90% case                |
 | Error handling    | Derive macro with `#[status]` | Declarative, auto content negotiation                             |
-| Multi-tenant pool | LRU cache with lazy init      | SQLite connections cheap; LRU bounds memory                       |
+| Multi-tenancy     | Shared-DB first, per-DB later | Simpler to operate/backup; per-DB deferred to Phase 5             |
 | Template context  | `BaseContext` extractor       | Auto HTMX/flash/CSRF injection                                    |
 | Session backend   | SQLite only                   | Single-binary philosophy                                          |
 | Test approach     | In-memory SQLite              | Fast, isolated, real DB behavior                                  |

--- a/docs/plans/2026-03-04-modo-architecture-design.md
+++ b/docs/plans/2026-03-04-modo-architecture-design.md
@@ -630,49 +630,50 @@ Features: in-memory SQLite, fake auth, request builders, CSS selector assertions
 
 ## 14. Implementation Phases
 
-### Phase 1: Foundation
+### Phase 1: Foundation — COMPLETE
 
-- `modo-macros`: `#[handler]`, `#[modo::main]`
-- `inventory`-based auto-discovery
-- `AppBuilder` with config, graceful shutdown
-- `Db` extractor, SeaORM v2 + SQLite + WAL mode
-- `Error` with content negotiation
-- `Service<T>` extractor
+- ~~`modo-macros`: `#[handler]`, `#[modo::main]`~~
+- ~~`inventory`-based auto-discovery~~
+- ~~`AppBuilder` with config, graceful shutdown~~
+- ~~`Db` extractor, SeaORM v2 + SQLite + WAL mode~~
+- ~~`Error` with content negotiation~~
+- ~~`Service<T>` extractor~~
 
-**Milestone:** `#[handler(GET, "/")] async fn index() -> &'static str { "Hello modo" }` works with `#[modo::main]`.
+**Milestone:** Achieved. `#[handler(GET, "/")] async fn index() -> &'static str { "Hello modo" }` works with `#[modo::main]`.
 
-### Phase 2: Auth, Sessions, Templates
+### Phase 2: Auth, Sessions, Templates — COMPLETE
 
-- `SqliteSessionStore`, auth traits + default impls
-- `Auth<User>`, `OptionalAuth<User>` extractors
-- Askama + `BaseContext` + HTMX auto-detection
-- Flash messages, CSRF middleware
-- `#[middleware]` and `#[module]` macros
+- ~~`SqliteSessionStore` with `SessionManager`, fingerprinting, token rotation, touch interval~~
+- ~~`Auth<User>`, `OptionalAuth<User>` extractors, `UserProvider` trait~~
+- ~~Askama + `BaseContext` + HTMX auto-detection~~
+- ~~Flash messages (cookie-based), CSRF middleware (double-submit signed cookie)~~
+- ~~`#[middleware]`, `#[module]`, `#[context]` macros~~
 
-**Milestone:** Login/register flow with HTMX partial rendering and CSRF protection.
+**Milestone:** Achieved. Login/register flow with HTMX partial rendering and CSRF protection.
 
-### Phase 3: Jobs, Shared-DB Multi-Tenancy
+### Phase 3: Jobs, Entity-First Migrations — IN PROGRESS
 
-- SQLite job queue: schema, polling, retries, cron, dedup, transactional enqueue
-- `#[job]` macro
-- Shared-database multi-tenancy: `TenantResolver` trait, `TenantId` extractor, `TenantScoped` query extension
-- Tenant resolution middleware
+- ~~SQLite job queue: schema, polling, retries, cron, dedup, transactional enqueue~~ ✅
+- ~~`#[job]` macro~~ ✅
+- Entity-first migrations: **NOT STARTED** — design doc at `docs/plans/2026-03-05-entity-first-migrations-design.md`; pending items: `#[modo::entity]` macro, `EntityRegistration`, schema-sync on startup, `#[modo::migration]` escape hatch
+- Multi-tenancy: **DEFERRED** to Phase 5
 
-**Milestone:** Job enqueued in a transaction executes after commit. Tenant-scoped queries work transparently.
+**Milestone:** Jobs complete. Entity-first migration system is next.
 
-### Phase 4: Email, Testing, DX
+### Phase 4: Email, Testing, DX — NOT STARTED
 
 - Mailer + Askama-templated emails + queue via jobs
 - `TestApp` builder, fake auth, request builders, HTML assertions
-- `#[derive(Entity)]` wrapper, `Validated<T>` extractor
+- `Validated<T>` extractor
 - Rate limiting middleware
 
 **Milestone:** Full integration test with auth, templates, jobs, and email in one test.
 
-### Phase 5: Advanced Modules
+### Phase 5: Advanced Modules — NOT STARTED
 
-- SSE, webhooks, file storage, i18n, JWT, TOTP, OAuth client, HTML sanitization
+- Shared-database multi-tenancy: `TenantResolver` trait, `TenantId` extractor, `TenantScoped` query extension, tenant resolution middleware
 - Per-database multi-tenancy (LRU connection pool, sharded dirs, cross-tenant migrations)
+- SSE, webhooks, file storage, i18n, JWT, TOTP, OAuth client, HTML sanitization
 - Documentation and example apps
 - Optional CLI scaffolding tool
 

--- a/docs/plans/2026-03-05-entity-first-migrations-design.md
+++ b/docs/plans/2026-03-05-entity-first-migrations-design.md
@@ -1,0 +1,622 @@
+# Entity-First Migrations & Auto-Schema Design
+
+## Context
+
+modo needs a schema management strategy that fits its "full magic, single binary" philosophy. The traditional approach — write SQL migrations, run a CLI, generate entity code — requires tooling, multiple files per change, and manual coordination. Instead, modo adopts an **entity-first** approach: define Rust structs, and the framework creates/updates the database schema automatically.
+
+**Built on:** SeaORM v2's `schema-sync` feature (addition-only incremental schema diff) + `entity-registry` + `inventory` auto-discovery.
+
+---
+
+## 1. Core Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Schema approach | Entity-first (hybrid) | Define structs = define schema. Escape hatches for edge cases |
+| `#[modo::entity]` macro | Replaces `DeriveEntityModel` entirely | Single macro does everything: SeaORM derives, relation enum, inventory registration, extended attributes |
+| Auto-sync behavior | Always sync on startup (all environments) | Sync is addition-only (never drops tables/columns), safe everywhere. Logs all SQL executed. |
+| Framework tables | Visible, queryable, framework-owned | Users can `Entity::find()` on framework tables (e.g., list sessions) but don't define the schema |
+| Framework table prefix | `_modo_` | Clear separation: `_modo_sessions`, `_modo_jobs`, etc. No collision with user tables |
+| Migration escape hatches | Auto-discovered via `inventory` | `#[modo::migration(version = N)]` for data migrations, column drops, type changes |
+
+---
+
+## 2. `#[modo::entity]` Macro
+
+### What It Generates
+
+The `#[modo::entity]` attribute macro is the single entry point for defining database entities. It generates:
+
+1. SeaORM `DeriveEntityModel` + `Entity` + `Column` + `PrimaryKey` + `ActiveModel`
+2. `DeriveRelation` enum from inline relation attributes
+3. `Related<T>` impls for each relation
+4. `ActiveModelBehavior` impl
+5. `inventory::submit!` for `EntityRegistration` (auto-discovery)
+6. `IndexCreateStatement` entries for composite indices
+
+### Basic Usage
+
+```rust
+#[modo::entity(table = "users")]
+pub struct User {
+    #[entity(primary_key)]
+    pub id: i32,
+
+    #[entity(unique)]
+    pub email: String,
+
+    #[entity(indexed)]
+    pub username: String,
+
+    #[entity(nullable)]
+    pub avatar_url: Option<String>,
+
+    #[entity(column_type = "Text")]
+    pub bio: String,
+
+    #[entity(default_value = 0)]
+    pub credits: i32,
+
+    #[entity(default_expr = "Expr::current_timestamp()")]
+    pub created_at: DateTimeUtc,
+}
+```
+
+### Relations with Foreign Key Actions
+
+```rust
+#[modo::entity(table = "posts")]
+pub struct Post {
+    #[entity(primary_key)]
+    pub id: i32,
+
+    #[entity(belongs_to = "User", on_delete = "Cascade")]
+    pub user_id: i32,
+
+    pub title: String,
+
+    #[entity(nullable, belongs_to = "Category", on_delete = "SetNull")]
+    pub category_id: Option<i32>,
+}
+```
+
+Supported `on_delete` / `on_update` values: `Cascade`, `SetNull`, `Restrict`, `NoAction`, `SetDefault`.
+
+### Composite Indices
+
+Declared as struct-level attributes:
+
+```rust
+#[modo::entity(table = "posts")]
+#[entity(index(columns = ["user_id", "created_at"]))]
+#[entity(index(columns = ["slug"], unique))]
+pub struct Post {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub user_id: i32,
+    pub slug: String,
+    pub created_at: DateTimeUtc,
+}
+```
+
+### Many-to-Many Relations
+
+```rust
+#[modo::entity(table = "posts")]
+pub struct Post {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub title: String,
+
+    #[entity(has_many, via = "PostTag")]
+    pub tags: HasMany<Tag>,
+}
+```
+
+### Column Attribute Reference
+
+| Attribute | Description |
+|-----------|-------------|
+| `primary_key` | Marks field as primary key |
+| `unique` | Adds UNIQUE constraint |
+| `indexed` | Creates a single-column index |
+| `nullable` | Allows NULL values |
+| `column_type = "..."` | Override column type (e.g., `"Text"`, `"Blob"`) |
+| `default_value = ...` | Static default value |
+| `default_expr = "..."` | SQL expression default (e.g., `"Expr::current_timestamp()"`) |
+| `belongs_to = "Entity"` | Foreign key relation (this table owns the FK) |
+| `has_many` | One-to-many relation (other table has FK) |
+| `has_one` | One-to-one relation (other table has FK) |
+| `on_delete = "..."` | FK delete action: Cascade, SetNull, Restrict, NoAction, SetDefault |
+| `on_update = "..."` | FK update action: same options as on_delete |
+| `via = "JunctionEntity"` | Many-to-many via junction table |
+| `from = "col"` | Override FK source column (defaults to field name) |
+| `to = "col"` | Override FK target column (defaults to target's PK) |
+| `renamed_from = "old_name"` | Column rename — sync will ALTER RENAME instead of ADD |
+
+### Struct-Level Attribute Reference
+
+| Attribute | Description |
+|-----------|-------------|
+| `table = "name"` | Database table name |
+| `index(columns = [...])` | Composite index |
+| `index(columns = [...], unique)` | Unique composite index |
+
+---
+
+## 3. Auto-Discovery & Registration
+
+### EntityRegistration
+
+```rust
+pub struct EntityRegistration {
+    pub table_name: &'static str,
+    pub register_fn: fn(SchemaBuilder) -> SchemaBuilder,
+    pub is_framework: bool,  // true for _modo_* tables
+}
+
+inventory::collect!(EntityRegistration);
+```
+
+The `#[modo::entity]` macro generates an `inventory::submit!` block for each entity, just like `#[modo::handler]` does for routes.
+
+### Framework Entity Registration
+
+Framework entities (sessions, jobs, etc.) register themselves identically:
+
+```rust
+// Inside modo crate — not user-facing
+#[modo::entity(table = "_modo_sessions")]
+pub struct ModoSession {
+    #[entity(primary_key)]
+    pub id: String,           // ULID
+    pub token: String,        // hex, indexed
+    #[entity(indexed)]
+    pub user_id: String,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+    pub device_name: Option<String>,
+    pub device_type: Option<String>,
+    pub fingerprint: Option<String>,
+    #[entity(column_type = "Text")]
+    pub data: String,         // JSON
+    pub created_at: DateTimeUtc,
+    pub last_active_at: DateTimeUtc,
+    pub expires_at: DateTimeUtc,
+}
+```
+
+Users can query these directly:
+
+```rust
+// List user's active sessions for a "manage devices" page
+let sessions = modo::session::Entity::find()
+    .filter(modo::session::Column::UserId.eq(user.id))
+    .filter(modo::session::Column::ExpiresAt.gt(now))
+    .all(&db)
+    .await?;
+```
+
+---
+
+## 4. Startup Schema Sync
+
+### Lifecycle
+
+During `AppBuilder::run()`, after DB connection and WAL pragmas:
+
+1. Collect all `EntityRegistration` entries from `inventory`
+2. Collect all `MigrationRegistration` entries from `inventory`
+3. Build `SchemaBuilder` from `Schema::new(DbBackend::Sqlite)`
+4. Register framework entities first (sorted by dependency order)
+5. Register user entities (sorted by dependency order)
+6. Call `schema_builder.sync(&db)` — creates missing tables, adds missing columns, renames columns marked with `renamed_from`
+7. Run pending `#[modo::migration]` functions (ordered by version, tracked in `_modo_migrations` table)
+8. Log all schema changes at `INFO` level
+
+### What Sync Does (SeaORM v2 `schema-sync`)
+
+- Creates tables that don't exist
+- Adds columns that are missing from existing tables
+- Renames columns annotated with `renamed_from = "old_name"` (via column comment convention)
+- Creates missing indices and foreign keys
+- **Never drops** tables, columns, or constraints (addition-only)
+
+### What Sync Does NOT Do
+
+- Drop columns (use `#[modo::migration]` escape hatch)
+- Change column types (SQLite limitation — use migration)
+- Remove indices (use migration)
+- Migrate data (use migration)
+
+---
+
+## 5. Migration Escape Hatches
+
+For operations that entity-first can't express (destructive changes, data transformations), modo provides `#[modo::migration]`:
+
+```rust
+#[modo::migration(version = 1, description = "Backfill default roles")]
+async fn backfill_roles(db: &DatabaseConnection) -> Result<()> {
+    db.execute_unprepared(
+        "UPDATE users SET role = 'member' WHERE role IS NULL"
+    ).await?;
+    Ok(())
+}
+
+#[modo::migration(version = 2, description = "Drop legacy column")]
+async fn drop_legacy_column(db: &DatabaseConnection) -> Result<()> {
+    // SQLite doesn't support DROP COLUMN before 3.35.0
+    // For older SQLite, this would need table rebuild
+    db.execute_unprepared("ALTER TABLE users DROP COLUMN legacy_field").await?;
+    Ok(())
+}
+```
+
+### MigrationRegistration
+
+```rust
+pub struct MigrationRegistration {
+    pub version: u64,
+    pub description: &'static str,
+    pub handler: fn(&DatabaseConnection) -> BoxFuture<'_, Result<()>>,
+}
+
+inventory::collect!(MigrationRegistration);
+```
+
+### Migration Tracking
+
+Executed migrations are tracked in `_modo_migrations`:
+
+```sql
+CREATE TABLE _modo_migrations (
+    version INTEGER PRIMARY KEY,
+    description TEXT NOT NULL,
+    executed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+- Migrations run in `version` order
+- Each migration runs exactly once (idempotent by tracking)
+- Migrations run **after** schema sync (so new columns exist before data migrations reference them)
+- If a migration fails, the application aborts startup with a clear error
+
+### Version Numbering
+
+- Versions are monotonically increasing integers
+- Framework reserves versions 0-999 for internal migrations
+- User migrations start at version 1000+ (or any number > 999)
+- Duplicate version numbers are a compile-time error (detected at startup via inventory scan)
+
+---
+
+## 6. Framework Internal Entities
+
+### Table Inventory
+
+All framework tables use the `_modo_` prefix:
+
+| Table | Feature | Purpose |
+|-------|---------|---------|
+| `_modo_sessions` | `sessions` | Session persistence |
+| `_modo_jobs` | `jobs` | Background job queue |
+| `_modo_migrations` | (always) | Migration version tracking |
+
+Future framework tables (added in later phases):
+
+| Table | Feature | Purpose |
+|-------|---------|---------|
+| `_modo_rate_limits` | `rate-limiting` | Rate limit counters |
+| `_modo_webhook_deliveries` | `webhooks` | Webhook delivery log |
+
+### Visibility
+
+- Framework entities are `pub` types under their module (e.g., `modo::session::Entity`, `modo::jobs::Entity`)
+- Users can query them with standard SeaORM API
+- Users cannot modify the entity struct definitions — those are owned by the framework
+- Schema sync handles framework tables alongside user tables in a single pass
+
+### Feature-Gated Registration
+
+Framework entities only register when their feature is enabled:
+
+```rust
+#[cfg(feature = "sessions")]
+inventory::submit! {
+    EntityRegistration {
+        table_name: "_modo_sessions",
+        register_fn: |sb| sb.register(session::Entity),
+        is_framework: true,
+    }
+}
+```
+
+---
+
+## 7. Dev vs Production Behavior
+
+| Behavior | All Environments |
+|----------|-----------------|
+| Schema sync on startup | Yes — always runs |
+| Addition-only (no drops) | Yes — enforced by SeaORM sync |
+| Log schema changes | Yes — `INFO` level |
+| Run pending migrations | Yes — ordered by version |
+| Abort on migration failure | Yes — prevents serving with broken state |
+
+Since sync is addition-only, there is no separate dev/prod behavior. The same binary behaves identically everywhere. This matches modo's single-binary deployment philosophy.
+
+---
+
+## 8. Complete Startup Sequence
+
+Updated lifecycle from architecture doc section 3:
+
+```
+1. #[modo::main] expands, collects all auto-discovered routes/jobs/modules/entities/migrations via inventory
+2. User calls .service(), .layer(), etc.
+3. .run():
+   a. Connect to SQLite, enable WAL mode + pragmas
+   b. Schema sync: merge framework + user entities, call sync()
+   c. Run pending migrations (version-ordered, tracked in _modo_migrations)
+   d. Build Router from inventory
+   e. Apply middleware
+   f. Start job workers (if jobs feature enabled)
+   g. Execute startup hooks
+   h. Serve with graceful shutdown
+```
+
+---
+
+## 9. Example: Full Entity Definitions
+
+```rust
+use modo::prelude::*;
+
+// User with soft deletes + timestamps
+#[modo::entity(table = "users")]
+#[entity(timestamps)]
+#[entity(soft_delete)]
+pub struct User {
+    #[entity(primary_key)]
+    pub id: i32,
+
+    #[entity(unique)]
+    pub email: String,
+
+    pub name: String,
+
+    #[entity(default_value = "member")]
+    pub role: String,
+
+    // created_at, updated_at auto-added by #[entity(timestamps)]
+    // deleted_at auto-added by #[entity(soft_delete)]
+}
+
+// Post with FK actions, composite indices, tenant scoping
+#[modo::entity(table = "posts")]
+#[entity(timestamps)]
+#[entity(tenant_scoped)]
+#[entity(index(columns = ["user_id", "created_at"]))]
+#[entity(index(columns = ["slug"], unique))]
+pub struct Post {
+    #[entity(primary_key)]
+    pub id: i32,
+
+    #[entity(belongs_to = "User", on_delete = "Cascade")]
+    pub user_id: i32,
+
+    pub title: String,
+    pub slug: String,
+
+    #[entity(column_type = "Text")]
+    pub body: String,
+
+    #[entity(nullable, belongs_to = "Category", on_delete = "SetNull")]
+    pub category_id: Option<i32>,
+
+    // tenant_id auto-added by #[entity(tenant_scoped)]
+    // created_at, updated_at auto-added by #[entity(timestamps)]
+}
+
+// Simple entity — no extras
+#[modo::entity(table = "categories")]
+#[entity(timestamps)]
+pub struct Category {
+    #[entity(primary_key)]
+    pub id: i32,
+
+    #[entity(unique)]
+    pub name: String,
+}
+
+// Junction table with composite PK
+#[modo::entity(table = "post_tags")]
+pub struct PostTag {
+    #[entity(primary_key, belongs_to = "Post", on_delete = "Cascade")]
+    pub post_id: i32,
+    #[entity(primary_key, belongs_to = "Tag", on_delete = "Cascade")]
+    pub tag_id: i32,
+}
+
+#[modo::entity(table = "tags")]
+pub struct Tag {
+    #[entity(primary_key)]
+    pub id: i32,
+
+    #[entity(unique)]
+    pub name: String,
+}
+
+// Migration escape hatch — runs after schema sync
+#[modo::migration(version = 1000, description = "Backfill default user roles")]
+async fn backfill_roles(db: &DatabaseConnection) -> Result<()> {
+    db.execute_unprepared("UPDATE users SET role = 'member' WHERE role IS NULL").await?;
+    Ok(())
+}
+```
+
+On first startup: creates all tables with columns, indices, foreign keys, and auto-generated columns (timestamps, tenant_id, deleted_at). On subsequent startups: syncs any new fields added to the structs. Pending migrations run after sync.
+
+---
+
+## 10. Composite Primary Keys
+
+Supported. Multiple `#[entity(primary_key)]` fields on a single entity create a composite PK. This is essential for junction tables in many-to-many relations.
+
+```rust
+#[modo::entity(table = "post_tags")]
+pub struct PostTag {
+    #[entity(primary_key, belongs_to = "Post", on_delete = "Cascade")]
+    pub post_id: i32,
+    #[entity(primary_key, belongs_to = "Tag", on_delete = "Cascade")]
+    pub tag_id: i32,
+}
+```
+
+SeaORM natively supports composite PKs, so the macro passes through multiple `#[sea_orm(primary_key)]` annotations.
+
+---
+
+## 11. Soft Deletes
+
+Struct-level `#[entity(soft_delete)]` attribute that:
+
+1. Auto-adds a `deleted_at: Option<DateTimeUtc>` column (nullable, default NULL)
+2. Auto-filters all `Entity::find()` queries to include `WHERE deleted_at IS NULL`
+3. Provides `.with_deleted()` escape hatch to bypass the filter
+4. `delete()` sets `deleted_at = now()` instead of issuing SQL `DELETE`
+5. Provides `.force_delete()` for actual row removal
+
+```rust
+#[modo::entity(table = "users")]
+#[entity(soft_delete)]
+pub struct User {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub email: String,
+    // deleted_at: Option<DateTimeUtc> auto-added by soft_delete
+}
+
+// Usage:
+User::find().all(&db).await?;                  // WHERE deleted_at IS NULL
+User::find().with_deleted().all(&db).await?;    // no filter
+user.delete(&db).await?;                        // SET deleted_at = now()
+user.force_delete(&db).await?;                  // actual DELETE
+```
+
+### Implementation Strategy
+
+- The macro adds `deleted_at` to the generated `Model` and `Column` enum
+- Generates a custom `Select` wrapper (or overrides `Entity::find()`) that applies the default filter
+- `with_deleted()` returns a standard `Select` without the filter
+- `ActiveModelBehavior::before_delete()` intercepts delete and converts to update
+- `force_delete()` bypasses the behavior override
+
+---
+
+## 12. Auto-Timestamps
+
+Struct-level `#[entity(timestamps)]` attribute that:
+
+1. Auto-adds `created_at: DateTimeUtc` column (default: current timestamp, set on insert)
+2. Auto-adds `updated_at: DateTimeUtc` column (default: current timestamp, set on every save)
+
+```rust
+#[modo::entity(table = "posts")]
+#[entity(timestamps)]
+pub struct Post {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub title: String,
+    // created_at: DateTimeUtc auto-added
+    // updated_at: DateTimeUtc auto-added
+}
+```
+
+### Behavior
+
+- `created_at` — set to `Utc::now()` on insert, never modified after
+- `updated_at` — set to `Utc::now()` on every insert and update
+- Both implemented via `ActiveModelBehavior::before_save()`
+- If user also defines `created_at` or `updated_at` fields explicitly, the macro errors with a clear message (no silent shadowing)
+
+### Interaction with Soft Deletes
+
+When both `#[entity(timestamps)]` and `#[entity(soft_delete)]` are present, `deleted_at` is a third timestamp column. Soft delete sets `deleted_at` but does NOT update `updated_at` (the record isn't being "updated" from the user's perspective — it's being archived).
+
+---
+
+## 13. Tenant Scoping
+
+Struct-level `#[entity(tenant_scoped)]` attribute that:
+
+1. Auto-adds `tenant_id: String` column (NOT NULL, indexed)
+2. Auto-scopes all queries via `TenantScoped` trait (adds `WHERE tenant_id = ?`)
+3. Auto-sets `tenant_id` on insert from the request's `TenantId` extractor
+
+```rust
+#[modo::entity(table = "posts")]
+#[entity(tenant_scoped)]
+pub struct Post {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub title: String,
+    // tenant_id: String auto-added + indexed
+}
+
+// All queries auto-scoped:
+Post::find().all(&db).await?;  // WHERE tenant_id = 'tenant_abc'
+
+// Cross-tenant (admin use):
+Post::find().unscoped().all(&db).await?;  // no tenant filter
+```
+
+### Implementation Strategy
+
+- The macro adds `tenant_id` to the generated `Model` and `Column` enum
+- Adds a composite index on `(tenant_id, id)` by default
+- Integrates with the `TenantId` extractor from modo's multi-tenancy module
+- `Entity::find()` override injects the tenant filter from request context
+- `.unscoped()` returns a standard `Select` without the tenant filter
+- `ActiveModelBehavior::before_save()` sets `tenant_id` from the current tenant context
+
+### Phase Note
+
+The `#[entity(tenant_scoped)]` attribute is designed now to prevent entity definition changes later. Implementation lands in **Phase 3** alongside the multi-tenancy module. Using it before Phase 3 will produce a compile error: "tenant_scoped requires the `tenancy` feature".
+
+---
+
+## 14. Complete Struct-Level Attribute Reference
+
+| Attribute | Description | Phase |
+|-----------|-------------|-------|
+| `table = "name"` | Database table name | 1 |
+| `index(columns = [...])` | Composite index | 1 |
+| `index(columns = [...], unique)` | Unique composite index | 1 |
+| `timestamps` | Auto-add created_at + updated_at | 1 |
+| `soft_delete` | Auto-add deleted_at + query filtering | 2 |
+| `tenant_scoped` | Auto-add tenant_id + query scoping | 3 |
+
+---
+
+## 15. Complete Column-Level Attribute Reference
+
+| Attribute | Description | Phase |
+|-----------|-------------|-------|
+| `primary_key` | Marks field as primary key (supports composite) | 1 |
+| `unique` | UNIQUE constraint | 1 |
+| `indexed` | Single-column index | 1 |
+| `nullable` | Allows NULL | 1 |
+| `column_type = "..."` | Override column type (Text, Blob, etc.) | 1 |
+| `default_value = ...` | Static default | 1 |
+| `default_expr = "..."` | SQL expression default | 1 |
+| `belongs_to = "Entity"` | Foreign key (this table owns FK) | 1 |
+| `has_many` | One-to-many (other table has FK) | 1 |
+| `has_one` | One-to-one (other table has FK) | 1 |
+| `on_delete = "..."` | FK delete action | 1 |
+| `on_update = "..."` | FK update action | 1 |
+| `via = "JunctionEntity"` | Many-to-many junction | 1 |
+| `from = "col"` | Override FK source column | 1 |
+| `to = "col"` | Override FK target column | 1 |
+| `renamed_from = "old"` | Column rename (sync uses ALTER RENAME) | 1 |

--- a/docs/plans/2026-03-06-crate-split-design.md
+++ b/docs/plans/2026-03-06-crate-split-design.md
@@ -118,3 +118,27 @@ Extension crates integrate via the existing service registry + middleware + extr
 4. Extract `modo-templates`
 5. Extract `modo-csrf`
 6. Clean up core — remove all feature flags for extracted modules
+
+## Example Apps
+
+Build after each extraction step to validate the framework works end-to-end. Each example lives in `examples/<name>/` as a standalone binary with its own `Cargo.toml` (workspace member).
+
+| # | Example | Validates | Built after |
+|---|---|---|---|
+| 1 | `hello` | Routes, error handling, core only | Step 6 (core cleanup) |
+| 2 | `todo-api` | JSON REST CRUD, DB entities, migrations, `Db` extractor, `Service<T>` | Step 6 (core cleanup) |
+| 3 | `blog` | Templates, flash messages, CSRF forms, HTML rendering | Steps 4-5 (templates + csrf) |
+| 4 | `auth-app` | Signup/login/logout, sessions, protected routes, password hashing | Steps 1-2 (session + auth) |
+| 5 | `saas-starter` | Full stack: auth + DB + jobs + templates + CSRF — the "real app" smoke test | Step 5 (all extracted) |
+
+### Example Descriptions
+
+**hello** — Bare minimum. A few GET routes, a JSON error route. Proves core works standalone with zero extensions.
+
+**todo-api** — JSON REST API. CRUD for todos with SQLite. Entity-first migrations. No auth, no templates. Validates that core DB + extractors + error handling work without any extension crate.
+
+**blog** — Server-rendered blog with Askama templates. Create/edit/delete posts via HTML forms with CSRF protection. Flash messages for success/error feedback. Validates modo-templates + modo-csrf integration.
+
+**auth-app** — Login/signup/logout with session-based auth. Protected dashboard route. Session listing and revocation. Validates modo-session + modo-auth working together.
+
+**saas-starter** — Realistic micro-SaaS skeleton. User auth, a DB-backed resource (e.g., projects), background jobs (e.g., email on signup), server-rendered UI, CSRF. The ultimate integration test — if this works cleanly, the framework is ready.

--- a/docs/plans/2026-03-06-crate-split-design.md
+++ b/docs/plans/2026-03-06-crate-split-design.md
@@ -1,0 +1,120 @@
+# ADR: Split modo Into Core + Extension Crates
+
+> **Priority: HIGHEST — must be implemented before any other work.**
+
+## Status
+
+Accepted (2026-03-06)
+
+## Context
+
+The current monolithic `modo` crate bundles everything: HTTP, DB, sessions, auth, jobs, templates, CSRF. Every change ripples across the entire framework. This causes:
+
+1. **Compile time waste** — users pay for session/jobs/templates even if unused
+2. **Rigidity** — users can't swap session/auth/jobs implementations
+3. **Maintenance burden** — independent features are coupled in one crate
+4. **Developer fatigue** — any change requires fixes across the whole framework
+
+## Decision
+
+Split modo into a minimal core crate + independent extension crates (Approach C: extension-to-extension deps, no core traits for session/auth/jobs).
+
+### Core (`modo`)
+
+Stable foundation that rarely changes:
+
+- axum HTTP server, app builder, lifecycle (graceful shutdown)
+- DB connection, SeaORM, entity-first migrations, schema sync
+- Cookie jar (signed + private) — a primitive, not a feature
+- Service registry + `Service<T>` extractor
+- `Db` extractor
+- Error types
+- Config loading (env + .env)
+- Router + `inventory` auto-discovery
+- `#[handler]`, `#[main]`, `#[module]`, `#[entity]`, `#[migration]` macros
+- Re-exports (axum, sea_orm, etc.)
+
+### Extension Crates
+
+| Crate | Contains | Depends on |
+|---|---|---|
+| `modo-session` | Session types, store trait+impl, manager, middleware, fingerprint, device | `modo` (core) |
+| `modo-auth` | `UserProvider` trait, `Auth<User>`, `OptionalAuth<User>` extractors | `modo`, `modo-session` |
+| `modo-jobs` | Queue, runner, cron, job entity/store, `#[job]` macro | `modo` (core) |
+| `modo-templates` | Askama integration, BaseContext, flash, HTMX helpers, `#[context]` macro | `modo` (core) |
+| `modo-csrf` | CSRF double-submit cookie middleware | `modo` (core) |
+
+### Monorepo Structure
+
+All crates live in one Cargo workspace (standard Rust practice for related crates):
+
+```
+modo/
+  Cargo.toml          # workspace root
+  modo/               # core
+  modo-macros/        # proc macros
+  modo-session/
+  modo-auth/
+  modo-jobs/
+  modo-templates/
+  modo-csrf/
+```
+
+### End-User DX
+
+```toml
+# Cargo.toml
+[dependencies]
+modo = "0.1"
+modo-session = "0.1"    # opt-in
+modo-auth = "0.1"       # opt-in
+```
+
+```rust
+use modo::prelude::*;
+use modo_session::{SessionManager, SqliteSessionStore};
+
+#[modo::main]
+async fn main(app: modo::App) {
+    let session_store = SqliteSessionStore::new(app.db()).await;
+
+    app.service(session_store)
+        .middleware(modo_session::layer())
+        .run()
+        .await
+}
+
+#[modo::handler(GET, "/dashboard")]
+async fn dashboard(session: SessionManager) -> Result<String> {
+    let user_id: Option<String> = session.get("user_id").await?;
+    match user_id {
+        Some(id) => Ok(format!("Welcome back, {id}")),
+        None => Ok("Not logged in".into()),
+    }
+}
+```
+
+Extension crates integrate via the existing service registry + middleware + extractor pattern. Core knows nothing about sessions, auth, or jobs.
+
+## Consequences
+
+**Positive:**
+- Core becomes a rock — almost never needs to change
+- "Fix one thing, touch everything" disappears
+- Users only compile what they use
+- Extensions evolve and version independently
+- Matches Rust ecosystem conventions (axum/axum-extra/axum-login pattern)
+
+**Negative:**
+- Users add multiple crates to `Cargo.toml`
+- Extension-to-extension version compatibility must be managed
+- Some proc macros (`#[job]`, `#[context]`) move to extension macro crates or the extension crates themselves
+
+## Implementation Order
+
+1. Extract `modo-session` (largest, most coupled module)
+2. Extract `modo-auth` (depends on modo-session)
+3. Extract `modo-jobs`
+4. Extract `modo-templates`
+5. Extract `modo-csrf`
+6. Clean up core — remove all feature flags for extracted modules

--- a/docs/plans/2026-03-06-crate-split-design.md
+++ b/docs/plans/2026-03-06-crate-split-design.md
@@ -11,36 +11,36 @@ Accepted (2026-03-06)
 The current monolithic `modo` crate bundles everything: HTTP, DB, sessions, auth, jobs, templates, CSRF. Every change ripples across the entire framework. This causes:
 
 1. **Compile time waste** — users pay for session/jobs/templates even if unused
-2. **Rigidity** — users can't swap session/auth/jobs implementations
+2. **Rigidity** — users can't swap session/auth/jobs implementations or DB backends
 3. **Maintenance burden** — independent features are coupled in one crate
 4. **Developer fatigue** — any change requires fixes across the whole framework
+5. **SQLite lock-in** — Postgres is sometimes the better choice, but the framework hardcodes SQLite
 
 ## Decision
 
-Split modo into a minimal core crate + independent extension crates (Approach C: extension-to-extension deps, no core traits for session/auth/jobs).
+Split modo into a minimal core crate + independent extension crates (Approach C: extension-to-extension deps, no core traits for session/auth/jobs/db).
 
 ### Core (`modo`)
 
-Stable foundation that rarely changes:
+Stable foundation that rarely changes. **No database dependency.**
 
 - axum HTTP server, app builder, lifecycle (graceful shutdown)
-- DB connection, SeaORM, entity-first migrations, schema sync
 - Cookie jar (signed + private) — a primitive, not a feature
 - Service registry + `Service<T>` extractor
-- `Db` extractor
 - Error types
 - Config loading (env + .env)
 - Router + `inventory` auto-discovery
-- `#[handler]`, `#[main]`, `#[module]`, `#[entity]`, `#[migration]` macros
-- Re-exports (axum, sea_orm, etc.)
+- `#[handler]`, `#[main]`, `#[module]` macros
+- Re-exports (axum, tokio, tracing, etc.)
 
 ### Extension Crates
 
 | Crate | Contains | Depends on |
 |---|---|---|
-| `modo-session` | Session types, store trait+impl, manager, middleware, fingerprint, device | `modo` (core) |
+| `modo-db` | DB connection, `Db` extractor, entity-first migrations, schema sync, `#[entity]`/`#[migration]` macros. Features: `sqlite`, `postgres` | `modo` (core) |
+| `modo-session` | Session types, store trait+impl, manager, middleware, fingerprint, device | `modo`, `modo-db` |
 | `modo-auth` | `UserProvider` trait, `Auth<User>`, `OptionalAuth<User>` extractors | `modo`, `modo-session` |
-| `modo-jobs` | Queue, runner, cron, job entity/store, `#[job]` macro | `modo` (core) |
+| `modo-jobs` | Queue, runner, cron, job entity/store, `#[job]` macro | `modo`, `modo-db` |
 | `modo-templates` | Askama integration, BaseContext, flash, HTMX helpers, `#[context]` macro | `modo` (core) |
 | `modo-csrf` | CSRF double-submit cookie middleware | `modo` (core) |
 
@@ -51,8 +51,9 @@ All crates live in one Cargo workspace (standard Rust practice for related crate
 ```
 modo/
   Cargo.toml          # workspace root
-  modo/               # core
-  modo-macros/        # proc macros
+  modo/               # core (no DB)
+  modo-macros/        # proc macros (core macros only)
+  modo-db/            # database layer
   modo-session/
   modo-auth/
   modo-jobs/
@@ -62,26 +63,54 @@ modo/
 
 ### End-User DX
 
+**SQLite app (recommended default):**
+
 ```toml
-# Cargo.toml
 [dependencies]
 modo = "0.1"
-modo-session = "0.1"    # opt-in
-modo-auth = "0.1"       # opt-in
+modo-db = { version = "0.1", features = ["sqlite"] }
+modo-session = "0.1"
 ```
+
+**Postgres app:**
+
+```toml
+[dependencies]
+modo = "0.1"
+modo-db = { version = "0.1", features = ["postgres"] }
+modo-session = "0.1"
+```
+
+**No-DB app (webhook receiver, proxy, etc.):**
+
+```toml
+[dependencies]
+modo = "0.1"
+```
+
+**App code:**
 
 ```rust
 use modo::prelude::*;
+use modo_db::Db;
 use modo_session::{SessionManager, SqliteSessionStore};
 
 #[modo::main]
 async fn main(app: modo::App) {
-    let session_store = SqliteSessionStore::new(app.db()).await;
+    // DB setup — backend-specific pragmas/pool handled internally
+    let db = modo_db::connect_from_env().await;
+    let session_store = SqliteSessionStore::new(&db).await;
 
-    app.service(session_store)
+    app.service(db)
+        .service(session_store)
         .middleware(modo_session::layer())
         .run()
         .await
+}
+
+#[modo::handler(GET, "/users")]
+async fn list_users(Db(db): Db) -> Result<Json<Vec<User>>> {
+    // works the same regardless of sqlite or postgres
 }
 
 #[modo::handler(GET, "/dashboard")]
@@ -94,7 +123,16 @@ async fn dashboard(session: SessionManager) -> Result<String> {
 }
 ```
 
-Extension crates integrate via the existing service registry + middleware + extractor pattern. Core knows nothing about sessions, auth, or jobs.
+Extension crates integrate via the existing service registry + middleware + extractor pattern. Core knows nothing about databases, sessions, auth, or jobs.
+
+### modo-db Backend Details
+
+`modo-db` uses SeaORM under the hood and exposes a unified API regardless of backend. Backend-specific behavior is behind feature flags:
+
+- **`sqlite` feature:** WAL mode, `busy_timeout`, `synchronous=NORMAL`, `foreign_keys=ON`
+- **`postgres` feature:** connection pool sizing, SSL mode, statement caching
+- **Entity macros** (`#[entity]`, `#[migration]`) live in `modo-db` (or `modo-db-macros`) — not in core
+- **Schema sync** works the same for both backends (SeaORM's `schema-sync` feature)
 
 ## Consequences
 
@@ -104,20 +142,24 @@ Extension crates integrate via the existing service registry + middleware + extr
 - Users only compile what they use
 - Extensions evolve and version independently
 - Matches Rust ecosystem conventions (axum/axum-extra/axum-login pattern)
+- Postgres support without workarounds — just change a feature flag
+- No-DB apps are possible (webhooks, proxies, static servers)
 
 **Negative:**
-- Users add multiple crates to `Cargo.toml`
+- Users add multiple crates to `Cargo.toml` (mitigated by clear examples)
 - Extension-to-extension version compatibility must be managed
-- Some proc macros (`#[job]`, `#[context]`) move to extension macro crates or the extension crates themselves
+- Some proc macros (`#[entity]`, `#[job]`, `#[context]`) move to extension crates
+- Two DB backends to test and maintain in modo-db
 
 ## Implementation Order
 
-1. Extract `modo-session` (largest, most coupled module)
-2. Extract `modo-auth` (depends on modo-session)
-3. Extract `modo-jobs`
-4. Extract `modo-templates`
-5. Extract `modo-csrf`
-6. Clean up core — remove all feature flags for extracted modules
+1. Extract `modo-db` (move DB out of core, add sqlite/postgres features)
+2. Extract `modo-session` (depends on modo-db)
+3. Extract `modo-auth` (depends on modo-session)
+4. Extract `modo-jobs` (depends on modo-db)
+5. Extract `modo-templates`
+6. Extract `modo-csrf`
+7. Clean up core — remove all DB/feature flags, leave only HTTP + cookies + services
 
 ## Example Apps
 
@@ -125,17 +167,17 @@ Build after each extraction step to validate the framework works end-to-end. Eac
 
 | # | Example | Validates | Built after |
 |---|---|---|---|
-| 1 | `hello` | Routes, error handling, core only | Step 6 (core cleanup) |
-| 2 | `todo-api` | JSON REST CRUD, DB entities, migrations, `Db` extractor, `Service<T>` | Step 6 (core cleanup) |
-| 3 | `blog` | Templates, flash messages, CSRF forms, HTML rendering | Steps 4-5 (templates + csrf) |
-| 4 | `auth-app` | Signup/login/logout, sessions, protected routes, password hashing | Steps 1-2 (session + auth) |
-| 5 | `saas-starter` | Full stack: auth + DB + jobs + templates + CSRF — the "real app" smoke test | Step 5 (all extracted) |
+| 1 | `hello` | Routes, error handling, core only — no DB | Step 7 (core cleanup) |
+| 2 | `todo-api` | JSON REST CRUD, DB entities, migrations, `Db` extractor, `Service<T>` | Step 1 (modo-db) |
+| 3 | `blog` | Templates, flash messages, CSRF forms, HTML rendering | Steps 5-6 (templates + csrf) |
+| 4 | `auth-app` | Signup/login/logout, sessions, protected routes, password hashing | Steps 2-3 (session + auth) |
+| 5 | `saas-starter` | Full stack: auth + DB + jobs + templates + CSRF — the "real app" smoke test | Step 6 (all extracted) |
 
 ### Example Descriptions
 
-**hello** — Bare minimum. A few GET routes, a JSON error route. Proves core works standalone with zero extensions.
+**hello** — Bare minimum. A few GET routes, a JSON error route. Proves core works standalone with zero extensions and no DB.
 
-**todo-api** — JSON REST API. CRUD for todos with SQLite. Entity-first migrations. No auth, no templates. Validates that core DB + extractors + error handling work without any extension crate.
+**todo-api** — JSON REST API. CRUD for todos with SQLite. Entity-first migrations. No auth, no templates. Validates that modo-db + core extractors + error handling work together.
 
 **blog** — Server-rendered blog with Askama templates. Create/edit/delete posts via HTML forms with CSRF protection. Flash messages for success/error feedback. Validates modo-templates + modo-csrf integration.
 

--- a/docs/plans/2026-03-06-session-entity-feature-flags-design.md
+++ b/docs/plans/2026-03-06-session-entity-feature-flags-design.md
@@ -1,0 +1,215 @@
+# Session Entity-First Refactor + Feature Flags
+
+## Overview
+
+Replace the trait-based session store with a concrete `#[modo::entity]` session entity and `SessionStore` struct. Add granular feature flags so different app types (web, API, worker) only pull in what they need. Default features: none (core HTTP only).
+
+## Feature Flag Map
+
+```toml
+[features]
+default = []
+
+# Internal feature (enabled by session or templates)
+cookies = []  # axum-extra cookie features, cookie crate
+
+# User-facing
+session = ["cookies"]
+auth = ["session"]
+templates = ["cookies", "dep:askama", "dep:askama_web"]
+jobs = ["dep:tokio-util", "dep:cron"]
+sentry = ["dep:sentry"]
+```
+
+Dependency graph:
+```
+auth -> session -> cookies
+templates -> cookies
+jobs (independent)
+sentry (independent)
+```
+
+### What Each Feature Gates
+
+| Feature | Modules/Files | Deps Made Optional |
+|---------|--------------|-------------------|
+| `cookies` | `cookie_key` in AppState, `FromRef<AppState> for Key` | `cookie` (key-expansion), `axum-extra` cookie features |
+| `session` | `session/` module, `middleware/session.rs`, session config fields, session entity | `sha2`, `ipnet` |
+| `auth` | `extractors/auth.rs` (Auth, OptionalAuth, UserProvider) | (none beyond session) |
+| `templates` | `templates/` module (flash, BaseContext, HTMX), `middleware/csrf.rs` | `askama`, `askama_web` |
+| `jobs` | `jobs/` module | `tokio-util`, `cron` |
+| `sentry` | sentry re-export, sentry config fields | `sentry` |
+
+### Always-On Core
+
+axum, tokio, tower, tracing, sea-orm, inventory, serde, serde_json, thiserror, anyhow, dotenvy, rand, ulid, nanoid, chrono.
+
+Modules: `app`, `config`, `db`, `error`, `router`, `extractors/db.rs`, `extractors/service.rs`.
+
+### Typical Usage
+
+- Web app: `features = ["auth", "templates", "jobs"]`
+- API server: `features = ["auth"]`
+- Worker: `features = ["jobs"]`
+- Minimal HTTP: `default-features = false` (or just `features = []`)
+
+## Session Entity
+
+Replaces the `SessionData` struct as the source of truth. Uses `#[modo::entity]` macro for auto-discovery and schema sync.
+
+```rust
+#[modo::entity(table = "_modo_sessions")]
+#[entity(timestamps)]  // adds created_at, updated_at
+pub struct Session {
+    #[entity(primary_key, auto_increment = false)]
+    pub id: String,              // ULID
+
+    #[entity(indexed, unique)]
+    pub token: String,           // 64-char hex, cookie lookup key
+
+    #[entity(indexed)]
+    pub user_id: String,
+
+    pub ip_address: String,
+    pub user_agent: String,
+    pub device_name: String,
+    pub device_type: String,
+    pub fingerprint: String,
+
+    #[entity(column_type = "Text")]
+    pub data: String,            // JSON blob
+
+    pub expires_at: DateTimeUtc,
+    // created_at, updated_at auto-added by timestamps
+}
+```
+
+Key decisions:
+- `updated_at` replaces `last_active_at` (same semantic, no extra column)
+- `data` is `String` in DB, converted to/from `serde_json::Value` in store methods
+- Registers as framework entity (`is_framework: true`)
+- `SessionId` and `SessionToken` newtypes stay in `types.rs` (domain types, not DB types)
+
+## Concrete SessionStore
+
+Replaces `SessionStore` trait + `SessionStoreDyn` trait + blanket impl.
+
+```rust
+pub struct SessionStore {
+    db: DatabaseConnection,
+    ttl: Duration,
+}
+
+impl SessionStore {
+    pub fn new(db: DatabaseConnection, ttl: Duration) -> Self;
+
+    pub async fn create(&self, user_id: &str, meta: &SessionMeta) -> Result<SessionData, Error>;
+    pub async fn create_with(&self, user_id: &str, meta: &SessionMeta, data: Value) -> Result<SessionData, Error>;
+    pub async fn read(&self, id: &SessionId) -> Result<Option<SessionData>, Error>;
+    pub async fn read_by_token(&self, token: &SessionToken) -> Result<Option<SessionData>, Error>;
+    pub async fn touch(&self, id: &SessionId, ttl: Duration) -> Result<(), Error>;
+    pub async fn update_data(&self, id: &SessionId, data: Value) -> Result<(), Error>;
+    pub async fn update_token(&self, id: &SessionId, new_token: &SessionToken) -> Result<(), Error>;
+    pub async fn destroy(&self, id: &SessionId) -> Result<(), Error>;
+    pub async fn destroy_all_for_user(&self, user_id: &str) -> Result<(), Error>;
+    pub async fn destroy_all_except(&self, user_id: &str, except_id: &SessionId) -> Result<(), Error>;
+    pub async fn cleanup_expired(&self) -> Result<u64, Error>;
+}
+```
+
+Each method uses SeaORM queries against the session entity.
+
+## What Gets Deleted
+
+- `SessionStore` trait (63 lines)
+- `SessionStoreDyn` trait (60 lines)
+- Blanket `impl<T: SessionStore> SessionStoreDyn for T` (78 lines)
+- `MemoryStore` test helper (~100 lines)
+- All `Arc<dyn SessionStoreDyn>` casts in tests (~20 occurrences)
+- `.session_store()` builder method on `AppBuilder` (auto-wired instead)
+
+Total: ~350 lines of abstraction plumbing removed.
+
+## What Gets Added
+
+- Session entity definition (~30 lines)
+- Concrete `SessionStore` with SeaORM queries (~170 lines)
+- `impl From<session::Model> for SessionData` conversion (~20 lines)
+- `#[cfg]` annotations across the codebase
+
+Net: ~150 fewer lines, simpler code, full SeaORM queryability.
+
+## Auto-Wiring
+
+In `AppBuilder::run()`, when `session` feature is enabled and DB is available:
+
+```rust
+#[cfg(feature = "session")]
+let session_store = db.as_ref().map(|db| {
+    Arc::new(SessionStore::new(db.clone(), config.session_ttl))
+});
+```
+
+No manual `.session_store()` call needed. Session entity syncs via `sync_and_migrate()` (handles framework entities).
+
+## User-Facing Queries
+
+Because session is a real SeaORM entity, users can query it directly:
+
+```rust
+use modo::session::Entity as Session;
+use modo::session::Column;
+
+let sessions = Session::find()
+    .filter(Column::UserId.eq("user123"))
+    .filter(Column::ExpiresAt.gt(Utc::now()))
+    .order_by_desc(Column::UpdatedAt)
+    .limit(10)
+    .all(&db)
+    .await?;
+```
+
+## Impact on Existing Code
+
+### SessionManager (minimal changes)
+- `store: Arc<dyn SessionStoreDyn>` -> `store: Arc<SessionStore>` (concrete type)
+- All public API unchanged
+- Gated under `#[cfg(feature = "session")]`
+
+### Session Middleware (minimal changes)
+- Same type change for store reference
+- Gated under `#[cfg(feature = "session")]`
+
+### Auth Extractors
+- Gated under `#[cfg(feature = "auth")]`
+- Still reads `SessionData` from extensions (no direct store dependency)
+
+### Templates/CSRF
+- `middleware/csrf.rs` -> `#[cfg(feature = "templates")]`
+- `templates/` module -> `#[cfg(feature = "templates")]`
+
+### Config
+- Session fields (`session_ttl`, `session_cookie_name`, etc.) gated under `#[cfg(feature = "session")]`
+- `trusted_proxies` gated under `#[cfg(feature = "session")]`
+- `secret_key` stays always-on in config; `cookie_key: Key` in AppState gated under `#[cfg(feature = "cookies")]`
+
+### Proc Macros
+- `#[modo::main]` must emit `#[cfg(feature = "session")]` / `#[cfg(not(feature = "session"))]` branches for session middleware registration
+- `#[modo::context]` must emit conditional branches for session/auth fields
+
+## Testing Strategy
+
+- Session store tests use `:memory:` SQLite (real DB, no mocks)
+- CI must verify feature combinations compile:
+  - `cargo check --no-default-features`
+  - `cargo check --features session`
+  - `cargo check --features auth`
+  - `cargo check --features templates`
+  - `cargo check --features "auth,templates,jobs"`
+  - `cargo check --all-features`
+- `just check` updated to verify minimum set of combinations
+
+## Cleanup Job
+
+- When both `session` and `jobs` features are enabled, wire `cleanup_expired()` as a periodic cron job
+- When only `session` is enabled, expired sessions filtered out at query time (`expires_at > now`), accumulate in DB until manual cleanup or user-defined cron

--- a/docs/plans/2026-03-06-session-entity-feature-flags-plan.md
+++ b/docs/plans/2026-03-06-session-entity-feature-flags-plan.md
@@ -1,0 +1,1045 @@
+# Session Entity-First Refactor + Feature Flags — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace trait-based session store with concrete entity + store, add granular feature flags (default = none).
+
+**Architecture:** Session becomes a `#[modo::entity]` framework entity auto-synced at startup. `SessionStore` becomes a concrete struct with SeaORM queries. Feature flags gate session, auth, templates, cookies, jobs, and sentry independently.
+
+**Tech Stack:** SeaORM v2 RC (entity + queries), inventory (auto-discovery), axum 0.8 (extractors/middleware)
+
+**Design doc:** `docs/plans/2026-03-06-session-entity-feature-flags-design.md`
+
+---
+
+### Task 1: Feature Flags in Cargo.toml
+
+Makes `sha2`, `ipnet`, `cookie`, `axum-extra` cookie features optional. Changes default to `[]`.
+
+**Files:**
+- Modify: `modo/Cargo.toml`
+
+**Step 1: Update Cargo.toml**
+
+```toml
+[dependencies]
+# Core (always on)
+modo-macros = { path = "../modo-macros" }
+axum = "0.8"
+axum-extra = { version = "0.10", default-features = false }
+tokio = { version = "1", features = ["full"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["trace", "cors"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+inventory = "0.3"
+sea-orm = { version = "2.0.0-rc", features = ["sqlx-sqlite", "runtime-tokio-native-tls", "macros", "schema-sync"] }
+thiserror = "2"
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+dotenvy = "0.15"
+rand = "0.9"
+ulid = "1"
+nanoid = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
+
+# Optional deps (gated by features)
+cookie = { version = "0.18", features = ["key-expansion"], optional = true }
+sha2 = { version = "0.10", optional = true }
+ipnet = { version = "2", optional = true }
+askama = { version = "0.13", optional = true }
+askama_web = { version = "0.14", features = ["axum-0.8"], optional = true }
+sentry = { version = "0.46", features = ["tracing"], optional = true }
+tokio-util = { version = "0.7", features = ["rt"], optional = true }
+cron = { version = "0.15", optional = true }
+
+[features]
+default = []
+cookies = ["dep:cookie", "axum-extra/cookie-signed", "axum-extra/cookie-private"]
+session = ["cookies", "dep:sha2", "dep:ipnet"]
+auth = ["session"]
+templates = ["cookies", "dep:askama", "dep:askama_web"]
+jobs = ["dep:tokio-util", "dep:cron"]
+sentry = ["dep:sentry"]
+```
+
+Key points:
+- `axum-extra` is always-on (may have non-cookie uses) but cookie features are gated via `cookies`
+- `rand`, `ulid`, `nanoid` stay always-on (used by core: CSRF, request IDs, DB IDs)
+- `sha2` and `ipnet` are session-only
+
+**Step 2: Verify it compiles with no features**
+
+Run: `cargo check --no-default-features -p modo`
+
+This WILL fail with many errors -- expected. The remaining tasks fix each one.
+
+**Step 3: Commit**
+
+```
+feat: restructure feature flags in Cargo.toml
+
+Default features are now empty (core HTTP only).
+New features: cookies, session, auth, templates.
+Jobs default changed from on to off.
+```
+
+---
+
+### Task 2: Gate `cookies` -- AppState and Key
+
+Gate `cookie_key` field and `FromRef<AppState> for Key` behind `#[cfg(feature = "cookies")]`.
+
+**Files:**
+- Modify: `modo/src/app.rs` (lines 6, 16-30, 125-136)
+
+**Step 1: Gate cookie_key in AppState**
+
+In `modo/src/app.rs`:
+
+```rust
+// Line 6: conditional import
+#[cfg(feature = "cookies")]
+use axum_extra::extract::cookie::Key;
+
+// AppState struct:
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Option<DatabaseConnection>,
+    pub services: ServiceRegistry,
+    pub config: AppConfig,
+    #[cfg(feature = "cookies")]
+    pub cookie_key: Key,
+    #[cfg(feature = "session")]
+    pub session_store: Option<Arc<SessionStore>>,  // will fix in Task 5
+    #[cfg(feature = "jobs")]
+    pub job_queue: Option<crate::jobs::JobQueue>,
+}
+
+// FromRef impl:
+#[cfg(feature = "cookies")]
+impl FromRef<AppState> for Key {
+    fn from_ref(state: &AppState) -> Self {
+        state.cookie_key.clone()
+    }
+}
+```
+
+In `AppBuilder::run()`, gate cookie_key generation (lines 125-136):
+
+```rust
+#[cfg(feature = "cookies")]
+let cookie_key = if self.config.secret_key.is_empty() {
+    if self.config.environment == Environment::Production {
+        warn!("MODO_SECRET_KEY is empty in production! ...");
+    } else {
+        warn!("MODO_SECRET_KEY is empty -- generating random key");
+    }
+    axum_extra::extract::cookie::Key::generate()
+} else {
+    axum_extra::extract::cookie::Key::derive_from(self.config.secret_key.as_bytes())
+};
+```
+
+And in AppState construction:
+
+```rust
+let state = AppState {
+    db,
+    services: ServiceRegistry { services: Arc::new(services) },
+    config: self.config.clone(),
+    #[cfg(feature = "cookies")]
+    cookie_key,
+    #[cfg(feature = "session")]
+    session_store: todo!(),  // Task 5 will implement
+    #[cfg(feature = "jobs")]
+    job_queue,
+};
+```
+
+**Step 2: Verify**
+
+Run: `cargo check --no-default-features -p modo`
+
+Expect fewer errors (cookie-related ones resolved).
+
+**Step 3: Commit**
+
+```
+feat: gate cookie_key behind cookies feature flag
+```
+
+---
+
+### Task 3: Gate `session` module in lib.rs and config.rs
+
+**Files:**
+- Modify: `modo/src/lib.rs` (line 12)
+- Modify: `modo/src/config.rs` (lines 15-19, 45-49, 85-125)
+
+**Step 1: Gate session module in lib.rs**
+
+```rust
+// modo/src/lib.rs line 12
+#[cfg(feature = "session")]
+pub mod session;
+```
+
+**Step 2: Gate session config fields**
+
+In `modo/src/config.rs`, apply `#[cfg(feature = "session")]` to:
+
+Struct fields (lines 15-19):
+```rust
+#[cfg(feature = "session")]
+pub session_ttl: Duration,
+#[cfg(feature = "session")]
+pub session_cookie_name: String,
+#[cfg(feature = "session")]
+pub session_validate_fingerprint: bool,
+#[cfg(feature = "session")]
+pub session_touch_interval: Duration,
+#[cfg(feature = "session")]
+pub trusted_proxies: Vec<ipnet::IpNet>,
+```
+
+Default impl (lines 45-49):
+```rust
+#[cfg(feature = "session")]
+session_ttl: Duration::from_secs(30 * 24 * 60 * 60),
+#[cfg(feature = "session")]
+session_cookie_name: "_session".to_string(),
+#[cfg(feature = "session")]
+session_validate_fingerprint: true,
+#[cfg(feature = "session")]
+session_touch_interval: Duration::from_secs(5 * 60),
+#[cfg(feature = "session")]
+trusted_proxies: Vec::new(),
+```
+
+`from_env()` (lines 85-125): wrap the session fields block:
+```rust
+#[cfg(feature = "session")]
+session_ttl: Duration::from_secs({ ... }),
+#[cfg(feature = "session")]
+session_cookie_name: env::var("MODO_SESSION_COOKIE_NAME")
+    .unwrap_or_else(|_| "_session".to_string()),
+#[cfg(feature = "session")]
+session_validate_fingerprint: env::var("MODO_SESSION_VALIDATE_FINGERPRINT")
+    .map(|v| v != "false" && v != "0")
+    .unwrap_or(true),
+#[cfg(feature = "session")]
+session_touch_interval: Duration::from_secs({ ... }),
+#[cfg(feature = "session")]
+trusted_proxies: env::var("MODO_TRUSTED_PROXIES").unwrap_or_default()
+    .split(',')
+    .filter(|s| !s.trim().is_empty())
+    .filter_map(|s| { ... })
+    .collect(),
+```
+
+**Step 3: Verify**
+
+Run: `cargo check --no-default-features -p modo`
+
+**Step 4: Commit**
+
+```
+feat: gate session module and config behind session feature flag
+```
+
+---
+
+### Task 4: Gate `templates` and `auth` modules
+
+**Files:**
+- Modify: `modo/src/lib.rs` (line 13)
+- Modify: `modo/src/middleware/mod.rs`
+- Modify: `modo/src/extractors/mod.rs`
+
+**Step 1: Gate templates module**
+
+In `modo/src/lib.rs`:
+```rust
+#[cfg(feature = "templates")]
+pub mod templates;
+```
+
+In `modo/src/middleware/mod.rs`:
+```rust
+#[cfg(feature = "templates")]
+pub mod csrf;
+#[cfg(feature = "session")]
+pub mod session;
+
+#[cfg(feature = "templates")]
+pub use csrf::{CsrfToken, csrf_protection};
+#[cfg(feature = "session")]
+pub use session::session;
+```
+
+**Step 2: Gate auth extractor**
+
+In `modo/src/extractors/mod.rs`:
+```rust
+#[cfg(feature = "auth")]
+pub mod auth;
+pub mod db;
+pub mod service;
+```
+
+**Step 3: Verify**
+
+Run: `cargo check --no-default-features -p modo`
+
+**Step 4: Commit**
+
+```
+feat: gate templates, csrf, and auth behind feature flags
+```
+
+---
+
+### Task 5: Session Entity Definition
+
+Create the SeaORM entity for `_modo_sessions` following the jobs entity pattern (manual SeaORM derives + `inventory::submit!`).
+
+**Files:**
+- Create: `modo/src/session/entity.rs`
+- Modify: `modo/src/session/mod.rs`
+
+**Step 1: Create session entity**
+
+```rust
+// modo/src/session/entity.rs
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "_modo_sessions")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    #[sea_orm(unique, indexed)]
+    pub token: String,
+    #[sea_orm(indexed)]
+    pub user_id: String,
+    pub ip_address: String,
+    pub user_agent: String,
+    pub device_name: String,
+    pub device_type: String,
+    pub fingerprint: String,
+    #[sea_orm(column_type = "Text")]
+    pub data: String,
+    pub expires_at: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+inventory::submit! {
+    crate::db::EntityRegistration {
+        table_name: "_modo_sessions",
+        register_fn: |sb| sb.register(Entity),
+        is_framework: true,
+        extra_sql: &[],
+    }
+}
+```
+
+Note: Using `String` for timestamps (like the jobs entity does) because SQLite stores dates as text. The store will handle conversion to/from `chrono::DateTime<Utc>`.
+
+**Step 2: Add to session mod.rs**
+
+```rust
+// modo/src/session/mod.rs
+pub mod entity;
+// ... existing modules ...
+```
+
+**Step 3: Verify entity compiles**
+
+Run: `cargo check --features session -p modo`
+
+**Step 4: Commit**
+
+```
+feat: add session entity for _modo_sessions table
+```
+
+---
+
+### Task 6: Concrete SessionStore
+
+Replace the trait-based store with a concrete struct using SeaORM queries.
+
+**Files:**
+- Rewrite: `modo/src/session/store.rs`
+- Modify: `modo/src/session/types.rs` (add `SessionId::from_raw`)
+
+**Step 1: Add `from_raw` to SessionId**
+
+In `modo/src/session/types.rs`, add to `impl SessionId`:
+```rust
+pub(crate) fn from_raw(s: String) -> Self {
+    Self(s)
+}
+```
+
+**Step 2: Write concrete SessionStore**
+
+Replace entire `modo/src/session/store.rs`:
+
+```rust
+use crate::error::Error;
+use crate::session::entity::{self, ActiveModel, Column, Entity};
+use crate::session::meta::SessionMeta;
+use crate::session::types::{SessionData, SessionId, SessionToken};
+use chrono::Utc;
+use sea_orm::*;
+use std::time::Duration;
+
+pub struct SessionStore {
+    db: DatabaseConnection,
+    ttl: Duration,
+}
+
+impl SessionStore {
+    pub fn new(db: DatabaseConnection, ttl: Duration) -> Self {
+        Self { db, ttl }
+    }
+
+    pub async fn create(
+        &self,
+        user_id: &str,
+        meta: &SessionMeta,
+    ) -> Result<SessionData, Error> {
+        self.create_with(user_id, meta, serde_json::json!({})).await
+    }
+
+    pub async fn create_with(
+        &self,
+        user_id: &str,
+        meta: &SessionMeta,
+        data: serde_json::Value,
+    ) -> Result<SessionData, Error> {
+        let id = SessionId::new();
+        let token = SessionToken::generate();
+        let now = Utc::now();
+        let expires_at = now
+            + chrono::Duration::from_std(self.ttl)
+                .unwrap_or_else(|_| chrono::Duration::hours(1));
+
+        let model = ActiveModel {
+            id: Set(id.as_str().to_string()),
+            token: Set(token.as_str().to_string()),
+            user_id: Set(user_id.to_string()),
+            ip_address: Set(meta.ip_address.clone()),
+            user_agent: Set(meta.user_agent.clone()),
+            device_name: Set(meta.device_name.clone()),
+            device_type: Set(meta.device_type.clone()),
+            fingerprint: Set(meta.fingerprint.clone()),
+            data: Set(serde_json::to_string(&data).unwrap_or_else(|_| "{}".to_string())),
+            expires_at: Set(expires_at.to_rfc3339()),
+            created_at: Set(now.to_rfc3339()),
+            updated_at: Set(now.to_rfc3339()),
+        };
+
+        Entity::insert(model).exec(&self.db).await?;
+
+        Ok(SessionData {
+            id,
+            token,
+            user_id: user_id.to_string(),
+            ip_address: meta.ip_address.clone(),
+            user_agent: meta.user_agent.clone(),
+            device_name: meta.device_name.clone(),
+            device_type: meta.device_type.clone(),
+            fingerprint: meta.fingerprint.clone(),
+            data,
+            created_at: now,
+            last_active_at: now,
+            expires_at,
+        })
+    }
+
+    pub async fn read(&self, id: &SessionId) -> Result<Option<SessionData>, Error> {
+        let model = Entity::find_by_id(id.as_str().to_string())
+            .one(&self.db)
+            .await?;
+        Ok(model.map(model_to_session_data))
+    }
+
+    pub async fn read_by_token(
+        &self,
+        token: &SessionToken,
+    ) -> Result<Option<SessionData>, Error> {
+        let model = Entity::find()
+            .filter(Column::Token.eq(token.as_str()))
+            .one(&self.db)
+            .await?;
+        Ok(model.map(model_to_session_data))
+    }
+
+    pub async fn touch(&self, id: &SessionId, ttl: Duration) -> Result<(), Error> {
+        let now = Utc::now();
+        let expires_at = now
+            + chrono::Duration::from_std(ttl)
+                .unwrap_or_else(|_| chrono::Duration::hours(1));
+
+        Entity::update_many()
+            .filter(Column::Id.eq(id.as_str()))
+            .col_expr(Column::UpdatedAt, Expr::value(now.to_rfc3339()))
+            .col_expr(Column::ExpiresAt, Expr::value(expires_at.to_rfc3339()))
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn update_data(
+        &self,
+        id: &SessionId,
+        data: serde_json::Value,
+    ) -> Result<(), Error> {
+        let json = serde_json::to_string(&data).unwrap_or_else(|_| "{}".to_string());
+        Entity::update_many()
+            .filter(Column::Id.eq(id.as_str()))
+            .col_expr(Column::Data, Expr::value(json))
+            .col_expr(Column::UpdatedAt, Expr::value(Utc::now().to_rfc3339()))
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn update_token(
+        &self,
+        id: &SessionId,
+        new_token: &SessionToken,
+    ) -> Result<(), Error> {
+        Entity::update_many()
+            .filter(Column::Id.eq(id.as_str()))
+            .col_expr(Column::Token, Expr::value(new_token.as_str()))
+            .col_expr(Column::UpdatedAt, Expr::value(Utc::now().to_rfc3339()))
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn destroy(&self, id: &SessionId) -> Result<(), Error> {
+        Entity::delete_by_id(id.as_str().to_string())
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn destroy_all_for_user(&self, user_id: &str) -> Result<(), Error> {
+        Entity::delete_many()
+            .filter(Column::UserId.eq(user_id))
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn destroy_all_except(
+        &self,
+        user_id: &str,
+        except_id: &SessionId,
+    ) -> Result<(), Error> {
+        Entity::delete_many()
+            .filter(Column::UserId.eq(user_id))
+            .filter(Column::Id.ne(except_id.as_str()))
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn cleanup_expired(&self) -> Result<u64, Error> {
+        let result = Entity::delete_many()
+            .filter(Column::ExpiresAt.lt(Utc::now().to_rfc3339()))
+            .exec(&self.db)
+            .await?;
+        Ok(result.rows_affected)
+    }
+}
+
+fn model_to_session_data(m: entity::Model) -> SessionData {
+    SessionData {
+        id: SessionId::from_raw(m.id),
+        token: SessionToken::from_raw(m.token),
+        user_id: m.user_id,
+        ip_address: m.ip_address,
+        user_agent: m.user_agent,
+        device_name: m.device_name,
+        device_type: m.device_type,
+        fingerprint: m.fingerprint,
+        data: serde_json::from_str(&m.data).unwrap_or(serde_json::json!({})),
+        created_at: chrono::DateTime::parse_from_rfc3339(&m.created_at)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now()),
+        last_active_at: chrono::DateTime::parse_from_rfc3339(&m.updated_at)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now()),
+        expires_at: chrono::DateTime::parse_from_rfc3339(&m.expires_at)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now()),
+    }
+}
+```
+
+**Step 3: Verify**
+
+Run: `cargo check --features session -p modo`
+
+**Step 4: Commit**
+
+```
+feat: implement concrete SessionStore with SeaORM queries
+
+Replaces SessionStore trait, SessionStoreDyn trait, and blanket impl
+with a concrete struct that queries the _modo_sessions entity directly.
+```
+
+---
+
+### Task 7: Update SessionManager and Middleware
+
+Change `Arc<dyn SessionStoreDyn>` to `Arc<SessionStore>` (concrete).
+
+**Files:**
+- Modify: `modo/src/session/manager.rs` (lines 4, 23)
+- Modify: `modo/src/session/mod.rs`
+- Modify: `modo/src/middleware/session.rs` (line 33)
+- Modify: `modo/src/app.rs` (lines 3, 21, 65, 82-85, 145-148, 208)
+- Modify: `modo/src/extractors/auth.rs` (lines 159, 201)
+
+**Step 1: Update SessionManager internals**
+
+In `modo/src/session/manager.rs`:
+
+Line 4: Change import:
+```rust
+use crate::session::store::SessionStore;
+```
+
+Line 23: Change field type:
+```rust
+pub struct SessionManagerState {
+    pub action: Arc<Mutex<SessionAction>>,
+    pub meta: SessionMeta,
+    pub store: Arc<SessionStore>,  // was Arc<dyn SessionStoreDyn>
+    pub current_session: Option<SessionData>,
+}
+```
+
+All method calls on `self.state.store` stay identical (same method names).
+
+**Step 2: Update session mod.rs exports**
+
+```rust
+// modo/src/session/mod.rs
+mod device;
+pub mod entity;
+mod fingerprint;
+pub(crate) mod manager;
+mod meta;
+mod store;
+mod types;
+
+pub(crate) use device::{parse_device_name, parse_device_type};
+pub(crate) use fingerprint::compute_fingerprint;
+pub use manager::SessionManager;
+pub use meta::SessionMeta;
+pub use store::SessionStore;
+pub use types::{SessionData, SessionId, SessionToken};
+```
+
+Removed: `SessionStoreDyn` export (deleted).
+
+**Step 3: Update app.rs**
+
+Remove `SessionStore` trait import, `SessionStoreDyn` import. Change store type:
+
+```rust
+// Line 3: remove old import, add new
+#[cfg(feature = "session")]
+use crate::session::SessionStore;
+
+// AppState:
+#[cfg(feature = "session")]
+pub session_store: Option<Arc<SessionStore>>,
+
+// AppBuilder: remove session_store field and .session_store() method entirely
+```
+
+In `AppBuilder::run()`, auto-wire session store (replace lines 145-148):
+
+```rust
+#[cfg(feature = "session")]
+let session_store = db.as_ref().map(|db| {
+    Arc::new(SessionStore::new(db.clone(), self.config.session_ttl))
+});
+#[cfg(feature = "session")]
+if session_store.is_some() {
+    info!("Session store auto-initialized");
+}
+```
+
+And in AppState construction:
+```rust
+#[cfg(feature = "session")]
+session_store,
+```
+
+Remove the `session_store` field from `AppBuilder` and the `.session_store()` method (lines 65, 74, 82-85).
+
+**Step 4: Update auth extractors**
+
+In `modo/src/extractors/auth.rs`, the `state.session_store` references (lines 159, 201) are fine -- the whole file is already gated under `#[cfg(feature = "auth")]` which implies `session`.
+
+**Step 5: Update middleware/session.rs**
+
+Line 33-34: `state.session_store` type is now `Option<Arc<SessionStore>>` -- no code change needed, just the type flows through.
+
+**Step 6: Verify with session feature**
+
+Run: `cargo check --features session -p modo`
+
+**Step 7: Commit**
+
+```
+feat: wire concrete SessionStore through manager, middleware, and app
+
+Remove SessionStoreDyn, remove .session_store() builder method.
+Session store auto-wired from DB connection when session feature is on.
+```
+
+---
+
+### Task 8: Update Proc Macros for Feature Flags
+
+Gate session and auth references in generated code.
+
+**Files:**
+- Modify: `modo-macros/src/context.rs` (lines 112-132)
+
+**Step 1: Gate session extraction in context macro**
+
+In `modo-macros/src/context.rs`, change lines 126-132:
+
+```rust
+// Generate session extraction code
+let session_extraction = if let Some(session_name) = &session_field {
+    quote! {
+        #[cfg(feature = "session")]
+        let #session_name = parts.extensions.get::<modo::session::SessionData>().cloned();
+        #[cfg(not(feature = "session"))]
+        let #session_name: Option<()> = None;
+    }
+} else {
+    quote! {}
+};
+```
+
+Also gate the user extraction (which uses `OptionalAuth` from auth module), lines 112-123:
+
+```rust
+let user_extraction = if let (Some(user_name), Some(inner_ty)) =
+    (&user_field, &user_inner_type)
+{
+    quote! {
+        #[cfg(feature = "auth")]
+        let #user_name = match modo::extractors::auth::OptionalAuth::<#inner_ty>::from_request_parts(parts, state).await {
+            Ok(modo::extractors::auth::OptionalAuth(Some(auth_data))) => Some(auth_data.user),
+            Ok(modo::extractors::auth::OptionalAuth(None)) => None,
+            Err(never) => match never {},
+        };
+        #[cfg(not(feature = "auth"))]
+        let #user_name: Option<#inner_ty> = None;
+    }
+} else {
+    quote! {}
+};
+```
+
+**Step 2: Verify**
+
+Run: `cargo check --features "auth,templates" -p modo`
+
+**Step 3: Commit**
+
+```
+feat: gate session and auth extraction in context macro
+```
+
+---
+
+### Task 9: Update Integration Tests
+
+Gate session tests behind feature flags, rewrite to use `:memory:` SQLite.
+
+**Files:**
+- Modify: `modo/tests/integration.rs`
+
+**Step 1: Gate and rewrite**
+
+Wrap the `session_integration` module:
+
+```rust
+#[cfg(all(feature = "session", feature = "auth"))]
+mod session_integration {
+    // ... entire module ...
+}
+```
+
+Update `build_test_router()` (lines 18-37):
+
+```rust
+fn build_test_router() -> axum::Router {
+    let state = AppState {
+        db: None,
+        services: Default::default(),
+        config: modo::config::AppConfig::default(),
+        #[cfg(feature = "cookies")]
+        cookie_key: axum_extra::extract::cookie::Key::generate(),
+        #[cfg(feature = "session")]
+        session_store: None,
+        #[cfg(feature = "jobs")]
+        job_queue: None,
+    };
+    // ... rest unchanged ...
+}
+```
+
+Inside `session_integration` module, replace `MemoryStore` with `:memory:` SQLite:
+
+```rust
+use sea_orm::{Database, DatabaseConnection, ConnectionTrait};
+
+async fn setup_test_db() -> DatabaseConnection {
+    let db = Database::connect("sqlite::memory:").await.unwrap();
+    db.execute_unprepared("PRAGMA foreign_keys=ON").await.unwrap();
+    modo::db::sync_and_migrate(&db).await.unwrap();
+    db
+}
+```
+
+Replace `build_session_router` to be async and use real DB:
+
+```rust
+async fn build_session_router() -> (axum::Router, AppState) {
+    let db = setup_test_db().await;
+    let config = modo::config::AppConfig {
+        session_validate_fingerprint: true,
+        ..Default::default()
+    };
+    let store = Arc::new(modo::session::SessionStore::new(
+        db.clone(),
+        config.session_ttl,
+    ));
+    let services =
+        ServiceRegistry::new().with(UserProviderService::<TestUser>::new(TestUserProvider));
+    let state = AppState {
+        db: Some(db),
+        services,
+        config,
+        cookie_key: axum_extra::extract::cookie::Key::generate(),
+        session_store: Some(store),
+        #[cfg(feature = "jobs")]
+        job_queue: None,
+    };
+
+    let router = axum::Router::new()
+        .route("/login", post(login_handler))
+        .route("/check", get(check_handler))
+        .route("/auth", get(auth_handler))
+        .route("/optional-auth", get(optional_auth_handler))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            modo::middleware::session::session,
+        ))
+        .with_state(state.clone());
+
+    (router, state)
+}
+```
+
+Update each test to call `build_session_router().await`:
+
+```rust
+#[tokio::test]
+async fn session_authenticate_sets_cookie() {
+    let (app, _) = build_session_router().await;
+    // ... rest of test unchanged ...
+}
+```
+
+Delete `MemoryStore`, `FailingReadStore`, and their impls (lines 117-305).
+
+Delete the `session_transient_db_error_preserves_cookie` test -- `FailingReadStore` no longer exists, and transient DB errors are a middleware concern, not store concern.
+
+For `session_expired_removes_stale_cookie`: use raw SQL instead of in-memory mutation:
+
+```rust
+#[tokio::test]
+async fn session_expired_removes_stale_cookie() {
+    let (app, state) = build_session_router().await;
+    let db = state.db.as_ref().unwrap();
+
+    // Login
+    let response = app.clone().oneshot(/* login request */).await.unwrap();
+    let cookie = extract_session_cookie(&response, COOKIE_NAME).unwrap();
+
+    // Expire all sessions in the DB
+    db.execute_unprepared(
+        "UPDATE \"_modo_sessions\" SET expires_at = datetime('now', '-1 hour')"
+    ).await.unwrap();
+
+    // Request with expired cookie
+    let response = app.oneshot(/* check request with cookie */).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&body[..], b"no_session");
+}
+```
+
+For `session_fingerprint_mismatch_destroys_session`: verify via DB query instead of accessing store internals:
+
+```rust
+// Verify session destroyed in DB
+let count: u64 = modo::session::entity::Entity::find()
+    .filter(modo::session::entity::Column::Id.eq(session_id.as_str()))
+    .count(db)
+    .await
+    .unwrap();
+assert_eq!(count, 0, "session should be destroyed after fingerprint mismatch");
+```
+
+**Step 2: Also update SessionManager unit tests**
+
+In `modo/src/session/manager.rs` (lines 299-890): Replace `MemoryStore` with `:memory:` SQLite + `sync_and_migrate()`. Replace `Arc<dyn SessionStoreDyn>` with `Arc<SessionStore>`. Update `make_manager()` to accept `Arc<SessionStore>`.
+
+The `FailingDestroyStore` test (around line 870) should be deleted -- it was testing the manager's behavior when destroy fails, which is a store-level concern now tested via the real store.
+
+**Step 3: Verify all tests pass with session feature**
+
+Run: `cargo test --features "session,auth" -p modo`
+
+**Step 4: Verify tests pass without session feature**
+
+Run: `cargo test --no-default-features -p modo`
+
+**Step 5: Commit**
+
+```
+test: rewrite session tests to use :memory: SQLite
+
+Remove MemoryStore and FailingReadStore test helpers.
+All session tests now use real SQLite with sync_and_migrate().
+Tests gated behind session/auth feature flags.
+```
+
+---
+
+### Task 10: Verify All Feature Combinations
+
+**Files:** None (verification only)
+
+**Step 1: Check each combination compiles**
+
+```
+cargo check --no-default-features -p modo
+cargo check --features session -p modo
+cargo check --features auth -p modo
+cargo check --features templates -p modo
+cargo check --features jobs -p modo
+cargo check --features sentry -p modo
+cargo check --features "auth,templates" -p modo
+cargo check --features "auth,templates,jobs" -p modo
+cargo check --all-features -p modo
+```
+
+Each must succeed with no errors.
+
+**Step 2: Run tests for each**
+
+```
+cargo test --no-default-features -p modo
+cargo test --features session -p modo
+cargo test --features auth -p modo
+cargo test --features "auth,templates,jobs" -p modo
+cargo test --all-features -p modo
+```
+
+**Step 3: Run full check**
+
+```
+just fmt
+just check
+```
+
+**Step 4: Commit any fixes**
+
+```
+fix: resolve feature flag compilation issues
+```
+
+---
+
+### Task 11: Update CLAUDE.md and Documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Update CLAUDE.md**
+
+Add to **Key Decisions**:
+- Feature flags: `default = []` (core HTTP only). Enable session, auth, templates, jobs, sentry as needed.
+- Session store: concrete `SessionStore` struct with SeaORM queries (no trait abstraction)
+- Session entity: framework entity `_modo_sessions`, auto-synced at startup
+- Session auto-wiring: store created automatically when session feature + DB available
+
+Update **Conventions**:
+- Feature flags: session, auth, templates, cookies (internal), jobs, sentry
+- Session entity: `modo::session::entity::{Entity, Column, Model}` -- queryable with SeaORM
+- Session store: `modo::session::SessionStore` -- concrete struct, not a trait
+
+Update **Gotchas**:
+- When adding fields to AppState, gate them with `#[cfg(feature = "...")]` and update `modo/tests/integration.rs`
+- `axum-extra` has `default-features = false`; cookie features enabled via `cookies` feature flag
+- `rand`, `ulid`, `nanoid` are always-on (used by core, not feature-gated)
+
+**Step 2: Commit**
+
+```
+docs: update CLAUDE.md for feature flags and concrete session store
+```
+
+---
+
+## Task Dependencies
+
+```
+Task 1 (Cargo.toml) --+---> Task 2 (cookies gate)
+                       +---> Task 3 (session/config gate)
+                       +---> Task 4 (templates/auth gate)
+                              |
+Task 5 (entity) ------------> Task 6 (concrete store)
+                                     |
+Task 2 + Task 3 + Task 4 + Task 6 -> Task 7 (wire everything)
+                                     |
+                                     +---> Task 8 (proc macros)
+                                     +---> Task 9 (tests)
+                                              |
+                                              +---> Task 10 (verify)
+                                                       |
+                                                       +---> Task 11 (docs)
+```
+
+Tasks 2, 3, 4 can run in parallel after Task 1.
+Tasks 5, 6 can run in parallel with Tasks 2-4 (independent).
+Task 7 needs everything before it.
+Tasks 8, 9 can run in parallel after Task 7.
+Task 10 needs everything.

--- a/modo-macros/src/entity.rs
+++ b/modo-macros/src/entity.rs
@@ -8,9 +8,14 @@ use syn::{Fields, Ident, ItemStruct, Lit, LitStr, Result, Token, Type, parse2};
 
 fn to_snake_case(s: &str) -> String {
     let mut result = String::new();
-    for (i, ch) in s.chars().enumerate() {
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &ch) in chars.iter().enumerate() {
         if ch.is_uppercase() && i > 0 {
-            result.push('_');
+            let prev_upper = chars[i - 1].is_uppercase();
+            let next_lower = chars.get(i + 1).is_some_and(|c| c.is_lowercase());
+            if !prev_upper || next_lower {
+                result.push('_');
+            }
         }
         result.push(ch.to_ascii_lowercase());
     }
@@ -131,14 +136,14 @@ fn parse_struct_attrs(input: &mut ItemStruct) -> Result<StructAttrs> {
     let mut timestamps = false;
     let mut soft_delete = false;
     let mut indices = Vec::new();
+    let mut parse_errors: Vec<syn::Error> = Vec::new();
 
     input.attrs.retain(|attr| {
         if !attr.path().is_ident("entity") {
             return true; // keep non-entity attrs
         }
 
-        // Try to parse the inner tokens
-        let _ = attr.parse_nested_meta(|meta| {
+        if let Err(e) = attr.parse_nested_meta(|meta| {
             if meta.path.is_ident("timestamps") {
                 timestamps = true;
                 Ok(())
@@ -175,10 +180,19 @@ fn parse_struct_attrs(input: &mut ItemStruct) -> Result<StructAttrs> {
             } else {
                 Err(meta.error("expected `timestamps`, `soft_delete`, or `index(...)`"))
             }
-        });
+        }) {
+            parse_errors.push(e);
+        }
 
         false // remove all #[entity(...)] struct-level attrs
     });
+
+    if let Some(first) = parse_errors.into_iter().reduce(|mut a, b| {
+        a.combine(b);
+        a
+    }) {
+        return Err(first);
+    }
 
     Ok(StructAttrs {
         timestamps,
@@ -193,13 +207,14 @@ fn parse_struct_attrs(input: &mut ItemStruct) -> Result<StructAttrs> {
 
 fn parse_field_attrs(field: &mut syn::Field) -> Result<FieldAttrs> {
     let mut attrs = FieldAttrs::default();
+    let mut parse_errors: Vec<syn::Error> = Vec::new();
 
     field.attrs.retain(|attr| {
         if !attr.path().is_ident("entity") {
             return true; // keep non-entity attrs
         }
 
-        let _ = attr.parse_nested_meta(|meta| {
+        if let Err(e) = attr.parse_nested_meta(|meta| {
             let name = meta
                 .path
                 .get_ident()
@@ -262,10 +277,19 @@ fn parse_field_attrs(field: &mut syn::Field) -> Result<FieldAttrs> {
                 }
             }
             Ok(())
-        });
+        }) {
+            parse_errors.push(e);
+        }
 
         false // remove all #[entity(...)] field attrs
     });
+
+    if let Some(first) = parse_errors.into_iter().reduce(|mut a, b| {
+        a.combine(b);
+        a
+    }) {
+        return Err(first);
+    }
 
     Ok(attrs)
 }

--- a/modo-macros/src/entity.rs
+++ b/modo-macros/src/entity.rs
@@ -108,6 +108,7 @@ struct FieldAttrs {
     on_update: Option<String>,
     via: Option<String>,
     renamed_from: Option<String>,
+    auto: Option<String>,
 }
 
 enum FieldKind {
@@ -248,6 +249,14 @@ fn parse_field_attrs(field: &mut syn::Field) -> Result<FieldAttrs> {
                     let lit: LitStr = meta.value()?.parse()?;
                     attrs.renamed_from = Some(lit.value());
                 }
+                "auto" => {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    let val = lit.value();
+                    if val != "ulid" && val != "nanoid" {
+                        return Err(meta.error("auto must be \"ulid\" or \"nanoid\""));
+                    }
+                    attrs.auto = Some(val);
+                }
                 other => {
                     return Err(meta.error(format!("unknown entity field attribute: {other}")));
                 }
@@ -346,6 +355,16 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     // Collect primary key fields
     let pk_count = parsed_fields.iter().filter(|f| f.attrs.primary_key).count();
 
+    // Validate auto is only on primary_key fields
+    for f in &parsed_fields {
+        if f.attrs.auto.is_some() && !f.attrs.primary_key {
+            return Err(syn::Error::new_spanned(
+                &f.name,
+                "#[entity(auto = \"...\")] can only be used on primary_key fields",
+            ));
+        }
+    }
+
     // Generate column fields with #[sea_orm(...)] attributes
     let mut model_fields = Vec::new();
     for f in &parsed_fields {
@@ -358,8 +377,11 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
         let mut sea_orm_attrs = Vec::new();
 
         if f.attrs.primary_key {
-            // For composite PKs or string PKs, disable auto_increment
-            let auto_inc = f.attrs.auto_increment.unwrap_or(pk_count <= 1);
+            let auto_inc = if f.attrs.auto.is_some() {
+                false
+            } else {
+                f.attrs.auto_increment.unwrap_or(pk_count <= 1)
+            };
             if !auto_inc {
                 sea_orm_attrs.push(quote! { primary_key, auto_increment = false });
             } else {
@@ -530,8 +552,52 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
         }
     }
 
+    // Collect auto-ID fields
+    let auto_id_stmts: Vec<_> = parsed_fields
+        .iter()
+        .filter_map(|f| {
+            f.attrs.auto.as_ref().map(|strategy| {
+                let name = &f.name;
+                let gen_call = match strategy.as_str() {
+                    "ulid" => quote! { modo::db::generate_ulid() },
+                    "nanoid" => quote! { modo::db::generate_nanoid() },
+                    _ => unreachable!(),
+                };
+                quote! {
+                    if modo::sea_orm::ActiveValue::is_not_set(&this.#name) {
+                        this.#name = modo::sea_orm::ActiveValue::Set(#gen_call);
+                    }
+                }
+            })
+        })
+        .collect();
+
     // Generate ActiveModelBehavior
-    let active_model_behavior = if struct_attrs.timestamps {
+    let needs_before_save = struct_attrs.timestamps || !auto_id_stmts.is_empty();
+
+    let active_model_behavior = if needs_before_save {
+        let timestamp_stmts = if struct_attrs.timestamps {
+            quote! {
+                let now = modo::chrono::Utc::now();
+                if insert {
+                    this.created_at = modo::sea_orm::ActiveValue::Set(now);
+                }
+                this.updated_at = modo::sea_orm::ActiveValue::Set(now);
+            }
+        } else {
+            quote! {}
+        };
+
+        let auto_id_block = if !auto_id_stmts.is_empty() {
+            quote! {
+                if insert {
+                    #(#auto_id_stmts)*
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         quote! {
             #[async_trait::async_trait]
             impl ActiveModelBehavior for ActiveModel {
@@ -540,11 +606,8 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                     C: ConnectionTrait,
                 {
                     let mut this = self;
-                    let now = modo::chrono::Utc::now();
-                    if insert {
-                        this.created_at = modo::sea_orm::ActiveValue::Set(now);
-                    }
-                    this.updated_at = modo::sea_orm::ActiveValue::Set(now);
+                    #auto_id_block
+                    #timestamp_stmts
                     Ok(this)
                 }
             }

--- a/modo-macros/src/entity.rs
+++ b/modo-macros/src/entity.rs
@@ -1,0 +1,652 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Fields, Ident, ItemStruct, Lit, LitStr, Result, Token, Type, parse2};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            result.push('_');
+        }
+        result.push(ch.to_ascii_lowercase());
+    }
+    result
+}
+
+fn to_pascal_case(s: &str) -> String {
+    s.split('_')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect()
+}
+
+fn validate_fk_action(action: &str) -> Result<()> {
+    match action {
+        "Cascade" | "SetNull" | "Restrict" | "NoAction" | "SetDefault" => Ok(()),
+        _ => Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!(
+                "unsupported FK action: {action}. Expected one of: Cascade, SetNull, Restrict, NoAction, SetDefault"
+            ),
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing types
+// ---------------------------------------------------------------------------
+
+struct EntityArgs {
+    table_name: String,
+}
+
+impl syn::parse::Parse for EntityArgs {
+    fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+        let mut table_name = None;
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            match ident.to_string().as_str() {
+                "table" => {
+                    let val: LitStr = input.parse()?;
+                    table_name = Some(val.value());
+                }
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        ident,
+                        format!("unknown entity attribute: {other}"),
+                    ));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        let table_name = table_name.ok_or_else(|| input.error("missing `table` argument"))?;
+        Ok(EntityArgs { table_name })
+    }
+}
+
+struct StructAttrs {
+    timestamps: bool,
+    soft_delete: bool,
+    indices: Vec<CompositeIndex>,
+}
+
+struct CompositeIndex {
+    columns: Vec<String>,
+    unique: bool,
+}
+
+#[derive(Default)]
+struct FieldAttrs {
+    primary_key: bool,
+    auto_increment: Option<bool>,
+    unique: bool,
+    indexed: bool,
+    column_type: Option<String>,
+    default_value: Option<Lit>,
+    default_expr: Option<String>,
+    belongs_to: Option<String>,
+    has_many: bool,
+    has_one: bool,
+    on_delete: Option<String>,
+    on_update: Option<String>,
+    via: Option<String>,
+    renamed_from: Option<String>,
+}
+
+enum FieldKind {
+    Column,
+    RelationOnly,
+}
+
+struct ParsedField {
+    name: Ident,
+    ty: Type,
+    attrs: FieldAttrs,
+    kind: FieldKind,
+}
+
+// ---------------------------------------------------------------------------
+// Struct-level attribute parsing
+// ---------------------------------------------------------------------------
+
+fn parse_struct_attrs(input: &mut ItemStruct) -> Result<StructAttrs> {
+    let mut timestamps = false;
+    let mut soft_delete = false;
+    let mut indices = Vec::new();
+
+    input.attrs.retain(|attr| {
+        if !attr.path().is_ident("entity") {
+            return true; // keep non-entity attrs
+        }
+
+        // Try to parse the inner tokens
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("timestamps") {
+                timestamps = true;
+                Ok(())
+            } else if meta.path.is_ident("soft_delete") {
+                soft_delete = true;
+                Ok(())
+            } else if meta.path.is_ident("index") {
+                let mut columns = Vec::new();
+                let mut unique = false;
+
+                meta.parse_nested_meta(|inner| {
+                    if inner.path.is_ident("columns") {
+                        let value = inner.value()?;
+                        let content;
+                        syn::bracketed!(content in value);
+                        while !content.is_empty() {
+                            let lit: LitStr = content.parse()?;
+                            columns.push(lit.value());
+                            if content.peek(Token![,]) {
+                                content.parse::<Token![,]>()?;
+                            }
+                        }
+                        Ok(())
+                    } else if inner.path.is_ident("unique") {
+                        unique = true;
+                        Ok(())
+                    } else {
+                        Err(inner.error("expected `columns` or `unique`"))
+                    }
+                })?;
+
+                indices.push(CompositeIndex { columns, unique });
+                Ok(())
+            } else {
+                Err(meta.error("expected `timestamps`, `soft_delete`, or `index(...)`"))
+            }
+        });
+
+        false // remove all #[entity(...)] struct-level attrs
+    });
+
+    Ok(StructAttrs {
+        timestamps,
+        soft_delete,
+        indices,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Field-level attribute parsing
+// ---------------------------------------------------------------------------
+
+fn parse_field_attrs(field: &mut syn::Field) -> Result<FieldAttrs> {
+    let mut attrs = FieldAttrs::default();
+
+    field.attrs.retain(|attr| {
+        if !attr.path().is_ident("entity") {
+            return true; // keep non-entity attrs
+        }
+
+        let _ = attr.parse_nested_meta(|meta| {
+            let name = meta
+                .path
+                .get_ident()
+                .map(|i| i.to_string())
+                .unwrap_or_default();
+
+            match name.as_str() {
+                "primary_key" => attrs.primary_key = true,
+                "auto_increment" => {
+                    let lit: syn::LitBool = meta.value()?.parse()?;
+                    attrs.auto_increment = Some(lit.value);
+                }
+                "unique" => attrs.unique = true,
+                "indexed" => attrs.indexed = true,
+                "nullable" => {} // Option<T> handles this
+                "column_type" => {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    attrs.column_type = Some(lit.value());
+                }
+                "default_value" => {
+                    let lit: Lit = meta.value()?.parse()?;
+                    attrs.default_value = Some(lit);
+                }
+                "default_expr" => {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    attrs.default_expr = Some(lit.value());
+                }
+                "belongs_to" => {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    attrs.belongs_to = Some(lit.value());
+                }
+                "has_many" => attrs.has_many = true,
+                "has_one" => attrs.has_one = true,
+                "on_delete" => {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    attrs.on_delete = Some(lit.value());
+                }
+                "on_update" => {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    attrs.on_update = Some(lit.value());
+                }
+                "via" => {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    attrs.via = Some(lit.value());
+                }
+                "renamed_from" => {
+                    let lit: LitStr = meta.value()?.parse()?;
+                    attrs.renamed_from = Some(lit.value());
+                }
+                other => {
+                    return Err(meta.error(format!("unknown entity field attribute: {other}")));
+                }
+            }
+            Ok(())
+        });
+
+        false // remove all #[entity(...)] field attrs
+    });
+
+    Ok(attrs)
+}
+
+// ---------------------------------------------------------------------------
+// Code generation
+// ---------------------------------------------------------------------------
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
+    let args: EntityArgs = parse2(attr)?;
+    let mut input: ItemStruct = parse2(item)?;
+
+    let struct_name = input.ident.clone();
+    let mod_name = format_ident!("{}", to_snake_case(&struct_name.to_string()));
+    let table_name = &args.table_name;
+
+    // Parse struct-level attrs
+    let struct_attrs = parse_struct_attrs(&mut input)?;
+
+    // Parse fields
+    let fields = match &mut input.fields {
+        Fields::Named(f) => &mut f.named,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                &input,
+                "#[modo::entity] requires a struct with named fields",
+            ));
+        }
+    };
+
+    if fields.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &input,
+            "#[modo::entity] requires at least one field",
+        ));
+    }
+
+    // Validate no conflicts with auto-generated fields
+    if struct_attrs.timestamps {
+        for field in fields.iter() {
+            if let Some(ref name) = field.ident {
+                let s = name.to_string();
+                if s == "created_at" || s == "updated_at" {
+                    return Err(syn::Error::new_spanned(
+                        name,
+                        format!(
+                            "field `{s}` conflicts with #[entity(timestamps)] — remove it or remove the timestamps attribute"
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    if struct_attrs.soft_delete {
+        for field in fields.iter() {
+            if let Some(ref name) = field.ident
+                && name == "deleted_at"
+            {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "field `deleted_at` conflicts with #[entity(soft_delete)] — remove it or remove the soft_delete attribute",
+                ));
+            }
+        }
+    }
+
+    let mut parsed_fields = Vec::new();
+    for field in fields.iter_mut() {
+        let name = field.ident.clone().unwrap();
+        let ty = field.ty.clone();
+        let attrs = parse_field_attrs(field)?;
+
+        let kind = if (attrs.has_many || attrs.has_one) && attrs.belongs_to.is_none() {
+            FieldKind::RelationOnly
+        } else {
+            FieldKind::Column
+        };
+
+        parsed_fields.push(ParsedField {
+            name,
+            ty,
+            attrs,
+            kind,
+        });
+    }
+
+    // Collect primary key fields
+    let pk_count = parsed_fields.iter().filter(|f| f.attrs.primary_key).count();
+
+    // Generate column fields with #[sea_orm(...)] attributes
+    let mut model_fields = Vec::new();
+    for f in &parsed_fields {
+        if matches!(f.kind, FieldKind::RelationOnly) {
+            continue;
+        }
+
+        let name = &f.name;
+        let ty = &f.ty;
+        let mut sea_orm_attrs = Vec::new();
+
+        if f.attrs.primary_key {
+            // For composite PKs or string PKs, disable auto_increment
+            let auto_inc = f.attrs.auto_increment.unwrap_or(pk_count <= 1);
+            if !auto_inc {
+                sea_orm_attrs.push(quote! { primary_key, auto_increment = false });
+            } else {
+                sea_orm_attrs.push(quote! { primary_key });
+            }
+        }
+
+        if f.attrs.unique {
+            sea_orm_attrs.push(quote! { unique });
+        }
+
+        if f.attrs.indexed {
+            sea_orm_attrs.push(quote! { indexed });
+        }
+
+        if let Some(ref ct) = f.attrs.column_type {
+            sea_orm_attrs.push(quote! { column_type = #ct });
+        }
+
+        if let Some(ref lit) = f.attrs.default_value {
+            let val_str = match lit {
+                Lit::Int(i) => i.to_string(),
+                Lit::Float(f) => f.to_string(),
+                Lit::Str(s) => s.value(),
+                Lit::Bool(b) => b.value.to_string(),
+                _ => quote!(#lit).to_string(),
+            };
+            sea_orm_attrs.push(quote! { default_value = #val_str });
+        }
+
+        if let Some(ref expr) = f.attrs.default_expr {
+            sea_orm_attrs.push(quote! { default_expr = #expr });
+        }
+
+        if let Some(ref old_name) = f.attrs.renamed_from {
+            // SeaORM uses column comment convention for renamed_from
+            let comment = format!("renamed_from \"{old_name}\"");
+            sea_orm_attrs.push(quote! { comment = #comment });
+        }
+
+        let sea_orm_attr = if sea_orm_attrs.is_empty() {
+            quote! {}
+        } else {
+            quote! { #[sea_orm(#(#sea_orm_attrs),*)] }
+        };
+
+        model_fields.push(quote! {
+            #sea_orm_attr
+            pub #name: #ty,
+        });
+    }
+
+    // Add auto-generated timestamp fields
+    if struct_attrs.timestamps {
+        model_fields.push(quote! {
+            pub created_at: modo::chrono::DateTime<modo::chrono::Utc>,
+        });
+        model_fields.push(quote! {
+            pub updated_at: modo::chrono::DateTime<modo::chrono::Utc>,
+        });
+    }
+
+    // Add auto-generated soft_delete field
+    if struct_attrs.soft_delete {
+        model_fields.push(quote! {
+            pub deleted_at: Option<modo::chrono::DateTime<modo::chrono::Utc>>,
+        });
+    }
+
+    // Generate Relation enum variants for belongs_to fields
+    let mut relation_variants = Vec::new();
+    let mut related_impls = Vec::new();
+
+    for f in &parsed_fields {
+        if let Some(ref target) = f.attrs.belongs_to {
+            let target_mod = format_ident!("{}", to_snake_case(target));
+            let variant_name = format_ident!("{target}");
+            let from_col_str = format!("Column::{}", to_pascal_case(&f.name.to_string()));
+            let to_col_str = format!("super::{target_mod}::Column::Id");
+            let belongs_to_str = format!("super::{target_mod}::Entity");
+
+            let mut rel_attrs = vec![
+                quote! { belongs_to = #belongs_to_str },
+                quote! { from = #from_col_str },
+                quote! { to = #to_col_str },
+            ];
+
+            if let Some(ref action) = f.attrs.on_delete {
+                validate_fk_action(action)?;
+                rel_attrs.push(quote! { on_delete = #action });
+            }
+            if let Some(ref action) = f.attrs.on_update {
+                validate_fk_action(action)?;
+                rel_attrs.push(quote! { on_update = #action });
+            }
+
+            relation_variants.push(quote! {
+                #[sea_orm(#(#rel_attrs),*)]
+                #variant_name,
+            });
+
+            related_impls.push(quote! {
+                impl modo::sea_orm::entity::prelude::Related<super::#target_mod::Entity> for Entity {
+                    fn to() -> modo::sea_orm::entity::prelude::RelationDef {
+                        Relation::#variant_name.def()
+                    }
+                }
+            });
+        }
+    }
+
+    // Generate Related impls for has_many / has_one (reverse relations)
+    for f in &parsed_fields {
+        if !matches!(f.kind, FieldKind::RelationOnly) {
+            continue;
+        }
+
+        // Determine the target entity name
+        let target = if f.attrs.has_many {
+            f.attrs.via.as_ref().map_or_else(
+                || {
+                    // Infer target from field name (e.g., `posts` -> `Post`)
+                    to_pascal_case(&f.name.to_string())
+                        .trim_end_matches('s')
+                        .to_string()
+                },
+                |_via| {
+                    // M2M: target is the other entity, inferred from field name
+                    to_pascal_case(&f.name.to_string())
+                        .trim_end_matches('s')
+                        .to_string()
+                },
+            )
+        } else {
+            // has_one: infer from field name
+            to_pascal_case(&f.name.to_string())
+        };
+
+        let target_mod = format_ident!("{}", to_snake_case(&target));
+
+        if let Some(ref via) = f.attrs.via {
+            // M2M via junction table
+            let via_mod = format_ident!("{}", to_snake_case(via));
+            let self_variant = format_ident!("{struct_name}");
+            let target_variant = format_ident!("{target}");
+
+            related_impls.push(quote! {
+                impl modo::sea_orm::entity::prelude::Related<super::#target_mod::Entity> for Entity {
+                    fn to() -> modo::sea_orm::entity::prelude::RelationDef {
+                        super::#via_mod::Relation::#target_variant.def()
+                    }
+                    fn via() -> Option<modo::sea_orm::entity::prelude::RelationDef> {
+                        Some(super::#via_mod::Relation::#self_variant.def().rev())
+                    }
+                }
+            });
+        } else {
+            // Simple has_many / has_one (reverse relation)
+            let self_variant = format_ident!("{struct_name}");
+
+            related_impls.push(quote! {
+                impl modo::sea_orm::entity::prelude::Related<super::#target_mod::Entity> for Entity {
+                    fn to() -> modo::sea_orm::entity::prelude::RelationDef {
+                        super::#target_mod::Relation::#self_variant.def().rev()
+                    }
+                }
+            });
+        }
+    }
+
+    // Generate ActiveModelBehavior
+    let active_model_behavior = if struct_attrs.timestamps {
+        quote! {
+            #[async_trait::async_trait]
+            impl ActiveModelBehavior for ActiveModel {
+                async fn before_save<C>(self, _db: &C, insert: bool) -> std::result::Result<Self, DbErr>
+                where
+                    C: ConnectionTrait,
+                {
+                    let mut this = self;
+                    let now = modo::chrono::Utc::now();
+                    if insert {
+                        this.created_at = modo::sea_orm::ActiveValue::Set(now);
+                    }
+                    this.updated_at = modo::sea_orm::ActiveValue::Set(now);
+                    Ok(this)
+                }
+            }
+        }
+    } else {
+        quote! {
+            impl ActiveModelBehavior for ActiveModel {}
+        }
+    };
+
+    // Generate soft-delete helpers
+    let soft_delete_helpers = if struct_attrs.soft_delete {
+        quote! {
+            pub fn find_active() -> modo::sea_orm::Select<Entity> {
+                use modo::sea_orm::EntityTrait;
+                use modo::sea_orm::QueryFilter;
+                use modo::sea_orm::ColumnTrait;
+                Entity::find().filter(Column::DeletedAt.is_null())
+            }
+
+            pub async fn soft_delete<C: modo::sea_orm::ConnectionTrait>(
+                mut model: ActiveModel,
+                db: &C,
+            ) -> std::result::Result<Model, modo::sea_orm::DbErr> {
+                use modo::sea_orm::ActiveModelTrait;
+                model.deleted_at = modo::sea_orm::ActiveValue::Set(Some(modo::chrono::Utc::now()));
+                model.update(db).await
+            }
+
+            pub async fn force_delete<C: modo::sea_orm::ConnectionTrait>(
+                model: Model,
+                db: &C,
+            ) -> std::result::Result<modo::sea_orm::DeleteResult, modo::sea_orm::DbErr> {
+                use modo::sea_orm::ModelTrait;
+                model.delete(db).await
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    // Generate extra SQL for composite indices
+    let mut extra_sql_stmts = Vec::new();
+    for idx in &struct_attrs.indices {
+        let cols = idx.columns.join(", ");
+        let col_names = idx.columns.join("_");
+        let idx_name = format!("idx_{table_name}_{col_names}");
+        let sql = if idx.unique {
+            format!("CREATE UNIQUE INDEX IF NOT EXISTS {idx_name} ON {table_name}({cols})")
+        } else {
+            format!("CREATE INDEX IF NOT EXISTS {idx_name} ON {table_name}({cols})")
+        };
+        extra_sql_stmts.push(sql);
+    }
+
+    let extra_sql_tokens = if extra_sql_stmts.is_empty() {
+        quote! { &[] }
+    } else {
+        quote! { &[#(#extra_sql_stmts),*] }
+    };
+
+    // Assemble the generated module
+    let relation_enum = if relation_variants.is_empty() {
+        quote! {
+            #[derive(Copy, Clone, Debug, modo::sea_orm::EnumIter, modo::sea_orm::DeriveRelation)]
+            pub enum Relation {}
+        }
+    } else {
+        quote! {
+            #[derive(Copy, Clone, Debug, modo::sea_orm::EnumIter, modo::sea_orm::DeriveRelation)]
+            pub enum Relation {
+                #(#relation_variants)*
+            }
+        }
+    };
+
+    Ok(quote! {
+        pub mod #mod_name {
+            use modo::sea_orm::entity::prelude::*;
+
+            #[derive(Clone, Debug, PartialEq, Eq, modo::sea_orm::DeriveEntityModel)]
+            #[sea_orm(table_name = #table_name)]
+            pub struct Model {
+                #(#model_fields)*
+            }
+
+            #relation_enum
+
+            #(#related_impls)*
+
+            #active_model_behavior
+
+            #soft_delete_helpers
+        }
+
+        modo::inventory::submit! {
+            modo::db::EntityRegistration {
+                table_name: #table_name,
+                register_fn: |sb| sb.register(#mod_name::Entity),
+                is_framework: false,
+                extra_sql: #extra_sql_tokens,
+            }
+        }
+    })
+}

--- a/modo-macros/src/job.rs
+++ b/modo-macros/src/job.rs
@@ -1,0 +1,250 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{FnArg, Ident, ItemFn, LitInt, LitStr, Pat, Result, Token, Type, parse2};
+
+struct JobArgs {
+    queue: String,
+    max_retries: u32,
+    timeout_secs: u64,
+    cron: Option<String>,
+}
+
+impl syn::parse::Parse for JobArgs {
+    fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+        let mut queue = "default".to_string();
+        let mut max_retries = 3u32;
+        let mut timeout_secs = 300u64;
+        let mut cron = None;
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            match ident.to_string().as_str() {
+                "queue" => {
+                    let val: LitStr = input.parse()?;
+                    queue = val.value();
+                }
+                "max_retries" => {
+                    let val: LitInt = input.parse()?;
+                    max_retries = val.base10_parse()?;
+                }
+                "timeout" => {
+                    let val: LitStr = input.parse()?;
+                    timeout_secs = parse_duration_str(&val)?;
+                }
+                "cron" => {
+                    let val: LitStr = input.parse()?;
+                    cron = Some(val.value());
+                }
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        ident,
+                        format!("unknown job attribute: {other}"),
+                    ));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(JobArgs {
+            queue,
+            max_retries,
+            timeout_secs,
+            cron,
+        })
+    }
+}
+
+fn parse_duration_str(lit: &LitStr) -> Result<u64> {
+    let s = lit.value();
+    let s = s.trim();
+
+    if let Some(num) = s.strip_suffix('s') {
+        num.parse::<u64>()
+            .map_err(|_| syn::Error::new_spanned(lit, "invalid seconds value"))
+    } else if let Some(num) = s.strip_suffix('m') {
+        num.parse::<u64>()
+            .map(|n| n * 60)
+            .map_err(|_| syn::Error::new_spanned(lit, "invalid minutes value"))
+    } else if let Some(num) = s.strip_suffix('h') {
+        num.parse::<u64>()
+            .map(|n| n * 3600)
+            .map_err(|_| syn::Error::new_spanned(lit, "invalid hours value"))
+    } else {
+        Err(syn::Error::new_spanned(
+            lit,
+            "timeout must end with 's', 'm', or 'h' (e.g., \"30s\", \"5m\", \"1h\")",
+        ))
+    }
+}
+
+/// Convert snake_case to PascalCase and append "Job".
+fn to_struct_name(fn_name: &Ident) -> Ident {
+    let s = fn_name.to_string();
+    let pascal: String = s
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect();
+    format_ident!("{pascal}Job")
+}
+
+enum ParamKind {
+    Payload(Type),
+    Service(Type),
+    Db,
+}
+
+fn classify_param(ty: &Type) -> ParamKind {
+    let ty_str = quote!(#ty).to_string();
+
+    // Check for Db extractor
+    if ty_str == "Db" || ty_str.ends_with(":: Db") {
+        return ParamKind::Db;
+    }
+
+    // Check for Service<T>
+    if let Type::Path(type_path) = ty
+        && let Some(seg) = type_path.path.segments.last()
+        && seg.ident == "Service"
+        && let syn::PathArguments::AngleBracketed(args) = &seg.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return ParamKind::Service(inner.clone());
+    }
+
+    // Default: payload type
+    ParamKind::Payload(ty.clone())
+}
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
+    let args: JobArgs = parse2(attr)?;
+    let func: ItemFn = parse2(item)?;
+
+    let func_name = &func.sig.ident;
+    let func_name_str = func_name.to_string();
+    let struct_name = to_struct_name(func_name);
+    let impl_fn_name = format_ident!("__job_{}_impl", func_name);
+
+    let queue_str = &args.queue;
+    let max_retries = args.max_retries;
+    let timeout_secs = args.timeout_secs;
+    let cron_expr = match &args.cron {
+        Some(c) => quote! { Some(#c) },
+        None => quote! { None },
+    };
+
+    // Analyze parameters
+    let mut payload_type: Option<Type> = None;
+    let mut call_args: Vec<TokenStream> = Vec::new();
+    let mut setup_stmts: Vec<TokenStream> = Vec::new();
+
+    for arg in func.sig.inputs.iter() {
+        let FnArg::Typed(pat_type) = arg else {
+            continue;
+        };
+
+        let param_name = if let Pat::Ident(pi) = &*pat_type.pat {
+            &pi.ident
+        } else {
+            continue;
+        };
+
+        match classify_param(&pat_type.ty) {
+            ParamKind::Payload(ty) => {
+                payload_type = Some(ty.clone());
+                setup_stmts.push(quote! {
+                    let #param_name: #ty = ctx.payload()?;
+                });
+                call_args.push(quote! { #param_name });
+            }
+            ParamKind::Service(inner_ty) => {
+                setup_stmts.push(quote! {
+                    let #param_name = modo::extractors::service::Service(ctx.service::<#inner_ty>()?);
+                });
+                call_args.push(quote! { #param_name });
+            }
+            ParamKind::Db => {
+                setup_stmts.push(quote! {
+                    let #param_name = modo::extractors::db::Db(ctx.db()?.clone());
+                });
+                call_args.push(quote! { #param_name });
+            }
+        }
+    }
+
+    // Generate the enqueue methods only if there's a payload type
+    let enqueue_methods = if let Some(ref pt) = payload_type {
+        quote! {
+            impl #struct_name {
+                pub async fn enqueue(payload: &#pt) -> Result<modo::jobs::JobId, modo::error::Error> {
+                    modo::jobs::JobQueue::global().enqueue(#func_name_str, payload).await
+                }
+
+                pub async fn enqueue_at(
+                    payload: &#pt,
+                    run_at: modo::chrono::DateTime<modo::chrono::Utc>,
+                ) -> Result<modo::jobs::JobId, modo::error::Error> {
+                    modo::jobs::JobQueue::global().enqueue_at(#func_name_str, payload, run_at).await
+                }
+            }
+        }
+    } else {
+        // No payload — enqueue with empty value
+        quote! {
+            impl #struct_name {
+                pub async fn enqueue() -> Result<modo::jobs::JobId, modo::error::Error> {
+                    modo::jobs::JobQueue::global().enqueue(#func_name_str, &modo::serde_json::Value::Null).await
+                }
+
+                pub async fn enqueue_at(
+                    run_at: modo::chrono::DateTime<modo::chrono::Utc>,
+                ) -> Result<modo::jobs::JobId, modo::error::Error> {
+                    modo::jobs::JobQueue::global().enqueue_at(#func_name_str, &modo::serde_json::Value::Null, run_at).await
+                }
+            }
+        }
+    };
+
+    // Rename original function
+    let mut impl_func = func.clone();
+    impl_func.sig.ident = impl_fn_name.clone();
+    // Remove visibility (it's internal)
+    impl_func.vis = syn::Visibility::Inherited;
+
+    Ok(quote! {
+        #impl_func
+
+        pub struct #struct_name;
+
+        impl modo::jobs::JobHandler for #struct_name {
+            async fn run(&self, ctx: modo::jobs::JobContext) -> Result<(), modo::error::Error> {
+                #(#setup_stmts)*
+                #impl_fn_name(#(#call_args),*).await
+            }
+        }
+
+        #enqueue_methods
+
+        modo::inventory::submit! {
+            modo::jobs::JobRegistration {
+                name: #func_name_str,
+                queue: #queue_str,
+                max_retries: #max_retries,
+                timeout: std::time::Duration::from_secs(#timeout_secs),
+                cron: #cron_expr,
+                handler_factory: || Box::new(#struct_name) as Box<dyn modo::jobs::JobHandlerDyn>,
+            }
+        }
+    })
+}

--- a/modo-macros/src/lib.rs
+++ b/modo-macros/src/lib.rs
@@ -18,6 +18,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 mod context;
 mod handler;
+mod job;
 mod main_macro;
 mod middleware;
 mod module;
@@ -34,6 +35,14 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn context(attr: TokenStream, item: TokenStream) -> TokenStream {
     context::expand(attr.into(), item.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Attribute macro for declaring background jobs with auto-registration.
+#[proc_macro_attribute]
+pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
+    job::expand(attr.into(), item.into())
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/modo-macros/src/lib.rs
+++ b/modo-macros/src/lib.rs
@@ -17,10 +17,12 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 mod context;
+mod entity;
 mod handler;
 mod job;
 mod main_macro;
 mod middleware;
+mod migration;
 mod module;
 
 /// Attribute macro for declaring route modules with shared prefix and middleware.
@@ -43,6 +45,22 @@ pub fn context(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
     job::expand(attr.into(), item.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Attribute macro for declaring database entities with auto-registration.
+#[proc_macro_attribute]
+pub fn entity(attr: TokenStream, item: TokenStream) -> TokenStream {
+    entity::expand(attr.into(), item.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Attribute macro for declaring escape-hatch migrations with auto-registration.
+#[proc_macro_attribute]
+pub fn migration(attr: TokenStream, item: TokenStream) -> TokenStream {
+    migration::expand(attr.into(), item.into())
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/modo-macros/src/main_macro.rs
+++ b/modo-macros/src/main_macro.rs
@@ -54,6 +54,7 @@ pub fn expand(_attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                     let stdout_filter = modo::tracing_subscriber::EnvFilter::try_from_default_env()
                         .unwrap_or_else(|_| modo::tracing_subscriber::EnvFilter::new(&config.log_level));
 
+                    #[cfg(feature = "sentry")]
                     let _sentry_guard = config.sentry_dsn.as_deref().map(|dsn| {
                         modo::sentry::init((dsn, modo::sentry::ClientOptions {
                             traces_sample_rate: match config.environment {
@@ -70,6 +71,7 @@ pub fn expand(_attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                         }))
                     });
 
+                    #[cfg(feature = "sentry")]
                     if _sentry_guard.is_some() {
                         use modo::tracing_subscriber::prelude::*;
                         let sentry_filter = modo::tracing_subscriber::EnvFilter::new(&config.sentry_log_level);
@@ -79,6 +81,13 @@ pub fn expand(_attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                             .init();
                         modo::tracing::info!("Sentry initialized");
                     } else {
+                        modo::tracing_subscriber::fmt()
+                            .with_env_filter(stdout_filter)
+                            .init();
+                    }
+
+                    #[cfg(not(feature = "sentry"))]
+                    {
                         modo::tracing_subscriber::fmt()
                             .with_env_filter(stdout_filter)
                             .init();

--- a/modo-macros/src/migration.rs
+++ b/modo-macros/src/migration.rs
@@ -1,0 +1,71 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{ItemFn, LitInt, LitStr, Result, Token, parse2};
+
+struct MigrationArgs {
+    version: u64,
+    description: String,
+}
+
+impl syn::parse::Parse for MigrationArgs {
+    fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+        let mut version = None;
+        let mut description = None;
+
+        while !input.is_empty() {
+            let ident: syn::Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            match ident.to_string().as_str() {
+                "version" => {
+                    let val: LitInt = input.parse()?;
+                    version = Some(val.base10_parse::<u64>()?);
+                }
+                "description" => {
+                    let val: LitStr = input.parse()?;
+                    description = Some(val.value());
+                }
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        ident,
+                        format!("unknown migration attribute: {other}"),
+                    ));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        let version = version.ok_or_else(|| input.error("missing `version` argument"))?;
+        let description =
+            description.ok_or_else(|| input.error("missing `description` argument"))?;
+
+        Ok(MigrationArgs {
+            version,
+            description,
+        })
+    }
+}
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
+    let args: MigrationArgs = parse2(attr)?;
+    let func: ItemFn = parse2(item)?;
+
+    let func_name = &func.sig.ident;
+    let version = args.version;
+    let description = &args.description;
+
+    Ok(quote! {
+        #func
+
+        modo::inventory::submit! {
+            modo::db::MigrationRegistration {
+                version: #version,
+                description: #description,
+                handler: |db| Box::pin(#func_name(db)),
+            }
+        }
+    })
+}

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -31,7 +31,7 @@ anyhow = "1"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
-sentry = { version = "0.46", features = ["tracing"] }
+sentry = { version = "0.46", features = ["tracing"], optional = true }
 
 # Config
 dotenvy = "0.15"
@@ -59,6 +59,7 @@ cron = { version = "0.15", optional = true }
 [features]
 default = ["jobs"]
 jobs = ["dep:tokio-util", "dep:cron"]
+sentry = ["dep:sentry"]
 templates = ["dep:askama", "dep:askama_web"]
 
 [dev-dependencies]

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -22,7 +22,7 @@ askama = { version = "0.13", optional = true }
 askama_web = { version = "0.14", features = ["axum-0.8"], optional = true }
 
 # Database
-sea-orm = { version = "2.0.0-rc", features = ["sqlx-sqlite", "runtime-tokio-native-tls", "macros"] }
+sea-orm = { version = "2.0.0-rc", features = ["sqlx-sqlite", "runtime-tokio-native-tls", "macros", "schema-sync"] }
 
 # Error handling
 thiserror = "2"
@@ -52,8 +52,13 @@ sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 ipnet = "2"
 
+# Jobs (optional)
+tokio-util = { version = "0.7", features = ["rt"], optional = true }
+cron = { version = "0.15", optional = true }
+
 [features]
-default = []
+default = ["jobs"]
+jobs = ["dep:tokio-util", "dep:cron"]
 templates = ["dep:askama", "dep:askama_web"]
 
 [dev-dependencies]

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -44,6 +44,7 @@ rand = "0.9"
 
 # Session IDs and request IDs
 ulid = "1"
+nanoid = "0.4"
 
 # Fingerprint hashing
 sha2 = "0.10"

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -19,6 +19,8 @@ pub struct AppState {
     pub config: AppConfig,
     pub cookie_key: Key,
     pub session_store: Option<Arc<dyn SessionStoreDyn>>,
+    #[cfg(feature = "jobs")]
+    pub job_queue: Option<crate::jobs::JobQueue>,
 }
 
 impl FromRef<AppState> for Key {
@@ -138,14 +140,70 @@ impl AppBuilder {
             info!("Session store registered");
         }
 
+        let mut services = self.services;
+
+        // --- Job queue setup ---
+        #[cfg(feature = "jobs")]
+        let job_queue = {
+            use crate::jobs::JobQueue;
+            use crate::jobs::handler::JobRegistration;
+            use crate::jobs::store::SqliteJobStore;
+            use std::collections::HashSet;
+
+            let has_registrations = inventory::iter::<JobRegistration>
+                .into_iter()
+                .next()
+                .is_some();
+
+            if let Some(ref db_conn) = db {
+                if has_registrations {
+                    // Check for duplicate handler names
+                    let mut seen = HashSet::new();
+                    for reg in inventory::iter::<JobRegistration> {
+                        if !seen.insert(reg.name) {
+                            panic!(
+                                "Duplicate job handler name: '{}'. Each #[job] must have a unique function name.",
+                                reg.name
+                            );
+                        }
+                    }
+
+                    let store = Arc::new(SqliteJobStore::new(db_conn.clone()));
+                    if let Err(e) = store.setup().await {
+                        panic!("Failed to setup modo_jobs table: {e}");
+                    }
+                    info!("Job queue initialized (modo_jobs table synced)");
+
+                    let queue = JobQueue::new(store);
+                    JobQueue::set_global(queue.clone());
+
+                    // Register as a service for Service<JobQueue> extraction
+                    services.insert(TypeId::of::<JobQueue>(), Arc::new(queue.clone()));
+
+                    Some(queue)
+                } else {
+                    None
+                }
+            } else {
+                if has_registrations {
+                    warn!(
+                        "Job handlers registered but no database configured — job queue disabled"
+                    );
+                }
+                None
+            }
+        };
+
         let state = AppState {
             db,
             services: ServiceRegistry {
-                services: Arc::new(self.services),
+                services: Arc::new(services),
             },
             config: self.config.clone(),
             cookie_key,
             session_store,
+            #[cfg(feature = "jobs")]
+            job_queue,
         };
 
         // Collect module registrations into a lookup by name
@@ -211,7 +269,38 @@ impl AppBuilder {
             router = layer_fn(router);
         }
 
-        let app = router.with_state(state);
+        let app = router.with_state(state.clone());
+
+        // --- Start job runner + cron scheduler ---
+        #[cfg(feature = "jobs")]
+        let (job_cancel, _cron_scheduler) = {
+            use crate::jobs::cron::CronScheduler;
+            use crate::jobs::runner::JobRunner;
+            use tokio_util::sync::CancellationToken;
+
+            let cancel = CancellationToken::new();
+
+            if let Some(ref queue) = state.job_queue {
+                let runner = JobRunner::new(
+                    queue.store.clone(),
+                    self.config.job_poll_interval,
+                    self.config.job_concurrency,
+                    cancel.clone(),
+                    state.clone(),
+                );
+                tokio::spawn(runner.run());
+                info!(
+                    "Job runner started (poll={}ms, concurrency={})",
+                    self.config.job_poll_interval.as_millis(),
+                    self.config.job_concurrency,
+                );
+            }
+
+            // Start cron scheduler (works even without DB for cron jobs that don't need it)
+            let cron = CronScheduler::start(cancel.clone(), state.clone());
+
+            (cancel, cron)
+        };
 
         let listener = TcpListener::bind(&self.config.bind_address).await?;
         info!("Listening on {}", self.config.bind_address);
@@ -222,6 +311,15 @@ impl AppBuilder {
         )
         .with_graceful_shutdown(shutdown_signal())
         .await?;
+
+        // --- Shutdown: cancel job runner + cron ---
+        #[cfg(feature = "jobs")]
+        {
+            job_cancel.cancel();
+            _cron_scheduler.abort();
+            // Give runner time to drain
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
 
         info!("Server shut down gracefully");
         Ok(())

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -135,6 +135,13 @@ impl AppBuilder {
             Key::derive_from(self.config.secret_key.as_bytes())
         };
 
+        // --- Schema sync and migrations ---
+        if let Some(ref db_conn) = db
+            && let Err(e) = crate::db::sync_and_migrate(db_conn).await
+        {
+            panic!("Schema sync/migration failed: {e}");
+        }
+
         let session_store = self.session_store;
         if session_store.is_some() {
             info!("Session store registered");
@@ -169,10 +176,7 @@ impl AppBuilder {
                     }
 
                     let store = Arc::new(SqliteJobStore::new(db_conn.clone()));
-                    if let Err(e) = store.setup().await {
-                        panic!("Failed to setup modo_jobs table: {e}");
-                    }
-                    info!("Job queue initialized (modo_jobs table synced)");
+                    info!("Job queue initialized");
 
                     let queue = JobQueue::new(store);
                     JobQueue::set_global(queue.clone());

--- a/modo/src/config.rs
+++ b/modo/src/config.rs
@@ -8,7 +8,9 @@ pub struct AppConfig {
     pub secret_key: String,
     pub environment: Environment,
     pub log_level: String,
+    #[cfg(feature = "sentry")]
     pub sentry_dsn: Option<String>,
+    #[cfg(feature = "sentry")]
     pub sentry_log_level: String,
     pub session_ttl: Duration,
     pub session_cookie_name: String,
@@ -36,7 +38,9 @@ impl Default for AppConfig {
             secret_key: String::new(),
             environment: Environment::Development,
             log_level: "info".to_string(),
+            #[cfg(feature = "sentry")]
             sentry_dsn: None,
+            #[cfg(feature = "sentry")]
             sentry_log_level: "error".to_string(),
             session_ttl: Duration::from_secs(30 * 24 * 60 * 60), // 30 days
             session_cookie_name: "_session".to_string(),
@@ -73,7 +77,9 @@ impl AppConfig {
             secret_key: env::var("MODO_SECRET_KEY").unwrap_or_default(),
             environment,
             log_level: env::var("MODO_LOG_LEVEL").unwrap_or_else(|_| "info".to_string()),
+            #[cfg(feature = "sentry")]
             sentry_dsn: env::var("MODO_SENTRY_DSN").ok().filter(|s| !s.is_empty()),
+            #[cfg(feature = "sentry")]
             sentry_log_level: env::var("MODO_SENTRY_LOG_LEVEL")
                 .unwrap_or_else(|_| "error".to_string()),
             session_ttl: Duration::from_secs({

--- a/modo/src/config.rs
+++ b/modo/src/config.rs
@@ -15,6 +15,10 @@ pub struct AppConfig {
     pub session_validate_fingerprint: bool,
     pub session_touch_interval: Duration,
     pub trusted_proxies: Vec<ipnet::IpNet>,
+    #[cfg(feature = "jobs")]
+    pub job_poll_interval: Duration,
+    #[cfg(feature = "jobs")]
+    pub job_concurrency: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,6 +43,10 @@ impl Default for AppConfig {
             session_validate_fingerprint: true,
             session_touch_interval: Duration::from_secs(5 * 60), // 5 minutes
             trusted_proxies: Vec::new(),
+            #[cfg(feature = "jobs")]
+            job_poll_interval: Duration::from_secs(1),
+            #[cfg(feature = "jobs")]
+            job_concurrency: 4,
         }
     }
 }
@@ -109,6 +117,28 @@ impl AppConfig {
                         .ok()
                 })
                 .collect(),
+            #[cfg(feature = "jobs")]
+            job_poll_interval: Duration::from_millis({
+                let default = 1000;
+                match env::var("MODO_JOB_POLL_INTERVAL") {
+                    Ok(v) => v.parse().unwrap_or_else(|e| {
+                        tracing::warn!("Invalid MODO_JOB_POLL_INTERVAL='{v}': {e}, using default");
+                        default
+                    }),
+                    Err(_) => default,
+                }
+            }),
+            #[cfg(feature = "jobs")]
+            job_concurrency: {
+                let default = 4;
+                match env::var("MODO_JOB_CONCURRENCY") {
+                    Ok(v) => v.parse().unwrap_or_else(|e| {
+                        tracing::warn!("Invalid MODO_JOB_CONCURRENCY='{v}': {e}, using default");
+                        default
+                    }),
+                    Err(_) => default,
+                }
+            },
         }
     }
 }

--- a/modo/src/db/entity.rs
+++ b/modo/src/db/entity.rs
@@ -1,0 +1,15 @@
+use sea_orm::schema::SchemaBuilder;
+
+/// Registration info for a SeaORM entity, collected via `inventory`.
+///
+/// The `#[modo::entity]` macro generates an `inventory::submit!` block
+/// for each entity. Framework entities (jobs, migrations, sessions)
+/// register themselves identically with `is_framework: true`.
+pub struct EntityRegistration {
+    pub table_name: &'static str,
+    pub register_fn: fn(SchemaBuilder) -> SchemaBuilder,
+    pub is_framework: bool,
+    pub extra_sql: &'static [&'static str],
+}
+
+inventory::collect!(EntityRegistration);

--- a/modo/src/db/id.rs
+++ b/modo/src/db/id.rs
@@ -1,4 +1,4 @@
-/// Generate a new ULID as a lowercase string (26 chars).
+/// Generate a new ULID string (26 chars, Crockford Base32).
 pub fn generate_ulid() -> String {
     ulid::Ulid::new().to_string()
 }

--- a/modo/src/db/id.rs
+++ b/modo/src/db/id.rs
@@ -1,0 +1,9 @@
+/// Generate a new ULID as a lowercase string (26 chars).
+pub fn generate_ulid() -> String {
+    ulid::Ulid::new().to_string()
+}
+
+/// Generate a new NanoID (21 chars, default alphabet).
+pub fn generate_nanoid() -> String {
+    nanoid::nanoid!()
+}

--- a/modo/src/db/migration.rs
+++ b/modo/src/db/migration.rs
@@ -1,0 +1,50 @@
+use std::future::Future;
+use std::pin::Pin;
+
+/// The `_modo_migrations` table tracks which migrations have been executed.
+pub(crate) mod migration_entity {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "_modo_migrations")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub version: i64,
+        pub description: String,
+        pub executed_at: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+/// Type alias for migration handler functions.
+pub type MigrationFn =
+    fn(
+        &sea_orm::DatabaseConnection,
+    ) -> Pin<Box<dyn Future<Output = Result<(), crate::error::Error>> + Send + '_>>;
+
+/// Registration info for a migration, collected via `inventory`.
+///
+/// The `#[modo::migration]` macro generates an `inventory::submit!` block
+/// for each migration function. Migrations run after schema sync, ordered
+/// by version. Each runs exactly once (tracked in `_modo_migrations`).
+pub struct MigrationRegistration {
+    pub version: u64,
+    pub description: &'static str,
+    pub handler: MigrationFn,
+}
+
+inventory::collect!(MigrationRegistration);
+
+// Register _modo_migrations as a framework entity
+inventory::submit! {
+    crate::db::EntityRegistration {
+        table_name: "_modo_migrations",
+        register_fn: |sb| sb.register(migration_entity::Entity),
+        is_framework: true,
+        extra_sql: &[],
+    }
+}

--- a/modo/src/db/mod.rs
+++ b/modo/src/db/mod.rs
@@ -1,0 +1,7 @@
+pub mod entity;
+pub mod migration;
+pub mod sync;
+
+pub use entity::EntityRegistration;
+pub use migration::MigrationRegistration;
+pub use sync::sync_and_migrate;

--- a/modo/src/db/mod.rs
+++ b/modo/src/db/mod.rs
@@ -1,7 +1,9 @@
 pub mod entity;
+pub mod id;
 pub mod migration;
 pub mod sync;
 
 pub use entity::EntityRegistration;
+pub use id::{generate_nanoid, generate_ulid};
 pub use migration::MigrationRegistration;
 pub use sync::sync_and_migrate;

--- a/modo/src/db/sync.rs
+++ b/modo/src/db/sync.rs
@@ -50,7 +50,15 @@ pub async fn sync_and_migrate(db: &DatabaseConnection) -> Result<(), Error> {
     // 4. Run extra SQL (composite indices, partial unique indices, etc.)
     for reg in inventory::iter::<EntityRegistration> {
         for sql in reg.extra_sql {
-            db.execute_unprepared(sql).await.ok();
+            if let Err(e) = db.execute_unprepared(sql).await {
+                tracing::error!(
+                    table = reg.table_name,
+                    sql = sql,
+                    error = %e,
+                    "Failed to execute extra SQL for entity"
+                );
+                return Err(e.into());
+            }
         }
     }
 
@@ -77,7 +85,10 @@ async fn run_pending_migrations(db: &DatabaseConnection) -> Result<(), Error> {
     let mut seen = HashSet::new();
     for m in &migrations {
         if !seen.insert(m.version) {
-            panic!("Duplicate migration version: {}", m.version);
+            return Err(Error::internal(format!(
+                "Duplicate migration version: {}",
+                m.version
+            )));
         }
     }
 
@@ -100,8 +111,15 @@ async fn run_pending_migrations(db: &DatabaseConnection) -> Result<(), Error> {
         (migration.handler)(db).await?;
 
         // Record migration as executed
+        let version_i64 = i64::try_from(migration.version).map_err(|_| {
+            Error::internal(format!(
+                "Migration version {} exceeds maximum ({})",
+                migration.version,
+                i64::MAX
+            ))
+        })?;
         let record = migration_entity::ActiveModel {
-            version: sea_orm::Set(migration.version as i64),
+            version: sea_orm::Set(version_i64),
             description: sea_orm::Set(migration.description.to_string()),
             executed_at: sea_orm::Set(chrono::Utc::now().to_rfc3339()),
         };

--- a/modo/src/db/sync.rs
+++ b/modo/src/db/sync.rs
@@ -1,0 +1,113 @@
+use crate::db::entity::EntityRegistration;
+use crate::db::migration::MigrationRegistration;
+use crate::error::Error;
+use sea_orm::{ConnectionTrait, DatabaseConnection, Schema};
+use tracing::info;
+
+/// Synchronize database schema from registered entities, then run pending migrations.
+///
+/// Called during `AppBuilder::run()` after DB connection and WAL pragmas.
+///
+/// 1. Bootstrap `_modo_migrations` table (must exist before schema sync)
+/// 2. Collect all `EntityRegistration` entries from `inventory`
+/// 3. Register framework entities first, then user entities
+/// 4. Run `SchemaBuilder::sync()` (addition-only, topo-sorted by SeaORM)
+/// 5. Run extra SQL (composite indices, partial unique indices)
+/// 6. Run pending migrations (version-ordered, tracked in `_modo_migrations`)
+pub async fn sync_and_migrate(db: &DatabaseConnection) -> Result<(), Error> {
+    // 1. Bootstrap _modo_migrations (raw SQL — must exist before sync
+    //    so that migration tracking works even on first run)
+    db.execute_unprepared(
+        "CREATE TABLE IF NOT EXISTS _modo_migrations (\
+            version INTEGER PRIMARY KEY, \
+            description TEXT NOT NULL, \
+            executed_at TEXT NOT NULL DEFAULT (datetime('now'))\
+        )",
+    )
+    .await?;
+
+    // 2. Collect and register all entities
+    let backend = db.get_database_backend();
+    let schema = Schema::new(backend);
+    let mut builder = schema.builder();
+
+    // Framework entities first, then user entities
+    for reg in inventory::iter::<EntityRegistration> {
+        if reg.is_framework {
+            builder = (reg.register_fn)(builder);
+        }
+    }
+    for reg in inventory::iter::<EntityRegistration> {
+        if !reg.is_framework {
+            builder = (reg.register_fn)(builder);
+        }
+    }
+
+    // 3. Sync (addition-only — SeaORM handles topo sort)
+    builder.sync(db).await?;
+    info!("Schema sync complete");
+
+    // 4. Run extra SQL (composite indices, partial unique indices, etc.)
+    for reg in inventory::iter::<EntityRegistration> {
+        for sql in reg.extra_sql {
+            db.execute_unprepared(sql).await.ok();
+        }
+    }
+
+    // 5. Run pending migrations
+    run_pending_migrations(db).await?;
+
+    Ok(())
+}
+
+async fn run_pending_migrations(db: &DatabaseConnection) -> Result<(), Error> {
+    use crate::db::migration::migration_entity;
+    use sea_orm::EntityTrait;
+    use std::collections::HashSet;
+
+    let mut migrations: Vec<&MigrationRegistration> = inventory::iter::<MigrationRegistration>
+        .into_iter()
+        .collect();
+
+    if migrations.is_empty() {
+        return Ok(());
+    }
+
+    // Check for duplicate versions
+    let mut seen = HashSet::new();
+    for m in &migrations {
+        if !seen.insert(m.version) {
+            panic!("Duplicate migration version: {}", m.version);
+        }
+    }
+
+    migrations.sort_by_key(|m| m.version);
+
+    // Query already-executed versions
+    let executed: Vec<migration_entity::Model> = migration_entity::Entity::find().all(db).await?;
+    let executed_versions: HashSet<u64> = executed.iter().map(|m| m.version as u64).collect();
+
+    // Run pending
+    for migration in &migrations {
+        if executed_versions.contains(&migration.version) {
+            continue;
+        }
+        info!(
+            "Running migration v{}: {}",
+            migration.version, migration.description
+        );
+
+        (migration.handler)(db).await?;
+
+        // Record migration as executed
+        let record = migration_entity::ActiveModel {
+            version: sea_orm::Set(migration.version as i64),
+            description: sea_orm::Set(migration.description.to_string()),
+            executed_at: sea_orm::Set(chrono::Utc::now().to_rfc3339()),
+        };
+        migration_entity::Entity::insert(record).exec(db).await?;
+        info!("Migration v{} complete", migration.version);
+    }
+
+    Ok(())
+}

--- a/modo/src/jobs/cron.rs
+++ b/modo/src/jobs/cron.rs
@@ -1,0 +1,96 @@
+use crate::app::AppState;
+use crate::jobs::handler::{JobHandlerDyn, JobRegistration};
+use crate::jobs::types::{JobContext, JobId};
+use std::str::FromStr;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+pub(crate) struct CronScheduler {
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl CronScheduler {
+    pub fn start(cancel: CancellationToken, app_state: AppState) -> Self {
+        let mut tasks = Vec::new();
+
+        for reg in inventory::iter::<JobRegistration> {
+            let Some(cron_expr) = reg.cron else {
+                continue;
+            };
+
+            let schedule = match cron::Schedule::from_str(cron_expr) {
+                Ok(s) => s,
+                Err(e) => {
+                    panic!(
+                        "Invalid cron expression '{}' for job '{}': {}",
+                        cron_expr, reg.name, e
+                    );
+                }
+            };
+
+            let name = reg.name.to_string();
+            let handler = (reg.handler_factory)();
+            let cancel = cancel.clone();
+            let app_state = app_state.clone();
+
+            let handle = tokio::spawn(async move {
+                run_cron_loop(&name, schedule, handler, cancel, app_state).await;
+            });
+
+            info!(job = reg.name, cron = cron_expr, "Cron job scheduled");
+            tasks.push(handle);
+        }
+
+        Self { tasks }
+    }
+
+    pub fn abort(self) {
+        for handle in self.tasks {
+            handle.abort();
+        }
+    }
+}
+
+async fn run_cron_loop(
+    name: &str,
+    schedule: cron::Schedule,
+    handler: Box<dyn JobHandlerDyn>,
+    cancel: CancellationToken,
+    app_state: AppState,
+) {
+    loop {
+        let now = chrono::Utc::now();
+        let Some(next) = schedule.upcoming(chrono::Utc).next() else {
+            error!(job = name, "Cron schedule has no upcoming fires");
+            break;
+        };
+
+        let delay = (next - now).to_std().unwrap_or_default();
+
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = tokio::time::sleep(delay) => {}
+        }
+
+        if cancel.is_cancelled() {
+            break;
+        }
+
+        let ctx = JobContext {
+            job_id: JobId::new(),
+            name: name.to_string(),
+            queue: "cron".to_string(),
+            attempt: 1,
+            app_state: app_state.clone(),
+            payload_json: serde_json::Value::Null,
+        };
+
+        match handler.run(ctx).await {
+            Ok(()) => {}
+            Err(e) => {
+                error!(job = name, "Cron job failed: {e}");
+            }
+        }
+    }
+}

--- a/modo/src/jobs/entity.rs
+++ b/modo/src/jobs/entity.rs
@@ -1,0 +1,29 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "modo_jobs")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub name: String,
+    pub queue: String,
+    pub payload: String,
+    pub state: String,
+    pub priority: i32,
+    pub attempts: i32,
+    pub max_retries: i32,
+    pub run_at: String,
+    pub timeout_secs: i32,
+    pub dedupe_key: Option<String>,
+    pub tenant_id: Option<String>,
+    pub last_error: Option<String>,
+    pub locked_by: Option<String>,
+    pub locked_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modo/src/jobs/entity.rs
+++ b/modo/src/jobs/entity.rs
@@ -27,3 +27,15 @@ pub struct Model {
 pub enum Relation {}
 
 impl ActiveModelBehavior for ActiveModel {}
+
+inventory::submit! {
+    crate::db::EntityRegistration {
+        table_name: "modo_jobs",
+        register_fn: |sb| sb.register(Entity),
+        is_framework: true,
+        extra_sql: &[
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_modo_jobs_dedupe \
+             ON modo_jobs(dedupe_key) WHERE dedupe_key IS NOT NULL AND state IN ('pending', 'running')",
+        ],
+    }
+}

--- a/modo/src/jobs/handler.rs
+++ b/modo/src/jobs/handler.rs
@@ -1,0 +1,39 @@
+use crate::error::Error;
+use crate::jobs::types::JobContext;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+/// Trait for job handler execution.
+pub trait JobHandler: Send + Sync + 'static {
+    fn run(&self, ctx: JobContext) -> impl Future<Output = Result<(), Error>> + Send;
+}
+
+/// Object-safe version of `JobHandler`.
+pub trait JobHandlerDyn: Send + Sync + 'static {
+    fn run<'a>(
+        &'a self,
+        ctx: JobContext,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
+}
+
+impl<T: JobHandler> JobHandlerDyn for T {
+    fn run<'a>(
+        &'a self,
+        ctx: JobContext,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(JobHandler::run(self, ctx))
+    }
+}
+
+/// Registration entry for a job handler, collected via `inventory`.
+pub struct JobRegistration {
+    pub name: &'static str,
+    pub queue: &'static str,
+    pub max_retries: u32,
+    pub timeout: Duration,
+    pub cron: Option<&'static str>,
+    pub handler_factory: fn() -> Box<dyn JobHandlerDyn>,
+}
+
+inventory::collect!(JobRegistration);

--- a/modo/src/jobs/mod.rs
+++ b/modo/src/jobs/mod.rs
@@ -1,0 +1,11 @@
+pub(crate) mod cron;
+pub(crate) mod entity;
+pub(crate) mod handler;
+mod queue;
+pub(crate) mod runner;
+pub(crate) mod store;
+mod types;
+
+pub use handler::{JobHandler, JobHandlerDyn, JobRegistration};
+pub use queue::{JobBuilder, JobQueue};
+pub use types::{JobContext, JobId, JobState, NewJob};

--- a/modo/src/jobs/queue.rs
+++ b/modo/src/jobs/queue.rs
@@ -1,0 +1,185 @@
+use crate::error::Error;
+use crate::jobs::entity;
+use crate::jobs::handler::JobRegistration;
+use crate::jobs::store::SqliteJobStore;
+use crate::jobs::types::{JobId, NewJob};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::sync::Arc;
+use std::time::Duration;
+
+static GLOBAL_QUEUE: std::sync::OnceLock<JobQueue> = std::sync::OnceLock::new();
+
+#[derive(Clone)]
+pub struct JobQueue {
+    pub(crate) store: Arc<SqliteJobStore>,
+}
+
+impl JobQueue {
+    pub(crate) fn new(store: Arc<SqliteJobStore>) -> Self {
+        Self { store }
+    }
+
+    pub(crate) fn set_global(queue: JobQueue) {
+        GLOBAL_QUEUE.set(queue).ok();
+    }
+
+    /// Access the global job queue (set at startup).
+    pub fn global() -> &'static JobQueue {
+        GLOBAL_QUEUE.get().expect(
+            "JobQueue not initialized — ensure app has a database and jobs feature is enabled",
+        )
+    }
+
+    /// Enqueue a job using its registered defaults.
+    pub async fn enqueue<T: Serialize>(&self, name: &str, payload: &T) -> Result<JobId, Error> {
+        let reg = find_registration(name)?;
+        let payload_json = serde_json::to_value(payload)
+            .map_err(|e| Error::internal(format!("failed to serialize job payload: {e}")))?;
+
+        self.store
+            .enqueue(NewJob {
+                name: name.to_string(),
+                queue: reg.queue.to_string(),
+                payload: payload_json,
+                priority: 0,
+                max_retries: reg.max_retries,
+                run_at: Utc::now(),
+                timeout_secs: reg.timeout.as_secs() as u32,
+                dedupe_key: None,
+                tenant_id: None,
+            })
+            .await
+    }
+
+    /// Enqueue a job to run at a specific time.
+    pub async fn enqueue_at<T: Serialize>(
+        &self,
+        name: &str,
+        payload: &T,
+        run_at: DateTime<Utc>,
+    ) -> Result<JobId, Error> {
+        let reg = find_registration(name)?;
+        let payload_json = serde_json::to_value(payload)
+            .map_err(|e| Error::internal(format!("failed to serialize job payload: {e}")))?;
+
+        self.store
+            .enqueue(NewJob {
+                name: name.to_string(),
+                queue: reg.queue.to_string(),
+                payload: payload_json,
+                priority: 0,
+                max_retries: reg.max_retries,
+                run_at,
+                timeout_secs: reg.timeout.as_secs() as u32,
+                dedupe_key: None,
+                tenant_id: None,
+            })
+            .await
+    }
+
+    /// Create a `JobBuilder` for full control over job parameters.
+    pub fn build(&self, name: &str) -> JobBuilder {
+        let reg = find_registration(name).ok();
+        JobBuilder {
+            store: self.store.clone(),
+            name: name.to_string(),
+            queue: reg
+                .map(|r| r.queue.to_string())
+                .unwrap_or_else(|| "default".to_string()),
+            priority: 0,
+            max_retries: reg.map(|r| r.max_retries).unwrap_or(3),
+            timeout_secs: reg.map(|r| r.timeout.as_secs() as u32).unwrap_or(300),
+            run_at: Utc::now(),
+            dedupe_key: None,
+            tenant_id: None,
+        }
+    }
+
+    pub async fn get(&self, id: &JobId) -> Result<Option<entity::Model>, Error> {
+        self.store.get(id).await
+    }
+
+    pub async fn cancel(&self, id: &JobId) -> Result<(), Error> {
+        self.store.cancel(id).await
+    }
+
+    pub async fn cleanup(&self, older_than: Duration) -> Result<u64, Error> {
+        self.store.cleanup(older_than).await
+    }
+}
+
+fn find_registration(name: &str) -> Result<&'static JobRegistration, Error> {
+    inventory::iter::<JobRegistration>
+        .into_iter()
+        .find(|r| r.name == name)
+        .ok_or_else(|| Error::internal(format!("no job registration found for '{name}'")))
+}
+
+pub struct JobBuilder {
+    store: Arc<SqliteJobStore>,
+    name: String,
+    queue: String,
+    priority: i32,
+    max_retries: u32,
+    timeout_secs: u32,
+    run_at: DateTime<Utc>,
+    dedupe_key: Option<String>,
+    tenant_id: Option<String>,
+}
+
+impl JobBuilder {
+    pub fn queue(mut self, queue: &str) -> Self {
+        self.queue = queue.to_string();
+        self
+    }
+
+    pub fn priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    pub fn max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout_secs = timeout.as_secs() as u32;
+        self
+    }
+
+    pub fn run_at(mut self, run_at: DateTime<Utc>) -> Self {
+        self.run_at = run_at;
+        self
+    }
+
+    pub fn dedupe_key(mut self, key: &str) -> Self {
+        self.dedupe_key = Some(key.to_string());
+        self
+    }
+
+    pub fn tenant_id(mut self, id: &str) -> Self {
+        self.tenant_id = Some(id.to_string());
+        self
+    }
+
+    pub async fn enqueue<T: Serialize>(self, payload: &T) -> Result<JobId, Error> {
+        let payload_json = serde_json::to_value(payload)
+            .map_err(|e| Error::internal(format!("failed to serialize job payload: {e}")))?;
+
+        self.store
+            .enqueue(NewJob {
+                name: self.name,
+                queue: self.queue,
+                payload: payload_json,
+                priority: self.priority,
+                max_retries: self.max_retries,
+                run_at: self.run_at,
+                timeout_secs: self.timeout_secs,
+                dedupe_key: self.dedupe_key,
+                tenant_id: self.tenant_id,
+            })
+            .await
+    }
+}

--- a/modo/src/jobs/runner.rs
+++ b/modo/src/jobs/runner.rs
@@ -1,0 +1,214 @@
+use crate::app::AppState;
+use crate::jobs::handler::{JobHandlerDyn, JobRegistration};
+use crate::jobs::store::SqliteJobStore;
+use crate::jobs::types::{JobContext, JobId};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+pub(crate) struct JobRunner {
+    store: Arc<SqliteJobStore>,
+    worker_id: String,
+    poll_interval: Duration,
+    concurrency: usize,
+    handlers: HashMap<String, Box<dyn JobHandlerDyn>>,
+    cancel: CancellationToken,
+    app_state: AppState,
+}
+
+impl JobRunner {
+    pub fn new(
+        store: Arc<SqliteJobStore>,
+        poll_interval: Duration,
+        concurrency: usize,
+        cancel: CancellationToken,
+        app_state: AppState,
+    ) -> Self {
+        let worker_id = ulid::Ulid::new().to_string();
+
+        let mut handlers: HashMap<String, Box<dyn JobHandlerDyn>> = HashMap::new();
+        for reg in inventory::iter::<JobRegistration> {
+            handlers.insert(reg.name.to_string(), (reg.handler_factory)());
+        }
+
+        Self {
+            store,
+            worker_id,
+            poll_interval,
+            concurrency,
+            handlers,
+            cancel,
+            app_state,
+        }
+    }
+
+    pub async fn run(self) {
+        let semaphore = Arc::new(Semaphore::new(self.concurrency));
+        let store = self.store;
+        let worker_id = self.worker_id;
+        let cancel = self.cancel;
+        let app_state = self.app_state;
+
+        // Collect all queue names from registrations
+        let queues: Vec<String> = inventory::iter::<JobRegistration>
+            .into_iter()
+            .map(|r| r.queue.to_string())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        // Handlers map needs to be in an Arc for sharing with spawned tasks
+        let handlers: Arc<HashMap<String, Box<dyn JobHandlerDyn>>> = Arc::new(self.handlers);
+
+        let reap_store = store.clone();
+        let reap_cancel = cancel.clone();
+
+        // Spawn stale reaper task
+        let reaper = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                tokio::select! {
+                    _ = reap_cancel.cancelled() => break,
+                    _ = interval.tick() => {
+                        // Reap jobs stale for more than 10 minutes
+                        match reap_store.reap_stale(Duration::from_secs(600)).await {
+                            Ok(n) if n > 0 => warn!(count = n, "Reaped stale jobs"),
+                            Ok(_) => {}
+                            Err(e) => error!("Stale reaper error: {e}"),
+                        }
+                    }
+                }
+            }
+        });
+
+        info!(worker_id = %worker_id, "Job runner started");
+
+        let mut interval = tokio::time::interval(self.poll_interval);
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!("Job runner shutting down, draining...");
+                    break;
+                }
+                _ = interval.tick() => {
+                    // Try to claim a job if we have capacity
+                    let permit = match semaphore.clone().try_acquire_owned() {
+                        Ok(p) => p,
+                        Err(_) => continue, // all slots busy
+                    };
+
+                    let job = match store.claim_next(&queues, &worker_id).await {
+                        Ok(Some(job)) => job,
+                        Ok(None) => {
+                            drop(permit);
+                            continue;
+                        }
+                        Err(e) => {
+                            error!("Failed to claim job: {e}");
+                            drop(permit);
+                            continue;
+                        }
+                    };
+
+                    let job_id_str = job.id.clone();
+                    let job_name = job.name.clone();
+                    let job_attempts = job.attempts;
+                    let job_max_retries = job.max_retries;
+                    let job_timeout = Duration::from_secs(job.timeout_secs as u64);
+
+                    let task_store = store.clone();
+                    let task_handlers = handlers.clone();
+                    let task_app_state = app_state.clone();
+
+                    tokio::spawn(async move {
+                        let _permit = permit; // hold until done
+
+                        let id = JobId::from_raw(job_id_str);
+
+                        let payload: serde_json::Value =
+                            serde_json::from_str(&job.payload).unwrap_or_default();
+
+                        let ctx = JobContext {
+                            job_id: id.clone(),
+                            name: job_name.clone(),
+                            queue: job.queue.clone(),
+                            attempt: job_attempts as u32,
+                            app_state: task_app_state,
+                            payload_json: payload,
+                        };
+
+                        let result = if let Some(handler) = task_handlers.get(&job_name) {
+                            // Run with timeout + catch_unwind
+                            let future = handler.run(ctx);
+                            match tokio::time::timeout(job_timeout, future).await {
+                                Ok(Ok(())) => Ok(()),
+                                Ok(Err(e)) => Err(format!("{e}")),
+                                Err(_) => Err(format!("job timed out after {job_timeout:?}")),
+                            }
+                        } else {
+                            Err(format!("no handler registered for job '{job_name}'"))
+                        };
+
+                        match result {
+                            Ok(()) => {
+                                if let Err(e) = task_store.mark_completed(&id).await {
+                                    error!(job_id = %id, "Failed to mark job completed: {e}");
+                                }
+                            }
+                            Err(err) => {
+                                if job_attempts < job_max_retries {
+                                    // Exponential backoff: 5s * 2^(attempt-1), capped at 1hr
+                                    let backoff_secs =
+                                        (5u64 * 2u64.saturating_pow((job_attempts - 1) as u32))
+                                            .min(3600);
+                                    let retry_at = chrono::Utc::now()
+                                        + chrono::Duration::seconds(backoff_secs as i64);
+                                    warn!(
+                                        job_id = %id,
+                                        attempt = job_attempts,
+                                        max_retries = job_max_retries,
+                                        retry_at = %retry_at,
+                                        "Job failed, scheduling retry: {err}"
+                                    );
+                                    if let Err(e) =
+                                        task_store.mark_failed(&id, &err, retry_at).await
+                                    {
+                                        error!(job_id = %id, "Failed to mark job failed: {e}");
+                                    }
+                                } else {
+                                    error!(
+                                        job_id = %id,
+                                        attempts = job_attempts,
+                                        "Job dead (exhausted retries): {err}"
+                                    );
+                                    if let Err(e) = task_store.mark_dead(&id, &err).await {
+                                        error!(job_id = %id, "Failed to mark job dead: {e}");
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        }
+
+        // Wait for reaper to finish
+        reaper.abort();
+
+        // Wait for in-flight jobs (drain with timeout)
+        info!("Waiting up to 30s for in-flight jobs to complete...");
+        let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        while semaphore.available_permits() < self.concurrency {
+            if tokio::time::Instant::now() >= drain_deadline {
+                warn!("Drain timeout — some jobs may not have completed");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        info!("Job runner stopped");
+    }
+}

--- a/modo/src/jobs/store.rs
+++ b/modo/src/jobs/store.rs
@@ -1,0 +1,280 @@
+use crate::error::Error;
+use crate::jobs::entity;
+use crate::jobs::types::{JobId, JobState, NewJob};
+use chrono::{DateTime, Utc};
+use sea_orm::prelude::Expr;
+use sea_orm::*;
+use std::time::Duration;
+
+pub(crate) struct SqliteJobStore {
+    db: DatabaseConnection,
+}
+
+impl SqliteJobStore {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Sync the modo_jobs table schema. Called by AppBuilder::run().
+    pub async fn setup(&self) -> Result<(), Error> {
+        let backend = self.db.get_database_backend();
+        let schema = Schema::new(backend);
+        schema
+            .builder()
+            .register(entity::Entity)
+            .sync(&self.db)
+            .await?;
+
+        // Partial unique index for dedupe (raw SQL — SeaORM can't do conditional unique)
+        self.db
+            .execute_unprepared(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_modo_jobs_dedupe \
+                 ON modo_jobs(dedupe_key) WHERE dedupe_key IS NOT NULL AND state IN ('pending', 'running')",
+            )
+            .await
+            .ok();
+
+        Ok(())
+    }
+
+    /// Insert a new job into the store.
+    pub async fn enqueue(&self, job: NewJob) -> Result<JobId, Error> {
+        let id = JobId::new();
+        let now = Utc::now().to_rfc3339();
+
+        let model = entity::ActiveModel {
+            id: Set(id.as_str().to_string()),
+            name: Set(job.name),
+            queue: Set(job.queue),
+            payload: Set(job.payload.to_string()),
+            state: Set(JobState::Pending.to_string()),
+            priority: Set(job.priority),
+            attempts: Set(0),
+            max_retries: Set(job.max_retries as i32),
+            run_at: Set(job.run_at.to_rfc3339()),
+            timeout_secs: Set(job.timeout_secs as i32),
+            dedupe_key: Set(job.dedupe_key),
+            tenant_id: Set(job.tenant_id),
+            last_error: Set(None),
+            locked_by: Set(None),
+            locked_at: Set(None),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        };
+
+        entity::Entity::insert(model).exec(&self.db).await?;
+        Ok(id)
+    }
+
+    /// Atomically claim the next available job for a worker.
+    /// Uses BEGIN IMMEDIATE to prevent concurrent claims on SQLite.
+    pub async fn claim_next(
+        &self,
+        queues: &[String],
+        worker_id: &str,
+    ) -> Result<Option<entity::Model>, Error> {
+        let now = Utc::now().to_rfc3339();
+
+        let txn = self
+            .db
+            .begin_with_config(Some(IsolationLevel::Serializable), None)
+            .await?;
+
+        let mut query = entity::Entity::find()
+            .filter(entity::Column::State.eq(JobState::Pending.to_string()))
+            .filter(entity::Column::RunAt.lte(&now));
+
+        if !queues.is_empty() {
+            query = query.filter(entity::Column::Queue.is_in(queues.iter().map(|s| s.as_str())));
+        }
+
+        let job = query
+            .order_by_desc(entity::Column::Priority)
+            .order_by_asc(entity::Column::RunAt)
+            .one(&txn)
+            .await?;
+
+        let Some(job) = job else {
+            txn.commit().await?;
+            return Ok(None);
+        };
+
+        let mut active: entity::ActiveModel = job.into();
+        active.state = Set(JobState::Running.to_string());
+        active.locked_by = Set(Some(worker_id.to_string()));
+        active.locked_at = Set(Some(now.clone()));
+        active.attempts = Set(active.attempts.unwrap() + 1);
+        active.updated_at = Set(now);
+        let updated = active.update(&txn).await?;
+
+        txn.commit().await?;
+        Ok(Some(updated))
+    }
+
+    pub async fn mark_completed(&self, id: &JobId) -> Result<(), Error> {
+        let now = Utc::now().to_rfc3339();
+
+        entity::Entity::update_many()
+            .filter(entity::Column::Id.eq(id.as_str()))
+            .col_expr(
+                entity::Column::State,
+                Expr::value(JobState::Completed.to_string()),
+            )
+            .col_expr(
+                entity::Column::LockedBy,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entity::Column::LockedAt,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(entity::Column::UpdatedAt, Expr::value(&now))
+            .exec(&self.db)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn mark_failed(
+        &self,
+        id: &JobId,
+        error: &str,
+        retry_at: DateTime<Utc>,
+    ) -> Result<(), Error> {
+        let now = Utc::now().to_rfc3339();
+
+        entity::Entity::update_many()
+            .filter(entity::Column::Id.eq(id.as_str()))
+            .col_expr(
+                entity::Column::State,
+                Expr::value(JobState::Pending.to_string()),
+            )
+            .col_expr(
+                entity::Column::LastError,
+                Expr::value(Some(error.to_string())),
+            )
+            .col_expr(
+                entity::Column::LockedBy,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entity::Column::LockedAt,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(entity::Column::RunAt, Expr::value(retry_at.to_rfc3339()))
+            .col_expr(entity::Column::UpdatedAt, Expr::value(&now))
+            .exec(&self.db)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn mark_dead(&self, id: &JobId, error: &str) -> Result<(), Error> {
+        let now = Utc::now().to_rfc3339();
+
+        entity::Entity::update_many()
+            .filter(entity::Column::Id.eq(id.as_str()))
+            .col_expr(
+                entity::Column::State,
+                Expr::value(JobState::Dead.to_string()),
+            )
+            .col_expr(
+                entity::Column::LastError,
+                Expr::value(Some(error.to_string())),
+            )
+            .col_expr(
+                entity::Column::LockedBy,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entity::Column::LockedAt,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(entity::Column::UpdatedAt, Expr::value(&now))
+            .exec(&self.db)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Reap stale running jobs that have exceeded the threshold since lock.
+    pub async fn reap_stale(&self, threshold: Duration) -> Result<u64, Error> {
+        let cutoff =
+            (Utc::now() - chrono::Duration::from_std(threshold).unwrap_or_default()).to_rfc3339();
+
+        let result = entity::Entity::update_many()
+            .filter(entity::Column::State.eq(JobState::Running.to_string()))
+            .filter(entity::Column::LockedAt.lt(&cutoff))
+            .col_expr(
+                entity::Column::State,
+                Expr::value(JobState::Pending.to_string()),
+            )
+            .col_expr(
+                entity::Column::LockedBy,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entity::Column::LockedAt,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entity::Column::UpdatedAt,
+                Expr::value(Utc::now().to_rfc3339()),
+            )
+            .exec(&self.db)
+            .await?;
+
+        Ok(result.rows_affected)
+    }
+
+    /// Delete completed and dead jobs older than the given duration.
+    pub async fn cleanup(&self, older_than: Duration) -> Result<u64, Error> {
+        let cutoff =
+            (Utc::now() - chrono::Duration::from_std(older_than).unwrap_or_default()).to_rfc3339();
+
+        let result = entity::Entity::delete_many()
+            .filter(
+                entity::Column::State
+                    .is_in([JobState::Completed.to_string(), JobState::Dead.to_string()]),
+            )
+            .filter(entity::Column::UpdatedAt.lt(&cutoff))
+            .exec(&self.db)
+            .await?;
+
+        Ok(result.rows_affected)
+    }
+
+    pub async fn get(&self, id: &JobId) -> Result<Option<entity::Model>, Error> {
+        Ok(entity::Entity::find_by_id(id.as_str())
+            .one(&self.db)
+            .await?)
+    }
+
+    /// Cancel a pending job.
+    pub async fn cancel(&self, id: &JobId) -> Result<(), Error> {
+        let now = Utc::now().to_rfc3339();
+
+        let result = entity::Entity::update_many()
+            .filter(entity::Column::Id.eq(id.as_str()))
+            .filter(entity::Column::State.eq(JobState::Pending.to_string()))
+            .col_expr(
+                entity::Column::State,
+                Expr::value(JobState::Dead.to_string()),
+            )
+            .col_expr(
+                entity::Column::LastError,
+                Expr::value(Some("cancelled".to_string())),
+            )
+            .col_expr(entity::Column::UpdatedAt, Expr::value(&now))
+            .exec(&self.db)
+            .await?;
+
+        if result.rows_affected == 0 {
+            return Err(Error::BadRequest(
+                "Job not found or not in pending state".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/modo/src/jobs/store.rs
+++ b/modo/src/jobs/store.rs
@@ -15,28 +15,6 @@ impl SqliteJobStore {
         Self { db }
     }
 
-    /// Sync the modo_jobs table schema. Called by AppBuilder::run().
-    pub async fn setup(&self) -> Result<(), Error> {
-        let backend = self.db.get_database_backend();
-        let schema = Schema::new(backend);
-        schema
-            .builder()
-            .register(entity::Entity)
-            .sync(&self.db)
-            .await?;
-
-        // Partial unique index for dedupe (raw SQL — SeaORM can't do conditional unique)
-        self.db
-            .execute_unprepared(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_modo_jobs_dedupe \
-                 ON modo_jobs(dedupe_key) WHERE dedupe_key IS NOT NULL AND state IN ('pending', 'running')",
-            )
-            .await
-            .ok();
-
-        Ok(())
-    }
-
     /// Insert a new job into the store.
     pub async fn enqueue(&self, job: NewJob) -> Result<JobId, Error> {
         let id = JobId::new();

--- a/modo/src/jobs/types.rs
+++ b/modo/src/jobs/types.rs
@@ -1,0 +1,164 @@
+use crate::app::AppState;
+use crate::error::Error;
+use chrono::{DateTime, Utc};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+
+/// Opaque job identifier (ULID string).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct JobId(String);
+
+impl Default for JobId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JobId {
+    pub fn new() -> Self {
+        Self(ulid::Ulid::new().to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn from_raw(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl fmt::Display for JobId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Job execution state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JobState {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    Dead,
+}
+
+impl fmt::Display for JobState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pending => f.write_str("pending"),
+            Self::Running => f.write_str("running"),
+            Self::Completed => f.write_str("completed"),
+            Self::Failed => f.write_str("failed"),
+            Self::Dead => f.write_str("dead"),
+        }
+    }
+}
+
+impl FromStr for JobState {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "dead" => Ok(Self::Dead),
+            _ => Err(Error::internal(format!("unknown job state: {s}"))),
+        }
+    }
+}
+
+/// Input for enqueuing a new job.
+pub struct NewJob {
+    pub name: String,
+    pub queue: String,
+    pub payload: serde_json::Value,
+    pub priority: i32,
+    pub max_retries: u32,
+    pub run_at: DateTime<Utc>,
+    pub timeout_secs: u32,
+    pub dedupe_key: Option<String>,
+    pub tenant_id: Option<String>,
+}
+
+/// Context passed to job handlers during execution.
+pub struct JobContext {
+    pub job_id: JobId,
+    pub name: String,
+    pub queue: String,
+    pub attempt: u32,
+    pub(crate) app_state: AppState,
+    pub(crate) payload_json: serde_json::Value,
+}
+
+impl JobContext {
+    /// Deserialize the job payload.
+    pub fn payload<T: serde::de::DeserializeOwned>(&self) -> Result<T, Error> {
+        serde_json::from_value(self.payload_json.clone())
+            .map_err(|e| Error::internal(format!("failed to deserialize job payload: {e}")))
+    }
+
+    /// Get a service from the app's service registry.
+    pub fn service<T: Send + Sync + 'static>(&self) -> Result<Arc<T>, Error> {
+        self.app_state.services.get::<T>().ok_or_else(|| {
+            Error::internal(format!(
+                "Service not registered: {}",
+                std::any::type_name::<T>()
+            ))
+        })
+    }
+
+    /// Get the database connection.
+    pub fn db(&self) -> Result<&DatabaseConnection, Error> {
+        self.app_state
+            .db
+            .as_ref()
+            .ok_or_else(|| Error::internal("Database not configured"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_id_generates_unique() {
+        let a = JobId::new();
+        let b = JobId::new();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn job_id_is_26_char_ulid() {
+        let id = JobId::new();
+        assert_eq!(id.as_str().len(), 26);
+    }
+
+    #[test]
+    fn job_state_display_roundtrip() {
+        let states = [
+            JobState::Pending,
+            JobState::Running,
+            JobState::Completed,
+            JobState::Failed,
+            JobState::Dead,
+        ];
+        for state in states {
+            let s = state.to_string();
+            let parsed: JobState = s.parse().unwrap();
+            assert_eq!(state, parsed);
+        }
+    }
+
+    #[test]
+    fn job_state_from_str_invalid() {
+        let result = "bogus".parse::<JobState>();
+        assert!(result.is_err());
+    }
+}

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -17,6 +17,7 @@ pub use axum_extra;
 pub use chrono;
 pub use inventory;
 pub use sea_orm;
+#[cfg(feature = "sentry")]
 pub use sentry;
 pub use serde_json;
 pub use tokio;

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -1,9 +1,11 @@
-pub use modo_macros::{context, handler, main, module};
+pub use modo_macros::{context, handler, job, main, module};
 
 pub mod app;
 pub mod config;
 pub mod error;
 pub mod extractors;
+#[cfg(feature = "jobs")]
+pub mod jobs;
 pub mod middleware;
 pub mod router;
 pub mod session;
@@ -12,9 +14,11 @@ pub mod templates;
 // Re-exports for use in macro-generated code
 pub use axum;
 pub use axum_extra;
+pub use chrono;
 pub use inventory;
 pub use sea_orm;
 pub use sentry;
+pub use serde_json;
 pub use tokio;
 pub use tracing;
 pub use tracing_subscriber;

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -1,7 +1,8 @@
-pub use modo_macros::{context, handler, job, main, module};
+pub use modo_macros::{context, entity, handler, job, main, migration, module};
 
 pub mod app;
 pub mod config;
+pub mod db;
 pub mod error;
 pub mod extractors;
 #[cfg(feature = "jobs")]

--- a/modo/tests/entity_macro.rs
+++ b/modo/tests/entity_macro.rs
@@ -194,6 +194,67 @@ fn test_renamed_entity_compiles() {
     };
 }
 
+// --- Entity with auto ULID ---
+
+#[modo::entity(table = "test_auto_ulid")]
+pub struct TestAutoUlid {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub name: String,
+}
+
+#[test]
+fn test_auto_ulid_entity_registers() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let tables: Vec<&str> = registrations.iter().map(|r| r.table_name).collect();
+    assert!(tables.contains(&"test_auto_ulid"));
+}
+
+#[test]
+fn test_auto_ulid_model_compiles() {
+    let _ = test_auto_ulid::Model {
+        id: "01HXYZ".to_string(),
+        name: "test".to_string(),
+    };
+}
+
+// --- Entity with auto NanoID ---
+
+#[modo::entity(table = "test_auto_nanoid")]
+pub struct TestAutoNanoid {
+    #[entity(primary_key, auto = "nanoid")]
+    pub id: String,
+    pub name: String,
+}
+
+#[test]
+fn test_auto_nanoid_entity_registers() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let tables: Vec<&str> = registrations.iter().map(|r| r.table_name).collect();
+    assert!(tables.contains(&"test_auto_nanoid"));
+}
+
+// --- Entity with auto ULID + timestamps ---
+
+#[modo::entity(table = "test_auto_ulid_ts")]
+#[entity(timestamps)]
+pub struct TestAutoUlidTs {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub title: String,
+}
+
+#[test]
+fn test_auto_ulid_with_timestamps_compiles() {
+    let now = chrono::Utc::now();
+    let _ = test_auto_ulid_ts::Model {
+        id: "01HXYZ".to_string(),
+        title: "test".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+}
+
 // --- User entity not marked as framework ---
 
 #[test]

--- a/modo/tests/entity_macro.rs
+++ b/modo/tests/entity_macro.rs
@@ -1,0 +1,207 @@
+use modo::db::EntityRegistration;
+
+// --- Basic entity ---
+
+#[modo::entity(table = "test_users")]
+pub struct TestUser {
+    #[entity(primary_key)]
+    pub id: i32,
+    #[entity(unique)]
+    pub email: String,
+    #[entity(indexed)]
+    pub username: String,
+    #[entity(nullable)]
+    pub avatar_url: Option<String>,
+    #[entity(column_type = "Text")]
+    pub bio: String,
+    #[entity(default_value = 0)]
+    pub credits: i32,
+}
+
+#[test]
+fn test_basic_entity_registers() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let tables: Vec<&str> = registrations.iter().map(|r| r.table_name).collect();
+    assert!(
+        tables.contains(&"test_users"),
+        "test_users not registered. Found: {tables:?}"
+    );
+}
+
+#[test]
+fn test_basic_entity_module_types_exist() {
+    // Verify the generated module has the expected types
+    let _: test_user::Model = test_user::Model {
+        id: 1,
+        email: "test@example.com".to_string(),
+        username: "test".to_string(),
+        avatar_url: None,
+        bio: "hello".to_string(),
+        credits: 0,
+    };
+}
+
+// --- Entity with belongs_to ---
+
+#[modo::entity(table = "test_posts")]
+pub struct TestPost {
+    #[entity(primary_key)]
+    pub id: i32,
+    #[entity(belongs_to = "TestUser", on_delete = "Cascade")]
+    pub test_user_id: i32,
+    pub title: String,
+}
+
+#[test]
+fn test_belongs_to_entity_registers() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let tables: Vec<&str> = registrations.iter().map(|r| r.table_name).collect();
+    assert!(
+        tables.contains(&"test_posts"),
+        "test_posts not registered. Found: {tables:?}"
+    );
+}
+
+// --- Entity with timestamps ---
+
+#[modo::entity(table = "test_articles")]
+#[entity(timestamps)]
+pub struct TestArticle {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub title: String,
+}
+
+#[test]
+fn test_timestamps_entity_has_fields() {
+    let now = chrono::Utc::now();
+    let _: test_article::Model = test_article::Model {
+        id: 1,
+        title: "Test".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+}
+
+// --- Entity with timestamps + soft_delete ---
+
+#[modo::entity(table = "test_items")]
+#[entity(timestamps)]
+#[entity(soft_delete)]
+pub struct TestItem {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub name: String,
+}
+
+#[test]
+fn test_soft_delete_entity_has_deleted_at() {
+    let now = chrono::Utc::now();
+    let _: test_item::Model = test_item::Model {
+        id: 1,
+        name: "Test".to_string(),
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    };
+}
+
+#[test]
+fn test_soft_delete_helpers_exist() {
+    // Just verify the functions exist and have the right signatures
+    let _ = test_item::find_active;
+    let _ = test_item::soft_delete::<sea_orm::DatabaseConnection>;
+    let _ = test_item::force_delete::<sea_orm::DatabaseConnection>;
+}
+
+// --- Entity with composite index ---
+
+#[modo::entity(table = "test_indexed")]
+#[entity(index(columns = ["user_id", "created_at"]))]
+#[entity(index(columns = ["slug"], unique))]
+pub struct TestIndexed {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub user_id: i32,
+    pub slug: String,
+    pub created_at: String,
+}
+
+#[test]
+fn test_composite_index_generates_extra_sql() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let reg = registrations
+        .iter()
+        .find(|r| r.table_name == "test_indexed")
+        .expect("test_indexed not registered");
+    assert_eq!(reg.extra_sql.len(), 2);
+    assert!(reg.extra_sql[0].contains("idx_test_indexed_user_id_created_at"));
+    assert!(reg.extra_sql[1].contains("UNIQUE"));
+    assert!(reg.extra_sql[1].contains("idx_test_indexed_slug"));
+}
+
+// --- Composite primary key (junction table) ---
+
+#[modo::entity(table = "test_post_tags")]
+pub struct TestPostTag {
+    #[entity(
+        primary_key,
+        auto_increment = false,
+        belongs_to = "TestPost",
+        on_delete = "Cascade"
+    )]
+    pub test_post_id: i32,
+    #[entity(
+        primary_key,
+        auto_increment = false,
+        belongs_to = "TestTag",
+        on_delete = "Cascade"
+    )]
+    pub test_tag_id: i32,
+}
+
+#[modo::entity(table = "test_tags")]
+pub struct TestTag {
+    #[entity(primary_key)]
+    pub id: i32,
+    #[entity(unique)]
+    pub name: String,
+}
+
+#[test]
+fn test_junction_table_registers() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let tables: Vec<&str> = registrations.iter().map(|r| r.table_name).collect();
+    assert!(tables.contains(&"test_post_tags"));
+    assert!(tables.contains(&"test_tags"));
+}
+
+// --- Entity with renamed_from ---
+
+#[modo::entity(table = "test_renamed")]
+pub struct TestRenamed {
+    #[entity(primary_key)]
+    pub id: i32,
+    #[entity(renamed_from = "name")]
+    pub display_name: String,
+}
+
+#[test]
+fn test_renamed_entity_compiles() {
+    let _ = test_renamed::Model {
+        id: 1,
+        display_name: "test".to_string(),
+    };
+}
+
+// --- User entity not marked as framework ---
+
+#[test]
+fn test_user_entities_not_framework() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let user_reg = registrations
+        .iter()
+        .find(|r| r.table_name == "test_users")
+        .unwrap();
+    assert!(!user_reg.is_framework);
+}

--- a/modo/tests/integration.rs
+++ b/modo/tests/integration.rs
@@ -22,6 +22,8 @@ fn build_test_router() -> axum::Router {
         config: modo::config::AppConfig::default(),
         cookie_key: axum_extra::extract::cookie::Key::generate(),
         session_store: None,
+        #[cfg(feature = "jobs")]
+        job_queue: None,
     };
 
     let mut router = axum::Router::new();
@@ -366,6 +368,8 @@ mod session_integration {
             config,
             cookie_key: axum_extra::extract::cookie::Key::generate(),
             session_store: Some(store),
+            #[cfg(feature = "jobs")]
+            job_queue: None,
         };
 
         let router = axum::Router::new()
@@ -602,6 +606,8 @@ mod session_integration {
             config,
             cookie_key: axum_extra::extract::cookie::Key::generate(),
             session_store: Some(store),
+            #[cfg(feature = "jobs")]
+            job_queue: None,
         };
 
         // We need to create an encrypted cookie value. To do this, we'll

--- a/modo/tests/migration_macro.rs
+++ b/modo/tests/migration_macro.rs
@@ -1,0 +1,36 @@
+use modo::db::MigrationRegistration;
+
+#[modo::migration(version = 9000, description = "Test migration")]
+async fn test_migration(db: &sea_orm::DatabaseConnection) -> Result<(), modo::error::Error> {
+    let _ = db;
+    Ok(())
+}
+
+#[modo::migration(version = 9001, description = "Another test migration")]
+async fn another_test(db: &sea_orm::DatabaseConnection) -> Result<(), modo::error::Error> {
+    let _ = db;
+    Ok(())
+}
+
+#[test]
+fn test_migration_macro_registers() {
+    let migrations: Vec<&MigrationRegistration> =
+        inventory::iter::<MigrationRegistration>().collect();
+    let versions: Vec<u64> = migrations.iter().map(|m| m.version).collect();
+    assert!(
+        versions.contains(&9000),
+        "migration v9000 not registered. Found: {versions:?}"
+    );
+    assert!(
+        versions.contains(&9001),
+        "migration v9001 not registered. Found: {versions:?}"
+    );
+}
+
+#[test]
+fn test_migration_descriptions() {
+    let migrations: Vec<&MigrationRegistration> =
+        inventory::iter::<MigrationRegistration>().collect();
+    let m = migrations.iter().find(|m| m.version == 9000).unwrap();
+    assert_eq!(m.description, "Test migration");
+}


### PR DESCRIPTION
## Summary

- Add `#[modo::entity]` proc macro that generates SeaORM entity modules with auto-registration via `inventory`. Supports `timestamps`, `soft_delete`, `belongs_to`, `has_many`/`has_one`, composite indices, `renamed_from`, and composite primary keys.
- Add `#[modo::migration]` proc macro for escape-hatch migrations (data migrations, column drops) tracked in `_modo_migrations` table.
- Add unified `sync_and_migrate()` orchestrator called in `AppBuilder::run()` — collects all registered entities, syncs schema (addition-only via SeaORM v2), runs extra SQL (composite indices), then runs pending migrations in version order.
- Migrate jobs entity to the unified sync path, removing `SqliteJobStore::setup()`.

## New Files
| File | Purpose |
|------|---------|
| `modo/src/db/entity.rs` | `EntityRegistration` type + `inventory::collect!` |
| `modo/src/db/migration.rs` | `MigrationRegistration` type + `_modo_migrations` entity |
| `modo/src/db/sync.rs` | `sync_and_migrate()` orchestrator |
| `modo-macros/src/entity.rs` | `#[modo::entity]` proc macro (~600 lines) |
| `modo-macros/src/migration.rs` | `#[modo::migration]` proc macro |
| `modo/tests/entity_macro.rs` | 10 compile/registration tests |
| `modo/tests/migration_macro.rs` | 2 registration tests |

## Test Plan
- [x] `just check` passes (fmt + clippy + 84 tests)
- [x] Entity macro tests: basic entity, belongs_to, timestamps, soft_delete, composite index, junction table, renamed_from
- [x] Migration macro tests: registration and description verification
- [x] All existing tests still pass (integration, session, handler, etc.)