### PR TITLE
feat: implement modo-jobs background job system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,5 +122,5 @@ Refactor strategy:
 - Clippy enforces `collapsible_if` — collapse nested `if`/`if let` with `&&`
 - In handler macro: `func_name` must be cloned (`func.sig.ident.clone()`) before mutating `func` — otherwise borrow checker blocks `&mut func`
 - Re-exports in `modo/src/lib.rs` must be alphabetically sorted (`cargo fmt` enforces this)
-- `modo-jobs` entity module is named `modo_jobs` — imports in tests can shadow the crate; use `use modo_jobs::entity::modo_jobs as jobs_entity;`
-- `inventory` registration from library crates may not link in tests — force with `use modo_jobs::entity::modo_jobs as _;`
+- `modo-jobs` entity module is named `job` (from `struct Job`); use `use modo_jobs::entity::job as jobs_entity;` in tests to avoid shadowing
+- `inventory` registration from library crates may not link in tests — force with `use modo_jobs::entity::job as _;`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ Refactor strategy:
 - `modo-db/` — database layer (features: sqlite, postgres)
 - `modo-session/` — session management
 - `modo-auth/` — authentication
-- `modo-jobs/` — background jobs
+- `modo-jobs/` — background jobs (**implemented**)
+- `modo-jobs-macros/` — `#[job(...)]` proc macro (**implemented**)
 - `modo-templates/` — Askama + HTMX + flash
 - `modo-csrf/` — CSRF protection
 - ADR: `docs/plans/2026-03-06-crate-split-design.md`
@@ -72,6 +73,23 @@ Refactor strategy:
 - Template context: `#[modo::context]` with `#[base]` + `#[user]` + `#[session]` fields
 - BaseContext: includes request_id, is_htmx, current_url, flash_messages, csrf_token, locale
 
+## Jobs (modo-jobs)
+
+- Define jobs: `#[modo_jobs::job(queue = "...", priority = N, max_retries = N, timeout = "5m")]`
+- Cron jobs: `#[modo_jobs::job(cron = "0 0 * * * *", timeout = "5m")]` — in-memory only
+- Cron + queue/priority/max_retries = compile error (mutually exclusive)
+- Job params: `payload: T` (Serialize/Deserialize), `Service<T>`, `Db(db): Db`
+- Enqueue: `MyJob::enqueue(&queue, &payload).await?` or `MyJob::enqueue_at(&queue, &payload, run_at).await?`
+- Extractor: `queue: JobQueue` in handlers (requires `JobsHandle` registered as service)
+- Start runner: `let jobs = modo_jobs::start(&db, &config.jobs, services).await?;`
+- `start()` takes `ServiceRegistry` as third arg for DI in job handlers
+- Cancel: `queue.cancel(&job_id).await?`
+- Entity: `modo_jobs` table with `is_framework: true` — auto-created by `sync_and_migrate`
+- Retry backoff: `5s * 2^(attempt-1)`, capped at 1h
+- Stale reaper: resets stuck `running` jobs older than `stale_threshold_secs` back to `pending`
+- Cleanup: auto-purges `completed`/`dead` jobs older than `retention_secs`
+- Design doc: `docs/plans/2026-03-07-modo-jobs-design.md`
+
 ## Key Decisions
 
 - "Full magic" — proc macros for everything, auto-discovery, zero runtime cost
@@ -104,3 +122,5 @@ Refactor strategy:
 - Clippy enforces `collapsible_if` — collapse nested `if`/`if let` with `&&`
 - In handler macro: `func_name` must be cloned (`func.sig.ident.clone()`) before mutating `func` — otherwise borrow checker blocks `&mut func`
 - Re-exports in `modo/src/lib.rs` must be alphabetically sorted (`cargo fmt` enforces this)
+- `modo-jobs` entity module is named `modo_jobs` — imports in tests can shadow the crate; use `use modo_jobs::entity::modo_jobs as jobs_entity;`
+- `inventory` registration from library crates may not link in tests — force with `use modo_jobs::entity::modo_jobs as _;`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,19 +75,22 @@ Refactor strategy:
 
 ## Jobs (modo-jobs)
 
-- Define jobs: `#[modo_jobs::job(queue = "...", priority = N, max_retries = N, timeout = "5m")]`
+- Define jobs: `#[modo_jobs::job(queue = "...", priority = N, max_attempts = N, timeout = "5m")]`
 - Cron jobs: `#[modo_jobs::job(cron = "0 0 * * * *", timeout = "5m")]` — in-memory only
-- Cron + queue/priority/max_retries = compile error (mutually exclusive)
+- Cron + queue/priority/max_attempts = compile error (mutually exclusive)
 - Job params: `payload: T` (Serialize/Deserialize), `Service<T>`, `Db(db): Db`
 - Enqueue: `MyJob::enqueue(&queue, &payload).await?` or `MyJob::enqueue_at(&queue, &payload, run_at).await?`
 - Extractor: `queue: JobQueue` in handlers (requires `JobsHandle` registered as service)
 - Start runner: `let jobs = modo_jobs::start(&db, &config.jobs, services).await?;`
 - `start()` takes `ServiceRegistry` as third arg for DI in job handlers
-- Cancel: `queue.cancel(&job_id).await?`
+- Cancel: `queue.cancel(&job_id).await?` — sets state to `cancelled` (distinct from `dead`)
 - Entity: `modo_jobs` table with `is_framework: true` — auto-created by `sync_and_migrate`
+- Job states: `pending`, `running`, `completed`, `dead`, `cancelled` (no `failed` state)
 - Retry backoff: `5s * 2^(attempt-1)`, capped at 1h
-- Stale reaper: resets stuck `running` jobs older than `stale_threshold_secs` back to `pending`
-- Cleanup: auto-purges `completed`/`dead` jobs older than `retention_secs`
+- Stale reaper: resets stuck `running` jobs older than `stale_threshold_secs` back to `pending`, decrements attempts
+- Cleanup: auto-purges `completed`/`dead`/`cancelled` jobs older than `retention_secs`
+- Shutdown: `jobs.shutdown().await` — signals cancel + waits up to `drain_timeout_secs` for in-flight jobs
+- Cron failures: consecutive failure counter warns after 5 failures in a row
 - Design doc: `docs/plans/2026-03-07-modo-jobs-design.md`
 
 ## Key Decisions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-upload", "modo-upload-macros", "examples/*"]
+members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-jobs", "modo-jobs-macros", "modo-upload", "modo-upload-macros", "examples/*"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/modo-db-macros/src/entity.rs
+++ b/modo-db-macros/src/entity.rs
@@ -89,6 +89,7 @@ impl syn::parse::Parse for EntityArgs {
 struct StructAttrs {
     timestamps: bool,
     soft_delete: bool,
+    framework: bool,
     indices: Vec<CompositeIndex>,
 }
 
@@ -135,6 +136,7 @@ struct ParsedField {
 fn parse_struct_attrs(input: &mut ItemStruct) -> Result<StructAttrs> {
     let mut timestamps = false;
     let mut soft_delete = false;
+    let mut framework = false;
     let mut indices = Vec::new();
     let mut parse_errors: Vec<syn::Error> = Vec::new();
 
@@ -149,6 +151,9 @@ fn parse_struct_attrs(input: &mut ItemStruct) -> Result<StructAttrs> {
                 Ok(())
             } else if meta.path.is_ident("soft_delete") {
                 soft_delete = true;
+                Ok(())
+            } else if meta.path.is_ident("framework") {
+                framework = true;
                 Ok(())
             } else if meta.path.is_ident("index") {
                 let mut columns = Vec::new();
@@ -178,7 +183,8 @@ fn parse_struct_attrs(input: &mut ItemStruct) -> Result<StructAttrs> {
                 indices.push(CompositeIndex { columns, unique });
                 Ok(())
             } else {
-                Err(meta.error("expected `timestamps`, `soft_delete`, or `index(...)`"))
+                Err(meta
+                    .error("expected `timestamps`, `soft_delete`, `framework`, or `index(...)`"))
             }
         }) {
             parse_errors.push(e);
@@ -197,6 +203,7 @@ fn parse_struct_attrs(input: &mut ItemStruct) -> Result<StructAttrs> {
     Ok(StructAttrs {
         timestamps,
         soft_delete,
+        framework,
         indices,
     })
 }
@@ -659,6 +666,8 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
         extra_sql_stmts.push(sql);
     }
 
+    let is_framework = struct_attrs.framework;
+
     let extra_sql_tokens = if extra_sql_stmts.is_empty() {
         quote! { &[] }
     } else {
@@ -703,7 +712,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
             modo_db::EntityRegistration {
                 table_name: #table_name,
                 register_fn: |sb| sb.register(#mod_name::Entity),
-                is_framework: false,
+                is_framework: #is_framework,
                 extra_sql: #extra_sql_tokens,
             }
         }

--- a/modo-jobs-macros/Cargo.toml
+++ b/modo-jobs-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "modo-jobs-macros"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"

--- a/modo-jobs-macros/src/job.rs
+++ b/modo-jobs-macros/src/job.rs
@@ -9,7 +9,7 @@ use syn::{FnArg, Ident, ItemFn, Lit, LitStr, Pat, Result, Token, Type, parse2};
 struct JobArgs {
     queue: String,
     priority: i32,
-    max_retries: u32,
+    max_attempts: u32,
     timeout: String,
     cron: Option<String>,
 }
@@ -19,7 +19,7 @@ impl Default for JobArgs {
         Self {
             queue: "default".to_string(),
             priority: 0,
-            max_retries: 3,
+            max_attempts: 3,
             timeout: "5m".to_string(),
             cron: None,
         }
@@ -31,7 +31,7 @@ impl syn::parse::Parse for JobArgs {
         let mut args = JobArgs::default();
         let mut has_queue = false;
         let mut has_priority = false;
-        let mut has_max_retries = false;
+        let mut has_max_attempts = false;
 
         while !input.is_empty() {
             let ident: Ident = input.parse()?;
@@ -51,13 +51,13 @@ impl syn::parse::Parse for JobArgs {
                     };
                     has_priority = true;
                 }
-                "max_retries" => {
+                "max_attempts" => {
                     let val: Lit = input.parse()?;
-                    args.max_retries = match val {
+                    args.max_attempts = match val {
                         Lit::Int(i) => i.base10_parse()?,
                         _ => return Err(syn::Error::new_spanned(val, "expected integer")),
                     };
-                    has_max_retries = true;
+                    has_max_attempts = true;
                 }
                 "timeout" => {
                     let val: LitStr = input.parse()?;
@@ -80,11 +80,11 @@ impl syn::parse::Parse for JobArgs {
             }
         }
 
-        // Mutual exclusion: cron + queue/priority/max_retries
-        if args.cron.is_some() && (has_queue || has_priority || has_max_retries) {
+        // Mutual exclusion: cron + queue/priority/max_attempts
+        if args.cron.is_some() && (has_queue || has_priority || has_max_attempts) {
             return Err(syn::Error::new(
                 proc_macro2::Span::call_site(),
-                "cron jobs cannot have queue, priority, or max_retries attributes",
+                "cron jobs cannot have queue, priority, or max_attempts attributes",
             ));
         }
 
@@ -200,7 +200,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     let timeout_secs = parse_duration_secs(&args.timeout)?;
     let queue = &args.queue;
     let priority = args.priority;
-    let max_retries = args.max_retries;
+    let max_attempts = args.max_attempts;
     let is_cron = args.cron.is_some();
 
     let cron_expr = match &args.cron {
@@ -315,7 +315,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                 name: #func_name_str,
                 queue: #queue,
                 priority: #priority,
-                max_retries: #max_retries,
+                max_attempts: #max_attempts,
                 timeout_secs: #timeout_secs,
                 cron: #cron_expr,
                 handler_factory: || Box::new(#struct_name),

--- a/modo-jobs-macros/src/job.rs
+++ b/modo-jobs-macros/src/job.rs
@@ -113,15 +113,24 @@ fn parse_duration_secs(s: &str) -> Result<u64> {
     let s = s.trim();
     if let Some(num) = s.strip_suffix('s') {
         num.parse::<u64>().map_err(|_| {
-            syn::Error::new(proc_macro2::Span::call_site(), format!("invalid timeout: {s}"))
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!("invalid timeout: {s}"),
+            )
         })
     } else if let Some(num) = s.strip_suffix('m') {
         num.parse::<u64>().map(|n| n * 60).map_err(|_| {
-            syn::Error::new(proc_macro2::Span::call_site(), format!("invalid timeout: {s}"))
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!("invalid timeout: {s}"),
+            )
         })
     } else if let Some(num) = s.strip_suffix('h') {
         num.parse::<u64>().map(|n| n * 3600).map_err(|_| {
-            syn::Error::new(proc_macro2::Span::call_site(), format!("invalid timeout: {s}"))
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!("invalid timeout: {s}"),
+            )
         })
     } else {
         Err(syn::Error::new(
@@ -149,27 +158,25 @@ fn classify_param(arg: &FnArg) -> Result<Option<ParamKind>> {
     let ty = &*pat_type.ty;
 
     // Check for Db(db): Db pattern
-    if let Pat::TupleStruct(ps) = &*pat_type.pat {
-        if let Some(last_seg) = ps.path.segments.last() {
-            if last_seg.ident == "Db" {
-                return Ok(Some(ParamKind::Db));
-            }
-        }
+    if let Pat::TupleStruct(ps) = &*pat_type.pat
+        && let Some(last_seg) = ps.path.segments.last()
+        && last_seg.ident == "Db"
+    {
+        return Ok(Some(ParamKind::Db));
     }
 
     // Check type path for Service<T> or Db
-    if let Type::Path(type_path) = ty {
-        if let Some(last_seg) = type_path.path.segments.last() {
-            if last_seg.ident == "Db" {
-                return Ok(Some(ParamKind::Db));
-            }
-            if last_seg.ident == "Service" {
-                if let syn::PathArguments::AngleBracketed(ref args) = last_seg.arguments {
-                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                        return Ok(Some(ParamKind::Service(inner.clone())));
-                    }
-                }
-            }
+    if let Type::Path(type_path) = ty
+        && let Some(last_seg) = type_path.path.segments.last()
+    {
+        if last_seg.ident == "Db" {
+            return Ok(Some(ParamKind::Db));
+        }
+        if last_seg.ident == "Service"
+            && let syn::PathArguments::AngleBracketed(ref args) = last_seg.arguments
+            && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+        {
+            return Ok(Some(ParamKind::Service(inner.clone())));
         }
     }
 

--- a/modo-jobs-macros/src/job.rs
+++ b/modo-jobs-macros/src/job.rs
@@ -1,6 +1,350 @@
 use proc_macro2::TokenStream;
-use syn::Result;
+use quote::{format_ident, quote};
+use syn::{FnArg, Ident, ItemFn, Lit, LitStr, Pat, Result, Token, Type, parse2};
 
-pub fn expand(_attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
-    Ok(item)
+// ---------------------------------------------------------------------------
+// Attribute parsing
+// ---------------------------------------------------------------------------
+
+struct JobArgs {
+    queue: String,
+    priority: i32,
+    max_retries: u32,
+    timeout: String,
+    cron: Option<String>,
+}
+
+impl Default for JobArgs {
+    fn default() -> Self {
+        Self {
+            queue: "default".to_string(),
+            priority: 0,
+            max_retries: 3,
+            timeout: "5m".to_string(),
+            cron: None,
+        }
+    }
+}
+
+impl syn::parse::Parse for JobArgs {
+    fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+        let mut args = JobArgs::default();
+        let mut has_queue = false;
+        let mut has_priority = false;
+        let mut has_max_retries = false;
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            match ident.to_string().as_str() {
+                "queue" => {
+                    let val: LitStr = input.parse()?;
+                    args.queue = val.value();
+                    has_queue = true;
+                }
+                "priority" => {
+                    let val: Lit = input.parse()?;
+                    args.priority = match val {
+                        Lit::Int(i) => i.base10_parse()?,
+                        _ => return Err(syn::Error::new_spanned(val, "expected integer")),
+                    };
+                    has_priority = true;
+                }
+                "max_retries" => {
+                    let val: Lit = input.parse()?;
+                    args.max_retries = match val {
+                        Lit::Int(i) => i.base10_parse()?,
+                        _ => return Err(syn::Error::new_spanned(val, "expected integer")),
+                    };
+                    has_max_retries = true;
+                }
+                "timeout" => {
+                    let val: LitStr = input.parse()?;
+                    args.timeout = val.value();
+                }
+                "cron" => {
+                    let val: LitStr = input.parse()?;
+                    args.cron = Some(val.value());
+                }
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        ident,
+                        format!("unknown job attribute: {other}"),
+                    ));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        // Mutual exclusion: cron + queue/priority/max_retries
+        if args.cron.is_some() && (has_queue || has_priority || has_max_retries) {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "cron jobs cannot have queue, priority, or max_retries attributes",
+            ));
+        }
+
+        Ok(args)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn to_pascal_case(s: &str) -> String {
+    s.split('_')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect()
+}
+
+fn parse_duration_secs(s: &str) -> Result<u64> {
+    let s = s.trim();
+    if let Some(num) = s.strip_suffix('s') {
+        num.parse::<u64>().map_err(|_| {
+            syn::Error::new(proc_macro2::Span::call_site(), format!("invalid timeout: {s}"))
+        })
+    } else if let Some(num) = s.strip_suffix('m') {
+        num.parse::<u64>().map(|n| n * 60).map_err(|_| {
+            syn::Error::new(proc_macro2::Span::call_site(), format!("invalid timeout: {s}"))
+        })
+    } else if let Some(num) = s.strip_suffix('h') {
+        num.parse::<u64>().map(|n| n * 3600).map_err(|_| {
+            syn::Error::new(proc_macro2::Span::call_site(), format!("invalid timeout: {s}"))
+        })
+    } else {
+        Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("invalid timeout format: {s}. Use e.g. '30s', '5m', '1h'"),
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parameter classification
+// ---------------------------------------------------------------------------
+
+enum ParamKind {
+    Payload(Type),
+    Service(Type),
+    Db,
+}
+
+fn classify_param(arg: &FnArg) -> Result<Option<ParamKind>> {
+    let FnArg::Typed(pat_type) = arg else {
+        return Ok(None);
+    };
+
+    let ty = &*pat_type.ty;
+
+    // Check for Db(db): Db pattern
+    if let Pat::TupleStruct(ps) = &*pat_type.pat {
+        if let Some(last_seg) = ps.path.segments.last() {
+            if last_seg.ident == "Db" {
+                return Ok(Some(ParamKind::Db));
+            }
+        }
+    }
+
+    // Check type path for Service<T> or Db
+    if let Type::Path(type_path) = ty {
+        if let Some(last_seg) = type_path.path.segments.last() {
+            if last_seg.ident == "Db" {
+                return Ok(Some(ParamKind::Db));
+            }
+            if last_seg.ident == "Service" {
+                if let syn::PathArguments::AngleBracketed(ref args) = last_seg.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                        return Ok(Some(ParamKind::Service(inner.clone())));
+                    }
+                }
+            }
+        }
+    }
+
+    // Otherwise it's a payload
+    Ok(Some(ParamKind::Payload(ty.clone())))
+}
+
+// ---------------------------------------------------------------------------
+// Code generation
+// ---------------------------------------------------------------------------
+
+pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
+    let args: JobArgs = parse2(attr)?;
+    let func: ItemFn = parse2(item)?;
+
+    let func_name = func.sig.ident.clone();
+    let func_name_str = func_name.to_string();
+    let impl_name = format_ident!("__job_{}_impl", func_name);
+    let struct_name = format_ident!("{}Job", to_pascal_case(&func_name_str));
+
+    let timeout_secs = parse_duration_secs(&args.timeout)?;
+    let queue = &args.queue;
+    let priority = args.priority;
+    let max_retries = args.max_retries;
+    let is_cron = args.cron.is_some();
+
+    let cron_expr = match &args.cron {
+        Some(expr) => quote! { Some(#expr) },
+        None => quote! { None },
+    };
+
+    // Classify parameters
+    let mut payload_type: Option<Type> = None;
+    let mut setup_stmts = Vec::new();
+    let mut call_args = Vec::new();
+
+    for arg in &func.sig.inputs {
+        let FnArg::Typed(pat_type) = arg else {
+            continue;
+        };
+
+        let param_pat = &pat_type.pat;
+
+        match classify_param(arg)? {
+            Some(ParamKind::Payload(ty)) => {
+                payload_type = Some(ty.clone());
+                setup_stmts.push(quote! {
+                    let #param_pat: #ty = ctx.payload()?;
+                });
+                call_args.push(quote! { #param_pat });
+            }
+            Some(ParamKind::Service(inner_ty)) => {
+                // Extract the pattern ident for the call arg
+                let ident = extract_pat_ident(param_pat);
+                setup_stmts.push(quote! {
+                    let #ident = modo_jobs::modo::extractors::service::Service(ctx.service::<#inner_ty>()?);
+                });
+                call_args.push(quote! { #ident });
+            }
+            Some(ParamKind::Db) => {
+                setup_stmts.push(quote! {
+                    let __db = modo_jobs::modo_db::extractor::Db(ctx.db()?.clone());
+                });
+                // Use the original pattern for the call
+                call_args.push(quote! { __db });
+            }
+            None => {}
+        }
+    }
+
+    // Rename original function
+    let mut impl_func = func.clone();
+    impl_func.sig.ident = impl_name.clone();
+    impl_func.vis = syn::Visibility::Inherited;
+
+    // Generate handler impl
+    let handler_impl = quote! {
+        pub struct #struct_name;
+
+        impl modo_jobs::JobHandler for #struct_name {
+            async fn run(&self, ctx: modo_jobs::JobContext) -> Result<(), modo_jobs::modo::error::Error> {
+                #(#setup_stmts)*
+                #impl_name(#(#call_args),*).await
+            }
+        }
+    };
+
+    // Generate enqueue methods (only for non-cron jobs)
+    let enqueue_methods = if !is_cron {
+        if let Some(ref payload_ty) = payload_type {
+            quote! {
+                impl #struct_name {
+                    pub async fn enqueue(
+                        queue: &modo_jobs::JobQueue,
+                        payload: &#payload_ty,
+                    ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
+                        queue.enqueue(#func_name_str, payload).await
+                    }
+
+                    pub async fn enqueue_at(
+                        queue: &modo_jobs::JobQueue,
+                        payload: &#payload_ty,
+                        run_at: modo_jobs::chrono::DateTime<modo_jobs::chrono::Utc>,
+                    ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
+                        queue.enqueue_at(#func_name_str, payload, run_at).await
+                    }
+                }
+            }
+        } else {
+            // No-payload job
+            quote! {
+                impl #struct_name {
+                    pub async fn enqueue(
+                        queue: &modo_jobs::JobQueue,
+                    ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
+                        queue.enqueue(#func_name_str, &()).await
+                    }
+
+                    pub async fn enqueue_at(
+                        queue: &modo_jobs::JobQueue,
+                        run_at: modo_jobs::chrono::DateTime<modo_jobs::chrono::Utc>,
+                    ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
+                        queue.enqueue_at(#func_name_str, &(), run_at).await
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    // Registration
+    let registration = quote! {
+        modo_jobs::inventory::submit! {
+            modo_jobs::JobRegistration {
+                name: #func_name_str,
+                queue: #queue,
+                priority: #priority,
+                max_retries: #max_retries,
+                timeout_secs: #timeout_secs,
+                cron: #cron_expr,
+                handler_factory: || Box::new(#struct_name),
+            }
+        }
+    };
+
+    Ok(quote! {
+        #impl_func
+
+        #handler_impl
+
+        #enqueue_methods
+
+        #registration
+    })
+}
+
+fn extract_pat_ident(pat: &Pat) -> TokenStream {
+    match pat {
+        Pat::Ident(ident) => {
+            let i = &ident.ident;
+            quote! { #i }
+        }
+        Pat::TupleStruct(ts) => {
+            // For patterns like Service(svc), extract the inner ident
+            if let Some(inner) = ts.elems.first() {
+                extract_pat_ident(inner)
+            } else {
+                let fallback = format_ident!("__param");
+                quote! { #fallback }
+            }
+        }
+        _ => {
+            let fallback = format_ident!("__param");
+            quote! { #fallback }
+        }
+    }
 }

--- a/modo-jobs-macros/src/job.rs
+++ b/modo-jobs-macros/src/job.rs
@@ -1,0 +1,6 @@
+use proc_macro2::TokenStream;
+use syn::Result;
+
+pub fn expand(_attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
+    Ok(item)
+}

--- a/modo-jobs-macros/src/lib.rs
+++ b/modo-jobs-macros/src/lib.rs
@@ -1,0 +1,11 @@
+use proc_macro::TokenStream;
+
+mod job;
+
+#[proc_macro_attribute]
+pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match job::expand(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}

--- a/modo-jobs/Cargo.toml
+++ b/modo-jobs/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "modo-jobs"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[dependencies]
+modo = { path = "../modo" }
+modo-db = { path = "../modo-db" }
+modo-jobs-macros = { path = "../modo-jobs-macros" }
+
+inventory = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+cron = "0.15"
+tokio = { version = "1", features = ["rt", "time", "sync", "macros"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = "0.1"
+ulid = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+serde_yaml_ng = "0.10"

--- a/modo-jobs/src/config.rs
+++ b/modo-jobs/src/config.rs
@@ -1,3 +1,4 @@
+use crate::types::JobState;
 use serde::Deserialize;
 
 /// Top-level jobs configuration, deserialized from YAML.
@@ -49,7 +50,7 @@ pub struct CleanupConfig {
     /// Jobs older than this are eligible for cleanup (seconds).
     pub retention_secs: u64,
     /// Which job states to clean up.
-    pub statuses: Vec<String>,
+    pub statuses: Vec<JobState>,
 }
 
 impl Default for CleanupConfig {
@@ -57,7 +58,7 @@ impl Default for CleanupConfig {
         Self {
             interval_secs: 3600,
             retention_secs: 86400,
-            statuses: vec!["completed".to_string(), "dead".to_string()],
+            statuses: vec![JobState::Completed, JobState::Dead, JobState::Cancelled],
         }
     }
 }

--- a/modo-jobs/src/config.rs
+++ b/modo-jobs/src/config.rs
@@ -1,0 +1,63 @@
+use serde::Deserialize;
+
+/// Top-level jobs configuration, deserialized from YAML.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct JobsConfig {
+    /// How often each queue polls for new jobs (seconds).
+    pub poll_interval_secs: u64,
+    /// Jobs running longer than this are considered stale and re-queued (seconds).
+    pub stale_threshold_secs: u64,
+    /// Maximum time to wait for in-flight jobs during shutdown (seconds).
+    pub drain_timeout_secs: u64,
+    /// Per-queue concurrency configuration.
+    pub queues: Vec<QueueConfig>,
+    /// Auto-cleanup configuration for finished jobs.
+    pub cleanup: CleanupConfig,
+}
+
+impl Default for JobsConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval_secs: 1,
+            stale_threshold_secs: 600,
+            drain_timeout_secs: 30,
+            queues: vec![QueueConfig {
+                name: "default".to_string(),
+                concurrency: 4,
+            }],
+            cleanup: CleanupConfig::default(),
+        }
+    }
+}
+
+/// Configuration for a single named queue.
+#[derive(Debug, Clone, Deserialize)]
+pub struct QueueConfig {
+    /// Queue name (must match the queue name used in `#[job(queue = "...")]`).
+    pub name: String,
+    /// Maximum number of concurrent jobs in this queue.
+    pub concurrency: usize,
+}
+
+/// Configuration for automatic cleanup of finished jobs.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct CleanupConfig {
+    /// How often the cleanup task runs (seconds).
+    pub interval_secs: u64,
+    /// Jobs older than this are eligible for cleanup (seconds).
+    pub retention_secs: u64,
+    /// Which job states to clean up.
+    pub statuses: Vec<String>,
+}
+
+impl Default for CleanupConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: 3600,
+            retention_secs: 86400,
+            statuses: vec!["completed".to_string(), "dead".to_string()],
+        }
+    }
+}

--- a/modo-jobs/src/cron.rs
+++ b/modo-jobs/src/cron.rs
@@ -4,14 +4,10 @@ use modo::app::ServiceRegistry;
 use modo_db::pool::DbPool;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// Spawn in-memory cron job tasks for all registered cron jobs.
-pub(crate) async fn start_cron_jobs(
-    cancel: CancellationToken,
-    services: ServiceRegistry,
-    db_pool: Option<Arc<DbPool>>,
-) {
+pub(crate) async fn start_cron_jobs(cancel: CancellationToken, services: ServiceRegistry) {
     for reg in inventory::iter::<JobRegistration> {
         let Some(cron_expr) = reg.cron else {
             continue;
@@ -26,7 +22,6 @@ pub(crate) async fn start_cron_jobs(
 
         let cancel = cancel.clone();
         let services = services.clone();
-        let db_pool = db_pool.clone();
         let name = reg.name;
         let timeout_secs = reg.timeout_secs;
         let handler_factory = reg.handler_factory;
@@ -35,7 +30,6 @@ pub(crate) async fn start_cron_jobs(
             run_cron_loop(
                 cancel,
                 services,
-                db_pool,
                 name,
                 timeout_secs,
                 handler_factory,
@@ -51,12 +45,14 @@ pub(crate) async fn start_cron_jobs(
 async fn run_cron_loop(
     cancel: CancellationToken,
     services: ServiceRegistry,
-    db_pool: Option<Arc<DbPool>>,
     name: &'static str,
     timeout_secs: u64,
     handler_factory: fn() -> Box<dyn crate::handler::JobHandlerDyn>,
     schedule: cron::Schedule,
 ) {
+    let db_pool: Option<Arc<DbPool>> = services.get::<DbPool>();
+    let mut consecutive_failures: u32 = 0;
+
     loop {
         // Calculate time until next fire
         let now = chrono::Utc::now();
@@ -95,13 +91,30 @@ async fn run_cron_loop(
 
                 match result {
                     Ok(Ok(())) => {
+                        consecutive_failures = 0;
                         info!(job = name, "Cron job completed");
                     }
                     Ok(Err(e)) => {
+                        consecutive_failures += 1;
                         error!(job = name, error = %e, "Cron job failed");
+                        if consecutive_failures >= 5 {
+                            warn!(
+                                job = name,
+                                consecutive_failures,
+                                "Cron job has failed {consecutive_failures} consecutive times, investigate"
+                            );
+                        }
                     }
                     Err(_) => {
+                        consecutive_failures += 1;
                         error!(job = name, "Cron job timed out");
+                        if consecutive_failures >= 5 {
+                            warn!(
+                                job = name,
+                                consecutive_failures,
+                                "Cron job has failed {consecutive_failures} consecutive times, investigate"
+                            );
+                        }
                     }
                 }
             }

--- a/modo-jobs/src/cron.rs
+++ b/modo-jobs/src/cron.rs
@@ -17,9 +17,12 @@ pub(crate) async fn start_cron_jobs(
             continue;
         };
 
-        let schedule: cron::Schedule = cron_expr
-            .parse()
-            .unwrap_or_else(|e| panic!("Invalid cron expression '{}' for job '{}': {e}", cron_expr, reg.name));
+        let schedule: cron::Schedule = cron_expr.parse().unwrap_or_else(|e| {
+            panic!(
+                "Invalid cron expression '{}' for job '{}': {e}",
+                cron_expr, reg.name
+            )
+        });
 
         let cancel = cancel.clone();
         let services = services.clone();
@@ -29,8 +32,16 @@ pub(crate) async fn start_cron_jobs(
         let handler_factory = reg.handler_factory;
 
         tokio::spawn(async move {
-            run_cron_loop(cancel, services, db_pool, name, timeout_secs, handler_factory, schedule)
-                .await;
+            run_cron_loop(
+                cancel,
+                services,
+                db_pool,
+                name,
+                timeout_secs,
+                handler_factory,
+                schedule,
+            )
+            .await;
         });
 
         info!(job = reg.name, cron = cron_expr, "Scheduled cron job");

--- a/modo-jobs/src/cron.rs
+++ b/modo-jobs/src/cron.rs
@@ -1,0 +1,99 @@
+use crate::handler::{JobContext, JobRegistration};
+use crate::types::JobId;
+use modo::app::ServiceRegistry;
+use modo_db::pool::DbPool;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+/// Spawn in-memory cron job tasks for all registered cron jobs.
+pub(crate) async fn start_cron_jobs(
+    cancel: CancellationToken,
+    services: ServiceRegistry,
+    db_pool: Option<Arc<DbPool>>,
+) {
+    for reg in inventory::iter::<JobRegistration> {
+        let Some(cron_expr) = reg.cron else {
+            continue;
+        };
+
+        let schedule: cron::Schedule = cron_expr
+            .parse()
+            .unwrap_or_else(|e| panic!("Invalid cron expression '{}' for job '{}': {e}", cron_expr, reg.name));
+
+        let cancel = cancel.clone();
+        let services = services.clone();
+        let db_pool = db_pool.clone();
+        let name = reg.name;
+        let timeout_secs = reg.timeout_secs;
+        let handler_factory = reg.handler_factory;
+
+        tokio::spawn(async move {
+            run_cron_loop(cancel, services, db_pool, name, timeout_secs, handler_factory, schedule)
+                .await;
+        });
+
+        info!(job = reg.name, cron = cron_expr, "Scheduled cron job");
+    }
+}
+
+async fn run_cron_loop(
+    cancel: CancellationToken,
+    services: ServiceRegistry,
+    db_pool: Option<Arc<DbPool>>,
+    name: &'static str,
+    timeout_secs: u64,
+    handler_factory: fn() -> Box<dyn crate::handler::JobHandlerDyn>,
+    schedule: cron::Schedule,
+) {
+    loop {
+        // Calculate time until next fire
+        let now = chrono::Utc::now();
+        let next = match schedule.upcoming(chrono::Utc).next() {
+            Some(t) => t,
+            None => {
+                info!(job = name, "Cron schedule exhausted, stopping");
+                break;
+            }
+        };
+
+        let duration = (next - now).to_std().unwrap_or(std::time::Duration::ZERO);
+
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!(job = name, "Cron job shutting down");
+                break;
+            }
+            _ = tokio::time::sleep(duration) => {
+                let handler = handler_factory();
+                let ctx = JobContext {
+                    job_id: JobId::new(),
+                    name: name.to_string(),
+                    queue: "cron".to_string(),
+                    attempt: 1,
+                    services: services.clone(),
+                    db: db_pool.as_ref().map(|p| (**p).clone()),
+                    payload_json: "null".to_string(),
+                };
+
+                let result = tokio::time::timeout(
+                    std::time::Duration::from_secs(timeout_secs),
+                    handler.run_dyn(ctx),
+                )
+                .await;
+
+                match result {
+                    Ok(Ok(())) => {
+                        info!(job = name, "Cron job completed");
+                    }
+                    Ok(Err(e)) => {
+                        error!(job = name, error = %e, "Cron job failed");
+                    }
+                    Err(_) => {
+                        error!(job = name, "Cron job timed out");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modo-jobs/src/entity.rs
+++ b/modo-jobs/src/entity.rs
@@ -1,58 +1,19 @@
-pub mod modo_jobs {
-    use modo_db::sea_orm;
-    use modo_db::sea_orm::entity::prelude::*;
-
-    #[derive(Clone, Debug, PartialEq, Eq, modo_db::sea_orm::DeriveEntityModel)]
-    #[sea_orm(table_name = "modo_jobs")]
-    pub struct Model {
-        #[sea_orm(primary_key, auto_increment = false)]
-        pub id: String,
-        pub name: String,
-        pub queue: String,
-        #[sea_orm(column_type = "Text")]
-        pub payload: String,
-        pub state: String,
-        pub priority: i32,
-        pub attempts: i32,
-        pub max_retries: i32,
-        pub run_at: ChronoDateTimeUtc,
-        pub timeout_secs: i32,
-        pub locked_by: Option<String>,
-        pub locked_at: Option<ChronoDateTimeUtc>,
-        pub created_at: ChronoDateTimeUtc,
-        pub updated_at: ChronoDateTimeUtc,
-    }
-
-    #[derive(Copy, Clone, Debug, modo_db::sea_orm::EnumIter, modo_db::sea_orm::DeriveRelation)]
-    pub enum Relation {}
-
-    #[async_trait::async_trait]
-    impl ActiveModelBehavior for ActiveModel {
-        async fn before_save<C>(self, _db: &C, insert: bool) -> std::result::Result<Self, DbErr>
-        where
-            C: ConnectionTrait,
-        {
-            let mut this = self;
-            if insert && modo_db::sea_orm::ActiveValue::is_not_set(&this.id) {
-                this.id = modo_db::sea_orm::ActiveValue::Set(modo_db::generate_ulid());
-            }
-            let now = modo_db::chrono::Utc::now();
-            if insert {
-                this.created_at = modo_db::sea_orm::ActiveValue::Set(now);
-            }
-            this.updated_at = modo_db::sea_orm::ActiveValue::Set(now);
-            Ok(this)
-        }
-    }
-}
-
-modo_db::inventory::submit! {
-    modo_db::EntityRegistration {
-        table_name: "modo_jobs",
-        register_fn: |sb| sb.register(modo_jobs::Entity),
-        is_framework: true,
-        extra_sql: &[
-            "CREATE INDEX IF NOT EXISTS idx_modo_jobs_claim ON modo_jobs(state, queue, run_at, priority)"
-        ],
-    }
+#[modo_db::entity(table = "modo_jobs")]
+#[entity(timestamps, framework)]
+#[entity(index(columns = ["state", "queue", "run_at", "priority"]))]
+pub struct Job {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub name: String,
+    pub queue: String,
+    #[entity(column_type = "Text")]
+    pub payload: String,
+    pub state: String,
+    pub priority: i32,
+    pub attempts: i32,
+    pub max_retries: i32,
+    pub run_at: modo_db::chrono::DateTime<modo_db::chrono::Utc>,
+    pub timeout_secs: i32,
+    pub locked_by: Option<String>,
+    pub locked_at: Option<modo_db::chrono::DateTime<modo_db::chrono::Utc>>,
 }

--- a/modo-jobs/src/entity.rs
+++ b/modo-jobs/src/entity.rs
@@ -11,7 +11,7 @@ pub struct Job {
     pub state: String,
     pub priority: i32,
     pub attempts: i32,
-    pub max_retries: i32,
+    pub max_attempts: i32,
     pub run_at: modo_db::chrono::DateTime<modo_db::chrono::Utc>,
     pub timeout_secs: i32,
     pub locked_by: Option<String>,

--- a/modo-jobs/src/entity.rs
+++ b/modo-jobs/src/entity.rs
@@ -1,0 +1,58 @@
+pub mod modo_jobs {
+    use modo_db::sea_orm;
+    use modo_db::sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, modo_db::sea_orm::DeriveEntityModel)]
+    #[sea_orm(table_name = "modo_jobs")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: String,
+        pub name: String,
+        pub queue: String,
+        #[sea_orm(column_type = "Text")]
+        pub payload: String,
+        pub state: String,
+        pub priority: i32,
+        pub attempts: i32,
+        pub max_retries: i32,
+        pub run_at: ChronoDateTimeUtc,
+        pub timeout_secs: i32,
+        pub locked_by: Option<String>,
+        pub locked_at: Option<ChronoDateTimeUtc>,
+        pub created_at: ChronoDateTimeUtc,
+        pub updated_at: ChronoDateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, modo_db::sea_orm::EnumIter, modo_db::sea_orm::DeriveRelation)]
+    pub enum Relation {}
+
+    #[async_trait::async_trait]
+    impl ActiveModelBehavior for ActiveModel {
+        async fn before_save<C>(self, _db: &C, insert: bool) -> std::result::Result<Self, DbErr>
+        where
+            C: ConnectionTrait,
+        {
+            let mut this = self;
+            if insert && modo_db::sea_orm::ActiveValue::is_not_set(&this.id) {
+                this.id = modo_db::sea_orm::ActiveValue::Set(modo_db::generate_ulid());
+            }
+            let now = modo_db::chrono::Utc::now();
+            if insert {
+                this.created_at = modo_db::sea_orm::ActiveValue::Set(now);
+            }
+            this.updated_at = modo_db::sea_orm::ActiveValue::Set(now);
+            Ok(this)
+        }
+    }
+}
+
+modo_db::inventory::submit! {
+    modo_db::EntityRegistration {
+        table_name: "modo_jobs",
+        register_fn: |sb| sb.register(modo_jobs::Entity),
+        is_framework: true,
+        extra_sql: &[
+            "CREATE INDEX IF NOT EXISTS idx_modo_jobs_claim ON modo_jobs(state, queue, run_at, priority)"
+        ],
+    }
+}

--- a/modo-jobs/src/extractor.rs
+++ b/modo-jobs/src/extractor.rs
@@ -1,0 +1,26 @@
+use crate::queue::JobQueue;
+use modo::app::AppState;
+use modo::axum::extract::FromRequestParts;
+use modo::axum::http::request::Parts;
+use modo::error::Error;
+
+impl FromRequestParts<AppState> for JobQueue {
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        state
+            .services
+            .get::<JobQueue>()
+            .map(|q| JobQueue {
+                db: q.db.clone(),
+            })
+            .ok_or_else(|| {
+                Error::internal(
+                    "JobQueue not configured. Start the job runner and register JobsHandle as a service.",
+                )
+            })
+    }
+}

--- a/modo-jobs/src/handler.rs
+++ b/modo-jobs/src/handler.rs
@@ -19,9 +19,8 @@ pub struct JobContext {
 impl JobContext {
     /// Deserialize the job payload from JSON.
     pub fn payload<T: serde::de::DeserializeOwned>(&self) -> Result<T, modo::Error> {
-        serde_json::from_str(&self.payload_json).map_err(|e| {
-            modo::Error::internal(format!("Failed to deserialize job payload: {e}"))
-        })
+        serde_json::from_str(&self.payload_json)
+            .map_err(|e| modo::Error::internal(format!("Failed to deserialize job payload: {e}")))
     }
 
     /// Retrieve a service from the registry.

--- a/modo-jobs/src/handler.rs
+++ b/modo-jobs/src/handler.rs
@@ -68,7 +68,7 @@ pub struct JobRegistration {
     pub name: &'static str,
     pub queue: &'static str,
     pub priority: i32,
-    pub max_retries: u32,
+    pub max_attempts: u32,
     pub timeout_secs: u64,
     pub cron: Option<&'static str>,
     pub handler_factory: fn() -> Box<dyn JobHandlerDyn>,

--- a/modo-jobs/src/handler.rs
+++ b/modo-jobs/src/handler.rs
@@ -1,0 +1,78 @@
+use crate::types::JobId;
+use modo::app::ServiceRegistry;
+use modo_db::pool::DbPool;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Context passed to job handler functions.
+pub struct JobContext {
+    pub job_id: JobId,
+    pub name: String,
+    pub queue: String,
+    pub attempt: i32,
+    pub(crate) services: ServiceRegistry,
+    pub(crate) db: Option<DbPool>,
+    pub(crate) payload_json: String,
+}
+
+impl JobContext {
+    /// Deserialize the job payload from JSON.
+    pub fn payload<T: serde::de::DeserializeOwned>(&self) -> Result<T, modo::Error> {
+        serde_json::from_str(&self.payload_json).map_err(|e| {
+            modo::Error::internal(format!("Failed to deserialize job payload: {e}"))
+        })
+    }
+
+    /// Retrieve a service from the registry.
+    pub fn service<T: Send + Sync + 'static>(&self) -> Result<Arc<T>, modo::Error> {
+        self.services.get::<T>().ok_or_else(|| {
+            modo::Error::internal(format!(
+                "Service not registered: {}",
+                std::any::type_name::<T>()
+            ))
+        })
+    }
+
+    /// Get the database connection pool.
+    pub fn db(&self) -> Result<&DbPool, modo::Error> {
+        self.db
+            .as_ref()
+            .ok_or_else(|| modo::Error::internal("Database not available in job context"))
+    }
+}
+
+/// Trait for job handlers (user-facing, async fn friendly).
+pub trait JobHandler: Send + Sync + 'static {
+    fn run(&self, ctx: JobContext) -> impl Future<Output = Result<(), modo::Error>> + Send;
+}
+
+/// Object-safe version of `JobHandler`.
+pub trait JobHandlerDyn: Send + Sync + 'static {
+    fn run_dyn(
+        &self,
+        ctx: JobContext,
+    ) -> Pin<Box<dyn Future<Output = Result<(), modo::Error>> + Send + '_>>;
+}
+
+impl<T: JobHandler> JobHandlerDyn for T {
+    fn run_dyn(
+        &self,
+        ctx: JobContext,
+    ) -> Pin<Box<dyn Future<Output = Result<(), modo::Error>> + Send + '_>> {
+        Box::pin(self.run(ctx))
+    }
+}
+
+/// Registration entry for a job handler, collected via `inventory`.
+pub struct JobRegistration {
+    pub name: &'static str,
+    pub queue: &'static str,
+    pub priority: i32,
+    pub max_retries: u32,
+    pub timeout_secs: u64,
+    pub cron: Option<&'static str>,
+    pub handler_factory: fn() -> Box<dyn JobHandlerDyn>,
+}
+
+inventory::collect!(JobRegistration);

--- a/modo-jobs/src/lib.rs
+++ b/modo-jobs/src/lib.rs
@@ -1,8 +1,13 @@
 pub mod config;
+pub mod entity;
+pub mod handler;
+pub mod queue;
 pub mod types;
 
 // Public API
 pub use config::{CleanupConfig, JobsConfig, QueueConfig};
+pub use handler::{JobContext, JobHandler, JobHandlerDyn, JobRegistration};
+pub use queue::JobQueue;
 pub use types::{JobId, JobState};
 
 // Re-export proc macros

--- a/modo-jobs/src/lib.rs
+++ b/modo-jobs/src/lib.rs
@@ -1,14 +1,17 @@
 pub mod config;
+pub(crate) mod cron;
 pub mod entity;
 pub mod extractor;
 pub mod handler;
 pub mod queue;
+pub mod runner;
 pub mod types;
 
 // Public API
 pub use config::{CleanupConfig, JobsConfig, QueueConfig};
 pub use handler::{JobContext, JobHandler, JobHandlerDyn, JobRegistration};
 pub use queue::JobQueue;
+pub use runner::{JobsHandle, start};
 pub use types::{JobId, JobState};
 
 // Re-export proc macros

--- a/modo-jobs/src/lib.rs
+++ b/modo-jobs/src/lib.rs
@@ -1,0 +1,16 @@
+pub mod config;
+pub mod types;
+
+// Public API
+pub use config::{CleanupConfig, JobsConfig, QueueConfig};
+pub use types::{JobId, JobState};
+
+// Re-export proc macros
+pub use modo_jobs_macros::job;
+
+// Re-exports for macro-generated code
+pub use chrono;
+pub use inventory;
+pub use modo;
+pub use modo_db;
+pub use serde_json;

--- a/modo-jobs/src/lib.rs
+++ b/modo-jobs/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod entity;
+pub mod extractor;
 pub mod handler;
 pub mod queue;
 pub mod types;

--- a/modo-jobs/src/queue.rs
+++ b/modo-jobs/src/queue.rs
@@ -1,0 +1,113 @@
+use crate::entity::modo_jobs;
+use crate::handler::JobRegistration;
+use crate::types::{JobId, JobState};
+use chrono::{DateTime, Utc};
+use modo_db::sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter};
+use std::sync::Arc;
+
+/// Handle for enqueuing and cancelling jobs.
+///
+/// Implements `FromRequestParts` for use as an axum extractor.
+#[derive(Clone)]
+pub struct JobQueue {
+    pub(crate) db: Arc<modo_db::sea_orm::DatabaseConnection>,
+}
+
+impl JobQueue {
+    pub fn new(db: &modo_db::pool::DbPool) -> Self {
+        Self {
+            db: Arc::new(db.connection().clone()),
+        }
+    }
+
+    /// Enqueue a job for immediate execution.
+    pub async fn enqueue<T: serde::Serialize>(
+        &self,
+        name: &str,
+        payload: &T,
+    ) -> Result<JobId, modo::Error> {
+        self.enqueue_at(name, payload, Utc::now()).await
+    }
+
+    /// Enqueue a job to run at a specific time.
+    pub async fn enqueue_at<T: serde::Serialize>(
+        &self,
+        name: &str,
+        payload: &T,
+        run_at: DateTime<Utc>,
+    ) -> Result<JobId, modo::Error> {
+        let reg = inventory::iter::<JobRegistration>
+            .into_iter()
+            .find(|r| r.name == name)
+            .ok_or_else(|| {
+                modo::Error::internal(format!("No job registered with name: {name}"))
+            })?;
+
+        let payload_json = serde_json::to_string(payload)
+            .map_err(|e| modo::Error::internal(format!("Failed to serialize job payload: {e}")))?;
+
+        self.insert_job(reg, payload_json, run_at).await
+    }
+
+    /// Cancel a pending job by ID.
+    pub async fn cancel(&self, id: &JobId) -> Result<(), modo::Error> {
+        let result = modo_db::sea_orm::UpdateMany::exec(
+            modo_jobs::Entity::update_many()
+                .filter(modo_jobs::Column::Id.eq(id.as_str()))
+                .filter(modo_jobs::Column::State.eq(JobState::Pending.as_str()))
+                .col_expr(
+                    modo_jobs::Column::State,
+                    modo_db::sea_orm::sea_query::Expr::value(JobState::Dead.as_str()),
+                )
+                .col_expr(
+                    modo_jobs::Column::UpdatedAt,
+                    modo_db::sea_orm::sea_query::Expr::value(Utc::now()),
+                ),
+            self.db.as_ref(),
+        )
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to cancel job: {e}")))?;
+
+        if result.rows_affected == 0 {
+            return Err(modo::Error::internal(format!(
+                "Job {} not found or not in pending state",
+                id
+            )));
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn insert_job(
+        &self,
+        reg: &JobRegistration,
+        payload_json: String,
+        run_at: DateTime<Utc>,
+    ) -> Result<JobId, modo::Error> {
+        let id = JobId::new();
+
+        let model = modo_jobs::ActiveModel {
+            id: ActiveValue::Set(id.as_str().to_string()),
+            name: ActiveValue::Set(reg.name.to_string()),
+            queue: ActiveValue::Set(reg.queue.to_string()),
+            payload: ActiveValue::Set(payload_json),
+            state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
+            priority: ActiveValue::Set(reg.priority),
+            attempts: ActiveValue::Set(0),
+            max_retries: ActiveValue::Set(reg.max_retries as i32),
+            run_at: ActiveValue::Set(run_at),
+            timeout_secs: ActiveValue::Set(reg.timeout_secs as i32),
+            locked_by: ActiveValue::Set(None),
+            locked_at: ActiveValue::Set(None),
+            created_at: ActiveValue::Set(Utc::now()),
+            updated_at: ActiveValue::Set(Utc::now()),
+        };
+
+        model
+            .insert(self.db.as_ref())
+            .await
+            .map_err(|e| modo::Error::internal(format!("Failed to insert job: {e}")))?;
+
+        Ok(id)
+    }
+}

--- a/modo-jobs/src/queue.rs
+++ b/modo-jobs/src/queue.rs
@@ -55,7 +55,7 @@ impl JobQueue {
                 .filter(job::Column::State.eq(JobState::Pending.as_str()))
                 .col_expr(
                     job::Column::State,
-                    modo_db::sea_orm::sea_query::Expr::value(JobState::Dead.as_str()),
+                    modo_db::sea_orm::sea_query::Expr::value(JobState::Cancelled.as_str()),
                 )
                 .col_expr(
                     job::Column::UpdatedAt,
@@ -92,9 +92,9 @@ impl JobQueue {
             state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
             priority: ActiveValue::Set(reg.priority),
             attempts: ActiveValue::Set(0),
-            max_retries: ActiveValue::Set(reg.max_retries as i32),
+            max_attempts: ActiveValue::Set(reg.max_attempts.min(i32::MAX as u32) as i32),
             run_at: ActiveValue::Set(run_at),
-            timeout_secs: ActiveValue::Set(reg.timeout_secs as i32),
+            timeout_secs: ActiveValue::Set(reg.timeout_secs.min(i32::MAX as u64) as i32),
             locked_by: ActiveValue::Set(None),
             locked_at: ActiveValue::Set(None),
             created_at: ActiveValue::Set(Utc::now()),

--- a/modo-jobs/src/queue.rs
+++ b/modo-jobs/src/queue.rs
@@ -1,4 +1,4 @@
-use crate::entity::modo_jobs;
+use crate::entity::job;
 use crate::handler::JobRegistration;
 use crate::types::{JobId, JobState};
 use chrono::{DateTime, Utc};
@@ -50,15 +50,15 @@ impl JobQueue {
     /// Cancel a pending job by ID.
     pub async fn cancel(&self, id: &JobId) -> Result<(), modo::Error> {
         let result = modo_db::sea_orm::UpdateMany::exec(
-            modo_jobs::Entity::update_many()
-                .filter(modo_jobs::Column::Id.eq(id.as_str()))
-                .filter(modo_jobs::Column::State.eq(JobState::Pending.as_str()))
+            job::Entity::update_many()
+                .filter(job::Column::Id.eq(id.as_str()))
+                .filter(job::Column::State.eq(JobState::Pending.as_str()))
                 .col_expr(
-                    modo_jobs::Column::State,
+                    job::Column::State,
                     modo_db::sea_orm::sea_query::Expr::value(JobState::Dead.as_str()),
                 )
                 .col_expr(
-                    modo_jobs::Column::UpdatedAt,
+                    job::Column::UpdatedAt,
                     modo_db::sea_orm::sea_query::Expr::value(Utc::now()),
                 ),
             self.db.as_ref(),
@@ -84,7 +84,7 @@ impl JobQueue {
     ) -> Result<JobId, modo::Error> {
         let id = JobId::new();
 
-        let model = modo_jobs::ActiveModel {
+        let model = job::ActiveModel {
             id: ActiveValue::Set(id.as_str().to_string()),
             name: ActiveValue::Set(reg.name.to_string()),
             queue: ActiveValue::Set(reg.queue.to_string()),

--- a/modo-jobs/src/queue.rs
+++ b/modo-jobs/src/queue.rs
@@ -39,9 +39,7 @@ impl JobQueue {
         let reg = inventory::iter::<JobRegistration>
             .into_iter()
             .find(|r| r.name == name)
-            .ok_or_else(|| {
-                modo::Error::internal(format!("No job registered with name: {name}"))
-            })?;
+            .ok_or_else(|| modo::Error::internal(format!("No job registered with name: {name}")))?;
 
         let payload_json = serde_json::to_string(payload)
             .map_err(|e| modo::Error::internal(format!("Failed to serialize job payload: {e}")))?;

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use modo::app::ServiceRegistry;
 use modo_db::pool::DbPool;
 use modo_db::sea_orm::{
-    ColumnTrait, DatabaseBackend, EntityTrait, FromQueryResult, QueryFilter, Statement,
+    ColumnTrait, DatabaseBackend, EntityTrait, ExprTrait, FromQueryResult, QueryFilter, Statement,
 };
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -24,12 +24,26 @@ use tracing::{error, info, warn};
 pub struct JobsHandle {
     queue: JobQueue,
     cancel: CancellationToken,
+    semaphores: Vec<(Arc<Semaphore>, usize)>,
+    drain_timeout_secs: u64,
 }
 
 impl JobsHandle {
     /// Signal all background tasks to stop and wait for in-flight jobs to drain.
-    pub fn shutdown(&self) {
+    ///
+    /// Waits up to `drain_timeout_secs` for running jobs to complete.
+    pub async fn shutdown(&self) {
         self.cancel.cancel();
+        let deadline = Duration::from_secs(self.drain_timeout_secs);
+        let drain = async {
+            for (sem, capacity) in &self.semaphores {
+                // Wait until all permits are returned (= all slots idle)
+                let _permits = sem.acquire_many(*capacity as u32).await;
+            }
+        };
+        if tokio::time::timeout(deadline, drain).await.is_err() {
+            warn!("Drain timeout expired, some jobs may still be running");
+        }
     }
 
     /// Get a reference to the cancellation token.
@@ -44,6 +58,17 @@ impl Deref for JobsHandle {
     fn deref(&self) -> &Self::Target {
         &self.queue
     }
+}
+
+/// Shared context for a poll loop, replacing many individual parameters.
+struct PollContext {
+    db: modo_db::sea_orm::DatabaseConnection,
+    services: ServiceRegistry,
+    semaphore: Arc<Semaphore>,
+    notify: Arc<Notify>,
+    queue_name: String,
+    worker_id: String,
+    poll_interval: Duration,
 }
 
 /// Start the job runner: spawns poll loops, stale reaper, cleanup, and cron scheduler.
@@ -78,32 +103,26 @@ pub async fn start(
     let cancel = CancellationToken::new();
     let queue = JobQueue::new(db);
     let worker_id = ulid::Ulid::new().to_string();
+    let mut semaphores = Vec::new();
 
     // Spawn per-queue poll loops
     for queue_config in &config.queues {
-        let db = db.connection().clone();
-        let cancel = cancel.clone();
-        let services = services.clone();
-        let poll_interval = Duration::from_secs(config.poll_interval_secs);
         let semaphore = Arc::new(Semaphore::new(queue_config.concurrency));
-        let notify = Arc::new(Notify::new());
-        let queue_name = queue_config.name.clone();
-        let worker_id = worker_id.clone();
-        let db_pool_opt = services.get::<DbPool>();
+        semaphores.push((semaphore.clone(), queue_config.concurrency));
+
+        let ctx = PollContext {
+            db: db.connection().clone(),
+            services: services.clone(),
+            semaphore,
+            notify: Arc::new(Notify::new()),
+            queue_name: queue_config.name.clone(),
+            worker_id: worker_id.clone(),
+            poll_interval: Duration::from_secs(config.poll_interval_secs),
+        };
+        let cancel = cancel.clone();
 
         tokio::spawn(async move {
-            poll_loop(
-                &db,
-                cancel,
-                services,
-                db_pool_opt,
-                semaphore,
-                notify,
-                &queue_name,
-                &worker_id,
-                poll_interval,
-            )
-            .await;
+            poll_loop(cancel, &ctx).await;
         });
     }
 
@@ -133,64 +152,56 @@ pub async fn start(
     {
         let cancel = cancel.clone();
         let services = services.clone();
-        let db_pool_opt = services.get::<DbPool>();
 
         tokio::spawn(async move {
-            crate::cron::start_cron_jobs(cancel, services, db_pool_opt).await;
+            crate::cron::start_cron_jobs(cancel, services).await;
         });
     }
 
     info!("Job runner started (worker_id={worker_id})");
 
-    Ok(JobsHandle { queue, cancel })
+    Ok(JobsHandle {
+        queue,
+        cancel,
+        semaphores,
+        drain_timeout_secs: config.drain_timeout_secs,
+    })
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn poll_loop(
-    db: &modo_db::sea_orm::DatabaseConnection,
-    cancel: CancellationToken,
-    services: ServiceRegistry,
-    db_pool: Option<Arc<DbPool>>,
-    semaphore: Arc<Semaphore>,
-    notify: Arc<Notify>,
-    queue_name: &str,
-    worker_id: &str,
-    poll_interval: Duration,
-) {
-    let mut interval = tokio::time::interval(poll_interval);
+async fn poll_loop(cancel: CancellationToken, ctx: &PollContext) {
+    let mut interval = tokio::time::interval(ctx.poll_interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut queue_empty = false;
 
     loop {
         tokio::select! {
             _ = cancel.cancelled() => {
-                info!(queue = queue_name, "Poll loop shutting down");
+                info!(queue = %ctx.queue_name, "Poll loop shutting down");
                 break;
             }
             _ = interval.tick() => {
                 queue_empty = false; // reset on tick — always re-check
             }
-            _ = notify.notified(), if !queue_empty => {
+            _ = ctx.notify.notified(), if !queue_empty => {
                 // job completed, slot freed — try to refill
             }
         }
 
         // Inner loop: fill all available concurrency slots
         loop {
-            let permit = match semaphore.clone().try_acquire_owned() {
+            let permit = match ctx.semaphore.clone().try_acquire_owned() {
                 Ok(p) => p,
                 Err(_) => break, // all slots full
             };
 
-            match claim_next(db, queue_name, worker_id).await {
+            match claim_next(&ctx.db, &ctx.queue_name, &ctx.worker_id).await {
                 Ok(Some(job)) => {
-                    let services = services.clone();
-                    let db_pool = db_pool.clone();
-                    let db_clone = db.clone();
-                    let notify = notify.clone();
+                    let services = ctx.services.clone();
+                    let db_clone = ctx.db.clone();
+                    let notify = ctx.notify.clone();
 
                     tokio::spawn(async move {
-                        execute_job(&db_clone, job, services, db_pool).await;
+                        execute_job(&db_clone, job, services).await;
                         drop(permit);
                         notify.notify_one();
                     });
@@ -202,7 +213,7 @@ async fn poll_loop(
                 }
                 Err(e) => {
                     drop(permit);
-                    error!(queue = queue_name, error = %e, "Failed to claim job");
+                    error!(queue = %ctx.queue_name, error = %e, "Failed to claim job");
                     break; // don't hammer DB on errors
                 }
             }
@@ -210,7 +221,8 @@ async fn poll_loop(
     }
 }
 
-async fn claim_next(
+#[doc(hidden)]
+pub async fn claim_next(
     db: &modo_db::sea_orm::DatabaseConnection,
     queue: &str,
     worker_id: &str,
@@ -281,14 +293,13 @@ async fn execute_job(
     db: &modo_db::sea_orm::DatabaseConnection,
     job: job::Model,
     services: ServiceRegistry,
-    db_pool: Option<Arc<DbPool>>,
 ) {
     let job_id = JobId::from_raw(&job.id);
     let job_name = job.name.clone();
     let queue = job.queue.clone();
     let attempt = job.attempts;
-    let max_retries = job.max_retries;
-    let timeout_secs = job.timeout_secs as u64;
+    let max_attempts = job.max_attempts;
+    let timeout_secs = Ord::max(job.timeout_secs, 1) as u64;
 
     // Find handler
     let handler: Option<Box<dyn JobHandlerDyn>> = inventory::iter::<JobRegistration>
@@ -306,6 +317,7 @@ async fn execute_job(
         return;
     };
 
+    let db_pool = services.get::<DbPool>();
     let ctx = JobContext {
         job_id: job_id.clone(),
         name: job_name.clone(),
@@ -329,7 +341,7 @@ async fn execute_job(
                 job_name = %job_name,
                 queue = %queue,
                 attempt = attempt,
-                max_retries = max_retries,
+                max_attempts = max_attempts,
                 error = %e,
                 "Job failed"
             );
@@ -341,7 +353,7 @@ async fn execute_job(
                 job_name = %job_name,
                 queue = %queue,
                 attempt = attempt,
-                max_retries = max_retries,
+                max_attempts = max_attempts,
                 "Job timed out"
             );
             handle_failure(db, &job).await;
@@ -349,15 +361,17 @@ async fn execute_job(
     }
 }
 
-async fn handle_failure(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
-    if job.attempts < job.max_retries {
+#[doc(hidden)]
+pub async fn handle_failure(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
+    if job.attempts < job.max_attempts {
         mark_failed(db, job).await;
     } else {
         mark_dead(db, &job.id).await;
     }
 }
 
-async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
+#[doc(hidden)]
+pub async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
     let now = Utc::now();
     if let Err(e) = job::Entity::update_many()
         .filter(job::Column::Id.eq(id))
@@ -376,7 +390,8 @@ async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
     }
 }
 
-async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
+#[doc(hidden)]
+pub async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
     let now = Utc::now();
     // Exponential backoff: 5s * 2^(attempt-1), capped at 1h
     let backoff_secs = std::cmp::min(5u64 * 2u64.pow((job.attempts - 1) as u32), 3600);
@@ -411,7 +426,8 @@ async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model
     }
 }
 
-async fn mark_dead(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
+#[doc(hidden)]
+pub async fn mark_dead(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
     let now = Utc::now();
     if let Err(e) = job::Entity::update_many()
         .filter(job::Column::Id.eq(id))
@@ -462,6 +478,10 @@ async fn reap_stale_loop(
                         modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
                     )
                     .col_expr(
+                        job::Column::Attempts,
+                        modo_db::sea_orm::sea_query::Expr::col(job::Column::Attempts).sub(1),
+                    )
+                    .col_expr(
                         job::Column::UpdatedAt,
                         modo_db::sea_orm::sea_query::Expr::value(Utc::now()),
                     )
@@ -489,7 +509,11 @@ async fn cleanup_loop(
     let mut interval = tokio::time::interval(Duration::from_secs(cleanup.interval_secs));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-    let statuses = cleanup.statuses.clone();
+    let status_strs: Vec<String> = cleanup
+        .statuses
+        .iter()
+        .map(|s| s.as_str().to_string())
+        .collect();
     let retention_secs = cleanup.retention_secs;
 
     loop {
@@ -501,7 +525,7 @@ async fn cleanup_loop(
             _ = interval.tick() => {
                 let cutoff = Utc::now() - chrono::Duration::seconds(retention_secs as i64);
                 match job::Entity::delete_many()
-                    .filter(job::Column::State.is_in(&statuses))
+                    .filter(job::Column::State.is_in(&status_strs))
                     .filter(job::Column::UpdatedAt.lt(cutoff))
                     .exec(db)
                     .await

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -143,6 +143,7 @@ pub async fn start(
     Ok(JobsHandle { queue, cancel })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn poll_loop(
     db: &modo_db::sea_orm::DatabaseConnection,
     cancel: CancellationToken,
@@ -291,7 +292,8 @@ async fn execute_job(
         payload_json: job.payload.clone(),
     };
 
-    let result = tokio::time::timeout(Duration::from_secs(timeout_secs), handler.run_dyn(ctx)).await;
+    let result =
+        tokio::time::timeout(Duration::from_secs(timeout_secs), handler.run_dyn(ctx)).await;
 
     match result {
         Ok(Ok(())) => {

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -364,7 +364,7 @@ async fn execute_job(
 #[doc(hidden)]
 pub async fn handle_failure(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
     if job.attempts < job.max_attempts {
-        mark_failed(db, job).await;
+        schedule_retry(db, job).await;
     } else {
         mark_dead(db, &job.id).await;
     }
@@ -391,7 +391,7 @@ pub async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str)
 }
 
 #[doc(hidden)]
-pub async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
+pub async fn schedule_retry(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
     let now = Utc::now();
     // Exponential backoff: 5s * 2^(attempt-1), capped at 1h
     let backoff_secs = std::cmp::min(5u64 * 2u64.pow((job.attempts - 1) as u32), 3600);
@@ -422,7 +422,7 @@ pub async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &job::M
         .exec(db)
         .await
     {
-        error!(job_id = &job.id, error = %e, "Failed to mark job failed");
+        error!(job_id = &job.id, error = %e, "Failed to schedule job retry");
     }
 }
 

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -1,5 +1,5 @@
 use crate::config::JobsConfig;
-use crate::entity::modo_jobs;
+use crate::entity::job;
 use crate::handler::{JobContext, JobHandlerDyn, JobRegistration};
 use crate::queue::JobQueue;
 use crate::types::{JobId, JobState};
@@ -198,7 +198,7 @@ async fn claim_next(
     db: &modo_db::sea_orm::DatabaseConnection,
     queue: &str,
     worker_id: &str,
-) -> Result<Option<modo_jobs::Model>, modo::Error> {
+) -> Result<Option<job::Model>, modo::Error> {
     let now = Utc::now();
     let backend = db.get_database_backend();
 
@@ -245,7 +245,7 @@ async fn claim_next(
         }
     };
 
-    let result = modo_jobs::Model::find_by_statement(Statement::from_string(backend, sql))
+    let result = job::Model::find_by_statement(Statement::from_string(backend, sql))
         .one(db)
         .await
         .map_err(|e| modo::Error::internal(format!("Claim query failed: {e}")))?;
@@ -255,7 +255,7 @@ async fn claim_next(
 
 async fn execute_job(
     db: &modo_db::sea_orm::DatabaseConnection,
-    job: modo_jobs::Model,
+    job: job::Model,
     services: ServiceRegistry,
     db_pool: Option<Arc<DbPool>>,
 ) {
@@ -325,7 +325,7 @@ async fn execute_job(
     }
 }
 
-async fn handle_failure(db: &modo_db::sea_orm::DatabaseConnection, job: &modo_jobs::Model) {
+async fn handle_failure(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
     if job.attempts < job.max_retries {
         mark_failed(db, job).await;
     } else {
@@ -335,14 +335,14 @@ async fn handle_failure(db: &modo_db::sea_orm::DatabaseConnection, job: &modo_jo
 
 async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
     let now = Utc::now();
-    if let Err(e) = modo_jobs::Entity::update_many()
-        .filter(modo_jobs::Column::Id.eq(id))
+    if let Err(e) = job::Entity::update_many()
+        .filter(job::Column::Id.eq(id))
         .col_expr(
-            modo_jobs::Column::State,
+            job::Column::State,
             modo_db::sea_orm::sea_query::Expr::value(JobState::Completed.as_str()),
         )
         .col_expr(
-            modo_jobs::Column::UpdatedAt,
+            job::Column::UpdatedAt,
             modo_db::sea_orm::sea_query::Expr::value(now),
         )
         .exec(db)
@@ -352,32 +352,32 @@ async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
     }
 }
 
-async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &modo_jobs::Model) {
+async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &job::Model) {
     let now = Utc::now();
     // Exponential backoff: 5s * 2^(attempt-1), capped at 1h
     let backoff_secs = std::cmp::min(5u64 * 2u64.pow((job.attempts - 1) as u32), 3600);
     let next_run = now + chrono::Duration::seconds(backoff_secs as i64);
 
-    if let Err(e) = modo_jobs::Entity::update_many()
-        .filter(modo_jobs::Column::Id.eq(&job.id))
+    if let Err(e) = job::Entity::update_many()
+        .filter(job::Column::Id.eq(&job.id))
         .col_expr(
-            modo_jobs::Column::State,
+            job::Column::State,
             modo_db::sea_orm::sea_query::Expr::value(JobState::Pending.as_str()),
         )
         .col_expr(
-            modo_jobs::Column::RunAt,
+            job::Column::RunAt,
             modo_db::sea_orm::sea_query::Expr::value(next_run),
         )
         .col_expr(
-            modo_jobs::Column::LockedBy,
+            job::Column::LockedBy,
             modo_db::sea_orm::sea_query::Expr::value(Option::<String>::None),
         )
         .col_expr(
-            modo_jobs::Column::LockedAt,
+            job::Column::LockedAt,
             modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
         )
         .col_expr(
-            modo_jobs::Column::UpdatedAt,
+            job::Column::UpdatedAt,
             modo_db::sea_orm::sea_query::Expr::value(now),
         )
         .exec(db)
@@ -389,14 +389,14 @@ async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &modo_jobs:
 
 async fn mark_dead(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
     let now = Utc::now();
-    if let Err(e) = modo_jobs::Entity::update_many()
-        .filter(modo_jobs::Column::Id.eq(id))
+    if let Err(e) = job::Entity::update_many()
+        .filter(job::Column::Id.eq(id))
         .col_expr(
-            modo_jobs::Column::State,
+            job::Column::State,
             modo_db::sea_orm::sea_query::Expr::value(JobState::Dead.as_str()),
         )
         .col_expr(
-            modo_jobs::Column::UpdatedAt,
+            job::Column::UpdatedAt,
             modo_db::sea_orm::sea_query::Expr::value(now),
         )
         .exec(db)
@@ -422,23 +422,23 @@ async fn reap_stale_loop(
             }
             _ = interval.tick() => {
                 let cutoff = Utc::now() - chrono::Duration::seconds(threshold_secs as i64);
-                match modo_jobs::Entity::update_many()
-                    .filter(modo_jobs::Column::State.eq(JobState::Running.as_str()))
-                    .filter(modo_jobs::Column::LockedAt.lt(cutoff))
+                match job::Entity::update_many()
+                    .filter(job::Column::State.eq(JobState::Running.as_str()))
+                    .filter(job::Column::LockedAt.lt(cutoff))
                     .col_expr(
-                        modo_jobs::Column::State,
+                        job::Column::State,
                         modo_db::sea_orm::sea_query::Expr::value(JobState::Pending.as_str()),
                     )
                     .col_expr(
-                        modo_jobs::Column::LockedBy,
+                        job::Column::LockedBy,
                         modo_db::sea_orm::sea_query::Expr::value(Option::<String>::None),
                     )
                     .col_expr(
-                        modo_jobs::Column::LockedAt,
+                        job::Column::LockedAt,
                         modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
                     )
                     .col_expr(
-                        modo_jobs::Column::UpdatedAt,
+                        job::Column::UpdatedAt,
                         modo_db::sea_orm::sea_query::Expr::value(Utc::now()),
                     )
                     .exec(db)
@@ -476,9 +476,9 @@ async fn cleanup_loop(
             }
             _ = interval.tick() => {
                 let cutoff = Utc::now() - chrono::Duration::seconds(retention_secs as i64);
-                match modo_jobs::Entity::delete_many()
-                    .filter(modo_jobs::Column::State.is_in(&statuses))
-                    .filter(modo_jobs::Column::UpdatedAt.lt(cutoff))
+                match job::Entity::delete_many()
+                    .filter(job::Column::State.is_in(&statuses))
+                    .filter(job::Column::UpdatedAt.lt(cutoff))
                     .exec(db)
                     .await
                 {

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -202,50 +202,58 @@ async fn claim_next(
     let now = Utc::now();
     let backend = db.get_database_backend();
 
-    let sql = match backend {
-        DatabaseBackend::Sqlite => {
-            format!(
-                "UPDATE modo_jobs \
-                 SET state = 'running', locked_by = '{worker_id}', \
-                     locked_at = '{now_str}', attempts = attempts + 1, \
-                     updated_at = '{now_str}' \
-                 WHERE id = ( \
-                     SELECT id FROM modo_jobs \
-                     WHERE state = 'pending' AND queue = '{queue}' AND run_at <= '{now_str}' \
-                     ORDER BY priority DESC, run_at ASC \
-                     LIMIT 1 \
-                 ) \
-                 RETURNING *",
-                worker_id = worker_id,
-                queue = queue,
-                now_str = now.format("%Y-%m-%d %H:%M:%S"),
-            )
-        }
-        DatabaseBackend::Postgres => {
-            format!(
-                "UPDATE modo_jobs \
-                 SET state = 'running', locked_by = '{worker_id}', \
-                     locked_at = '{now_str}', attempts = attempts + 1, \
-                     updated_at = '{now_str}' \
-                 WHERE id = ( \
-                     SELECT id FROM modo_jobs \
-                     WHERE state = 'pending' AND queue = '{queue}' AND run_at <= '{now_str}' \
-                     ORDER BY priority DESC, run_at ASC \
-                     LIMIT 1 \
-                     FOR UPDATE SKIP LOCKED \
-                 ) \
-                 RETURNING *",
-                worker_id = worker_id,
-                queue = queue,
-                now_str = now.format("%Y-%m-%dT%H:%M:%S+00:00"),
-            )
-        }
+    // Raw SQL is required here because SeaORM doesn't support the atomic
+    // UPDATE...WHERE id = (SELECT...) RETURNING * pattern. This single-statement
+    // approach claims a job atomically without race conditions between workers.
+    let (sql, values) = match backend {
+        DatabaseBackend::Sqlite => (
+            "UPDATE modo_jobs \
+             SET state = 'running', locked_by = $1, \
+                 locked_at = $2, attempts = attempts + 1, \
+                 updated_at = $3 \
+             WHERE id = ( \
+                 SELECT id FROM modo_jobs \
+                 WHERE state = 'pending' AND queue = $4 AND run_at <= $5 \
+                 ORDER BY priority DESC, run_at ASC \
+                 LIMIT 1 \
+             ) \
+             RETURNING *",
+            vec![
+                worker_id.into(),
+                now.into(),
+                now.into(),
+                queue.into(),
+                now.into(),
+            ],
+        ),
+        DatabaseBackend::Postgres => (
+            "UPDATE modo_jobs \
+             SET state = 'running', locked_by = $1, \
+                 locked_at = $2, attempts = attempts + 1, \
+                 updated_at = $3 \
+             WHERE id = ( \
+                 SELECT id FROM modo_jobs \
+                 WHERE state = 'pending' AND queue = $4 AND run_at <= $5 \
+                 ORDER BY priority DESC, run_at ASC \
+                 LIMIT 1 \
+                 FOR UPDATE SKIP LOCKED \
+             ) \
+             RETURNING *",
+            vec![
+                worker_id.into(),
+                now.into(),
+                now.into(),
+                queue.into(),
+                now.into(),
+            ],
+        ),
         _ => {
             return Err(modo::Error::internal("Unsupported database backend"));
         }
     };
 
-    let result = job::Model::find_by_statement(Statement::from_string(backend, sql))
+    let stmt = Statement::from_sql_and_values(backend, sql, values);
+    let result = job::Model::find_by_statement(stmt)
         .one(db)
         .await
         .map_err(|e| modo::Error::internal(format!("Claim query failed: {e}")))?;

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Semaphore;
+use tokio::sync::{Notify, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -86,6 +86,7 @@ pub async fn start(
         let services = services.clone();
         let poll_interval = Duration::from_secs(config.poll_interval_secs);
         let semaphore = Arc::new(Semaphore::new(queue_config.concurrency));
+        let notify = Arc::new(Notify::new());
         let queue_name = queue_config.name.clone();
         let worker_id = worker_id.clone();
         let db_pool_opt = services.get::<DbPool>();
@@ -97,6 +98,7 @@ pub async fn start(
                 services,
                 db_pool_opt,
                 semaphore,
+                notify,
                 &queue_name,
                 &worker_id,
                 poll_interval,
@@ -150,12 +152,14 @@ async fn poll_loop(
     services: ServiceRegistry,
     db_pool: Option<Arc<DbPool>>,
     semaphore: Arc<Semaphore>,
+    notify: Arc<Notify>,
     queue_name: &str,
     worker_id: &str,
     poll_interval: Duration,
 ) {
     let mut interval = tokio::time::interval(poll_interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut queue_empty = false;
 
     loop {
         tokio::select! {
@@ -164,30 +168,42 @@ async fn poll_loop(
                 break;
             }
             _ = interval.tick() => {
-                // Try to acquire a permit before claiming
-                let permit = match semaphore.clone().try_acquire_owned() {
-                    Ok(p) => p,
-                    Err(_) => continue, // all slots busy
-                };
+                queue_empty = false; // reset on tick — always re-check
+            }
+            _ = notify.notified(), if !queue_empty => {
+                // job completed, slot freed — try to refill
+            }
+        }
 
-                match claim_next(db, queue_name, worker_id).await {
-                    Ok(Some(job)) => {
-                        let services = services.clone();
-                        let db_pool = db_pool.clone();
-                        let db_clone = db.clone();
+        // Inner loop: fill all available concurrency slots
+        loop {
+            let permit = match semaphore.clone().try_acquire_owned() {
+                Ok(p) => p,
+                Err(_) => break, // all slots full
+            };
 
-                        tokio::spawn(async move {
-                            execute_job(&db_clone, job, services, db_pool).await;
-                            drop(permit);
-                        });
-                    }
-                    Ok(None) => {
+            match claim_next(db, queue_name, worker_id).await {
+                Ok(Some(job)) => {
+                    let services = services.clone();
+                    let db_pool = db_pool.clone();
+                    let db_clone = db.clone();
+                    let notify = notify.clone();
+
+                    tokio::spawn(async move {
+                        execute_job(&db_clone, job, services, db_pool).await;
                         drop(permit);
-                    }
-                    Err(e) => {
-                        drop(permit);
-                        error!(queue = queue_name, error = %e, "Failed to claim job");
-                    }
+                        notify.notify_one();
+                    });
+                }
+                Ok(None) => {
+                    drop(permit);
+                    queue_empty = true;
+                    break; // no more jobs
+                }
+                Err(e) => {
+                    drop(permit);
+                    error!(queue = queue_name, error = %e, "Failed to claim job");
+                    break; // don't hammer DB on errors
                 }
             }
         }

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -1,0 +1,494 @@
+use crate::config::JobsConfig;
+use crate::entity::modo_jobs;
+use crate::handler::{JobContext, JobHandlerDyn, JobRegistration};
+use crate::queue::JobQueue;
+use crate::types::{JobId, JobState};
+use chrono::Utc;
+use modo::app::ServiceRegistry;
+use modo_db::pool::DbPool;
+use modo_db::sea_orm::{
+    ColumnTrait, DatabaseBackend, EntityTrait, FromQueryResult, QueryFilter, Statement,
+};
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+/// Handle returned from `start()`. Provides job enqueuing and shutdown control.
+///
+/// Implements `Deref<Target = JobQueue>` for easy access to enqueue/cancel.
+#[derive(Clone)]
+pub struct JobsHandle {
+    queue: JobQueue,
+    cancel: CancellationToken,
+}
+
+impl JobsHandle {
+    /// Signal all background tasks to stop and wait for in-flight jobs to drain.
+    pub fn shutdown(&self) {
+        self.cancel.cancel();
+    }
+
+    /// Get a reference to the cancellation token.
+    pub fn cancel_token(&self) -> &CancellationToken {
+        &self.cancel
+    }
+}
+
+impl Deref for JobsHandle {
+    type Target = JobQueue;
+
+    fn deref(&self) -> &Self::Target {
+        &self.queue
+    }
+}
+
+/// Start the job runner: spawns poll loops, stale reaper, cleanup, and cron scheduler.
+///
+/// Returns a `JobsHandle` that should be registered as a service.
+pub async fn start(
+    db: &DbPool,
+    config: &JobsConfig,
+    services: ServiceRegistry,
+) -> Result<JobsHandle, modo::Error> {
+    // Validate queue config against registered jobs
+    let queue_names: HashMap<&str, usize> = config
+        .queues
+        .iter()
+        .map(|q| (q.name.as_str(), q.concurrency))
+        .collect();
+
+    for reg in inventory::iter::<JobRegistration> {
+        if reg.cron.is_some() {
+            continue; // cron jobs don't use queues
+        }
+        if !queue_names.contains_key(reg.queue) {
+            panic!(
+                "Job '{}' references queue '{}' which is not configured. Available queues: {:?}",
+                reg.name,
+                reg.queue,
+                queue_names.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    let cancel = CancellationToken::new();
+    let queue = JobQueue::new(db);
+    let worker_id = ulid::Ulid::new().to_string();
+
+    // Spawn per-queue poll loops
+    for queue_config in &config.queues {
+        let db = db.connection().clone();
+        let cancel = cancel.clone();
+        let services = services.clone();
+        let poll_interval = Duration::from_secs(config.poll_interval_secs);
+        let semaphore = Arc::new(Semaphore::new(queue_config.concurrency));
+        let queue_name = queue_config.name.clone();
+        let worker_id = worker_id.clone();
+        let db_pool_opt = services.get::<DbPool>();
+
+        tokio::spawn(async move {
+            poll_loop(
+                &db,
+                cancel,
+                services,
+                db_pool_opt,
+                semaphore,
+                &queue_name,
+                &worker_id,
+                poll_interval,
+            )
+            .await;
+        });
+    }
+
+    // Spawn stale reaper
+    {
+        let db = db.connection().clone();
+        let cancel = cancel.clone();
+        let threshold_secs = config.stale_threshold_secs;
+
+        tokio::spawn(async move {
+            reap_stale_loop(&db, cancel, threshold_secs).await;
+        });
+    }
+
+    // Spawn cleanup task
+    {
+        let db = db.connection().clone();
+        let cancel = cancel.clone();
+        let cleanup = config.cleanup.clone();
+
+        tokio::spawn(async move {
+            cleanup_loop(&db, cancel, &cleanup).await;
+        });
+    }
+
+    // Spawn cron scheduler
+    {
+        let cancel = cancel.clone();
+        let services = services.clone();
+        let db_pool_opt = services.get::<DbPool>();
+
+        tokio::spawn(async move {
+            crate::cron::start_cron_jobs(cancel, services, db_pool_opt).await;
+        });
+    }
+
+    info!("Job runner started (worker_id={worker_id})");
+
+    Ok(JobsHandle { queue, cancel })
+}
+
+async fn poll_loop(
+    db: &modo_db::sea_orm::DatabaseConnection,
+    cancel: CancellationToken,
+    services: ServiceRegistry,
+    db_pool: Option<Arc<DbPool>>,
+    semaphore: Arc<Semaphore>,
+    queue_name: &str,
+    worker_id: &str,
+    poll_interval: Duration,
+) {
+    let mut interval = tokio::time::interval(poll_interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!(queue = queue_name, "Poll loop shutting down");
+                break;
+            }
+            _ = interval.tick() => {
+                // Try to acquire a permit before claiming
+                let permit = match semaphore.clone().try_acquire_owned() {
+                    Ok(p) => p,
+                    Err(_) => continue, // all slots busy
+                };
+
+                match claim_next(db, queue_name, worker_id).await {
+                    Ok(Some(job)) => {
+                        let services = services.clone();
+                        let db_pool = db_pool.clone();
+                        let db_clone = db.clone();
+
+                        tokio::spawn(async move {
+                            execute_job(&db_clone, job, services, db_pool).await;
+                            drop(permit);
+                        });
+                    }
+                    Ok(None) => {
+                        drop(permit);
+                    }
+                    Err(e) => {
+                        drop(permit);
+                        error!(queue = queue_name, error = %e, "Failed to claim job");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn claim_next(
+    db: &modo_db::sea_orm::DatabaseConnection,
+    queue: &str,
+    worker_id: &str,
+) -> Result<Option<modo_jobs::Model>, modo::Error> {
+    let now = Utc::now();
+    let backend = db.get_database_backend();
+
+    let sql = match backend {
+        DatabaseBackend::Sqlite => {
+            format!(
+                "UPDATE modo_jobs \
+                 SET state = 'running', locked_by = '{worker_id}', \
+                     locked_at = '{now_str}', attempts = attempts + 1, \
+                     updated_at = '{now_str}' \
+                 WHERE id = ( \
+                     SELECT id FROM modo_jobs \
+                     WHERE state = 'pending' AND queue = '{queue}' AND run_at <= '{now_str}' \
+                     ORDER BY priority DESC, run_at ASC \
+                     LIMIT 1 \
+                 ) \
+                 RETURNING *",
+                worker_id = worker_id,
+                queue = queue,
+                now_str = now.format("%Y-%m-%d %H:%M:%S"),
+            )
+        }
+        DatabaseBackend::Postgres => {
+            format!(
+                "UPDATE modo_jobs \
+                 SET state = 'running', locked_by = '{worker_id}', \
+                     locked_at = '{now_str}', attempts = attempts + 1, \
+                     updated_at = '{now_str}' \
+                 WHERE id = ( \
+                     SELECT id FROM modo_jobs \
+                     WHERE state = 'pending' AND queue = '{queue}' AND run_at <= '{now_str}' \
+                     ORDER BY priority DESC, run_at ASC \
+                     LIMIT 1 \
+                     FOR UPDATE SKIP LOCKED \
+                 ) \
+                 RETURNING *",
+                worker_id = worker_id,
+                queue = queue,
+                now_str = now.format("%Y-%m-%dT%H:%M:%S+00:00"),
+            )
+        }
+        _ => {
+            return Err(modo::Error::internal("Unsupported database backend"));
+        }
+    };
+
+    let result = modo_jobs::Model::find_by_statement(Statement::from_string(backend, sql))
+        .one(db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Claim query failed: {e}")))?;
+
+    Ok(result)
+}
+
+async fn execute_job(
+    db: &modo_db::sea_orm::DatabaseConnection,
+    job: modo_jobs::Model,
+    services: ServiceRegistry,
+    db_pool: Option<Arc<DbPool>>,
+) {
+    let job_id = JobId::from_raw(&job.id);
+    let job_name = job.name.clone();
+    let queue = job.queue.clone();
+    let attempt = job.attempts;
+    let max_retries = job.max_retries;
+    let timeout_secs = job.timeout_secs as u64;
+
+    // Find handler
+    let handler: Option<Box<dyn JobHandlerDyn>> = inventory::iter::<JobRegistration>
+        .into_iter()
+        .find(|r| r.name == job_name)
+        .map(|r| (r.handler_factory)());
+
+    let Some(handler) = handler else {
+        error!(
+            job_id = %job_id,
+            job_name = %job_name,
+            "No handler registered for job"
+        );
+        mark_dead(db, &job.id).await;
+        return;
+    };
+
+    let ctx = JobContext {
+        job_id: job_id.clone(),
+        name: job_name.clone(),
+        queue: queue.clone(),
+        attempt,
+        services,
+        db: db_pool.map(|p| (*p).clone()),
+        payload_json: job.payload.clone(),
+    };
+
+    let result = tokio::time::timeout(Duration::from_secs(timeout_secs), handler.run_dyn(ctx)).await;
+
+    match result {
+        Ok(Ok(())) => {
+            mark_completed(db, &job.id).await;
+        }
+        Ok(Err(e)) => {
+            error!(
+                job_id = %job_id,
+                job_name = %job_name,
+                queue = %queue,
+                attempt = attempt,
+                max_retries = max_retries,
+                error = %e,
+                "Job failed"
+            );
+            handle_failure(db, &job).await;
+        }
+        Err(_) => {
+            error!(
+                job_id = %job_id,
+                job_name = %job_name,
+                queue = %queue,
+                attempt = attempt,
+                max_retries = max_retries,
+                "Job timed out"
+            );
+            handle_failure(db, &job).await;
+        }
+    }
+}
+
+async fn handle_failure(db: &modo_db::sea_orm::DatabaseConnection, job: &modo_jobs::Model) {
+    if job.attempts < job.max_retries {
+        mark_failed(db, job).await;
+    } else {
+        mark_dead(db, &job.id).await;
+    }
+}
+
+async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
+    let now = Utc::now();
+    if let Err(e) = modo_jobs::Entity::update_many()
+        .filter(modo_jobs::Column::Id.eq(id))
+        .col_expr(
+            modo_jobs::Column::State,
+            modo_db::sea_orm::sea_query::Expr::value(JobState::Completed.as_str()),
+        )
+        .col_expr(
+            modo_jobs::Column::UpdatedAt,
+            modo_db::sea_orm::sea_query::Expr::value(now),
+        )
+        .exec(db)
+        .await
+    {
+        error!(job_id = id, error = %e, "Failed to mark job completed");
+    }
+}
+
+async fn mark_failed(db: &modo_db::sea_orm::DatabaseConnection, job: &modo_jobs::Model) {
+    let now = Utc::now();
+    // Exponential backoff: 5s * 2^(attempt-1), capped at 1h
+    let backoff_secs = std::cmp::min(5u64 * 2u64.pow((job.attempts - 1) as u32), 3600);
+    let next_run = now + chrono::Duration::seconds(backoff_secs as i64);
+
+    if let Err(e) = modo_jobs::Entity::update_many()
+        .filter(modo_jobs::Column::Id.eq(&job.id))
+        .col_expr(
+            modo_jobs::Column::State,
+            modo_db::sea_orm::sea_query::Expr::value(JobState::Pending.as_str()),
+        )
+        .col_expr(
+            modo_jobs::Column::RunAt,
+            modo_db::sea_orm::sea_query::Expr::value(next_run),
+        )
+        .col_expr(
+            modo_jobs::Column::LockedBy,
+            modo_db::sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            modo_jobs::Column::LockedAt,
+            modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
+        )
+        .col_expr(
+            modo_jobs::Column::UpdatedAt,
+            modo_db::sea_orm::sea_query::Expr::value(now),
+        )
+        .exec(db)
+        .await
+    {
+        error!(job_id = &job.id, error = %e, "Failed to mark job failed");
+    }
+}
+
+async fn mark_dead(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
+    let now = Utc::now();
+    if let Err(e) = modo_jobs::Entity::update_many()
+        .filter(modo_jobs::Column::Id.eq(id))
+        .col_expr(
+            modo_jobs::Column::State,
+            modo_db::sea_orm::sea_query::Expr::value(JobState::Dead.as_str()),
+        )
+        .col_expr(
+            modo_jobs::Column::UpdatedAt,
+            modo_db::sea_orm::sea_query::Expr::value(now),
+        )
+        .exec(db)
+        .await
+    {
+        error!(job_id = id, error = %e, "Failed to mark job dead");
+    }
+}
+
+async fn reap_stale_loop(
+    db: &modo_db::sea_orm::DatabaseConnection,
+    cancel: CancellationToken,
+    threshold_secs: u64,
+) {
+    let mut interval = tokio::time::interval(Duration::from_secs(60));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("Stale reaper shutting down");
+                break;
+            }
+            _ = interval.tick() => {
+                let cutoff = Utc::now() - chrono::Duration::seconds(threshold_secs as i64);
+                match modo_jobs::Entity::update_many()
+                    .filter(modo_jobs::Column::State.eq(JobState::Running.as_str()))
+                    .filter(modo_jobs::Column::LockedAt.lt(cutoff))
+                    .col_expr(
+                        modo_jobs::Column::State,
+                        modo_db::sea_orm::sea_query::Expr::value(JobState::Pending.as_str()),
+                    )
+                    .col_expr(
+                        modo_jobs::Column::LockedBy,
+                        modo_db::sea_orm::sea_query::Expr::value(Option::<String>::None),
+                    )
+                    .col_expr(
+                        modo_jobs::Column::LockedAt,
+                        modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
+                    )
+                    .col_expr(
+                        modo_jobs::Column::UpdatedAt,
+                        modo_db::sea_orm::sea_query::Expr::value(Utc::now()),
+                    )
+                    .exec(db)
+                    .await
+                {
+                    Ok(result) if result.rows_affected > 0 => {
+                        warn!(count = result.rows_affected, "Reaped stale jobs");
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        error!(error = %e, "Failed to reap stale jobs");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn cleanup_loop(
+    db: &modo_db::sea_orm::DatabaseConnection,
+    cancel: CancellationToken,
+    cleanup: &crate::config::CleanupConfig,
+) {
+    let mut interval = tokio::time::interval(Duration::from_secs(cleanup.interval_secs));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let statuses = cleanup.statuses.clone();
+    let retention_secs = cleanup.retention_secs;
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("Cleanup task shutting down");
+                break;
+            }
+            _ = interval.tick() => {
+                let cutoff = Utc::now() - chrono::Duration::seconds(retention_secs as i64);
+                match modo_jobs::Entity::delete_many()
+                    .filter(modo_jobs::Column::State.is_in(&statuses))
+                    .filter(modo_jobs::Column::UpdatedAt.lt(cutoff))
+                    .exec(db)
+                    .await
+                {
+                    Ok(result) if result.rows_affected > 0 => {
+                        info!(count = result.rows_affected, "Cleaned up old jobs");
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        error!(error = %e, "Failed to clean up jobs");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modo-jobs/src/types.rs
+++ b/modo-jobs/src/types.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
@@ -29,13 +30,14 @@ impl fmt::Display for JobId {
 }
 
 /// State of a job in the queue.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum JobState {
     Pending,
     Running,
     Completed,
-    Failed,
     Dead,
+    Cancelled,
 }
 
 impl JobState {
@@ -44,8 +46,8 @@ impl JobState {
             Self::Pending => "pending",
             Self::Running => "running",
             Self::Completed => "completed",
-            Self::Failed => "failed",
             Self::Dead => "dead",
+            Self::Cancelled => "cancelled",
         }
     }
 }
@@ -64,8 +66,8 @@ impl FromStr for JobState {
             "pending" => Ok(Self::Pending),
             "running" => Ok(Self::Running),
             "completed" => Ok(Self::Completed),
-            "failed" => Ok(Self::Failed),
             "dead" => Ok(Self::Dead),
+            "cancelled" => Ok(Self::Cancelled),
             other => Err(format!("unknown job state: {other}")),
         }
     }

--- a/modo-jobs/src/types.rs
+++ b/modo-jobs/src/types.rs
@@ -1,0 +1,72 @@
+use std::fmt;
+use std::str::FromStr;
+
+/// Unique identifier for a job, backed by a ULID string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct JobId(String);
+
+impl JobId {
+    /// Generate a new unique job ID.
+    pub fn new() -> Self {
+        Self(ulid::Ulid::new().to_string())
+    }
+
+    /// View the ID as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Create a `JobId` from an existing raw string (e.g. from DB).
+    pub fn from_raw(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+impl fmt::Display for JobId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// State of a job in the queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JobState {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    Dead,
+}
+
+impl JobState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Dead => "dead",
+        }
+    }
+}
+
+impl fmt::Display for JobState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for JobState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "dead" => Ok(Self::Dead),
+            other => Err(format!("unknown job state: {other}")),
+        }
+    }
+}

--- a/modo-jobs/tests/config.rs
+++ b/modo-jobs/tests/config.rs
@@ -1,4 +1,4 @@
-use modo_jobs::{CleanupConfig, JobsConfig};
+use modo_jobs::{CleanupConfig, JobState, JobsConfig};
 
 #[test]
 fn test_jobs_config_defaults() {
@@ -16,7 +16,10 @@ fn test_cleanup_config_defaults() {
     let config = CleanupConfig::default();
     assert_eq!(config.interval_secs, 3600);
     assert_eq!(config.retention_secs, 86400);
-    assert_eq!(config.statuses, vec!["completed", "dead"]);
+    assert_eq!(
+        config.statuses,
+        vec![JobState::Completed, JobState::Dead, JobState::Cancelled]
+    );
 }
 
 #[test]
@@ -46,7 +49,7 @@ cleanup:
     assert_eq!(config.queues[1].concurrency, 1);
     assert_eq!(config.cleanup.interval_secs, 7200);
     assert_eq!(config.cleanup.retention_secs, 172800);
-    assert_eq!(config.cleanup.statuses, vec!["completed"]);
+    assert_eq!(config.cleanup.statuses, vec![JobState::Completed]);
 }
 
 #[test]

--- a/modo-jobs/tests/config.rs
+++ b/modo-jobs/tests/config.rs
@@ -1,0 +1,65 @@
+use modo_jobs::{CleanupConfig, JobsConfig};
+
+#[test]
+fn test_jobs_config_defaults() {
+    let config = JobsConfig::default();
+    assert_eq!(config.poll_interval_secs, 1);
+    assert_eq!(config.stale_threshold_secs, 600);
+    assert_eq!(config.drain_timeout_secs, 30);
+    assert_eq!(config.queues.len(), 1);
+    assert_eq!(config.queues[0].name, "default");
+    assert_eq!(config.queues[0].concurrency, 4);
+}
+
+#[test]
+fn test_cleanup_config_defaults() {
+    let config = CleanupConfig::default();
+    assert_eq!(config.interval_secs, 3600);
+    assert_eq!(config.retention_secs, 86400);
+    assert_eq!(config.statuses, vec!["completed", "dead"]);
+}
+
+#[test]
+fn test_jobs_config_deserialize_yaml() {
+    let yaml = r#"
+poll_interval_secs: 5
+stale_threshold_secs: 300
+drain_timeout_secs: 60
+queues:
+  - name: emails
+    concurrency: 2
+  - name: reports
+    concurrency: 1
+cleanup:
+  interval_secs: 7200
+  retention_secs: 172800
+  statuses: [completed]
+"#;
+    let config: JobsConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(config.poll_interval_secs, 5);
+    assert_eq!(config.stale_threshold_secs, 300);
+    assert_eq!(config.drain_timeout_secs, 60);
+    assert_eq!(config.queues.len(), 2);
+    assert_eq!(config.queues[0].name, "emails");
+    assert_eq!(config.queues[0].concurrency, 2);
+    assert_eq!(config.queues[1].name, "reports");
+    assert_eq!(config.queues[1].concurrency, 1);
+    assert_eq!(config.cleanup.interval_secs, 7200);
+    assert_eq!(config.cleanup.retention_secs, 172800);
+    assert_eq!(config.cleanup.statuses, vec!["completed"]);
+}
+
+#[test]
+fn test_jobs_config_partial_yaml_uses_defaults() {
+    let yaml = r#"
+poll_interval_secs: 10
+"#;
+    let config: JobsConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(config.poll_interval_secs, 10);
+    // rest should be defaults
+    assert_eq!(config.stale_threshold_secs, 600);
+    assert_eq!(config.drain_timeout_secs, 30);
+    assert_eq!(config.queues.len(), 1);
+    assert_eq!(config.queues[0].name, "default");
+    assert_eq!(config.cleanup.interval_secs, 3600);
+}

--- a/modo-jobs/tests/entity.rs
+++ b/modo-jobs/tests/entity.rs
@@ -57,9 +57,7 @@ async fn test_entity_table_created() {
         .find(|r| r.table_name == "modo_jobs")
         .unwrap();
     for sql in reg.extra_sql {
-        db.execute_unprepared(sql)
-            .await
-            .expect("Extra SQL failed");
+        db.execute_unprepared(sql).await.expect("Extra SQL failed");
     }
 
     // Verify table exists by querying

--- a/modo-jobs/tests/entity.rs
+++ b/modo-jobs/tests/entity.rs
@@ -2,7 +2,7 @@ use modo_db::EntityRegistration;
 
 // Force the linker to include modo_jobs entity registration.
 #[allow(unused_imports)]
-use modo_jobs::entity::modo_jobs as _;
+use modo_jobs::entity::job as _;
 
 #[test]
 fn test_entity_registered() {
@@ -30,7 +30,7 @@ fn test_entity_has_claim_index() {
     assert!(
         reg.extra_sql
             .iter()
-            .any(|s| s.contains("idx_modo_jobs_claim")),
+            .any(|s| s.contains("idx_modo_jobs_state_queue_run_at_priority")),
         "Expected claim index in extra_sql"
     );
 }
@@ -89,7 +89,7 @@ async fn test_claim_index_created() {
     // Check sqlite_master for the index
     let result = db
         .execute_unprepared(
-            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_modo_jobs_claim'",
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_modo_jobs_state_queue_run_at_priority'",
         )
         .await;
     assert!(result.is_ok(), "claim index should exist");

--- a/modo-jobs/tests/entity.rs
+++ b/modo-jobs/tests/entity.rs
@@ -1,0 +1,98 @@
+use modo_db::EntityRegistration;
+
+// Force the linker to include modo_jobs entity registration.
+#[allow(unused_imports)]
+use modo_jobs::entity::modo_jobs as _;
+
+#[test]
+fn test_entity_registered() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let tables: Vec<&str> = registrations.iter().map(|r| r.table_name).collect();
+    assert!(
+        tables.contains(&"modo_jobs"),
+        "modo_jobs not registered. Found: {tables:?}"
+    );
+}
+
+#[test]
+fn test_entity_is_framework() {
+    let reg = inventory::iter::<EntityRegistration>()
+        .find(|r| r.table_name == "modo_jobs")
+        .expect("modo_jobs entity not found");
+    assert!(reg.is_framework, "modo_jobs entity should be framework");
+}
+
+#[test]
+fn test_entity_has_claim_index() {
+    let reg = inventory::iter::<EntityRegistration>()
+        .find(|r| r.table_name == "modo_jobs")
+        .expect("modo_jobs entity not found");
+    assert!(
+        reg.extra_sql
+            .iter()
+            .any(|s| s.contains("idx_modo_jobs_claim")),
+        "Expected claim index in extra_sql"
+    );
+}
+
+#[tokio::test]
+async fn test_entity_table_created() {
+    use modo_db::sea_orm::{ConnectionTrait, Database, Schema};
+
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("Failed to connect to in-memory SQLite");
+
+    // Sync schema
+    let schema = Schema::new(db.get_database_backend());
+    let mut builder = schema.builder();
+    builder = (inventory::iter::<EntityRegistration>()
+        .find(|r| r.table_name == "modo_jobs")
+        .unwrap()
+        .register_fn)(builder);
+    builder.sync(&db).await.expect("Schema sync failed");
+
+    // Execute extra SQL
+    let reg = inventory::iter::<EntityRegistration>()
+        .find(|r| r.table_name == "modo_jobs")
+        .unwrap();
+    for sql in reg.extra_sql {
+        db.execute_unprepared(sql)
+            .await
+            .expect("Extra SQL failed");
+    }
+
+    // Verify table exists by querying
+    let result = db
+        .execute_unprepared("SELECT COUNT(*) FROM modo_jobs")
+        .await;
+    assert!(result.is_ok(), "modo_jobs table should exist");
+}
+
+#[tokio::test]
+async fn test_claim_index_created() {
+    use modo_db::sea_orm::{ConnectionTrait, Database, Schema};
+
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("Failed to connect");
+
+    let schema = Schema::new(db.get_database_backend());
+    let mut builder = schema.builder();
+    let reg = inventory::iter::<EntityRegistration>()
+        .find(|r| r.table_name == "modo_jobs")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder.sync(&db).await.expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.execute_unprepared(sql).await.expect("Extra SQL failed");
+    }
+
+    // Check sqlite_master for the index
+    let result = db
+        .execute_unprepared(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_modo_jobs_claim'",
+        )
+        .await;
+    assert!(result.is_ok(), "claim index should exist");
+}

--- a/modo-jobs/tests/queue.rs
+++ b/modo-jobs/tests/queue.rs
@@ -1,7 +1,7 @@
 use modo_db::sea_orm::{
     ActiveModelTrait, ActiveValue, ConnectionTrait, Database, EntityTrait, Schema,
 };
-use modo_jobs::entity::modo_jobs as jobs_entity;
+use modo_jobs::entity::job as jobs_entity;
 use modo_jobs::{JobId, JobState};
 
 async fn setup_db() -> modo_db::sea_orm::DatabaseConnection {

--- a/modo-jobs/tests/queue.rs
+++ b/modo-jobs/tests/queue.rs
@@ -36,7 +36,7 @@ async fn test_insert_and_query_job() {
         state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
         priority: ActiveValue::Set(0),
         attempts: ActiveValue::Set(0),
-        max_retries: ActiveValue::Set(3),
+        max_attempts: ActiveValue::Set(3),
         run_at: ActiveValue::Set(now),
         timeout_secs: ActiveValue::Set(300),
         locked_by: ActiveValue::Set(None),
@@ -57,7 +57,7 @@ async fn test_insert_and_query_job() {
     assert_eq!(found.queue, "default");
     assert_eq!(found.state, "pending");
     assert_eq!(found.attempts, 0);
-    assert_eq!(found.max_retries, 3);
+    assert_eq!(found.max_attempts, 3);
 }
 
 #[tokio::test]
@@ -76,7 +76,7 @@ async fn test_cancel_pending_job() {
         state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
         priority: ActiveValue::Set(0),
         attempts: ActiveValue::Set(0),
-        max_retries: ActiveValue::Set(3),
+        max_attempts: ActiveValue::Set(3),
         run_at: ActiveValue::Set(now),
         timeout_secs: ActiveValue::Set(300),
         locked_by: ActiveValue::Set(None),
@@ -93,7 +93,7 @@ async fn test_cancel_pending_job() {
         .filter(jobs_entity::Column::State.eq(JobState::Pending.as_str()))
         .col_expr(
             jobs_entity::Column::State,
-            modo_db::sea_orm::sea_query::Expr::value(JobState::Dead.as_str()),
+            modo_db::sea_orm::sea_query::Expr::value(JobState::Cancelled.as_str()),
         )
         .exec(&db)
         .await
@@ -107,5 +107,5 @@ async fn test_cancel_pending_job() {
         .expect("Query failed")
         .expect("Job not found");
 
-    assert_eq!(found.state, "dead");
+    assert_eq!(found.state, "cancelled");
 }

--- a/modo-jobs/tests/queue.rs
+++ b/modo-jobs/tests/queue.rs
@@ -1,0 +1,111 @@
+use modo_db::sea_orm::{
+    ActiveModelTrait, ActiveValue, ConnectionTrait, Database, EntityTrait, Schema,
+};
+use modo_jobs::entity::modo_jobs as jobs_entity;
+use modo_jobs::{JobId, JobState};
+
+async fn setup_db() -> modo_db::sea_orm::DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("Failed to connect");
+
+    let schema = Schema::new(db.get_database_backend());
+    let mut builder = schema.builder();
+    let reg = inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_jobs")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder.sync(&db).await.expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.execute_unprepared(sql).await.expect("Extra SQL failed");
+    }
+    db
+}
+
+#[tokio::test]
+async fn test_insert_and_query_job() {
+    let db = setup_db().await;
+    let now = chrono::Utc::now();
+    let id = JobId::new();
+
+    let model = jobs_entity::ActiveModel {
+        id: ActiveValue::Set(id.as_str().to_string()),
+        name: ActiveValue::Set("test_job".to_string()),
+        queue: ActiveValue::Set("default".to_string()),
+        payload: ActiveValue::Set("{}".to_string()),
+        state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
+        priority: ActiveValue::Set(0),
+        attempts: ActiveValue::Set(0),
+        max_retries: ActiveValue::Set(3),
+        run_at: ActiveValue::Set(now),
+        timeout_secs: ActiveValue::Set(300),
+        locked_by: ActiveValue::Set(None),
+        locked_at: ActiveValue::Set(None),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+    };
+
+    model.insert(&db).await.expect("Insert failed");
+
+    let found = jobs_entity::Entity::find_by_id(id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed");
+
+    let found = found.expect("Job not found");
+    assert_eq!(found.name, "test_job");
+    assert_eq!(found.queue, "default");
+    assert_eq!(found.state, "pending");
+    assert_eq!(found.attempts, 0);
+    assert_eq!(found.max_retries, 3);
+}
+
+#[tokio::test]
+async fn test_cancel_pending_job() {
+    use modo_db::sea_orm::{ColumnTrait, QueryFilter};
+
+    let db = setup_db().await;
+    let now = chrono::Utc::now();
+    let id = JobId::new();
+
+    let model = jobs_entity::ActiveModel {
+        id: ActiveValue::Set(id.as_str().to_string()),
+        name: ActiveValue::Set("cancel_test".to_string()),
+        queue: ActiveValue::Set("default".to_string()),
+        payload: ActiveValue::Set("{}".to_string()),
+        state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
+        priority: ActiveValue::Set(0),
+        attempts: ActiveValue::Set(0),
+        max_retries: ActiveValue::Set(3),
+        run_at: ActiveValue::Set(now),
+        timeout_secs: ActiveValue::Set(300),
+        locked_by: ActiveValue::Set(None),
+        locked_at: ActiveValue::Set(None),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+    };
+
+    model.insert(&db).await.expect("Insert failed");
+
+    // Cancel via direct UPDATE (mimicking JobQueue::cancel without needing registry)
+    let result = jobs_entity::Entity::update_many()
+        .filter(jobs_entity::Column::Id.eq(id.as_str()))
+        .filter(jobs_entity::Column::State.eq(JobState::Pending.as_str()))
+        .col_expr(
+            jobs_entity::Column::State,
+            modo_db::sea_orm::sea_query::Expr::value(JobState::Dead.as_str()),
+        )
+        .exec(&db)
+        .await
+        .expect("Cancel failed");
+
+    assert_eq!(result.rows_affected, 1);
+
+    let found = jobs_entity::Entity::find_by_id(id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed")
+        .expect("Job not found");
+
+    assert_eq!(found.state, "dead");
+}

--- a/modo-jobs/tests/runner.rs
+++ b/modo-jobs/tests/runner.rs
@@ -1,0 +1,190 @@
+use modo_db::sea_orm::{
+    ActiveModelTrait, ActiveValue, ConnectionTrait, Database, EntityTrait, Schema,
+};
+use modo_jobs::entity::job as jobs_entity;
+use modo_jobs::runner;
+use modo_jobs::{JobId, JobState};
+
+async fn setup_db() -> modo_db::sea_orm::DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("Failed to connect");
+
+    let schema = Schema::new(db.get_database_backend());
+    let mut builder = schema.builder();
+    let reg = inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_jobs")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder.sync(&db).await.expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.execute_unprepared(sql).await.expect("Extra SQL failed");
+    }
+    db
+}
+
+async fn insert_job(
+    db: &modo_db::sea_orm::DatabaseConnection,
+    id: &JobId,
+    queue: &str,
+    priority: i32,
+    run_at: chrono::DateTime<chrono::Utc>,
+    max_attempts: i32,
+) {
+    let now = chrono::Utc::now();
+    let model = jobs_entity::ActiveModel {
+        id: ActiveValue::Set(id.as_str().to_string()),
+        name: ActiveValue::Set("test_job".to_string()),
+        queue: ActiveValue::Set(queue.to_string()),
+        payload: ActiveValue::Set("{}".to_string()),
+        state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
+        priority: ActiveValue::Set(priority),
+        attempts: ActiveValue::Set(0),
+        max_attempts: ActiveValue::Set(max_attempts),
+        run_at: ActiveValue::Set(run_at),
+        timeout_secs: ActiveValue::Set(300),
+        locked_by: ActiveValue::Set(None),
+        locked_at: ActiveValue::Set(None),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+    };
+    model.insert(db).await.expect("Insert failed");
+}
+
+#[tokio::test]
+async fn test_claim_next_returns_pending_job() {
+    let db = setup_db().await;
+    let id = JobId::new();
+    let now = chrono::Utc::now();
+    insert_job(&db, &id, "default", 0, now, 3).await;
+
+    let claimed = runner::claim_next(&db, "default", "worker-1")
+        .await
+        .expect("Claim failed");
+
+    let job = claimed.expect("Expected a job");
+    assert_eq!(job.id, id.as_str());
+    assert_eq!(job.state, "running");
+    assert_eq!(job.attempts, 1);
+    assert_eq!(job.locked_by.as_deref(), Some("worker-1"));
+}
+
+#[tokio::test]
+async fn test_claim_next_respects_run_at() {
+    let db = setup_db().await;
+    let id = JobId::new();
+    let future = chrono::Utc::now() + chrono::Duration::hours(1);
+    insert_job(&db, &id, "default", 0, future, 3).await;
+
+    let claimed = runner::claim_next(&db, "default", "worker-1")
+        .await
+        .expect("Claim failed");
+
+    assert!(claimed.is_none(), "Should not claim future job");
+}
+
+#[tokio::test]
+async fn test_claim_next_priority_ordering() {
+    let db = setup_db().await;
+    let now = chrono::Utc::now();
+
+    let low_id = JobId::new();
+    let high_id = JobId::new();
+    insert_job(&db, &low_id, "default", 0, now, 3).await;
+    insert_job(&db, &high_id, "default", 10, now, 3).await;
+
+    let claimed = runner::claim_next(&db, "default", "worker-1")
+        .await
+        .expect("Claim failed")
+        .expect("Expected a job");
+
+    assert_eq!(
+        claimed.id,
+        high_id.as_str(),
+        "Higher priority should be claimed first"
+    );
+}
+
+#[tokio::test]
+async fn test_mark_completed() {
+    let db = setup_db().await;
+    let id = JobId::new();
+    let now = chrono::Utc::now();
+    insert_job(&db, &id, "default", 0, now, 3).await;
+
+    // Claim it first
+    runner::claim_next(&db, "default", "worker-1")
+        .await
+        .expect("Claim failed");
+
+    // Mark completed
+    runner::mark_completed(&db, id.as_str()).await;
+
+    let job = jobs_entity::Entity::find_by_id(id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed")
+        .expect("Job not found");
+
+    assert_eq!(job.state, "completed");
+}
+
+#[tokio::test]
+async fn test_mark_failed_sets_pending_with_future_run_at() {
+    let db = setup_db().await;
+    let id = JobId::new();
+    let now = chrono::Utc::now();
+    insert_job(&db, &id, "default", 0, now, 3).await;
+
+    // Claim it
+    let claimed = runner::claim_next(&db, "default", "worker-1")
+        .await
+        .expect("Claim failed")
+        .expect("Expected a job");
+
+    // Mark failed (retry)
+    runner::mark_failed(&db, &claimed).await;
+
+    let job = jobs_entity::Entity::find_by_id(id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed")
+        .expect("Job not found");
+
+    assert_eq!(job.state, "pending");
+    assert!(
+        job.run_at > now,
+        "run_at should be in the future for backoff"
+    );
+    assert!(job.locked_by.is_none());
+    assert!(job.locked_at.is_none());
+}
+
+#[tokio::test]
+async fn test_handle_failure_marks_dead_after_max_attempts() {
+    let db = setup_db().await;
+    let id = JobId::new();
+    let now = chrono::Utc::now();
+    // max_attempts = 1 means only 1 attempt allowed
+    insert_job(&db, &id, "default", 0, now, 1).await;
+
+    // Claim it (sets attempts = 1)
+    let claimed = runner::claim_next(&db, "default", "worker-1")
+        .await
+        .expect("Claim failed")
+        .expect("Expected a job");
+
+    assert_eq!(claimed.attempts, 1);
+    assert_eq!(claimed.max_attempts, 1);
+
+    // handle_failure should mark dead since attempts >= max_attempts
+    runner::handle_failure(&db, &claimed).await;
+
+    let job = jobs_entity::Entity::find_by_id(id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed")
+        .expect("Job not found");
+
+    assert_eq!(job.state, "dead");
+}

--- a/modo-jobs/tests/runner.rs
+++ b/modo-jobs/tests/runner.rs
@@ -130,7 +130,7 @@ async fn test_mark_completed() {
 }
 
 #[tokio::test]
-async fn test_mark_failed_sets_pending_with_future_run_at() {
+async fn test_schedule_retry_sets_pending_with_future_run_at() {
     let db = setup_db().await;
     let id = JobId::new();
     let now = chrono::Utc::now();
@@ -143,7 +143,7 @@ async fn test_mark_failed_sets_pending_with_future_run_at() {
         .expect("Expected a job");
 
     // Mark failed (retry)
-    runner::mark_failed(&db, &claimed).await;
+    runner::schedule_retry(&db, &claimed).await;
 
     let job = jobs_entity::Entity::find_by_id(id.as_str())
         .one(&db)

--- a/modo-jobs/tests/types.rs
+++ b/modo-jobs/tests/types.rs
@@ -1,0 +1,43 @@
+use modo_jobs::{JobId, JobState};
+use std::str::FromStr;
+
+#[test]
+fn test_job_id_unique() {
+    let id1 = JobId::new();
+    let id2 = JobId::new();
+    assert_ne!(id1, id2);
+}
+
+#[test]
+fn test_job_id_is_26_char_ulid() {
+    let id = JobId::new();
+    assert_eq!(id.as_str().len(), 26);
+}
+
+#[test]
+fn test_job_id_display() {
+    let id = JobId::new();
+    assert_eq!(id.to_string(), id.as_str());
+}
+
+#[test]
+fn test_job_state_display_roundtrip() {
+    let states = [
+        JobState::Pending,
+        JobState::Running,
+        JobState::Completed,
+        JobState::Failed,
+        JobState::Dead,
+    ];
+    for state in states {
+        let s = state.to_string();
+        let parsed = JobState::from_str(&s).unwrap();
+        assert_eq!(parsed, state);
+    }
+}
+
+#[test]
+fn test_job_state_from_str_invalid() {
+    let result = JobState::from_str("unknown");
+    assert!(result.is_err());
+}

--- a/modo-jobs/tests/types.rs
+++ b/modo-jobs/tests/types.rs
@@ -26,8 +26,8 @@ fn test_job_state_display_roundtrip() {
         JobState::Pending,
         JobState::Running,
         JobState::Completed,
-        JobState::Failed,
         JobState::Dead,
+        JobState::Cancelled,
     ];
     for state in states {
         let s = state.to_string();


### PR DESCRIPTION
## Summary

- Adds modo-jobs and modo-jobs-macros crates implementing a full background job system with DB-backed persistent queues, retry with exponential backoff, stale job reaping, automatic cleanup, and in-memory cron scheduling

- #[job(...)] proc macro with DI support (payload, Service<T>, Db) and compile-time validation (cron vs queue mutual exclusivity)

- Poll loop fills all concurrency slots per tick and uses Notify for immediate refill when jobs complete, maximizing throughput