### PR TITLE
feat: add modo-session crate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Refactor strategy:
 - `modo/` — core crate (HTTP, cookies, services — no DB)
 - `modo-macros/` — core proc macros
 - `modo-db/` — database layer (features: sqlite, postgres)
-- `modo-session/` — session management
+- `modo-session/` — session management (**implemented**)
 - `modo-auth/` — authentication
 - `modo-jobs/` — background jobs (**implemented**)
 - `modo-jobs-macros/` — `#[job(...)]` proc macro (**implemented**)
@@ -66,9 +66,9 @@ Refactor strategy:
 - Middleware: plain async functions, attached via `#[middleware(fn_name(params))]`
 - Middleware stacking order: Global (outermost) → Module → Handler (innermost)
 - Services: manually constructed, registered via `.service(instance)`
-- Sessions: `app.session_store(my_store)` to register, `SessionManager` in handlers
-- SessionManager: `authenticate()` / `logout()` / `logout_all()` / `logout_other()` / `rotate()` — handles cookies automatically
-- SessionManager data: `data()` / `get::<T>()` / `set()` / `update_data()` / `remove_key()` — immediate store writes
+- Sessions: `SessionStore::new(&db, config)` + `app.service(store.clone()).layer(modo_session::layer(store))`
+- SessionManager extractor: `authenticate()` / `logout()` / `logout_all()` / `logout_other()` / `revoke(id)` / `rotate()` — handles cookies automatically
+- SessionManager data: `get::<T>(key)` / `set(key, value)` / `remove_key(key)` — immediate store writes
 - Auth: implement `UserProvider` trait, use `Auth<User>` / `OptionalAuth<User>` extractors
 - Template context: `#[modo::context]` with `#[base]` + `#[user]` + `#[session]` fields
 - BaseContext: includes request_id, is_htmx, current_url, flash_messages, csrf_token, locale
@@ -97,6 +97,27 @@ Refactor strategy:
 - Cron failures: consecutive failure counter warns after 5 failures in a row
 - Design doc: `docs/plans/2026-03-07-modo-jobs-design.md`
 
+## Sessions (modo-session)
+
+- Store: `SessionStore::new(&db, config)` — concrete struct, no trait
+- Middleware: `app.layer(modo_session::layer(store))` — custom Tower Layer/Service
+- Extractor: `SessionManager` reads from request extensions (generic over any state)
+- SessionManager: `authenticate(user_id)` / `authenticate_with(user_id, data)` — destroy old session (fixation prevention), create new, set cookie
+- SessionManager: `logout()` / `logout_all()` / `logout_other()` — destroy sessions, remove cookie
+- SessionManager: `revoke(id)` — destroy specific session by ID (for "manage my devices" UI), scoped to current user
+- SessionManager: `rotate()` — new token, update cookie
+- SessionManager: `current()` / `user_id()` / `is_authenticated()` / `list_my_sessions()` — read session state
+- SessionManager: `get::<T>(key)` / `set(key, value)` / `remove_key(key)` — typed key-value on JSON data blob, immediate DB writes
+- Cookies: plain HttpOnly + SameSite=Lax + Secure (release) — no encryption; token SHA256 hash in DB provides security
+- Token: 32 random bytes, hex-encoded in cookie, SHA256 hash stored in DB (`token_hash` field)
+- Session limit: `max_sessions_per_user` (default 10) with FIFO eviction of oldest sessions
+- Fingerprint: SHA256(user_agent + accept_language + accept_encoding), validated on every request by default
+- Touch: updates `last_active_at` + extends `expires_at` when `touch_interval_secs` elapses (default 5min)
+- Entity: `modo_sessions` table, `is_framework: true`, auto-discovered via `#[modo_db::entity]`
+- Cleanup: `store.cleanup_expired()` manual, or `cleanup-job` feature for modo-jobs cron (every 15min)
+- Config: `SessionConfig` with `#[serde(default)]` — `session_ttl_secs`, `cookie_name`, `validate_fingerprint`, `touch_interval_secs`, `max_sessions_per_user`, `trusted_proxies`
+- Design doc: `docs/plans/2026-03-07-modo-session-design.md`
+
 ## Key Decisions
 
 - "Full magic" — proc macros for everything, auto-discovery, zero runtime cost
@@ -109,13 +130,13 @@ Refactor strategy:
 - `axum-extra` SignedCookieJar for all cookie ops
 - Use official documentation only when researching dependencies
 - Session IDs: ULID (no UUID anywhere)
-- Session cookies: PrivateCookieJar (AES-encrypted), store token (not session ID); token is rotatable
-- `SessionToken` newtype for cookie tokens (mirrors `SessionId`); use `SessionToken::generate()` not free functions
+- Session cookies: plain HttpOnly (not encrypted); token SHA256 hash in DB provides security layer
+- `SessionToken`: 32-byte random, hex in cookie, SHA256 hash in DB; `SessionToken::generate()` / `from_hex()` / `hash()`
 - Session fingerprint: SHA256(user_agent + accept_language + accept_encoding), configurable validation
 - Session touch: only updates last_active_at when touch_interval elapses (default 5min)
 - Session fingerprint uses `\x00` separator between hash inputs to prevent ambiguity
-- `SessionStore` and `SessionStoreDyn` must have identical method sets (10 methods each)
-- `cleanup_expired` lives on concrete store types, not in the trait
+- `SessionStore` is a concrete struct (no trait/`SessionStoreDyn`) wrapping `DbPool` + `SessionConfig`
+- `cleanup_expired` lives on `SessionStore`; optionally via modo-jobs cron with `cleanup-job` feature
 
 ## Gotchas
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-jobs", "modo-jobs-macros", "modo-upload", "modo-upload-macros", "examples/*"]
+members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-upload", "modo-upload-macros", "examples/*"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/docs/plans/2026-03-07-modo-session-design.md
+++ b/docs/plans/2026-03-07-modo-session-design.md
@@ -119,6 +119,9 @@ impl SessionManager {
     pub async fn logout_all(&self) -> Result<()>;
     pub async fn logout_other(&self) -> Result<()>;
 
+    // Revoke a specific session (from "manage my devices" list)
+    pub async fn revoke(&self, id: &SessionId) -> Result<()>;
+
     // Token rotation
     pub async fn rotate(&self) -> Result<()>;
 
@@ -140,6 +143,7 @@ Behaviors:
 - `logout()` destroys current session, signals middleware to remove cookie.
 - `logout_all()` destroys all sessions for the user (including current).
 - `logout_other()` destroys all sessions except current.
+- `revoke(id)` destroys a specific session by ID (for "manage my devices" UI). Only works on sessions owned by the current user.
 - `rotate()` generates new token, signals middleware to update cookie.
 - `list_my_sessions()` returns all sessions for the authenticated user.
 - `get/set/remove_key` read-modify-write the JSON `data` blob with immediate DB writes.

--- a/docs/plans/2026-03-07-modo-session-design.md
+++ b/docs/plans/2026-03-07-modo-session-design.md
@@ -1,0 +1,312 @@
+# ADR: modo-session — Session Management Crate
+
+## Status
+
+Accepted (2026-03-07)
+
+## Context
+
+The modo framework needs a session management crate extracted from the legacy monolith. Rather than porting the legacy code directly, this design takes useful concepts (dual ID+token, fingerprinting, touch interval, device parsing) and rebuilds with cleaner internals.
+
+Key improvements over legacy:
+- **Token hashing** — store SHA256(token) in DB, not raw token. DB compromise doesn't enable session hijack.
+- **Concrete store** — no trait abstraction. Uses modo-db directly for DB-agnostic storage.
+- **No Arc\<Mutex\<SessionAction\>\>** visible to users — thin middleware handles cookie lifecycle transparently.
+- **Active session limit** — configurable max sessions per user with FIFO eviction.
+- **Cleanup via modo-jobs** — optional feature-gated cron job instead of built-in timer.
+
+## Decision
+
+### Core Types
+
+**Newtypes:**
+- `SessionId(String)` — ULID (26 chars), `Display`/`FromStr`/`Clone`/`Debug`
+- `SessionToken` — 32-byte cryptographically random, stored as 64 hex chars. Constructor: `SessionToken::generate()`. Never stored raw in DB.
+
+**SessionData** — full session record:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `SessionId` | Stable identifier (ULID) |
+| `token_hash` | `String` | SHA256(raw_token), 64 hex chars |
+| `user_id` | `String` | Session owner |
+| `ip_address` | `String` | Client IP (proxy-aware) |
+| `user_agent` | `String` | Raw UA string |
+| `device_name` | `String` | "Chrome on macOS" (parsed) |
+| `device_type` | `String` | "mobile" / "tablet" / "desktop" |
+| `fingerprint` | `String` | SHA256(ua + accept headers), 64 hex |
+| `data` | `serde_json::Value` | Arbitrary JSON key-value blob |
+| `created_at` | `DateTime<Utc>` | Immutable |
+| `last_active_at` | `DateTime<Utc>` | Updated on touch |
+| `expires_at` | `DateTime<Utc>` | Sliding window expiry |
+
+The session entity is registered via `#[modo_db::entity]` with `is_framework: true` and auto-discovered during `sync_and_migrate()`.
+
+### SessionStore (Concrete)
+
+No trait — a concrete struct wrapping `DbPool`. Uses modo-db for DB-agnostic queries.
+
+```rust
+pub struct SessionStore {
+    db: DbPool,
+}
+
+impl SessionStore {
+    pub fn new(db: &DbPool) -> Self;
+
+    // Core CRUD
+    pub async fn create(&self, meta: &SessionMeta, user_id: &str, data: Option<Value>) -> Result<(SessionData, SessionToken)>;
+    pub async fn read(&self, id: &SessionId) -> Result<Option<SessionData>>;
+    pub async fn read_by_token(&self, token: &SessionToken) -> Result<Option<SessionData>>;
+    pub async fn destroy(&self, id: &SessionId) -> Result<()>;
+
+    // Token rotation
+    pub async fn rotate_token(&self, id: &SessionId) -> Result<SessionToken>;
+
+    // Bulk operations
+    pub async fn destroy_all_for_user(&self, user_id: &str) -> Result<()>;
+    pub async fn destroy_all_except(&self, user_id: &str, keep: &SessionId) -> Result<()>;
+    pub async fn list_for_user(&self, user_id: &str) -> Result<Vec<SessionData>>;
+
+    // Data management
+    pub async fn update_data(&self, id: &SessionId, data: Value) -> Result<()>;
+
+    // Touch (update last_active_at + extend expires_at)
+    pub async fn touch(&self, id: &SessionId, new_expires_at: DateTime<Utc>) -> Result<()>;
+
+    // Cleanup
+    pub async fn cleanup_expired(&self) -> Result<u64>;
+}
+```
+
+Key behaviors:
+- `create()` hashes the token before storing; returns both `SessionData` and raw `SessionToken` (for cookie).
+- `create()` enforces `max_sessions_per_user` — evicts oldest sessions (by `last_active_at`, FIFO) when limit exceeded.
+- `read_by_token()` hashes the input token, queries by `token_hash`.
+- `rotate_token()` generates new token, updates hash in DB, returns new raw token.
+- `cleanup_expired()` deletes all sessions where `expires_at < now()`, returns count.
+
+### SessionMeta
+
+Extracted from the HTTP request automatically:
+
+```rust
+pub struct SessionMeta {
+    pub ip_address: String,
+    pub user_agent: String,
+    pub device_name: String,
+    pub device_type: String,
+    pub fingerprint: String,
+}
+```
+
+- IP extraction: X-Forwarded-For (validated against trusted proxies) → X-Real-IP → ConnectInfo → "unknown"
+- Device parsing: user-agent → device_name ("Chrome on macOS") + device_type ("mobile"/"tablet"/"desktop")
+- Fingerprint: SHA256(user_agent + `\x00` + accept_language + `\x00` + accept_encoding)
+
+### SessionManager (Extractor)
+
+The primary user-facing API. Extracted via `FromRequestParts<AppState>`.
+
+```rust
+pub struct SessionManager { /* shared state from middleware */ }
+
+impl SessionManager {
+    // Authentication
+    pub async fn authenticate(&self, user_id: &str) -> Result<()>;
+    pub async fn authenticate_with(&self, user_id: &str, data: Value) -> Result<()>;
+    pub async fn logout(&self) -> Result<()>;
+    pub async fn logout_all(&self) -> Result<()>;
+    pub async fn logout_other(&self) -> Result<()>;
+
+    // Token rotation
+    pub async fn rotate(&self) -> Result<()>;
+
+    // Session info
+    pub fn current(&self) -> Option<&SessionData>;
+    pub fn user_id(&self) -> Option<&str>;
+    pub fn is_authenticated(&self) -> bool;
+    pub async fn list_my_sessions(&self) -> Result<Vec<SessionData>>;
+
+    // Data access (typed key-value on JSON blob)
+    pub async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>>;
+    pub async fn set<T: Serialize>(&self, key: &str, value: &T) -> Result<()>;
+    pub async fn remove_key(&self, key: &str) -> Result<()>;
+}
+```
+
+Behaviors:
+- `authenticate()` destroys current session (fixation prevention), creates new one, signals middleware to set cookie.
+- `logout()` destroys current session, signals middleware to remove cookie.
+- `logout_all()` destroys all sessions for the user (including current).
+- `logout_other()` destroys all sessions except current.
+- `rotate()` generates new token, signals middleware to update cookie.
+- `list_my_sessions()` returns all sessions for the authenticated user.
+- `get/set/remove_key` read-modify-write the JSON `data` blob with immediate DB writes.
+
+### Middleware
+
+Thin middleware that handles cookie lifecycle. Registered explicitly via `modo_session::layer()`.
+
+**Request path:**
+1. Read session cookie from `PrivateCookieJar`
+2. Parse raw token from cookie value
+3. Hash token → query `SessionStore::read_by_token()`
+4. Validate fingerprint if enabled (compare stored vs. current request)
+5. Build `SessionManagerState` and insert into request extensions
+
+**Response path:**
+1. Read `SessionAction` from shared state (set by SessionManager methods)
+2. `Set(token)` → write cookie (HttpOnly, SameSite=Lax, Secure in prod, max_age=session_ttl)
+3. `Remove` → clear cookie
+4. `None` → touch session if touch_interval elapsed, refresh cookie max_age
+
+**Fingerprint mismatch:** Log warning, destroy session, remove cookie. Treat as potential hijack.
+
+**Stale cookie:** Cookie exists but session not found in DB → remove cookie silently.
+
+**Registration:**
+```rust
+let session_store = SessionStore::new(&db);
+
+app.service(session_store)
+   .layer(modo_session::layer(&session_config))
+```
+
+### Configuration
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SessionConfig {
+    pub session_ttl_secs: u64,           // default: 2_592_000 (30 days)
+    pub cookie_name: String,             // default: "_session"
+    pub validate_fingerprint: bool,      // default: true
+    pub touch_interval_secs: u64,        // default: 300 (5 min)
+    pub max_sessions_per_user: usize,    // default: 10
+    pub trusted_proxies: Vec<String>,    // default: [] (CIDR blocks)
+}
+```
+
+### Cleanup via modo-jobs (Optional)
+
+Feature-gated behind `cleanup-job`:
+
+```rust
+#[cfg(feature = "cleanup-job")]
+#[modo_jobs::job(cron = "0 */15 * * * *", timeout = "2m")]
+async fn cleanup_expired_sessions(store: Service<SessionStore>) -> Result<()> {
+    let count = store.cleanup_expired().await?;
+    if count > 0 {
+        tracing::info!(count, "purged expired sessions");
+    }
+    Ok(())
+}
+```
+
+Without the feature, apps call `store.cleanup_expired()` manually or via their own cron job.
+
+### End-User DX
+
+```rust
+use modo::prelude::*;
+use modo_db::Db;
+use modo_session::{SessionManager, SessionStore};
+
+#[modo::main]
+async fn main(app: modo::App) {
+    let db = modo_db::connect_from_env().await;
+    modo_db::sync_and_migrate(&db).await;
+
+    let session_store = SessionStore::new(&db);
+
+    app.service(db)
+       .service(session_store)
+       .layer(modo_session::layer(&config.session))
+       .run()
+       .await
+}
+
+#[modo::handler(POST, "/login")]
+async fn login(session: SessionManager, body: Json<LoginReq>) -> Result<Json<User>> {
+    let user = verify_password(&body.email, &body.password).await?;
+    session.authenticate(&user.id).await?;
+    Ok(Json(user))
+}
+
+#[modo::handler(POST, "/logout")]
+async fn logout(session: SessionManager) -> Result<()> {
+    session.logout().await?;
+    Ok(())
+}
+
+#[modo::handler(GET, "/me")]
+async fn me(session: SessionManager) -> Result<Json<User>> {
+    let user_id = session.user_id().ok_or(Error::unauthorized())?;
+    let user = load_user(user_id).await?;
+    Ok(Json(user))
+}
+
+#[modo::handler(GET, "/sessions")]
+async fn list_sessions(session: SessionManager) -> Result<Json<Vec<SessionData>>> {
+    let sessions = session.list_my_sessions().await?;
+    Ok(Json(sessions))
+}
+```
+
+### Crate Structure
+
+```
+modo-session/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs           # Public API, re-exports
+│   ├── config.rs        # SessionConfig
+│   ├── types.rs         # SessionId, SessionToken, SessionData
+│   ├── store.rs         # SessionStore (concrete, uses modo-db)
+│   ├── manager.rs       # SessionManager extractor + SessionAction
+│   ├── middleware.rs     # Thin session middleware + layer()
+│   ├── fingerprint.rs   # compute_fingerprint(), SHA256
+│   ├── device.rs        # parse_device_name(), parse_device_type()
+│   ├── meta.rs          # SessionMeta (FromRequestParts)
+│   └── cleanup.rs       # cleanup job (feature-gated)
+└── tests/
+    └── integration.rs
+```
+
+**Dependencies:**
+- `modo` (core)
+- `modo-db` (database)
+- `modo-jobs` (optional, for `cleanup-job` feature)
+- `sha2` (fingerprint + token hashing)
+- `rand` (token generation)
+
+## Consequences
+
+**Positive:**
+- Token hashing eliminates DB-compromise → session-hijack attack vector
+- Concrete store avoids trait boilerplate while modo-db handles DB abstraction
+- Active session limit prevents unbounded session accumulation
+- Clean handler DX — no need to return SessionManager in response
+- Device parsing enables "manage my sessions" UI out of the box
+- Cleanup via modo-jobs reuses existing infrastructure
+
+**Negative:**
+- No pluggable store backends (Redis, etc.) without modifying the crate
+- modo-jobs dependency for cleanup adds coupling (mitigated by feature gate)
+- Middleware is required — can't use SessionManager without it
+- Full device parsing adds ~100 lines of UA string handling
+
+## Implementation Order
+
+1. Types (`types.rs`) — SessionId, SessionToken, SessionData
+2. Fingerprint + device parsing (`fingerprint.rs`, `device.rs`)
+3. SessionMeta (`meta.rs`)
+4. Session entity registration (in `store.rs` or `entity.rs`)
+5. SessionStore (`store.rs`) — all CRUD + eviction logic
+6. Config (`config.rs`)
+7. Middleware (`middleware.rs`) — cookie lifecycle
+8. SessionManager (`manager.rs`) — extractor + high-level API
+9. Cleanup job (`cleanup.rs`) — feature-gated
+10. Integration tests
+11. Example app (auth-app)

--- a/docs/plans/2026-03-07-modo-session-impl.md
+++ b/docs/plans/2026-03-07-modo-session-impl.md
@@ -1,0 +1,393 @@
+# modo-session Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the `modo-session` crate — session management with token hashing, concrete store, thin middleware, fingerprinting, device parsing, active session limits.
+
+**Architecture:** Custom Tower Layer/Service middleware loads sessions from DB on request, manages cookies on response. SessionManager extractor reads from request extensions. SessionStore is a concrete struct wrapping DbPool. No traits. Plain cookies (HttpOnly + Secure + SameSite=Lax) — token hashing in DB provides the security layer.
+
+**Tech Stack:** axum 0.8, SeaORM v2 (via modo-db), sha2 (hashing), rand (token generation), cookie crate (cookie building), tower (middleware)
+
+**Design doc:** `docs/plans/2026-03-07-modo-session-design.md`
+
+---
+
+### Task 1: Scaffold modo-session crate
+
+**Files:**
+- Create: `modo-session/Cargo.toml`
+- Create: `modo-session/src/lib.rs`
+- Modify: `Cargo.toml` (workspace root — add `"modo-session"` to members)
+
+**Step 1: Create `modo-session/Cargo.toml`**
+
+```toml
+[package]
+name = "modo-session"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[features]
+default = []
+cleanup-job = ["dep:modo-jobs"]
+
+[dependencies]
+modo = { path = "../modo" }
+modo-db = { path = "../modo-db" }
+modo-jobs = { path = "../modo-jobs", optional = true }
+
+sha2 = "0.10"
+rand = "0.9"
+cookie = { version = "0.18", features = ["percent-encode"] }
+http = "1"
+tower = { version = "0.5", features = ["util"] }
+pin-project-lite = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+tracing = "0.1"
+tokio = { version = "1", features = ["sync"] }
+futures-util = "0.3"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+serde_yaml_ng = "0.10"
+```
+
+**Step 2: Create `modo-session/src/lib.rs` with module stubs**
+
+Declare all modules. Create empty stub files (`config.rs`, `device.rs`, `entity.rs`, `fingerprint.rs`, `manager.rs`, `meta.rs`, `middleware.rs`, `store.rs`, `types.rs`) each containing just a comment placeholder. Re-export public types (will fill in as modules are built).
+
+**Step 3: Add `"modo-session"` to workspace members in root `Cargo.toml`**
+
+**Step 4: Verify**
+
+Run: `cargo check -p modo-session`
+Expected: compiles with warnings
+
+**Step 5: Commit**
+
+```
+feat(modo-session): scaffold crate with dependencies
+```
+
+---
+
+### Task 2: Core types — SessionId, SessionToken, SessionData
+
+**Files:**
+- Create: `modo-session/src/types.rs`
+
+**Step 1: Write tests for SessionId** — uniqueness, ULID format (26 chars), Display/FromStr roundtrip, from_raw.
+
+**Step 2: Write tests for SessionToken** — generates 64 hex chars, unique, from_hex roundtrip, rejects bad input (wrong length, non-hex), hash() returns 64 hex, hash is deterministic, hash differs from token.
+
+**Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p modo-session -- types`
+
+**Step 4: Implement SessionId** — newtype over String, ULID generation via `ulid::Ulid::new()`, Display, FromStr, from_raw, as_str. Derive: Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize.
+
+**Step 5: Implement SessionToken** — 32-byte array, `generate()` via `rand::RngCore::fill_bytes`, `as_hex()` inline hex encoder, `from_hex()` with length + digit validation, `hash()` via SHA256. Debug impl redacts value.
+
+**Step 6: Define SessionData struct** — all fields from design doc. Derive: Debug, Clone, Serialize, Deserialize.
+
+**Step 7: Run tests**
+
+Run: `cargo test -p modo-session -- types`
+Expected: all PASS
+
+**Step 8: Commit**
+
+```
+feat(modo-session): add SessionId, SessionToken, SessionData types
+```
+
+---
+
+### Task 3: Fingerprint computation
+
+**Files:**
+- Create: `modo-session/src/fingerprint.rs`
+
+**Step 1: Write tests** — SHA256 hex format (64 chars), deterministic, varies on any input change, separator prevents collision (`"a\0b","c"` vs `"a","b\0c"`).
+
+**Step 2: Run tests — FAIL**
+
+**Step 3: Implement `compute_fingerprint(user_agent, accept_language, accept_encoding) -> String`** — SHA256 with `\x00` separators, inline hex encoding.
+
+**Step 4: Run tests — PASS**
+
+**Step 5: Commit**
+
+```
+feat(modo-session): add fingerprint computation
+```
+
+---
+
+### Task 4: Device parsing
+
+**Files:**
+- Create: `modo-session/src/device.rs`
+
+**Step 1: Write tests** — Chrome on macOS, Safari on iPhone (mobile), Firefox on Windows, Edge on Windows, Chrome on Android (mobile), Safari on iPad (tablet), Chrome on Linux, unknown UA, empty UA.
+
+**Step 2: Run tests — FAIL**
+
+**Step 3: Implement** — `parse_browser(ua)` checks in order: Edge, Firefox, Chromium, Chrome, Safari, Unknown. `parse_os(ua)` checks: iPhone, iPad, Android, HarmonyOS, ChromeOS, macOS, Windows, FreeBSD, OpenBSD, Linux, Unknown. `parse_device_name(ua)` = `"{browser} on {os}"`. `parse_device_type(ua)` = mobile (iPhone or Android+Mobile), tablet (iPad or Android without Mobile), desktop (everything else).
+
+**Step 4: Run tests — PASS**
+
+**Step 5: Commit**
+
+```
+feat(modo-session): add device name and type parsing
+```
+
+---
+
+### Task 5: SessionConfig
+
+**Files:**
+- Create: `modo-session/src/config.rs`
+
+**Step 1: Implement** — `#[derive(Debug, Clone, Deserialize)] #[serde(default)]` struct with: `session_ttl_secs` (default 2592000), `cookie_name` (default "_session"), `validate_fingerprint` (default true), `touch_interval_secs` (default 300), `max_sessions_per_user` (default 10), `trusted_proxies` (default empty vec).
+
+**Step 2: Write tests** — default values correct, partial YAML deserialization fills defaults.
+
+**Step 3: Run tests — PASS**
+
+**Step 4: Commit**
+
+```
+feat(modo-session): add SessionConfig with defaults
+```
+
+---
+
+### Task 6: Session entity
+
+**Files:**
+- Create: `modo-session/src/entity.rs`
+
+**Step 1: Define entity with `#[modo_db::entity(table = "modo_sessions")]`**
+
+Attributes: `#[entity(framework)]`, `#[entity(index(columns = ["token_hash"], unique))]`, `#[entity(index(columns = ["user_id"]))]`, `#[entity(index(columns = ["expires_at"]))]`.
+
+Fields: `id` (primary_key, auto = "ulid"), `token_hash`, `user_id`, `ip_address`, `user_agent` (column_type = "Text"), `device_name`, `device_type`, `fingerprint`, `data` (column_type = "Text"), `created_at`, `last_active_at`, `expires_at` — all three DateTime fields declared explicitly (no `#[entity(timestamps)]` since session uses `last_active_at` not `updated_at`).
+
+**Step 2: Verify**
+
+Run: `cargo check -p modo-session`
+Expected: compiles. Entity auto-discovered via inventory.
+
+**Step 3: Commit**
+
+```
+feat(modo-session): add session entity (framework, auto-discovered)
+```
+
+---
+
+### Task 7: SessionMeta
+
+**Files:**
+- Create: `modo-session/src/meta.rs`
+
+**Step 1: Write tests** — `SessionMeta::from_headers()` builds correct device/fingerprint, `extract_client_ip()` ignores XFF without trusted proxies, trusts XFF from trusted proxy, falls back to "unknown".
+
+**Step 2: Run tests — FAIL**
+
+**Step 3: Implement** — `SessionMeta` struct with `from_headers(ip, ua, accept_lang, accept_enc)`. Helper `header_str()` for safe header extraction. `extract_client_ip(headers, trusted_proxies, connect_ip)` with XFF/X-Real-IP logic.
+
+**Step 4: Run tests — PASS**
+
+**Step 5: Commit**
+
+```
+feat(modo-session): add SessionMeta with IP extraction
+```
+
+---
+
+### Task 8: SessionStore
+
+**Files:**
+- Create: `modo-session/src/store.rs`
+
+This is the largest single file. Implement in one pass since all methods are straightforward SeaORM CRUD.
+
+**Step 1: Implement SessionStore** — `new(db, config)`, `config()`, `create()` (with FIFO eviction via `enforce_session_limit`), `read()`, `read_by_token()` (hashes token, filters expired), `destroy()`, `rotate_token()`, `touch()`, `update_data()`, `destroy_all_for_user()`, `destroy_all_except()`, `list_for_user()`, `cleanup_expired()`. Plus `model_to_session_data()` helper to convert SeaORM Model to SessionData.
+
+**Step 2: Verify**
+
+Run: `cargo check -p modo-session`
+Expected: compiles
+
+**Step 3: Commit**
+
+```
+feat(modo-session): add SessionStore with CRUD, eviction, cleanup
+```
+
+---
+
+### Task 9: Session middleware
+
+**Files:**
+- Create: `modo-session/src/middleware.rs`
+
+**Step 1: Implement** — Custom Tower Layer (`SessionLayer`) and Service (`SessionMiddleware<S>`).
+
+Key internals:
+- `SessionAction` enum: None, Set(token), Remove
+- `SessionManagerState`: store, config, current_session (Mutex), meta, action (Mutex)
+- Cookie helpers: `read_session_cookie()` parses Cookie header, `build_set_cookie()` / `build_remove_cookie()` build Set-Cookie header values
+- `layer(store) -> SessionLayer`: creates layer, extracts config from store
+- Request path: extract meta, read cookie, load session, validate fingerprint, insert `Arc<SessionManagerState>` into extensions
+- Response path: read action, set/remove/touch cookie
+
+Plain cookies (HttpOnly, SameSite=Lax, Path=/, Secure in release builds). No encryption — token hashing in DB is the security layer.
+
+**Step 2: Verify**
+
+Run: `cargo check -p modo-session`
+Expected: compiles
+
+**Step 3: Commit**
+
+```
+feat(modo-session): add session middleware (Tower Layer/Service)
+```
+
+---
+
+### Task 10: SessionManager extractor
+
+**Files:**
+- Create: `modo-session/src/manager.rs`
+
+**Step 1: Implement** — `FromRequestParts<AppState>` reads `Arc<SessionManagerState>` from extensions.
+
+Methods:
+- `authenticate(user_id)` / `authenticate_with(user_id, data)` — destroy current (fixation prevention), create new, signal Set
+- `logout()` / `logout_all()` / `logout_other()` — destroy, signal Remove
+- `rotate()` — new token, signal Set
+- `current()`, `user_id()`, `is_authenticated()` — read from Mutex
+- `list_my_sessions()` — delegates to store
+- `get::<T>(key)`, `set(key, value)`, `remove_key(key)` — read-modify-write JSON blob with immediate DB write
+
+**Step 2: Verify**
+
+Run: `cargo check -p modo-session`
+Expected: compiles
+
+**Step 3: Commit**
+
+```
+feat(modo-session): add SessionManager extractor
+```
+
+---
+
+### Task 11: Wire up lib.rs
+
+**Files:**
+- Modify: `modo-session/src/lib.rs`
+
+**Step 1:** Finalize all module declarations, re-exports (alphabetically sorted): `SessionConfig`, `SessionData`, `SessionId`, `SessionManager`, `SessionMeta`, `SessionStore`, `SessionToken`, `layer`. Re-export dependencies for macro-generated code: `chrono`, `modo`, `modo_db`, `serde`, `serde_json`.
+
+**Step 2: Verify**
+
+Run: `cargo check -p modo-session`
+Expected: clean compile
+
+**Step 3: Commit**
+
+```
+feat(modo-session): wire up public API re-exports
+```
+
+---
+
+### Task 12: Integration tests
+
+**Files:**
+- Create: `modo-session/tests/integration.rs`
+
+**Step 1: Write tests** using real SQLite in-memory DB:
+- `create_and_read_by_token` — create session, read back by token
+- `destroy_removes_session` — destroy, verify token lookup fails
+- `rotate_token_changes_hash` — old token fails, new token works
+- `max_sessions_evicts_oldest` — create 3 with limit 2, first evicted
+- `list_for_user_returns_all_active` — multiple users, correct count
+- `destroy_all_except_keeps_one` — only specified session survives
+- `update_data_roundtrip` — write JSON, read back
+- `cleanup_expired_removes_old` — TTL=0, cleanup deletes them
+
+**Step 2: Run tests**
+
+Run: `cargo test -p modo-session`
+Expected: all PASS
+
+**Step 3: Commit**
+
+```
+test(modo-session): add integration tests for store and session lifecycle
+```
+
+---
+
+### Task 13: Cleanup job (feature-gated)
+
+**Files:**
+- Create: `modo-session/src/cleanup.rs`
+
+**Step 1:** Implement `#[cfg(feature = "cleanup-job")]` module with `#[modo_jobs::job(cron = "0 */15 * * * *", timeout = "2m")]` that calls `store.cleanup_expired()`.
+
+**Step 2: Verify**
+
+Run: `cargo check -p modo-session --features cleanup-job`
+Expected: compiles
+
+**Step 3: Commit**
+
+```
+feat(modo-session): add feature-gated cleanup cron job
+```
+
+---
+
+### Task 14: Final verification
+
+**Step 1:** Run `just fmt`
+**Step 2:** Run `just check`
+**Step 3:** Fix any clippy/test issues
+**Step 4:** Commit fixes
+
+```
+fix(modo-session): address clippy and formatting issues
+```
+
+---
+
+### Task 15: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+Add modo-session section with conventions:
+- `SessionStore::new(&db, config)` + `app.service(store.clone()).layer(modo_session::layer(store))`
+- SessionManager extractor: authenticate/logout/rotate/get/set
+- Plain cookies (HttpOnly, not encrypted) — token_hash in DB
+- max_sessions_per_user FIFO eviction
+- Fingerprint validation on by default
+- Cleanup via modo-jobs `cleanup-job` feature
+
+**Step 1: Commit**
+
+```
+docs: add modo-session conventions to CLAUDE.md
+```

--- a/docs/plans/2026-03-07-modo-session-impl.md
+++ b/docs/plans/2026-03-07-modo-session-impl.md
@@ -274,6 +274,7 @@ feat(modo-session): add session middleware (Tower Layer/Service)
 Methods:
 - `authenticate(user_id)` / `authenticate_with(user_id, data)` — destroy current (fixation prevention), create new, signal Set
 - `logout()` / `logout_all()` / `logout_other()` — destroy, signal Remove
+- `revoke(id: &SessionId)` — destroy a specific session by ID (must belong to current user)
 - `rotate()` — new token, signal Set
 - `current()`, `user_id()`, `is_authenticated()` — read from Mutex
 - `list_my_sessions()` — delegates to store

--- a/modo-session/Cargo.toml
+++ b/modo-session/Cargo.toml
@@ -15,10 +15,8 @@ modo-jobs = { path = "../modo-jobs", optional = true }
 
 sha2 = "0.10"
 rand = "0.9"
-cookie = { version = "0.18", features = ["percent-encode"] }
 http = "1"
 tower = { version = "0.5", features = ["util"] }
-pin-project-lite = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/modo-session/Cargo.toml
+++ b/modo-session/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "modo-session"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[features]
+default = []
+cleanup-job = ["dep:modo-jobs"]
+
+[dependencies]
+modo = { path = "../modo" }
+modo-db = { path = "../modo-db" }
+modo-jobs = { path = "../modo-jobs", optional = true }
+
+sha2 = "0.10"
+rand = "0.9"
+cookie = { version = "0.18", features = ["percent-encode"] }
+http = "1"
+tower = { version = "0.5", features = ["util"] }
+pin-project-lite = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+tracing = "0.1"
+tokio = { version = "1", features = ["sync"] }
+futures-util = "0.3"
+ulid = "1"
+ipnet = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+serde_yaml_ng = "0.10"

--- a/modo-session/src/cleanup.rs
+++ b/modo-session/src/cleanup.rs
@@ -2,7 +2,9 @@ use crate::store::SessionStore;
 use modo::extractors::service::Service;
 
 #[modo_jobs::job(cron = "0 */15 * * * *", timeout = "2m")]
-async fn cleanup_expired_sessions(Service(store): Service<SessionStore>) -> Result<(), modo::Error> {
+async fn cleanup_expired_sessions(
+    Service(store): Service<SessionStore>,
+) -> Result<(), modo::Error> {
     let count = store.cleanup_expired().await?;
     if count > 0 {
         tracing::info!(count, "purged expired sessions");

--- a/modo-session/src/cleanup.rs
+++ b/modo-session/src/cleanup.rs
@@ -1,0 +1,11 @@
+use crate::store::SessionStore;
+use modo::extractors::service::Service;
+
+#[modo_jobs::job(cron = "0 */15 * * * *", timeout = "2m")]
+async fn cleanup_expired_sessions(Service(store): Service<SessionStore>) -> Result<(), modo::Error> {
+    let count = store.cleanup_expired().await?;
+    if count > 0 {
+        tracing::info!(count, "purged expired sessions");
+    }
+    Ok(())
+}

--- a/modo-session/src/config.rs
+++ b/modo-session/src/config.rs
@@ -1,1 +1,56 @@
-// SessionConfig — session configuration with defaults
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SessionConfig {
+    pub session_ttl_secs: u64,
+    pub cookie_name: String,
+    pub validate_fingerprint: bool,
+    pub touch_interval_secs: u64,
+    pub max_sessions_per_user: usize,
+    pub trusted_proxies: Vec<String>,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            session_ttl_secs: 2_592_000, // 30 days
+            cookie_name: "_session".to_string(),
+            validate_fingerprint: true,
+            touch_interval_secs: 300, // 5 minutes
+            max_sessions_per_user: 10,
+            trusted_proxies: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = SessionConfig::default();
+        assert_eq!(config.session_ttl_secs, 2_592_000);
+        assert_eq!(config.cookie_name, "_session");
+        assert!(config.validate_fingerprint);
+        assert_eq!(config.touch_interval_secs, 300);
+        assert_eq!(config.max_sessions_per_user, 10);
+        assert!(config.trusted_proxies.is_empty());
+    }
+
+    #[test]
+    fn partial_yaml_deserialization() {
+        let yaml = r#"
+session_ttl_secs: 3600
+cookie_name: "my_sess"
+"#;
+        let config: SessionConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.session_ttl_secs, 3600);
+        assert_eq!(config.cookie_name, "my_sess");
+        // defaults for omitted fields
+        assert!(config.validate_fingerprint);
+        assert_eq!(config.touch_interval_secs, 300);
+        assert_eq!(config.max_sessions_per_user, 10);
+    }
+}

--- a/modo-session/src/config.rs
+++ b/modo-session/src/config.rs
@@ -1,0 +1,1 @@
+// SessionConfig — session configuration with defaults

--- a/modo-session/src/device.rs
+++ b/modo-session/src/device.rs
@@ -1,1 +1,131 @@
-// Device name and type parsing from User-Agent
+/// Parse a human-readable device name from User-Agent string.
+/// Returns format like "Chrome on macOS", "Safari on iPhone", etc.
+pub fn parse_device_name(user_agent: &str) -> String {
+    let browser = parse_browser(user_agent);
+    let os = parse_os(user_agent);
+    format!("{browser} on {os}")
+}
+
+/// Parse device type from User-Agent string.
+/// Returns "mobile", "tablet", or "desktop".
+pub fn parse_device_type(user_agent: &str) -> String {
+    let ua = user_agent.to_lowercase();
+    if ua.contains("tablet") || ua.contains("ipad") {
+        "tablet".to_string()
+    } else if ua.contains("mobile")
+        || ua.contains("iphone")
+        || (ua.contains("android") && !ua.contains("tablet"))
+    {
+        "mobile".to_string()
+    } else {
+        "desktop".to_string()
+    }
+}
+
+fn parse_browser(ua: &str) -> &str {
+    if ua.contains("Edg/") {
+        "Edge"
+    } else if ua.contains("Firefox/") {
+        "Firefox"
+    } else if ua.contains("Chromium/") {
+        "Chromium"
+    } else if ua.contains("Chrome/") {
+        "Chrome"
+    } else if ua.contains("Safari/") {
+        "Safari"
+    } else {
+        "Unknown"
+    }
+}
+
+fn parse_os(ua: &str) -> &str {
+    if ua.contains("iPhone") {
+        "iPhone"
+    } else if ua.contains("iPad") {
+        "iPad"
+    } else if ua.contains("HarmonyOS") {
+        "HarmonyOS"
+    } else if ua.contains("Android") {
+        "Android"
+    } else if ua.contains("CrOS") {
+        "ChromeOS"
+    } else if ua.contains("Mac OS X") || ua.contains("Macintosh") || ua.contains("OS X") {
+        "macOS"
+    } else if ua.contains("Windows") {
+        "Windows"
+    } else if ua.contains("FreeBSD") {
+        "FreeBSD"
+    } else if ua.contains("OpenBSD") {
+        "OpenBSD"
+    } else if ua.contains("Linux") {
+        "Linux"
+    } else {
+        "Unknown"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chrome_on_macos() {
+        let ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+        assert_eq!(parse_device_name(ua), "Chrome on macOS");
+        assert_eq!(parse_device_type(ua), "desktop");
+    }
+
+    #[test]
+    fn safari_on_iphone() {
+        let ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+        assert_eq!(parse_device_name(ua), "Safari on iPhone");
+        assert_eq!(parse_device_type(ua), "mobile");
+    }
+
+    #[test]
+    fn firefox_on_windows() {
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0";
+        assert_eq!(parse_device_name(ua), "Firefox on Windows");
+        assert_eq!(parse_device_type(ua), "desktop");
+    }
+
+    #[test]
+    fn edge_on_windows() {
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0";
+        assert_eq!(parse_device_name(ua), "Edge on Windows");
+        assert_eq!(parse_device_type(ua), "desktop");
+    }
+
+    #[test]
+    fn chrome_on_android_mobile() {
+        let ua = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36";
+        assert_eq!(parse_device_name(ua), "Chrome on Android");
+        assert_eq!(parse_device_type(ua), "mobile");
+    }
+
+    #[test]
+    fn safari_on_ipad() {
+        let ua = "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+        assert_eq!(parse_device_name(ua), "Safari on iPad");
+        assert_eq!(parse_device_type(ua), "tablet");
+    }
+
+    #[test]
+    fn chrome_on_linux() {
+        let ua = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+        assert_eq!(parse_device_name(ua), "Chrome on Linux");
+        assert_eq!(parse_device_type(ua), "desktop");
+    }
+
+    #[test]
+    fn unknown_ua() {
+        assert_eq!(parse_device_name("curl/7.88.1"), "Unknown on Unknown");
+        assert_eq!(parse_device_type("curl/7.88.1"), "desktop");
+    }
+
+    #[test]
+    fn empty_ua() {
+        assert_eq!(parse_device_name(""), "Unknown on Unknown");
+        assert_eq!(parse_device_type(""), "desktop");
+    }
+}

--- a/modo-session/src/device.rs
+++ b/modo-session/src/device.rs
@@ -1,0 +1,1 @@
+// Device name and type parsing from User-Agent

--- a/modo-session/src/entity.rs
+++ b/modo-session/src/entity.rs
@@ -1,1 +1,22 @@
-// Session entity (framework, auto-discovered)
+#[modo_db::entity(table = "modo_sessions")]
+#[entity(framework)]
+#[entity(index(columns = ["token_hash"], unique))]
+#[entity(index(columns = ["user_id"]))]
+#[entity(index(columns = ["expires_at"]))]
+pub struct Session {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub token_hash: String,
+    pub user_id: String,
+    pub ip_address: String,
+    #[entity(column_type = "Text")]
+    pub user_agent: String,
+    pub device_name: String,
+    pub device_type: String,
+    pub fingerprint: String,
+    #[entity(column_type = "Text")]
+    pub data: String,
+    pub created_at: modo_db::chrono::DateTime<modo_db::chrono::Utc>,
+    pub last_active_at: modo_db::chrono::DateTime<modo_db::chrono::Utc>,
+    pub expires_at: modo_db::chrono::DateTime<modo_db::chrono::Utc>,
+}

--- a/modo-session/src/entity.rs
+++ b/modo-session/src/entity.rs
@@ -1,0 +1,1 @@
+// Session entity (framework, auto-discovered)

--- a/modo-session/src/fingerprint.rs
+++ b/modo-session/src/fingerprint.rs
@@ -1,0 +1,1 @@
+// Fingerprint computation (SHA256)

--- a/modo-session/src/fingerprint.rs
+++ b/modo-session/src/fingerprint.rs
@@ -1,1 +1,56 @@
-// Fingerprint computation (SHA256)
+use sha2::{Digest, Sha256};
+use std::fmt::Write;
+
+/// Compute a server-side fingerprint from stable request attributes.
+/// Uses `\x00` separators to prevent ambiguity between inputs.
+pub fn compute_fingerprint(
+    user_agent: &str,
+    accept_language: &str,
+    accept_encoding: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(user_agent.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(accept_language.as_bytes());
+    hasher.update(b"\x00");
+    hasher.update(accept_encoding.as_bytes());
+    let digest = hasher.finalize();
+    let mut s = String::with_capacity(64);
+    for b in digest {
+        write!(s, "{b:02x}").expect("writing to String cannot fail");
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_sha256_hex() {
+        let fp = compute_fingerprint("test", "en", "gzip");
+        assert_eq!(fp.len(), 64);
+        assert!(fp.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn fingerprint_deterministic() {
+        let a = compute_fingerprint("Mozilla/5.0", "en-US", "gzip");
+        let b = compute_fingerprint("Mozilla/5.0", "en-US", "gzip");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn fingerprint_varies_on_input_change() {
+        let a = compute_fingerprint("Mozilla/5.0", "en-US", "gzip");
+        let b = compute_fingerprint("Mozilla/5.0", "fr-FR", "gzip");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn fingerprint_separator_prevents_collision() {
+        let a = compute_fingerprint("ab", "cd", "ef");
+        let b = compute_fingerprint("abc", "de", "f");
+        assert_ne!(a, b);
+    }
+}

--- a/modo-session/src/lib.rs
+++ b/modo-session/src/lib.rs
@@ -7,3 +7,21 @@ pub mod meta;
 pub mod middleware;
 pub mod store;
 pub mod types;
+
+#[cfg(feature = "cleanup-job")]
+pub mod cleanup;
+
+// Public API
+pub use config::SessionConfig;
+pub use manager::SessionManager;
+pub use meta::SessionMeta;
+pub use middleware::layer;
+pub use store::SessionStore;
+pub use types::{SessionData, SessionId, SessionToken};
+
+// Re-exports for macro-generated code
+pub use chrono;
+pub use modo;
+pub use modo_db;
+pub use serde;
+pub use serde_json;

--- a/modo-session/src/lib.rs
+++ b/modo-session/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod config;
+pub mod device;
+pub mod entity;
+pub mod fingerprint;
+pub mod manager;
+pub mod meta;
+pub mod middleware;
+pub mod store;
+pub mod types;

--- a/modo-session/src/manager.rs
+++ b/modo-session/src/manager.rs
@@ -3,6 +3,7 @@ use crate::types::{SessionData, SessionId};
 use modo::Error;
 use modo::axum::extract::FromRequestParts;
 use modo::axum::http::request::Parts;
+use modo::error::HttpError;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::sync::Arc;
@@ -117,12 +118,10 @@ impl SessionManager {
             .store
             .read(id)
             .await?
-            .ok_or_else(|| Error::internal("session not found"))?;
+            .ok_or_else(|| HttpError::NotFound.with_message("session not found"))?;
 
         if target.user_id != session.user_id {
-            return Err(Error::internal(
-                "cannot revoke session belonging to another user",
-            ));
+            return Err(HttpError::NotFound.with_message("session not found"));
         }
 
         self.state.store.destroy(id).await

--- a/modo-session/src/manager.rs
+++ b/modo-session/src/manager.rs
@@ -1,9 +1,8 @@
 use crate::middleware::{SessionAction, SessionManagerState};
 use crate::types::{SessionData, SessionId};
-use modo::Error;
 use modo::axum::extract::FromRequestParts;
 use modo::axum::http::request::Parts;
-use modo::error::HttpError;
+use modo::{Error, HttpError};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::sync::Arc;
@@ -98,7 +97,7 @@ impl SessionManager {
         let current = self.state.current_session.lock().await;
         let session = current
             .as_ref()
-            .ok_or_else(|| Error::internal("no active session"))?;
+            .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
         self.state
             .store
             .destroy_all_except(&session.user_id, &session.id)
@@ -111,17 +110,17 @@ impl SessionManager {
         let current = self.state.current_session.lock().await;
         let session = current
             .as_ref()
-            .ok_or_else(|| Error::internal("no active session"))?;
+            .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
 
         let target = self
             .state
             .store
             .read(id)
             .await?
-            .ok_or_else(|| HttpError::NotFound.with_message("session not found"))?;
+            .ok_or_else(|| Error::from(HttpError::NotFound))?;
 
         if target.user_id != session.user_id {
-            return Err(HttpError::NotFound.with_message("session not found"));
+            return Err(Error::from(HttpError::NotFound));
         }
 
         self.state.store.destroy(id).await
@@ -133,7 +132,7 @@ impl SessionManager {
             let current = self.state.current_session.lock().await;
             let session = current
                 .as_ref()
-                .ok_or_else(|| Error::internal("no active session"))?;
+                .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
             session.id.clone()
         };
 
@@ -176,7 +175,7 @@ impl SessionManager {
             let current = self.state.current_session.lock().await;
             let session = current
                 .as_ref()
-                .ok_or_else(|| Error::internal("no active session"))?;
+                .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
             session.user_id.clone()
         };
         self.state.store.list_for_user(&user_id).await
@@ -206,7 +205,7 @@ impl SessionManager {
         let mut current = self.state.current_session.lock().await;
         let session = current
             .as_mut()
-            .ok_or_else(|| Error::internal("no active session"))?;
+            .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
 
         if !session.data.is_object() {
             session.data = serde_json::Value::Object(Default::default());
@@ -229,7 +228,7 @@ impl SessionManager {
         let mut current = self.state.current_session.lock().await;
         let session = current
             .as_mut()
-            .ok_or_else(|| Error::internal("no active session"))?;
+            .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
 
         if let serde_json::Value::Object(ref mut map) = session.data {
             map.remove(key);

--- a/modo-session/src/manager.rs
+++ b/modo-session/src/manager.rs
@@ -14,10 +14,7 @@ pub struct SessionManager {
 impl<S: Send + Sync> FromRequestParts<S> for SessionManager {
     type Rejection = Error;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        _state: &S,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let state = parts
             .extensions
             .get::<Arc<SessionManagerState>>()
@@ -123,7 +120,9 @@ impl SessionManager {
             .ok_or_else(|| Error::internal("session not found"))?;
 
         if target.user_id != session.user_id {
-            return Err(Error::internal("cannot revoke session belonging to another user"));
+            return Err(Error::internal(
+                "cannot revoke session belonging to another user",
+            ));
         }
 
         self.state.store.destroy(id).await

--- a/modo-session/src/manager.rs
+++ b/modo-session/src/manager.rs
@@ -1,0 +1,1 @@
+// SessionManager extractor

--- a/modo-session/src/manager.rs
+++ b/modo-session/src/manager.rs
@@ -1,1 +1,244 @@
-// SessionManager extractor
+use crate::middleware::{SessionAction, SessionManagerState};
+use crate::types::{SessionData, SessionId};
+use modo::Error;
+use modo::axum::extract::FromRequestParts;
+use modo::axum::http::request::Parts;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use std::sync::Arc;
+
+pub struct SessionManager {
+    state: Arc<SessionManagerState>,
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for SessionManager {
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let state = parts
+            .extensions
+            .get::<Arc<SessionManagerState>>()
+            .cloned()
+            .ok_or_else(|| Error::internal("SessionManager requires session middleware"))?;
+
+        Ok(Self { state })
+    }
+}
+
+impl SessionManager {
+    /// Create a session for the given user.
+    /// Destroys any existing session first (fixation prevention).
+    pub async fn authenticate(&self, user_id: &str) -> Result<(), Error> {
+        self.authenticate_with(user_id, serde_json::json!({})).await
+    }
+
+    /// Create a session with custom data attached.
+    pub async fn authenticate_with(
+        &self,
+        user_id: &str,
+        data: serde_json::Value,
+    ) -> Result<(), Error> {
+        // Destroy current session (fixation prevention)
+        {
+            let current = self.state.current_session.lock().await;
+            if let Some(ref session) = *current {
+                self.state.store.destroy(&session.id).await.map_err(|e| {
+                    tracing::error!(
+                        session_id = session.id.as_str(),
+                        "Failed to destroy previous session during authentication: {e}"
+                    );
+                    Error::internal(format!("failed to invalidate previous session: {e}"))
+                })?;
+            }
+        }
+
+        let (session_data, token) = self
+            .state
+            .store
+            .create(&self.state.meta, user_id, Some(data))
+            .await?;
+
+        *self.state.current_session.lock().await = Some(session_data);
+        *self.state.action.lock().await = SessionAction::Set(token);
+        Ok(())
+    }
+
+    /// Destroy the current session. Cookie is removed automatically.
+    pub async fn logout(&self) -> Result<(), Error> {
+        {
+            let current = self.state.current_session.lock().await;
+            if let Some(ref session) = *current {
+                self.state.store.destroy(&session.id).await?;
+            }
+        }
+        *self.state.action.lock().await = SessionAction::Remove;
+        *self.state.current_session.lock().await = None;
+        Ok(())
+    }
+
+    /// Destroy ALL sessions for the current user.
+    pub async fn logout_all(&self) -> Result<(), Error> {
+        {
+            let current = self.state.current_session.lock().await;
+            if let Some(ref session) = *current {
+                self.state
+                    .store
+                    .destroy_all_for_user(&session.user_id)
+                    .await?;
+            }
+        }
+        *self.state.action.lock().await = SessionAction::Remove;
+        *self.state.current_session.lock().await = None;
+        Ok(())
+    }
+
+    /// Destroy all sessions for the current user except the current one.
+    pub async fn logout_other(&self) -> Result<(), Error> {
+        let current = self.state.current_session.lock().await;
+        let session = current
+            .as_ref()
+            .ok_or_else(|| Error::internal("no active session"))?;
+        self.state
+            .store
+            .destroy_all_except(&session.user_id, &session.id)
+            .await
+    }
+
+    /// Destroy a specific session by ID (for "manage my devices" UI).
+    /// Only works on sessions owned by the current user.
+    pub async fn revoke(&self, id: &SessionId) -> Result<(), Error> {
+        let current = self.state.current_session.lock().await;
+        let session = current
+            .as_ref()
+            .ok_or_else(|| Error::internal("no active session"))?;
+
+        let target = self
+            .state
+            .store
+            .read(id)
+            .await?
+            .ok_or_else(|| Error::internal("session not found"))?;
+
+        if target.user_id != session.user_id {
+            return Err(Error::internal("cannot revoke session belonging to another user"));
+        }
+
+        self.state.store.destroy(id).await
+    }
+
+    /// Regenerate the session token without changing the session ID.
+    pub async fn rotate(&self) -> Result<(), Error> {
+        let session_id = {
+            let current = self.state.current_session.lock().await;
+            let session = current
+                .as_ref()
+                .ok_or_else(|| Error::internal("no active session"))?;
+            session.id.clone()
+        };
+
+        let new_token = self.state.store.rotate_token(&session_id).await?;
+
+        {
+            let mut current = self.state.current_session.lock().await;
+            if let Some(ref mut s) = *current {
+                s.token_hash = new_token.hash();
+            }
+        }
+
+        *self.state.action.lock().await = SessionAction::Set(new_token);
+        Ok(())
+    }
+
+    /// Access the current session data (if authenticated).
+    pub async fn current(&self) -> Option<SessionData> {
+        self.state.current_session.lock().await.clone()
+    }
+
+    /// Get the current user ID.
+    pub async fn user_id(&self) -> Option<String> {
+        self.state
+            .current_session
+            .lock()
+            .await
+            .as_ref()
+            .map(|s| s.user_id.clone())
+    }
+
+    /// Check if a session is active.
+    pub async fn is_authenticated(&self) -> bool {
+        self.state.current_session.lock().await.is_some()
+    }
+
+    /// List all active sessions for the authenticated user.
+    pub async fn list_my_sessions(&self) -> Result<Vec<SessionData>, Error> {
+        let user_id = {
+            let current = self.state.current_session.lock().await;
+            let session = current
+                .as_ref()
+                .ok_or_else(|| Error::internal("no active session"))?;
+            session.user_id.clone()
+        };
+        self.state.store.list_for_user(&user_id).await
+    }
+
+    /// Get a typed value from the session data by key.
+    pub async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>, Error> {
+        let current = self.state.current_session.lock().await;
+        let session = match current.as_ref() {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        match session.data.get(key) {
+            Some(v) => match serde_json::from_value(v.clone()) {
+                Ok(val) => Ok(Some(val)),
+                Err(e) => {
+                    tracing::warn!(key, error = %e, "Failed to deserialize session data key");
+                    Ok(None)
+                }
+            },
+            None => Ok(None),
+        }
+    }
+
+    /// Set a single key in the session data (immediate DB write).
+    pub async fn set<T: Serialize>(&self, key: &str, value: &T) -> Result<(), Error> {
+        let mut current = self.state.current_session.lock().await;
+        let session = current
+            .as_mut()
+            .ok_or_else(|| Error::internal("no active session"))?;
+
+        if !session.data.is_object() {
+            session.data = serde_json::Value::Object(Default::default());
+        }
+        if let serde_json::Value::Object(ref mut map) = session.data {
+            map.insert(
+                key.to_string(),
+                serde_json::to_value(value)
+                    .map_err(|e| Error::internal(format!("serialize session value: {e}")))?,
+            );
+        }
+        self.state
+            .store
+            .update_data(&session.id, session.data.clone())
+            .await
+    }
+
+    /// Remove a key from the session data (immediate DB write).
+    pub async fn remove_key(&self, key: &str) -> Result<(), Error> {
+        let mut current = self.state.current_session.lock().await;
+        let session = current
+            .as_mut()
+            .ok_or_else(|| Error::internal("no active session"))?;
+
+        if let serde_json::Value::Object(ref mut map) = session.data {
+            map.remove(key);
+        }
+        self.state
+            .store
+            .update_data(&session.id, session.data.clone())
+            .await
+    }
+}

--- a/modo-session/src/meta.rs
+++ b/modo-session/src/meta.rs
@@ -1,0 +1,1 @@
+// SessionMeta — request metadata for session creation

--- a/modo-session/src/meta.rs
+++ b/modo-session/src/meta.rs
@@ -1,1 +1,162 @@
-// SessionMeta — request metadata for session creation
+use crate::device::{parse_device_name, parse_device_type};
+use crate::fingerprint::compute_fingerprint;
+use http::HeaderMap;
+use std::net::IpAddr;
+
+/// Request metadata used to create sessions.
+/// Built by the middleware from request headers.
+#[derive(Debug, Clone)]
+pub struct SessionMeta {
+    pub ip_address: String,
+    pub user_agent: String,
+    pub device_name: String,
+    pub device_type: String,
+    pub fingerprint: String,
+}
+
+impl SessionMeta {
+    pub fn from_headers(
+        ip_address: String,
+        user_agent: &str,
+        accept_language: &str,
+        accept_encoding: &str,
+    ) -> Self {
+        Self {
+            ip_address,
+            device_name: parse_device_name(user_agent),
+            device_type: parse_device_type(user_agent),
+            fingerprint: compute_fingerprint(user_agent, accept_language, accept_encoding),
+            user_agent: user_agent.to_string(),
+        }
+    }
+}
+
+pub fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+}
+
+/// Extract client IP with trusted proxy validation.
+///
+/// If `connect_ip` is from a trusted proxy (or no trusted proxies configured),
+/// trust X-Forwarded-For / X-Real-IP headers. Otherwise use the socket IP.
+pub fn extract_client_ip(
+    headers: &HeaderMap,
+    trusted_proxies: &[String],
+    connect_ip: Option<IpAddr>,
+) -> String {
+    let parsed_nets: Vec<ipnet::IpNet> = trusted_proxies
+        .iter()
+        .filter_map(|s| s.parse().ok())
+        .collect();
+
+    // If we have a direct connection IP and trusted_proxies is configured,
+    // only trust proxy headers when connection is from a trusted proxy.
+    if let Some(ip) = connect_ip
+        && !parsed_nets.is_empty()
+        && !parsed_nets.iter().any(|net| net.contains(&ip))
+    {
+        return ip.to_string();
+    }
+
+    // Connection from trusted proxy (or no ConnectInfo / no trusted_proxies configured)
+    if let Some(forwarded) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok())
+        && let Some(first) = forwarded.split(',').next()
+    {
+        let candidate = first.trim();
+        if candidate.parse::<IpAddr>().is_ok() {
+            return candidate.to_string();
+        }
+    }
+
+    if let Some(real_ip) = headers.get("x-real-ip").and_then(|v| v.to_str().ok()) {
+        let candidate = real_ip.trim();
+        if candidate.parse::<IpAddr>().is_ok() {
+            return candidate.to_string();
+        }
+    }
+
+    connect_ip
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_ip_from_xff() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4, 5.6.7.8".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers, &[], None), "1.2.3.4");
+    }
+
+    #[test]
+    fn extract_ip_from_x_real_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-real-ip", "9.8.7.6".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers, &[], None), "9.8.7.6");
+    }
+
+    #[test]
+    fn extract_ip_prefers_xff() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4".parse().unwrap());
+        headers.insert("x-real-ip", "9.8.7.6".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers, &[], None), "1.2.3.4");
+    }
+
+    #[test]
+    fn extract_ip_falls_back_to_unknown() {
+        let headers = HeaderMap::new();
+        assert_eq!(extract_client_ip(&headers, &[], None), "unknown");
+    }
+
+    #[test]
+    fn extract_ip_falls_back_to_connect_ip() {
+        let headers = HeaderMap::new();
+        let ip: IpAddr = "192.168.1.1".parse().unwrap();
+        assert_eq!(extract_client_ip(&headers, &[], Some(ip)), "192.168.1.1");
+    }
+
+    #[test]
+    fn untrusted_source_ignores_xff() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4".parse().unwrap());
+        let untrusted: IpAddr = "203.0.113.5".parse().unwrap();
+        let trusted = vec!["10.0.0.0/24".to_string()];
+        assert_eq!(
+            extract_client_ip(&headers, &trusted, Some(untrusted)),
+            "203.0.113.5"
+        );
+    }
+
+    #[test]
+    fn trusted_proxy_uses_xff() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "8.8.8.8".parse().unwrap());
+        let trusted_ip: IpAddr = "10.0.0.1".parse().unwrap();
+        let trusted = vec!["10.0.0.0/24".to_string()];
+        assert_eq!(
+            extract_client_ip(&headers, &trusted, Some(trusted_ip)),
+            "8.8.8.8"
+        );
+    }
+
+    #[test]
+    fn session_meta_from_headers() {
+        let meta = SessionMeta::from_headers(
+            "10.0.0.1".to_string(),
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0",
+            "en-US",
+            "gzip",
+        );
+        assert_eq!(meta.ip_address, "10.0.0.1");
+        assert_eq!(meta.device_name, "Chrome on macOS");
+        assert_eq!(meta.device_type, "desktop");
+        assert_eq!(meta.fingerprint.len(), 64);
+    }
+}

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -1,10 +1,10 @@
 use crate::meta::{SessionMeta, extract_client_ip, header_str};
 use crate::store::SessionStore;
 use crate::types::{SessionData, SessionToken};
-use modo::axum::extract::connect_info::ConnectInfo;
 use chrono::Utc;
 use futures_util::future::BoxFuture;
 use http::{Request, Response};
+use modo::axum::extract::connect_info::ConnectInfo;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -178,27 +178,18 @@ where
                     }
                 }
                 SessionAction::None => {
-                    if should_touch {
-                        if let Some(ref session) = current_session {
-                            let new_expires =
-                                Utc::now() + chrono::Duration::seconds(ttl_secs as i64);
-                            if let Err(e) = store.touch(&session.id, new_expires).await {
-                                tracing::error!(
-                                    session_id = session.id.as_str(),
-                                    "Failed to touch session: {e}"
-                                );
-                            } else if let Some(ref token) = session_token {
-                                let cookie_val = build_set_cookie(
-                                    cookie_name,
-                                    &token.as_hex(),
-                                    ttl_secs,
-                                    is_secure,
-                                );
-                                if let Ok(val) = cookie_val.parse() {
-                                    response
-                                        .headers_mut()
-                                        .append(http::header::SET_COOKIE, val);
-                                }
+                    if should_touch && let Some(ref session) = current_session {
+                        let new_expires = Utc::now() + chrono::Duration::seconds(ttl_secs as i64);
+                        if let Err(e) = store.touch(&session.id, new_expires).await {
+                            tracing::error!(
+                                session_id = session.id.as_str(),
+                                "Failed to touch session: {e}"
+                            );
+                        } else if let Some(ref token) = session_token {
+                            let cookie_val =
+                                build_set_cookie(cookie_name, &token.as_hex(), ttl_secs, is_secure);
+                            if let Ok(val) = cookie_val.parse() {
+                                response.headers_mut().append(http::header::SET_COOKIE, val);
                             }
                         }
                     }
@@ -221,23 +212,25 @@ where
 // --- Cookie helpers ---
 
 fn read_session_cookie(headers: &http::HeaderMap, cookie_name: &str) -> Option<SessionToken> {
-    headers.get_all(http::header::COOKIE).iter().find_map(|val| {
-        let val = val.to_str().ok()?;
-        for pair in val.split(';') {
-            let pair = pair.trim();
-            if let Some(value) = pair.strip_prefix(cookie_name) {
-                let value = value.strip_prefix('=')?;
-                return SessionToken::from_hex(value).ok();
+    headers
+        .get_all(http::header::COOKIE)
+        .iter()
+        .find_map(|val| {
+            let val = val.to_str().ok()?;
+            for pair in val.split(';') {
+                let pair = pair.trim();
+                if let Some(value) = pair.strip_prefix(cookie_name) {
+                    let value = value.strip_prefix('=')?;
+                    return SessionToken::from_hex(value).ok();
+                }
             }
-        }
-        None
-    })
+            None
+        })
 }
 
 fn build_set_cookie(name: &str, value: &str, max_age_secs: u64, secure: bool) -> String {
-    let mut cookie = format!(
-        "{name}={value}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age_secs}"
-    );
+    let mut cookie =
+        format!("{name}={value}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age_secs}");
     if secure {
         cookie.push_str("; Secure");
     }

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -1,1 +1,252 @@
-// Session middleware (Tower Layer/Service)
+use crate::config::SessionConfig;
+use crate::meta::{SessionMeta, extract_client_ip, header_str};
+use crate::store::SessionStore;
+use crate::types::{SessionData, SessionToken};
+use modo::axum::extract::connect_info::ConnectInfo;
+use chrono::Utc;
+use futures_util::future::BoxFuture;
+use http::{Request, Response};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::sync::Mutex;
+use tower::{Layer, Service};
+
+// --- Public types shared with SessionManager ---
+
+#[derive(Clone)]
+pub(crate) enum SessionAction {
+    None,
+    Set(SessionToken),
+    Remove,
+}
+
+pub(crate) struct SessionManagerState {
+    pub store: SessionStore,
+    pub config: SessionConfig,
+    pub current_session: Mutex<Option<SessionData>>,
+    pub meta: SessionMeta,
+    pub action: Mutex<SessionAction>,
+}
+
+// --- Layer ---
+
+#[derive(Clone)]
+pub struct SessionLayer {
+    store: Arc<SessionStore>,
+}
+
+impl SessionLayer {
+    fn new(store: SessionStore) -> Self {
+        Self {
+            store: Arc::new(store),
+        }
+    }
+}
+
+impl<S> Layer<S> for SessionLayer {
+    type Service = SessionMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SessionMiddleware {
+            inner,
+            store: self.store.clone(),
+        }
+    }
+}
+
+/// Create a session middleware layer from a `SessionStore`.
+pub fn layer(store: SessionStore) -> SessionLayer {
+    SessionLayer::new(store)
+}
+
+// --- Service ---
+
+#[derive(Clone)]
+pub struct SessionMiddleware<S> {
+    inner: S,
+    store: Arc<SessionStore>,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for SessionMiddleware<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: Request<ReqBody>) -> Self::Future {
+        let store = self.store.clone();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let config = store.config().clone();
+            let cookie_name = &config.cookie_name;
+
+            // Extract meta from request headers
+            let connect_ip = request
+                .extensions()
+                .get::<ConnectInfo<SocketAddr>>()
+                .map(|ci| ci.0.ip());
+            let headers = request.headers();
+            let ip = extract_client_ip(headers, &config.trusted_proxies, connect_ip);
+            let ua = header_str(headers, "user-agent");
+            let accept_lang = header_str(headers, "accept-language");
+            let accept_enc = header_str(headers, "accept-encoding");
+            let meta = SessionMeta::from_headers(ip, ua, accept_lang, accept_enc);
+
+            // Read session token from cookie
+            let session_token = read_session_cookie(headers, cookie_name);
+            let had_cookie = session_token.is_some();
+
+            // Load session from store
+            let (current_session, read_failed) = if let Some(ref token) = session_token {
+                match store.read_by_token(token).await {
+                    Ok(session) => (session, false),
+                    Err(e) => {
+                        tracing::error!("Failed to read session: {e}");
+                        (None, true)
+                    }
+                }
+            } else {
+                (None, false)
+            };
+
+            // Validate fingerprint
+            let current_session = if let Some(session) = current_session {
+                if config.validate_fingerprint && meta.fingerprint != session.fingerprint {
+                    tracing::warn!(
+                        session_id = session.id.as_str(),
+                        user_id = session.user_id,
+                        "Session fingerprint mismatch — possible hijack, destroying session"
+                    );
+                    let _ = store.destroy(&session.id).await;
+                    None
+                } else {
+                    Some(session)
+                }
+            } else {
+                None
+            };
+
+            // Check if we need to touch
+            let should_touch = current_session.as_ref().is_some_and(|s| {
+                let elapsed = Utc::now() - s.last_active_at;
+                elapsed >= chrono::Duration::seconds(config.touch_interval_secs as i64)
+            });
+
+            // Build shared state for SessionManager
+            let manager_state = Arc::new(SessionManagerState {
+                store: (*store).clone(),
+                config: config.clone(),
+                current_session: Mutex::new(current_session.clone()),
+                meta,
+                action: Mutex::new(SessionAction::None),
+            });
+
+            request.extensions_mut().insert(manager_state.clone());
+
+            // Run inner service
+            let mut response = inner.call(request).await?;
+
+            // Response path: apply session action
+            let action = {
+                let guard = manager_state.action.lock().await;
+                guard.clone()
+            };
+
+            let ttl_secs = config.session_ttl_secs;
+            let is_secure = cfg!(not(debug_assertions));
+
+            match action {
+                SessionAction::Set(token) => {
+                    let cookie_val =
+                        build_set_cookie(cookie_name, &token.as_hex(), ttl_secs, is_secure);
+                    if let Ok(val) = cookie_val.parse() {
+                        response.headers_mut().append(http::header::SET_COOKIE, val);
+                    }
+                }
+                SessionAction::Remove => {
+                    let cookie_val = build_remove_cookie(cookie_name);
+                    if let Ok(val) = cookie_val.parse() {
+                        response.headers_mut().append(http::header::SET_COOKIE, val);
+                    }
+                }
+                SessionAction::None => {
+                    if should_touch {
+                        if let Some(ref session) = current_session {
+                            let new_expires =
+                                Utc::now() + chrono::Duration::seconds(ttl_secs as i64);
+                            if let Err(e) = store.touch(&session.id, new_expires).await {
+                                tracing::error!(
+                                    session_id = session.id.as_str(),
+                                    "Failed to touch session: {e}"
+                                );
+                            } else if let Some(ref token) = session_token {
+                                let cookie_val = build_set_cookie(
+                                    cookie_name,
+                                    &token.as_hex(),
+                                    ttl_secs,
+                                    is_secure,
+                                );
+                                if let Ok(val) = cookie_val.parse() {
+                                    response
+                                        .headers_mut()
+                                        .append(http::header::SET_COOKIE, val);
+                                }
+                            }
+                        }
+                    }
+
+                    // Remove stale cookie (session not found, but cookie existed)
+                    if had_cookie && current_session.is_none() && !read_failed {
+                        let cookie_val = build_remove_cookie(cookie_name);
+                        if let Ok(val) = cookie_val.parse() {
+                            response.headers_mut().append(http::header::SET_COOKIE, val);
+                        }
+                    }
+                }
+            }
+
+            Ok(response)
+        })
+    }
+}
+
+// --- Cookie helpers ---
+
+fn read_session_cookie(headers: &http::HeaderMap, cookie_name: &str) -> Option<SessionToken> {
+    headers.get_all(http::header::COOKIE).iter().find_map(|val| {
+        let val = val.to_str().ok()?;
+        for pair in val.split(';') {
+            let pair = pair.trim();
+            if let Some(value) = pair.strip_prefix(cookie_name) {
+                let value = value.strip_prefix('=')?;
+                return SessionToken::from_hex(value).ok();
+            }
+        }
+        None
+    })
+}
+
+fn build_set_cookie(name: &str, value: &str, max_age_secs: u64, secure: bool) -> String {
+    let mut cookie = format!(
+        "{name}={value}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age_secs}"
+    );
+    if secure {
+        cookie.push_str("; Secure");
+    }
+    cookie
+}
+
+fn build_remove_cookie(name: &str) -> String {
+    format!("{name}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0")
+}

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -1,4 +1,3 @@
-use crate::config::SessionConfig;
 use crate::meta::{SessionMeta, extract_client_ip, header_str};
 use crate::store::SessionStore;
 use crate::types::{SessionData, SessionToken};
@@ -23,7 +22,6 @@ pub(crate) enum SessionAction {
 
 pub(crate) struct SessionManagerState {
     pub store: SessionStore,
-    pub config: SessionConfig,
     pub current_session: Mutex<Option<SessionData>>,
     pub meta: SessionMeta,
     pub action: Mutex<SessionAction>,
@@ -146,7 +144,6 @@ where
             // Build shared state for SessionManager
             let manager_state = Arc::new(SessionManagerState {
                 store: (*store).clone(),
-                config: config.clone(),
                 current_session: Mutex::new(current_session.clone()),
                 meta,
                 action: Mutex::new(SessionAction::None),

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -1,0 +1,1 @@
+// Session middleware (Tower Layer/Service)

--- a/modo-session/src/store.rs
+++ b/modo-session/src/store.rs
@@ -6,7 +6,8 @@ use chrono::{DateTime, Utc};
 use modo::Error;
 use modo_db::DbPool;
 use modo_db::sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, Set,
+    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set,
 };
 
 #[derive(Clone)]
@@ -191,8 +192,11 @@ impl SessionStore {
     }
 
     async fn enforce_session_limit(&self, user_id: &str) -> Result<(), Error> {
+        let now = Utc::now();
+
         let count = Entity::find()
             .filter(Column::UserId.eq(user_id))
+            .filter(Column::ExpiresAt.gt(now))
             .count(self.db.connection())
             .await
             .map_err(|e| Error::internal(format!("count sessions: {e}")))?;
@@ -203,19 +207,23 @@ impl SessionStore {
 
         let excess = count as usize - self.config.max_sessions_per_user;
 
-        // Find oldest sessions by last_active_at (FIFO eviction)
+        // Find least-recently-used sessions (LRU eviction)
         let oldest = Entity::find()
             .filter(Column::UserId.eq(user_id))
+            .filter(Column::ExpiresAt.gt(now))
             .order_by_asc(Column::LastActiveAt)
+            .limit(excess as u64)
             .all(self.db.connection())
             .await
             .map_err(|e| Error::internal(format!("find oldest sessions: {e}")))?;
 
-        for model in oldest.into_iter().take(excess) {
-            Entity::delete_by_id(&model.id)
+        let ids: Vec<String> = oldest.into_iter().map(|m| m.id).collect();
+        if !ids.is_empty() {
+            Entity::delete_many()
+                .filter(Column::Id.is_in(ids))
                 .exec(self.db.connection())
                 .await
-                .map_err(|e| Error::internal(format!("evict session: {e}")))?;
+                .map_err(|e| Error::internal(format!("evict sessions: {e}")))?;
         }
 
         Ok(())

--- a/modo-session/src/store.rs
+++ b/modo-session/src/store.rs
@@ -4,10 +4,10 @@ use crate::meta::SessionMeta;
 use crate::types::{SessionData, SessionId, SessionToken};
 use chrono::{DateTime, Utc};
 use modo::Error;
+use modo_db::DbPool;
 use modo_db::sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, Set,
 };
-use modo_db::DbPool;
 
 #[derive(Clone)]
 pub struct SessionStore {
@@ -36,8 +36,7 @@ impl SessionStore {
         let token = SessionToken::generate();
         let token_hash = token.hash();
         let now = Utc::now();
-        let expires_at =
-            now + chrono::Duration::seconds(self.config.session_ttl_secs as i64);
+        let expires_at = now + chrono::Duration::seconds(self.config.session_ttl_secs as i64);
         let data_json = data.unwrap_or(serde_json::json!({}));
 
         let model = ActiveModel {
@@ -78,10 +77,7 @@ impl SessionStore {
         }
     }
 
-    pub async fn read_by_token(
-        &self,
-        token: &SessionToken,
-    ) -> Result<Option<SessionData>, Error> {
+    pub async fn read_by_token(&self, token: &SessionToken) -> Result<Option<SessionData>, Error> {
         let hash = token.hash();
         let model = Entity::find()
             .filter(Column::TokenHash.eq(&hash))
@@ -122,11 +118,7 @@ impl SessionStore {
         Ok(new_token)
     }
 
-    pub async fn touch(
-        &self,
-        id: &SessionId,
-        new_expires_at: DateTime<Utc>,
-    ) -> Result<(), Error> {
+    pub async fn touch(&self, id: &SessionId, new_expires_at: DateTime<Utc>) -> Result<(), Error> {
         let model = ActiveModel {
             id: Set(id.as_str().to_string()),
             last_active_at: Set(Utc::now()),
@@ -142,11 +134,7 @@ impl SessionStore {
         Ok(())
     }
 
-    pub async fn update_data(
-        &self,
-        id: &SessionId,
-        data: serde_json::Value,
-    ) -> Result<(), Error> {
+    pub async fn update_data(&self, id: &SessionId, data: serde_json::Value) -> Result<(), Error> {
         let model = ActiveModel {
             id: Set(id.as_str().to_string()),
             data: Set(serde_json::to_string(&data)
@@ -171,11 +159,7 @@ impl SessionStore {
         Ok(())
     }
 
-    pub async fn destroy_all_except(
-        &self,
-        user_id: &str,
-        keep: &SessionId,
-    ) -> Result<(), Error> {
+    pub async fn destroy_all_except(&self, user_id: &str, keep: &SessionId) -> Result<(), Error> {
         Entity::delete_many()
             .filter(Column::UserId.eq(user_id))
             .filter(Column::Id.ne(keep.as_str()))

--- a/modo-session/src/store.rs
+++ b/modo-session/src/store.rs
@@ -1,0 +1,1 @@
+// SessionStore — concrete session persistence

--- a/modo-session/src/store.rs
+++ b/modo-session/src/store.rs
@@ -1,1 +1,259 @@
-// SessionStore — concrete session persistence
+use crate::config::SessionConfig;
+use crate::entity::session::{self, ActiveModel, Column, Entity};
+use crate::meta::SessionMeta;
+use crate::types::{SessionData, SessionId, SessionToken};
+use chrono::{DateTime, Utc};
+use modo::Error;
+use modo_db::sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, Set,
+};
+use modo_db::DbPool;
+
+#[derive(Clone)]
+pub struct SessionStore {
+    db: DbPool,
+    config: SessionConfig,
+}
+
+impl SessionStore {
+    pub fn new(db: &DbPool, config: SessionConfig) -> Self {
+        Self {
+            db: db.clone(),
+            config,
+        }
+    }
+
+    pub fn config(&self) -> &SessionConfig {
+        &self.config
+    }
+
+    pub async fn create(
+        &self,
+        meta: &SessionMeta,
+        user_id: &str,
+        data: Option<serde_json::Value>,
+    ) -> Result<(SessionData, SessionToken), Error> {
+        let token = SessionToken::generate();
+        let token_hash = token.hash();
+        let now = Utc::now();
+        let expires_at =
+            now + chrono::Duration::seconds(self.config.session_ttl_secs as i64);
+        let data_json = data.unwrap_or(serde_json::json!({}));
+
+        let model = ActiveModel {
+            id: Set(SessionId::new().to_string()),
+            token_hash: Set(token_hash),
+            user_id: Set(user_id.to_string()),
+            ip_address: Set(meta.ip_address.clone()),
+            user_agent: Set(meta.user_agent.clone()),
+            device_name: Set(meta.device_name.clone()),
+            device_type: Set(meta.device_type.clone()),
+            fingerprint: Set(meta.fingerprint.clone()),
+            data: Set(serde_json::to_string(&data_json)
+                .map_err(|e| Error::internal(format!("serialize session data: {e}")))?),
+            created_at: Set(now),
+            last_active_at: Set(now),
+            expires_at: Set(expires_at),
+        };
+
+        let result = model
+            .insert(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("insert session: {e}")))?;
+
+        self.enforce_session_limit(user_id).await?;
+
+        Ok((model_to_session_data(&result)?, token))
+    }
+
+    pub async fn read(&self, id: &SessionId) -> Result<Option<SessionData>, Error> {
+        let model = Entity::find_by_id(id.as_str())
+            .one(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("read session: {e}")))?;
+
+        match model {
+            Some(m) => Ok(Some(model_to_session_data(&m)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn read_by_token(
+        &self,
+        token: &SessionToken,
+    ) -> Result<Option<SessionData>, Error> {
+        let hash = token.hash();
+        let model = Entity::find()
+            .filter(Column::TokenHash.eq(&hash))
+            .filter(Column::ExpiresAt.gt(Utc::now()))
+            .one(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("read session by token: {e}")))?;
+
+        match model {
+            Some(m) => Ok(Some(model_to_session_data(&m)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn destroy(&self, id: &SessionId) -> Result<(), Error> {
+        Entity::delete_by_id(id.as_str())
+            .exec(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("destroy session: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn rotate_token(&self, id: &SessionId) -> Result<SessionToken, Error> {
+        let new_token = SessionToken::generate();
+        let new_hash = new_token.hash();
+
+        let model = ActiveModel {
+            id: Set(id.as_str().to_string()),
+            token_hash: Set(new_hash),
+            ..Default::default()
+        };
+
+        model
+            .update(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("rotate token: {e}")))?;
+
+        Ok(new_token)
+    }
+
+    pub async fn touch(
+        &self,
+        id: &SessionId,
+        new_expires_at: DateTime<Utc>,
+    ) -> Result<(), Error> {
+        let model = ActiveModel {
+            id: Set(id.as_str().to_string()),
+            last_active_at: Set(Utc::now()),
+            expires_at: Set(new_expires_at),
+            ..Default::default()
+        };
+
+        model
+            .update(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("touch session: {e}")))?;
+
+        Ok(())
+    }
+
+    pub async fn update_data(
+        &self,
+        id: &SessionId,
+        data: serde_json::Value,
+    ) -> Result<(), Error> {
+        let model = ActiveModel {
+            id: Set(id.as_str().to_string()),
+            data: Set(serde_json::to_string(&data)
+                .map_err(|e| Error::internal(format!("serialize session data: {e}")))?),
+            ..Default::default()
+        };
+
+        model
+            .update(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("update session data: {e}")))?;
+
+        Ok(())
+    }
+
+    pub async fn destroy_all_for_user(&self, user_id: &str) -> Result<(), Error> {
+        Entity::delete_many()
+            .filter(Column::UserId.eq(user_id))
+            .exec(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("destroy all sessions for user: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn destroy_all_except(
+        &self,
+        user_id: &str,
+        keep: &SessionId,
+    ) -> Result<(), Error> {
+        Entity::delete_many()
+            .filter(Column::UserId.eq(user_id))
+            .filter(Column::Id.ne(keep.as_str()))
+            .exec(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("destroy all except: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn list_for_user(&self, user_id: &str) -> Result<Vec<SessionData>, Error> {
+        let models = Entity::find()
+            .filter(Column::UserId.eq(user_id))
+            .filter(Column::ExpiresAt.gt(Utc::now()))
+            .order_by_desc(Column::LastActiveAt)
+            .all(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("list sessions: {e}")))?;
+
+        models.iter().map(model_to_session_data).collect()
+    }
+
+    pub async fn cleanup_expired(&self) -> Result<u64, Error> {
+        let result = Entity::delete_many()
+            .filter(Column::ExpiresAt.lt(Utc::now()))
+            .exec(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("cleanup expired sessions: {e}")))?;
+        Ok(result.rows_affected)
+    }
+
+    async fn enforce_session_limit(&self, user_id: &str) -> Result<(), Error> {
+        let count = Entity::find()
+            .filter(Column::UserId.eq(user_id))
+            .count(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("count sessions: {e}")))?;
+
+        if count as usize <= self.config.max_sessions_per_user {
+            return Ok(());
+        }
+
+        let excess = count as usize - self.config.max_sessions_per_user;
+
+        // Find oldest sessions by last_active_at (FIFO eviction)
+        let oldest = Entity::find()
+            .filter(Column::UserId.eq(user_id))
+            .order_by_asc(Column::LastActiveAt)
+            .all(self.db.connection())
+            .await
+            .map_err(|e| Error::internal(format!("find oldest sessions: {e}")))?;
+
+        for model in oldest.into_iter().take(excess) {
+            Entity::delete_by_id(&model.id)
+                .exec(self.db.connection())
+                .await
+                .map_err(|e| Error::internal(format!("evict session: {e}")))?;
+        }
+
+        Ok(())
+    }
+}
+
+fn model_to_session_data(model: &session::Model) -> Result<SessionData, Error> {
+    let data: serde_json::Value = serde_json::from_str(&model.data)
+        .map_err(|e| Error::internal(format!("deserialize session data: {e}")))?;
+
+    Ok(SessionData {
+        id: SessionId::from_raw(&model.id),
+        token_hash: model.token_hash.clone(),
+        user_id: model.user_id.clone(),
+        ip_address: model.ip_address.clone(),
+        user_agent: model.user_agent.clone(),
+        device_name: model.device_name.clone(),
+        device_type: model.device_type.clone(),
+        fingerprint: model.fingerprint.clone(),
+        data,
+        created_at: model.created_at,
+        last_active_at: model.last_active_at,
+        expires_at: model.expires_at,
+    })
+}

--- a/modo-session/src/types.rs
+++ b/modo-session/src/types.rs
@@ -126,7 +126,7 @@ fn hex_digit(b: u8) -> Option<u8> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionData {
     pub id: SessionId,
-    pub token_hash: String,
+    pub(crate) token_hash: String,
     pub user_id: String,
     pub ip_address: String,
     pub user_agent: String,

--- a/modo-session/src/types.rs
+++ b/modo-session/src/types.rs
@@ -1,1 +1,238 @@
-// Core types: SessionId, SessionToken, SessionData
+use chrono::{DateTime, Utc};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::{self, Write};
+use std::str::FromStr;
+
+/// Opaque session identifier (ULID string).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SessionId(String);
+
+impl SessionId {
+    pub fn new() -> Self {
+        Self(ulid::Ulid::new().to_string())
+    }
+
+    pub fn from_raw(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for SessionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for SessionId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_string()))
+    }
+}
+
+/// Opaque session token (32 random bytes).
+///
+/// Stored in cookie; only the SHA256 hash is persisted to DB.
+/// Debug output is redacted to prevent accidental logging.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct SessionToken([u8; 32]);
+
+impl SessionToken {
+    pub fn generate() -> Self {
+        let mut bytes = [0u8; 32];
+        rand::rng().fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    pub fn from_hex(s: &str) -> Result<Self, &'static str> {
+        if s.len() != 64 {
+            return Err("token must be 64 hex characters");
+        }
+        let mut bytes = [0u8; 32];
+        for (i, chunk) in s.as_bytes().chunks(2).enumerate() {
+            let hi = hex_digit(chunk[0]).ok_or("invalid hex character")?;
+            let lo = hex_digit(chunk[1]).ok_or("invalid hex character")?;
+            bytes[i] = (hi << 4) | lo;
+        }
+        Ok(Self(bytes))
+    }
+
+    pub fn as_hex(&self) -> String {
+        let mut s = String::with_capacity(64);
+        for b in &self.0 {
+            write!(s, "{b:02x}").expect("writing to String cannot fail");
+        }
+        s
+    }
+
+    pub fn hash(&self) -> String {
+        let digest = Sha256::digest(self.0);
+        let mut s = String::with_capacity(64);
+        for b in digest {
+            write!(s, "{b:02x}").expect("writing to String cannot fail");
+        }
+        s
+    }
+}
+
+impl fmt::Debug for SessionToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SessionToken(****)")
+    }
+}
+
+impl fmt::Display for SessionToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("****")
+    }
+}
+
+impl Serialize for SessionToken {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.as_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionToken {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Full session record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionData {
+    pub id: SessionId,
+    pub token_hash: String,
+    pub user_id: String,
+    pub ip_address: String,
+    pub user_agent: String,
+    pub device_name: String,
+    pub device_type: String,
+    pub fingerprint: String,
+    pub data: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub last_active_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- SessionId tests ---
+
+    #[test]
+    fn session_id_generates_unique() {
+        let a = SessionId::new();
+        let b = SessionId::new();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn session_id_ulid_format() {
+        let id = SessionId::new();
+        assert_eq!(id.as_str().len(), 26);
+    }
+
+    #[test]
+    fn session_id_display_from_str_roundtrip() {
+        let id = SessionId::new();
+        let s = id.to_string();
+        let parsed: SessionId = s.parse().unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn session_id_from_raw() {
+        let id = SessionId::from_raw("test-id");
+        assert_eq!(id.as_str(), "test-id");
+    }
+
+    // --- SessionToken tests ---
+
+    #[test]
+    fn session_token_generates_64_hex() {
+        let token = SessionToken::generate();
+        let hex = token.as_hex();
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn session_token_unique() {
+        let a = SessionToken::generate();
+        let b = SessionToken::generate();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn session_token_from_hex_roundtrip() {
+        let token = SessionToken::generate();
+        let hex = token.as_hex();
+        let parsed = SessionToken::from_hex(&hex).unwrap();
+        assert_eq!(token, parsed);
+    }
+
+    #[test]
+    fn session_token_from_hex_rejects_wrong_length() {
+        assert!(SessionToken::from_hex("abcd").is_err());
+    }
+
+    #[test]
+    fn session_token_from_hex_rejects_non_hex() {
+        let bad = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+        assert!(SessionToken::from_hex(bad).is_err());
+    }
+
+    #[test]
+    fn session_token_hash_returns_64_hex() {
+        let token = SessionToken::generate();
+        let h = token.hash();
+        assert_eq!(h.len(), 64);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn session_token_hash_deterministic() {
+        let token = SessionToken::generate();
+        assert_eq!(token.hash(), token.hash());
+    }
+
+    #[test]
+    fn session_token_hash_differs_from_hex() {
+        let token = SessionToken::generate();
+        assert_ne!(token.hash(), token.as_hex());
+    }
+
+    #[test]
+    fn session_token_debug_is_redacted() {
+        let token = SessionToken::generate();
+        let dbg = format!("{token:?}");
+        assert_eq!(dbg, "SessionToken(****)");
+        assert!(!dbg.contains(&token.as_hex()));
+    }
+}

--- a/modo-session/src/types.rs
+++ b/modo-session/src/types.rs
@@ -1,0 +1,1 @@
+// Core types: SessionId, SessionToken, SessionData

--- a/modo-session/tests/integration.rs
+++ b/modo-session/tests/integration.rs
@@ -50,8 +50,6 @@ async fn create_and_read_by_token() {
 
     let (session, token) = store.create(&meta, "user1", None).await.unwrap();
     assert_eq!(session.user_id, "user1");
-    assert_eq!(session.token_hash, token.hash());
-
     let found = store.read_by_token(&token).await.unwrap();
     assert!(found.is_some());
     let found = found.unwrap();

--- a/modo-session/tests/integration.rs
+++ b/modo-session/tests/integration.rs
@@ -1,0 +1,177 @@
+use modo_db::sea_orm::{ConnectionTrait, Schema};
+use modo_db::{DatabaseConfig, DbPool};
+use modo_session::{SessionConfig, SessionMeta, SessionStore};
+
+async fn setup_db() -> DbPool {
+    let config = DatabaseConfig {
+        url: "sqlite::memory:".to_string(),
+        max_connections: 1,
+        min_connections: 1,
+    };
+    let db = modo_db::connect(&config).await.expect("Failed to connect");
+
+    let schema = Schema::new(db.connection().get_database_backend());
+    let mut builder = schema.builder();
+    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_sessions")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder
+        .sync(db.connection())
+        .await
+        .expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.connection()
+            .execute_unprepared(sql)
+            .await
+            .expect("Extra SQL failed");
+    }
+    db
+}
+
+fn test_meta() -> SessionMeta {
+    SessionMeta::from_headers(
+        "127.0.0.1".to_string(),
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0",
+        "en-US",
+        "gzip",
+    )
+}
+
+fn test_config() -> SessionConfig {
+    SessionConfig::default()
+}
+
+#[tokio::test]
+async fn create_and_read_by_token() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, test_config());
+    let meta = test_meta();
+
+    let (session, token) = store.create(&meta, "user1", None).await.unwrap();
+    assert_eq!(session.user_id, "user1");
+    assert_eq!(session.token_hash, token.hash());
+
+    let found = store.read_by_token(&token).await.unwrap();
+    assert!(found.is_some());
+    let found = found.unwrap();
+    assert_eq!(found.id, session.id);
+    assert_eq!(found.user_id, "user1");
+}
+
+#[tokio::test]
+async fn destroy_removes_session() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, test_config());
+    let meta = test_meta();
+
+    let (session, token) = store.create(&meta, "user1", None).await.unwrap();
+    store.destroy(&session.id).await.unwrap();
+
+    let found = store.read_by_token(&token).await.unwrap();
+    assert!(found.is_none());
+}
+
+#[tokio::test]
+async fn rotate_token_changes_hash() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, test_config());
+    let meta = test_meta();
+
+    let (session, old_token) = store.create(&meta, "user1", None).await.unwrap();
+    let new_token = store.rotate_token(&session.id).await.unwrap();
+
+    assert!(store.read_by_token(&old_token).await.unwrap().is_none());
+    let found = store.read_by_token(&new_token).await.unwrap();
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().id, session.id);
+}
+
+#[tokio::test]
+async fn max_sessions_evicts_oldest() {
+    let db = setup_db().await;
+    let mut config = test_config();
+    config.max_sessions_per_user = 2;
+    let store = SessionStore::new(&db, config);
+    let meta = test_meta();
+
+    let (s1, t1) = store.create(&meta, "user1", None).await.unwrap();
+    let (_s2, t2) = store.create(&meta, "user1", None).await.unwrap();
+    let (_s3, t3) = store.create(&meta, "user1", None).await.unwrap();
+
+    // First session should be evicted (FIFO)
+    assert!(store.read(&s1.id).await.unwrap().is_none());
+    assert!(store.read_by_token(&t1).await.unwrap().is_none());
+    // Second and third should survive
+    assert!(store.read_by_token(&t2).await.unwrap().is_some());
+    assert!(store.read_by_token(&t3).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn list_for_user_returns_all_active() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, test_config());
+    let meta = test_meta();
+
+    store.create(&meta, "user1", None).await.unwrap();
+    store.create(&meta, "user1", None).await.unwrap();
+    store.create(&meta, "user2", None).await.unwrap();
+
+    let user1_sessions = store.list_for_user("user1").await.unwrap();
+    assert_eq!(user1_sessions.len(), 2);
+
+    let user2_sessions = store.list_for_user("user2").await.unwrap();
+    assert_eq!(user2_sessions.len(), 1);
+}
+
+#[tokio::test]
+async fn destroy_all_except_keeps_one() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, test_config());
+    let meta = test_meta();
+
+    let (s1, _) = store.create(&meta, "user1", None).await.unwrap();
+    let (_s2, t2) = store.create(&meta, "user1", None).await.unwrap();
+    let (_s3, t3) = store.create(&meta, "user1", None).await.unwrap();
+
+    store.destroy_all_except("user1", &s1.id).await.unwrap();
+
+    assert!(store.read(&s1.id).await.unwrap().is_some());
+    assert!(store.read_by_token(&t2).await.unwrap().is_none());
+    assert!(store.read_by_token(&t3).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn update_data_roundtrip() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, test_config());
+    let meta = test_meta();
+
+    let (session, _) = store.create(&meta, "user1", None).await.unwrap();
+
+    let data = serde_json::json!({"theme": "dark", "lang": "en"});
+    store.update_data(&session.id, data.clone()).await.unwrap();
+
+    let found = store.read(&session.id).await.unwrap().unwrap();
+    assert_eq!(found.data, data);
+}
+
+#[tokio::test]
+async fn cleanup_expired_removes_old() {
+    let db = setup_db().await;
+    let mut config = test_config();
+    config.session_ttl_secs = 0;
+    let store = SessionStore::new(&db, config);
+    let meta = test_meta();
+
+    store.create(&meta, "user1", None).await.unwrap();
+    store.create(&meta, "user1", None).await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let count = store.cleanup_expired().await.unwrap();
+    assert_eq!(count, 2);
+
+    let sessions = store.list_for_user("user1").await.unwrap();
+    assert!(sessions.is_empty());
+}


### PR DESCRIPTION
## Summary

- Add `modo-session` crate with full session management: token hashing (SHA256), concrete `SessionStore`, Tower middleware, fingerprinting, device parsing, and FIFO session eviction
- SessionManager extractor with authenticate/logout/rotate/revoke/get/set API, plain HttpOnly cookies (no encryption), and configurable trusted proxy IP extraction
- Feature-gated cleanup cron job (`cleanup-job`), 44 tests (36 unit + 8 integration)

## Test Plan

- [x] `cargo test -p modo-session` — 44 tests pass (36 unit + 8 integration)
- [x] `cargo check -p modo-session --features cleanup-job` — compiles with cleanup feature
- [x] `just check` — full workspace fmt-check + clippy + tests pass