### PR TITLE
feat: add modo-templates with MiniJinja rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 
 - axum 0.8 (HTTP)
 - SeaORM v2 RC (database) — use v2 only, not v1.x
-- Askama (templates)
+- MiniJinja (templates)
 - inventory (auto-discovery, not linkme)
 - tokio (async runtime)
 
@@ -24,7 +24,8 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - `modo-upload-macros/` — upload proc macros
 - `modo-i18n/` — internationalization (YAML translations, locale middleware)
 - `modo-i18n-macros/` — `t!()` translation macro
-- `modo-templates/` — Askama + HTMX + flash (planned)
+- `modo-templates/` — MiniJinja template engine (views, render layer, context injection)
+- `modo-templates-macros/` — `#[view("path", htmx = "path")]` proc macro
 - `modo-csrf/` — CSRF protection (planned)
 
 ## Commands
@@ -50,7 +51,14 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - Modules: `#[modo::module(prefix = "/path", middleware = [...])]`
 - CSRF: `#[middleware(modo::middleware::csrf_protection)]` — uses double-submit cookie
 - Flash messages: `Flash` (write) / `FlashMessages` (read) — cookie-based, one-shot
-- Template context: `BaseContext` extractor — auto-gathers HTMX, flash, CSRF, locale
+- Templates config: `TemplateConfig { path, strict }` — YAML-deserializable with serde defaults
+- Template engine: `modo_templates::engine(&config)?` — config to engine (follows `modo_i18n::load` pattern)
+- Views: `#[modo::view("pages/home.html")]` or `#[modo::view("page.html", htmx = "htmx/frag.html")]`
+- View structs: fields must implement `Serialize`, handler returns struct directly
+- Template context: `TemplateContext` in request extensions, middleware adds via `ctx.insert("key", value)`
+- Template layers: auto-registered when `TemplateEngine` is a service — no manual `.layer()` needed
+- HTMX views: htmx template rendered on HX-Request, always HTTP 200, non-200 skips render
+- i18n in templates: `{{ t("key", name=val) }}` — register via `modo_i18n::register_template_functions`
 - Middleware: plain async functions, attached via `#[middleware(fn_name(params))]`
 - Middleware stacking order: Global (outermost) → Module → Handler (innermost)
 - Services: manually constructed, registered via `.service(instance)`
@@ -58,8 +66,6 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - SessionManager extractor: `authenticate()` / `logout()` / `logout_all()` / `logout_other()` / `revoke(id)` / `rotate()` — handles cookies automatically
 - SessionManager data: `get::<T>(key)` / `set(key, value)` / `remove_key(key)` — immediate store writes
 - Auth: implement `UserProvider` trait, use `Auth<User>` / `OptionalAuth<User>` extractors
-- Template context: `#[modo::context]` with `#[base]` + `#[user]` + `#[session]` fields
-- BaseContext: includes request_id, is_htmx, current_url, flash_messages, csrf_token, locale
 - Jobs: `#[modo_jobs::job(queue = "...", priority = N, max_attempts = N, timeout = "5m")]`
 - Cron jobs: `#[modo_jobs::job(cron = "0 0 * * * *", timeout = "5m")]` — in-memory only
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "examples/*"]
+members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "modo-templates-macros", "examples/*"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "modo-templates-macros", "examples/*"]
+members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "modo-templates", "modo-templates-macros", "examples/*"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # modo
 
-> **modo** (Latin: "way, method") — _the way_ to build micro-SaaS with Rust.
+> **modo** (Latin: "way, method") — _the way_ to build web apps with Rust.
 > Single binary, compile-time magic, multi-DB support.
 
 [![CI](https://github.com/dmitrymomot/modo/actions/workflows/ci.yml/badge.svg)](https://github.com/dmitrymomot/modo/actions/workflows/ci.yml)

--- a/docs/plans/2026-03-08-modo-templates-design.md
+++ b/docs/plans/2026-03-08-modo-templates-design.md
@@ -69,8 +69,9 @@ Default: `path = "templates"`, `strict = true`.
 Wraps `minijinja::Environment`. Arc-wrapped, registered as a service.
 
 ```rust
-let engine = modo_templates::engine(&config)
-    .build()?;
+let mut engine = modo_templates::engine(&config)?;
+// optionally register custom functions
+modo_i18n::register_template_functions(engine.env_mut(), &i18n_store);
 ```
 
 - Dev (`reload` feature): `minijinja-autoreload`, watches filesystem
@@ -223,11 +224,10 @@ Layouts use Jinja2 native `{% extends %}` / `{% block %}`. HTMX templates are fl
 ```rust
 #[modo::main]
 async fn main(app: Application) {
-    let mut engine = modo_templates::engine(&config.templates)
-        .build()?;
+    let mut engine = modo_templates::engine(&config.templates)?;
 
     // i18n registers t() function on the engine
-    modo_i18n::register_template_functions(&mut engine, &i18n_store);
+    modo_i18n::register_template_functions(engine.env_mut(), &i18n_store);
 
     // Just register as service — layers are auto-applied by the framework
     app.service(i18n_store)

--- a/docs/plans/2026-03-08-modo-templates-design.md
+++ b/docs/plans/2026-03-08-modo-templates-design.md
@@ -1,0 +1,279 @@
+# modo-templates Design
+
+Template engine for modo. Wraps MiniJinja, provides view structs with auto-rendered request context, HTMX partial support, and i18n integration.
+
+## Decision: MiniJinja over Askama
+
+MiniJinja chosen for:
+- Global functions with keyword args: `{{ t("key", name=val) }}` — native i18n support
+- Runtime context injection — request data (csrf, locale, flash) merged at render time without struct fields
+- Hot reload in dev via `minijinja-autoreload`
+- Single binary in release via `minijinja-embed`
+- Full Jinja2 compatibility (author is the creator of Jinja2)
+
+Tradeoff: no compile-time template checking. Mitigated by `UndefinedBehavior::Strict` in dev + integration tests.
+
+## Crates
+
+- `modo-templates` — runtime: engine, context, render layer, `View` type
+- `modo-templates-macros` — proc macro: `#[view("path", htmx = "path")]`
+
+## Architecture
+
+### View struct (user-facing)
+
+```rust
+#[modo::view("pages/order/show.html")]
+pub struct Show {
+    pub order: Order,
+}
+
+#[modo::view("pages/auth/login.html", htmx = "htmx/auth/login_form.html")]
+pub struct Login {
+    pub form_errors: Vec<String>,
+}
+```
+
+The `#[modo::view]` macro generates:
+1. `#[derive(Serialize)]` on the struct
+2. `impl IntoResponse` — wraps struct as `View` in response extensions
+3. Associates template path(s) with the struct
+
+Handler returns the struct directly:
+
+```rust
+#[modo::handler(GET, "/orders/{id}")]
+async fn show(db: Db, id: String) -> Result<views::orders::Show, Error> {
+    let order = db.find_order(&id).await?;
+    Ok(views::orders::Show { order })
+}
+```
+
+### TemplateEngine
+
+Wraps `minijinja::Environment`. Arc-wrapped, registered as a service.
+
+```rust
+let engine = modo_templates::engine()
+    .directory("templates")
+    .build()?;
+```
+
+- Dev (`reload` feature): `minijinja-autoreload`, watches filesystem
+- Release (`embed` feature): `minijinja-embed`, templates compiled into binary
+
+Global functions (i18n, helpers) registered on the engine at startup.
+
+### TemplateContext
+
+A `BTreeMap<String, minijinja::Value>` stored in request extensions. Each middleware adds its values:
+
+```
+context_layer()    → request_id, current_url
+modo-i18n layer    → locale
+modo-csrf layer    → csrf_token
+modo-flash layer   → flash_messages
+```
+
+Any middleware can add values via:
+
+```rust
+if let Some(ctx) = req.extensions_mut().get_mut::<TemplateContext>() {
+    ctx.insert("csrf_token", token);
+}
+```
+
+### Render layer
+
+Framework middleware that runs after the handler:
+
+1. Checks if response has a `View` in extensions
+2. If not, passes through (non-view responses like JSON, redirects)
+3. Gets `TemplateEngine` from state
+4. Gets `TemplateContext` from request extensions
+5. Merges request context + view user context
+6. Picks template based on HTMX detection (see below)
+7. Renders template, returns `text/html` response
+
+### context_layer()
+
+Outermost middleware. Creates `TemplateContext` with built-in values:
+
+| Key | Source |
+|-----|--------|
+| `request_id` | Request extensions or generated |
+| `current_url` | Request URI |
+
+Must be applied outermost of all context-writing middleware.
+
+## HTMX behavior
+
+When a view has `htmx = "..."`:
+
+| Request type | Status | Behavior |
+|---|---|---|
+| Normal request | Any | Render full template, normal status |
+| HTMX request | 200 | Render htmx template, 200 |
+| HTMX request | Non-200 | Don't render template, pass through error |
+
+HTMX detection: `HX-Request` header present.
+
+HTMX responses are always HTTP 200. Non-200 status on HTMX requests skips rendering entirely (HTMX doesn't process non-200 responses).
+
+Three view configurations:
+- `#[modo::view("page.html", htmx = "htmx/frag.html")]` — auto-detect, pick per request type
+- `#[modo::view("page.html")]` — always full page
+- `#[modo::view("htmx/frag.html")]` — always this template (for HTMX-only endpoints)
+
+## i18n integration
+
+`modo-i18n` registers `t()` as a global function on the engine:
+
+```rust
+pub fn register_template_functions(env: &mut Environment, store: Arc<TranslationStore>) {
+    let store = store.clone();
+    env.add_function("t", move |state: &State, key: String, kwargs: Kwargs| {
+        let locale = state.lookup("locale")
+            .and_then(|v| v.as_str())
+            .unwrap_or("en");
+        // extract kwargs as variable map, translate using store
+    });
+}
+```
+
+Template usage:
+
+```html
+{{ t("greeting") }}
+{{ t("order.summary", product=order.product, qty=order.qty) }}
+{{ t("items_count", count=items|length) }}
+```
+
+Locale comes from `TemplateContext` (set by i18n middleware). TranslationStore captured by closure at startup.
+
+## Extension pattern for other crates
+
+No extension traits needed. Crates just:
+1. Add values to `TemplateContext` in their middleware
+2. Optionally register global functions on `TemplateEngine`
+
+```rust
+// modo-csrf middleware:
+if let Some(ctx) = req.extensions_mut().get_mut::<TemplateContext>() {
+    ctx.insert("csrf_token", token);
+}
+// Template: {{ csrf_token }}
+```
+
+## Template conventions
+
+```
+templates/
+  layouts/
+    base.html         # outermost shell: html, head, body, scripts
+    app.html          # app layout: nav, sidebar, footer (extends base)
+    auth.html         # auth layout: centered card (extends app)
+  pages/
+    order/
+      show.html       # full page (extends layouts/app.html)
+      list.html
+    auth/
+      login.html      # full page (extends layouts/auth.html)
+  htmx/
+    order/
+      list_items.html # HTMX fragment (no extends)
+    auth/
+      login_form.html # HTMX fragment (no extends)
+```
+
+Layouts use Jinja2 native `{% extends %}` / `{% block %}`. HTMX templates are flat fragments without layout inheritance.
+
+## End-user setup
+
+```rust
+#[modo::main]
+async fn main(app: Application) {
+    let mut engine = modo_templates::engine()
+        .directory("templates")
+        .build()?;
+
+    // i18n registers t() function
+    modo_i18n::register_template_functions(&mut engine, &i18n_store);
+
+    app.service(engine)
+       .layer(modo_templates::render_layer())      // innermost — renders views
+       .layer(modo_csrf::layer())                  // adds csrf_token
+       .layer(modo_i18n::layer(&i18n_config))      // adds locale
+       .layer(modo_templates::context_layer())     // outermost — creates context
+}
+```
+
+## End-user handler
+
+```rust
+use crate::views;
+
+#[modo::handler(GET, "/orders/{id}")]
+async fn show(db: Db, id: String) -> Result<views::orders::Show, Error> {
+    let order = db.find_order(&id).await?;
+    Ok(views::orders::Show { order })
+}
+```
+
+## End-user view
+
+```rust
+// src/views/orders.rs
+use modo::prelude::*;
+
+#[modo::view("pages/order/show.html", htmx = "htmx/order/show.html")]
+pub struct Show {
+    pub order: Order,
+}
+
+#[modo::view("pages/order/list.html", htmx = "htmx/order/list_items.html")]
+pub struct List {
+    pub orders: Vec<Order>,
+}
+```
+
+## End-user template
+
+```html
+<!-- templates/pages/order/show.html -->
+{% extends "layouts/app.html" %}
+{% block content %}
+  <h1>{{ t("order.title", id=order.id) }}</h1>
+  <p>{{ t("order.summary", product=order.product, qty=order.qty, price=order.total) }}</p>
+  <form method="post" action="/orders/{{ order.id }}/cancel">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+    <button type="submit">{{ t("order.cancel") }}</button>
+  </form>
+{% endblock %}
+```
+
+```html
+<!-- templates/htmx/order/show.html -->
+<h1>{{ t("order.title", id=order.id) }}</h1>
+<p>{{ t("order.summary", product=order.product, qty=order.qty, price=order.total) }}</p>
+```
+
+## Dependencies
+
+### modo-templates
+- `minijinja` — template engine
+- `minijinja-embed` (feature: `embed`) — compile-time template embedding
+- `minijinja-autoreload` (feature: `reload`) — dev hot reload
+- `axum-core` — IntoResponse
+- `tower` / `tower-http` — middleware layers
+- `serde` — Serialize for view structs
+
+### modo-templates-macros
+- `syn`, `quote`, `proc-macro2` — proc macro tooling
+
+## Not in scope
+
+- CSRF protection — separate `modo-csrf` crate
+- Flash messages — separate crate, adds to TemplateContext
+- HTMX request/response helpers — separate concern
+- i18n runtime — `modo-i18n` crate, registers functions on engine

--- a/docs/plans/2026-03-08-modo-templates-design.md
+++ b/docs/plans/2026-03-08-modo-templates-design.md
@@ -49,13 +49,27 @@ async fn show(db: Db, id: String) -> Result<views::orders::Show, Error> {
 }
 ```
 
+### TemplateConfig
+
+YAML-deserializable config with serde defaults, following the same pattern as `DatabaseConfig`, `SessionConfig`, `I18nConfig`:
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct TemplateConfig {
+    pub path: String,       // "templates"
+    pub strict: bool,       // true — UndefinedBehavior::Strict
+}
+```
+
+Default: `path = "templates"`, `strict = true`.
+
 ### TemplateEngine
 
 Wraps `minijinja::Environment`. Arc-wrapped, registered as a service.
 
 ```rust
-let engine = modo_templates::engine()
-    .directory("templates")
+let engine = modo_templates::engine(&config)
     .build()?;
 ```
 
@@ -63,6 +77,22 @@ let engine = modo_templates::engine()
 - Release (`embed` feature): `minijinja-embed`, templates compiled into binary
 
 Global functions (i18n, helpers) registered on the engine at startup.
+
+### Auto-registration in app
+
+When `TemplateEngine` is registered as a service via `app.service(engine)`, the framework **automatically** inserts the context and render layers at the correct positions in the middleware stack. No manual `.layer()` calls needed.
+
+The framework guarantees correct ordering:
+
+```
+... framework layers > context_layer > user layers (csrf, i18n) > render_layer > handler
+```
+
+1. `context_layer` creates `TemplateContext` with `request_id` + `current_url`
+2. User middleware (i18n, csrf, flash) adds their values to `TemplateContext`
+3. `render_layer` intercepts `View` responses, merges context, renders via engine
+
+This is implemented in `app.rs` behind `#[cfg(feature = "templates")]` — same pattern planned for session, i18n, and auth auto-registration in the future.
 
 ### TemplateContext
 
@@ -193,19 +223,25 @@ Layouts use Jinja2 native `{% extends %}` / `{% block %}`. HTMX templates are fl
 ```rust
 #[modo::main]
 async fn main(app: Application) {
-    let mut engine = modo_templates::engine()
-        .directory("templates")
+    let mut engine = modo_templates::engine(&config.templates)
         .build()?;
 
-    // i18n registers t() function
+    // i18n registers t() function on the engine
     modo_i18n::register_template_functions(&mut engine, &i18n_store);
 
-    app.service(engine)
-       .layer(modo_templates::render_layer())      // innermost — renders views
-       .layer(modo_csrf::layer())                  // adds csrf_token
-       .layer(modo_i18n::layer(&i18n_config))      // adds locale
-       .layer(modo_templates::context_layer())     // outermost — creates context
+    // Just register as service — layers are auto-applied by the framework
+    app.service(i18n_store)
+       .service(engine)
+       .layer(modo_csrf::layer())    // adds csrf_token to TemplateContext
 }
+```
+
+Config in YAML (`config.yml`):
+
+```yaml
+templates:
+  path: "templates"
+  strict: true
 ```
 
 ## End-user handler

--- a/docs/plans/2026-03-08-modo-templates-implementation.md
+++ b/docs/plans/2026-03-08-modo-templates-implementation.md
@@ -1,0 +1,1634 @@
+# modo-templates Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add MiniJinja-based template engine to modo with view structs, auto-rendered request context, HTMX partial support, and i18n integration.
+
+**Architecture:** Two crates — `modo-templates` (runtime: engine, context map, render layer, View type) and `modo-templates-macros` (proc macro: `#[view]`). The render layer is axum middleware that intercepts View responses, merges request context from extensions, and renders via MiniJinja. Other crates (csrf, i18n, flash) add their values to a shared `TemplateContext` in request extensions.
+
+**Tech Stack:** MiniJinja (template engine), minijinja-embed (compile-time embedding), serde (context serialization), syn/quote (proc macro), axum/tower (middleware)
+
+---
+
+### Task 1: Scaffold modo-templates-macros crate
+
+**Files:**
+- Create: `modo-templates-macros/Cargo.toml`
+- Create: `modo-templates-macros/src/lib.rs`
+
+**Step 1: Create Cargo.toml**
+
+```toml
+[package]
+name = "modo-templates-macros"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
+```
+
+**Step 2: Create stub lib.rs**
+
+```rust
+use proc_macro::TokenStream;
+
+/// Marks a struct as a view with an associated template.
+///
+/// Usage:
+/// ```ignore
+/// #[view("pages/home.html")]
+/// struct HomePage { items: Vec<Item> }
+///
+/// #[view("pages/login.html", htmx = "htmx/login_form.html")]
+/// struct LoginPage { form_errors: Vec<String> }
+/// ```
+#[proc_macro_attribute]
+pub fn view(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match view_impl(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn view_impl(
+    _attr: proc_macro2::TokenStream,
+    _item: proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
+    todo!("implement in Task 4")
+}
+```
+
+**Step 3: Add to workspace**
+
+In workspace root `Cargo.toml`, add `"modo-templates-macros"` to the `members` list.
+
+**Step 4: Verify it compiles**
+
+Run: `cargo check -p modo-templates-macros`
+Expected: PASS (compiles, though `view_impl` will panic at runtime)
+
+**Step 5: Commit**
+
+```
+feat(modo-templates-macros): scaffold proc macro crate
+```
+
+---
+
+### Task 2: Scaffold modo-templates crate with TemplateContext and errors
+
+**Files:**
+- Create: `modo-templates/Cargo.toml`
+- Create: `modo-templates/src/lib.rs`
+- Create: `modo-templates/src/error.rs`
+- Create: `modo-templates/src/context.rs`
+
+**Step 1: Write test for TemplateContext**
+
+Create `modo-templates/src/context.rs` with tests at the bottom:
+
+```rust
+use minijinja::Value;
+use std::collections::BTreeMap;
+
+/// Request-scoped template context stored in request extensions.
+/// Middleware layers add their values here; the render layer merges
+/// this with the view's user context before rendering.
+#[derive(Debug, Clone, Default)]
+pub struct TemplateContext {
+    values: BTreeMap<String, Value>,
+}
+
+impl TemplateContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, key: impl Into<String>, value: impl Into<Value>) {
+        self.values.insert(key.into(), value.into());
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.values.get(key)
+    }
+
+    /// Consume into the inner map for merging with user context.
+    pub fn into_values(self) -> BTreeMap<String, Value> {
+        self.values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_get() {
+        let mut ctx = TemplateContext::new();
+        ctx.insert("locale", "en");
+        ctx.insert("request_id", "abc-123");
+
+        assert_eq!(ctx.get("locale").unwrap().to_string(), "en");
+        assert_eq!(ctx.get("request_id").unwrap().to_string(), "abc-123");
+        assert!(ctx.get("missing").is_none());
+    }
+
+    #[test]
+    fn into_values_returns_all() {
+        let mut ctx = TemplateContext::new();
+        ctx.insert("a", "1");
+        ctx.insert("b", "2");
+
+        let values = ctx.into_values();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values["a"].to_string(), "1");
+        assert_eq!(values["b"].to_string(), "2");
+    }
+}
+```
+
+**Step 2: Create error.rs**
+
+```rust
+use std::fmt;
+
+#[derive(Debug)]
+pub enum TemplateError {
+    /// Template not found in the engine.
+    NotFound { name: String },
+    /// MiniJinja render error.
+    Render { source: minijinja::Error },
+    /// Engine not registered as a service.
+    EngineNotRegistered,
+}
+
+impl fmt::Display for TemplateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound { name } => write!(f, "template not found: {name}"),
+            Self::Render { source } => write!(f, "template render error: {source}"),
+            Self::EngineNotRegistered => write!(f, "TemplateEngine not registered as a service"),
+        }
+    }
+}
+
+impl std::error::Error for TemplateError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Render { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl From<minijinja::Error> for TemplateError {
+    fn from(err: minijinja::Error) -> Self {
+        if err.kind() == minijinja::ErrorKind::TemplateNotFound {
+            Self::NotFound {
+                name: err.template_source().unwrap_or("unknown").to_string(),
+            }
+        } else {
+            Self::Render { source: err }
+        }
+    }
+}
+```
+
+**Step 3: Create Cargo.toml**
+
+```toml
+[package]
+name = "modo-templates"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[dependencies]
+modo-templates-macros = { path = "../modo-templates-macros" }
+
+minijinja = { version = "2", features = ["loader"] }
+serde = { version = "1", features = ["derive"] }
+axum = "0.8"
+http = "1"
+tower = { version = "0.5", features = ["util"] }
+futures-util = "0.3"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.5", features = ["util"] }
+http = "1"
+serde = { version = "1", features = ["derive"] }
+```
+
+**Step 4: Create lib.rs**
+
+```rust
+pub mod context;
+pub mod error;
+
+pub use context::TemplateContext;
+pub use error::TemplateError;
+
+// Re-export macro
+pub use modo_templates_macros::view;
+
+// Re-export minijinja essentials for macro-generated code
+pub use minijinja;
+pub use minijinja::context;
+```
+
+**Step 5: Add to workspace and verify**
+
+Add `"modo-templates"` to workspace `Cargo.toml` members list.
+
+Run: `cargo test -p modo-templates`
+Expected: 2 tests pass (insert_and_get, into_values_returns_all)
+
+**Step 6: Commit**
+
+```
+feat(modo-templates): scaffold crate with TemplateContext and errors
+```
+
+---
+
+### Task 3: Implement TemplateEngine (MiniJinja Environment wrapper)
+
+**Files:**
+- Create: `modo-templates/src/engine.rs`
+- Modify: `modo-templates/src/lib.rs`
+
+**Step 1: Write tests for TemplateEngine**
+
+Add to end of `modo-templates/src/engine.rs`:
+
+```rust
+use minijinja::Environment;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Wraps MiniJinja's `Environment` for use as a modo service.
+pub struct TemplateEngine {
+    env: Environment<'static>,
+}
+
+impl TemplateEngine {
+    pub fn builder() -> TemplateEngineBuilder {
+        TemplateEngineBuilder {
+            directory: None,
+            strict: true,
+        }
+    }
+
+    /// Get a reference to the inner MiniJinja Environment for registering
+    /// custom functions, filters, or globals.
+    pub fn env(&self) -> &Environment<'static> {
+        &self.env
+    }
+
+    /// Get a mutable reference to the inner MiniJinja Environment.
+    pub fn env_mut(&mut self) -> &mut Environment<'static> {
+        &mut self.env
+    }
+
+    /// Render a template by name with the given context value.
+    pub fn render(&self, name: &str, ctx: minijinja::Value) -> Result<String, crate::TemplateError> {
+        let tmpl = self.env.get_template(name)?;
+        Ok(tmpl.render(ctx)?)
+    }
+}
+
+pub struct TemplateEngineBuilder {
+    directory: Option<PathBuf>,
+    strict: bool,
+}
+
+impl TemplateEngineBuilder {
+    /// Set the directory to load templates from.
+    pub fn directory(mut self, path: impl Into<PathBuf>) -> Self {
+        self.directory = Some(path.into());
+        self
+    }
+
+    /// Set strict undefined behavior (default: true).
+    /// When true, accessing undefined variables in templates is an error.
+    pub fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+
+    /// Build the template engine.
+    pub fn build(self) -> Result<TemplateEngine, crate::TemplateError> {
+        let mut env = Environment::new();
+
+        if self.strict {
+            env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+        }
+
+        if let Some(dir) = self.directory {
+            let dir = dir.clone();
+            env.set_loader(minijinja::path_loader(&dir));
+        }
+
+        Ok(TemplateEngine { env })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn setup_templates(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("modo_tmpl_test_{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("hello.html"), "Hello {{ name }}!").unwrap();
+        fs::write(
+            dir.join("layout.html"),
+            "{% block content %}{% endblock %}",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("page.html"),
+            r#"{% extends "layout.html" %}{% block content %}Page: {{ title }}{% endblock %}"#,
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn render_simple_template() {
+        let dir = setup_templates("simple");
+        let engine = TemplateEngine::builder()
+            .directory(&dir)
+            .build()
+            .unwrap();
+
+        let result = engine
+            .render("hello.html", minijinja::context! { name => "World" }.into())
+            .unwrap();
+        assert_eq!(result, "Hello World!");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn render_with_inheritance() {
+        let dir = setup_templates("inherit");
+        let engine = TemplateEngine::builder()
+            .directory(&dir)
+            .build()
+            .unwrap();
+
+        let result = engine
+            .render("page.html", minijinja::context! { title => "Home" }.into())
+            .unwrap();
+        assert_eq!(result, "Page: Home");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn strict_mode_rejects_undefined() {
+        let dir = setup_templates("strict");
+        let engine = TemplateEngine::builder()
+            .directory(&dir)
+            .strict(true)
+            .build()
+            .unwrap();
+
+        let result = engine.render(
+            "hello.html",
+            minijinja::context! {}.into(), // name is missing
+        );
+        assert!(result.is_err());
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn template_not_found_error() {
+        let dir = setup_templates("notfound");
+        let engine = TemplateEngine::builder()
+            .directory(&dir)
+            .build()
+            .unwrap();
+
+        let result = engine.render("nonexistent.html", minijinja::context! {}.into());
+        assert!(matches!(
+            result,
+            Err(crate::TemplateError::NotFound { .. })
+        ));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+}
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `cargo test -p modo-templates`
+Expected: All 6 tests pass (2 context + 4 engine)
+
+**Step 3: Update lib.rs**
+
+Add to `modo-templates/src/lib.rs`:
+
+```rust
+pub mod engine;
+
+pub use engine::{TemplateEngine, TemplateEngineBuilder};
+```
+
+**Step 4: Commit**
+
+```
+feat(modo-templates): implement TemplateEngine with MiniJinja
+```
+
+---
+
+### Task 4: Implement View struct and #[view] proc macro
+
+**Files:**
+- Create: `modo-templates/src/view.rs`
+- Modify: `modo-templates-macros/src/lib.rs`
+- Modify: `modo-templates/src/lib.rs`
+
+**Step 1: Create View type in modo-templates**
+
+Create `modo-templates/src/view.rs`:
+
+```rust
+use axum::response::{Html, IntoResponse, Response};
+use http::StatusCode;
+use minijinja::Value;
+
+/// A pending template render. Created by the `#[view]` macro's `IntoResponse` impl.
+/// The render layer middleware picks this up from response extensions and renders it.
+#[derive(Debug, Clone)]
+pub struct View {
+    /// Primary template path (full page).
+    pub template: String,
+    /// Optional HTMX template path (fragment).
+    pub htmx_template: Option<String>,
+    /// Serialized user context (struct fields).
+    pub user_context: Value,
+}
+
+impl View {
+    pub fn new(template: impl Into<String>, user_context: Value) -> Self {
+        Self {
+            template: template.into(),
+            htmx_template: None,
+            user_context,
+        }
+    }
+
+    pub fn with_htmx(mut self, htmx_template: impl Into<String>) -> Self {
+        self.htmx_template = Some(htmx_template.into());
+        self
+    }
+}
+
+/// Marker response: stashes the View in response extensions for the render layer.
+/// If no render layer is present, returns a 500 error.
+impl IntoResponse for View {
+    fn into_response(self) -> Response {
+        let mut response = Response::new(axum::body::Body::empty());
+        // Set a marker status that the render layer will replace
+        *response.status_mut() = StatusCode::OK;
+        response.extensions_mut().insert(self);
+        response
+    }
+}
+```
+
+**Step 2: Implement the #[view] proc macro**
+
+Replace the content of `modo-templates-macros/src/lib.rs`:
+
+```rust
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{Ident, ItemStruct, LitStr, Token};
+
+struct ViewAttr {
+    template: LitStr,
+    htmx_template: Option<LitStr>,
+}
+
+impl Parse for ViewAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let template: LitStr = input.parse()?;
+        let mut htmx_template = None;
+
+        while input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+            let key: Ident = input.parse()?;
+            if key == "htmx" {
+                input.parse::<Token![=]>()?;
+                htmx_template = Some(input.parse::<LitStr>()?);
+            } else {
+                return Err(syn::Error::new_spanned(
+                    key,
+                    "unknown attribute, expected `htmx`",
+                ));
+            }
+        }
+
+        Ok(ViewAttr {
+            template,
+            htmx_template,
+        })
+    }
+}
+
+/// Marks a struct as a view with an associated template.
+///
+/// Usage:
+/// ```ignore
+/// #[view("pages/home.html")]
+/// struct HomePage { items: Vec<Item> }
+///
+/// #[view("pages/login.html", htmx = "htmx/login_form.html")]
+/// struct LoginPage { form_errors: Vec<String> }
+/// ```
+#[proc_macro_attribute]
+pub fn view(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match view_impl(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn view_impl(
+    attr: proc_macro2::TokenStream,
+    item: proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let attr = syn::parse2::<ViewAttr>(attr)?;
+    let input = syn::parse2::<ItemStruct>(item)?;
+
+    let struct_name = &input.ident;
+    let template_path = &attr.template;
+
+    let htmx_expr = match &attr.htmx_template {
+        Some(lit) => quote! { Some(#lit.to_string()) },
+        None => quote! { None },
+    };
+
+    Ok(quote! {
+        #[derive(::serde::Serialize)]
+        #input
+
+        impl ::axum::response::IntoResponse for #struct_name {
+            fn into_response(self) -> ::axum::response::Response {
+                let user_context = ::modo_templates::minijinja::Value::from_serialize(&self);
+                let view = ::modo_templates::View::new(#template_path, user_context);
+                let view = match (#htmx_expr) {
+                    Some(htmx) => view.with_htmx(htmx),
+                    None => view,
+                };
+                view.into_response()
+            }
+        }
+    })
+}
+```
+
+**Step 3: Update lib.rs exports**
+
+Add to `modo-templates/src/lib.rs`:
+
+```rust
+pub mod view;
+
+pub use view::View;
+```
+
+**Step 4: Write a compile test**
+
+Create `modo-templates/tests/view_macro.rs`:
+
+```rust
+use modo_templates::view;
+use serde::Serialize;
+
+#[derive(Debug)]
+struct Item {
+    name: String,
+}
+
+// Need Serialize for Item since it's used in a view struct
+impl serde::Serialize for Item {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("Item", 1)?;
+        s.serialize_field("name", &self.name)?;
+        s.end()
+    }
+}
+
+#[modo_templates::view("pages/home.html")]
+pub struct HomePage {
+    pub items: Vec<Item>,
+}
+
+#[modo_templates::view("pages/login.html", htmx = "htmx/login_form.html")]
+pub struct LoginPage {
+    pub form_errors: Vec<String>,
+}
+
+#[test]
+fn view_macro_creates_into_response() {
+    use axum::response::IntoResponse;
+
+    let page = HomePage { items: vec![] };
+    let response = page.into_response();
+
+    // View should be stashed in extensions
+    let view = response.extensions().get::<modo_templates::View>().unwrap();
+    assert_eq!(view.template, "pages/home.html");
+    assert!(view.htmx_template.is_none());
+}
+
+#[test]
+fn view_macro_with_htmx() {
+    use axum::response::IntoResponse;
+
+    let page = LoginPage {
+        form_errors: vec!["bad email".to_string()],
+    };
+    let response = page.into_response();
+
+    let view = response.extensions().get::<modo_templates::View>().unwrap();
+    assert_eq!(view.template, "pages/login.html");
+    assert_eq!(
+        view.htmx_template.as_deref(),
+        Some("htmx/login_form.html")
+    );
+}
+```
+
+**Step 5: Run tests**
+
+Run: `cargo test -p modo-templates`
+Expected: All tests pass (2 context + 4 engine + 2 view macro)
+
+**Step 6: Commit**
+
+```
+feat(modo-templates): implement View struct and #[view] proc macro
+```
+
+---
+
+### Task 5: Implement context_layer middleware
+
+**Files:**
+- Create: `modo-templates/src/middleware.rs`
+- Modify: `modo-templates/src/lib.rs`
+
+**Step 1: Implement context_layer**
+
+Create `modo-templates/src/middleware.rs`:
+
+```rust
+use crate::context::TemplateContext;
+use axum::http::Request;
+use futures_util::future::BoxFuture;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+/// Layer that creates a `TemplateContext` in request extensions
+/// with built-in values (request_id, current_url).
+/// Must be applied outermost of all context-writing middleware.
+#[derive(Clone, Default)]
+pub struct ContextLayer;
+
+impl ContextLayer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for ContextLayer {
+    type Service = ContextMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ContextMiddleware { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct ContextMiddleware<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ContextMiddleware<S>
+where
+    S: Service<Request<ReqBody>, Response = axum::http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let (mut parts, body) = request.into_parts();
+
+            let mut ctx = TemplateContext::new();
+            ctx.insert("current_url", parts.uri.to_string());
+
+            // Read request_id from extensions if set by request_id middleware
+            if let Some(request_id) = parts.extensions.get::<modo::RequestId>() {
+                ctx.insert("request_id", request_id.to_string());
+            }
+
+            parts.extensions.insert(ctx);
+
+            let request = Request::from_parts(parts, body);
+            inner.call(request).await
+        })
+    }
+}
+```
+
+**Step 2: Write integration test**
+
+Create `modo-templates/tests/context_layer.rs`:
+
+```rust
+use axum::body::Body;
+use axum::routing::get;
+use axum::{Extension, Router};
+use http::Request;
+use modo_templates::TemplateContext;
+use modo_templates::middleware::ContextLayer;
+use tower::ServiceExt;
+
+async fn handler(Extension(ctx): Extension<TemplateContext>) -> String {
+    format!(
+        "url={} id={}",
+        ctx.get("current_url").map(|v| v.to_string()).unwrap_or_default(),
+        ctx.get("request_id").map(|v| v.to_string()).unwrap_or_default(),
+    )
+}
+
+#[tokio::test]
+async fn context_layer_sets_current_url() {
+    let app = Router::new()
+        .route("/hello", get(handler))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/hello").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body.contains("url=/hello"));
+}
+```
+
+**Step 3: Update lib.rs**
+
+Add to `modo-templates/src/lib.rs`:
+
+```rust
+pub mod middleware;
+
+pub use middleware::ContextLayer;
+```
+
+**Step 4: Add modo dependency to Cargo.toml**
+
+Add `modo = { path = "../modo" }` to `[dependencies]` in `modo-templates/Cargo.toml`.
+
+**Step 5: Run tests**
+
+Run: `cargo test -p modo-templates`
+Expected: All tests pass
+
+**Step 6: Commit**
+
+```
+feat(modo-templates): implement context_layer middleware
+```
+
+---
+
+### Task 6: Implement render_layer middleware
+
+**Files:**
+- Create: `modo-templates/src/render.rs`
+- Modify: `modo-templates/src/lib.rs`
+- Modify: `modo-templates/src/engine.rs`
+
+**Step 1: Implement render_layer**
+
+Create `modo-templates/src/render.rs`:
+
+```rust
+use crate::context::TemplateContext;
+use crate::engine::TemplateEngine;
+use crate::view::View;
+use axum::body::Body;
+use axum::http::{Request, header};
+use axum::response::{Html, IntoResponse, Response};
+use futures_util::future::BoxFuture;
+use http::StatusCode;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+use tracing::error;
+
+/// Layer that intercepts View responses and renders them via the TemplateEngine.
+/// Merges request TemplateContext with the view's user context.
+#[derive(Clone)]
+pub struct RenderLayer {
+    engine: Arc<TemplateEngine>,
+}
+
+impl RenderLayer {
+    pub fn new(engine: Arc<TemplateEngine>) -> Self {
+        Self { engine }
+    }
+}
+
+impl<S> Layer<S> for RenderLayer {
+    type Service = RenderMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RenderMiddleware {
+            inner,
+            engine: self.engine.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RenderMiddleware<S> {
+    inner: S,
+    engine: Arc<TemplateEngine>,
+}
+
+impl<S> Service<Request<Body>> for RenderMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<std::convert::Infallible> + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        let engine = self.engine.clone();
+        let mut inner = self.inner.clone();
+
+        // Capture request context and HTMX header before passing to handler
+        let template_ctx = request
+            .extensions()
+            .get::<TemplateContext>()
+            .cloned()
+            .unwrap_or_default();
+        let is_htmx = request.headers().get("hx-request").is_some();
+
+        Box::pin(async move {
+            let mut response = inner.call(request).await?;
+
+            // Only process responses that contain a View
+            let Some(view) = response.extensions_mut().remove::<View>() else {
+                return Ok(response);
+            };
+
+            let status = response.status();
+
+            // HTMX rule: non-200 status → don't render, pass through
+            if is_htmx && status != StatusCode::OK {
+                return Ok(response);
+            }
+
+            // Pick template: htmx template for HTMX requests, full template otherwise
+            let template_name = if is_htmx {
+                view.htmx_template.as_deref().unwrap_or(&view.template)
+            } else {
+                &view.template
+            };
+
+            // Merge request context with user context
+            let merged = merge_contexts(template_ctx, view.user_context);
+
+            match engine.render(template_name, merged) {
+                Ok(html) => {
+                    let mut resp = Html(html).into_response();
+                    // HTMX responses are always 200
+                    if is_htmx {
+                        *resp.status_mut() = StatusCode::OK;
+                    } else {
+                        *resp.status_mut() = status;
+                    }
+                    Ok(resp)
+                }
+                Err(err) => {
+                    error!(template = template_name, error = %err, "template render failed");
+                    Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+                }
+            }
+        })
+    }
+}
+
+/// Merge request-scoped context (locale, csrf, etc.) with user context (struct fields).
+/// User context values take precedence over request context on key collision.
+fn merge_contexts(
+    request_ctx: TemplateContext,
+    user_ctx: minijinja::Value,
+) -> minijinja::Value {
+    let mut map = request_ctx.into_values();
+
+    // user_ctx is a struct serialized to Value — iterate its keys
+    if let Some(keys) = user_ctx.try_iter() {
+        for key in keys {
+            if let Some(val) = user_ctx.get_attr(key.as_str().unwrap_or_default()) {
+                if let Ok(val) = val {
+                    map.insert(key.to_string(), val);
+                }
+            }
+        }
+    }
+
+    minijinja::Value::from_serialize(&map)
+}
+```
+
+Note: The `merge_contexts` function may need adjustment based on how MiniJinja's `Value` iteration works. The approach is: start with request context as base, overlay user context fields on top. We'll verify with tests.
+
+**Step 2: Write integration test**
+
+Create `modo-templates/tests/render_layer.rs`:
+
+```rust
+use axum::body::Body;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use http::Request;
+use modo_templates::middleware::ContextLayer;
+use modo_templates::render::RenderLayer;
+use modo_templates::{TemplateEngine, View};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn setup(name: &str) -> (Arc<TemplateEngine>, PathBuf) {
+    let dir = std::env::temp_dir().join(format!("modo_render_test_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("hello.html"), "Hello {{ name }}! url={{ current_url }}").unwrap();
+    fs::write(dir.join("hello_htmx.html"), "partial: {{ name }}").unwrap();
+
+    let engine = TemplateEngine::builder()
+        .directory(&dir)
+        .build()
+        .unwrap();
+    (Arc::new(engine), dir)
+}
+
+#[tokio::test]
+async fn renders_view_with_merged_context() {
+    let (engine, dir) = setup("merged");
+
+    async fn handler() -> impl IntoResponse {
+        View::new(
+            "hello.html",
+            minijinja::context! { name => "World" }.into(),
+        )
+    }
+
+    let app = Router::new()
+        .route("/test", get(handler))
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/test").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert_eq!(body, "Hello World! url=/test");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn htmx_request_uses_htmx_template() {
+    let (engine, dir) = setup("htmx");
+
+    async fn handler() -> impl IntoResponse {
+        View::new(
+            "hello.html",
+            minijinja::context! { name => "World" }.into(),
+        )
+        .with_htmx("hello_htmx.html")
+    }
+
+    let app = Router::new()
+        .route("/test", get(handler))
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(
+            Request::get("/test")
+                .header("hx-request", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert_eq!(body, "partial: World");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn non_view_response_passes_through() {
+    let (engine, dir) = setup("passthrough");
+
+    async fn handler() -> &'static str {
+        "plain text"
+    }
+
+    let app = Router::new()
+        .route("/test", get(handler))
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/test").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(String::from_utf8(body.to_vec()).unwrap(), "plain text");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+```
+
+**Step 3: Update lib.rs**
+
+Add to `modo-templates/src/lib.rs`:
+
+```rust
+pub mod render;
+
+pub use render::RenderLayer;
+```
+
+**Step 4: Run tests, iterate on merge_contexts if needed**
+
+Run: `cargo test -p modo-templates`
+Expected: All tests pass. If `merge_contexts` doesn't work as expected due to MiniJinja Value API, fix the implementation based on actual API.
+
+**Step 5: Commit**
+
+```
+feat(modo-templates): implement render_layer with HTMX support
+```
+
+---
+
+### Task 7: Add i18n integration (register_template_functions)
+
+**Files:**
+- Create: `modo-i18n/src/template.rs`
+- Modify: `modo-i18n/src/lib.rs`
+- Modify: `modo-i18n/Cargo.toml`
+
+**Step 1: Add modo-templates as optional dependency**
+
+In `modo-i18n/Cargo.toml`, add:
+
+```toml
+modo-templates = { path = "../modo-templates", optional = true }
+
+[features]
+default = []
+templates = ["dep:modo-templates"]
+```
+
+**Step 2: Implement register_template_functions**
+
+Create `modo-i18n/src/template.rs`:
+
+```rust
+use crate::store::TranslationStore;
+use minijinja::{Environment, Error, ErrorKind, State, Value};
+use std::sync::Arc;
+
+/// Register i18n template functions (`t`) on the MiniJinja environment.
+///
+/// The `t` function reads `locale` from the template render context
+/// (set by the i18n middleware via `TemplateContext`).
+///
+/// Template usage:
+/// ```jinja
+/// {{ t("auth.login.title") }}
+/// {{ t("greeting", name="Alice") }}
+/// {{ t("items_count", count=5) }}
+/// ```
+pub fn register_template_functions(
+    env: &mut Environment<'static>,
+    store: Arc<TranslationStore>,
+) {
+    let store_clone = store.clone();
+    env.add_function("t", move |state: &State, key: String, kwargs: Value| -> Result<String, Error> {
+        let locale = state
+            .lookup("locale")
+            .and_then(|v| Some(v.to_string()))
+            .unwrap_or_else(|| store_clone.config().default_lang.clone());
+
+        let default_lang = store_clone.config().default_lang.clone();
+
+        // Extract keyword arguments as (key, value) pairs
+        let mut vars: Vec<(String, String)> = Vec::new();
+        let mut count: Option<u64> = None;
+
+        if let Some(iter) = kwargs.try_iter() {
+            for k in iter {
+                let k_str = k.to_string();
+                if let Ok(v) = kwargs.get_attr(&k_str) {
+                    if k_str == "count" {
+                        count = v.as_usize().map(|n| n as u64)
+                            .or_else(|| v.to_string().parse().ok());
+                        // Also add count as a variable for interpolation
+                        vars.push((k_str, v.to_string()));
+                    } else {
+                        vars.push((k_str, v.to_string()));
+                    }
+                }
+            }
+        }
+
+        let var_refs: Vec<(&str, &str)> = vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+
+        // Try requested locale, fall back to default
+        let result = if let Some(count) = count {
+            store_clone
+                .get_plural(&locale, &key, count)
+                .or_else(|| store_clone.get_plural(&default_lang, &key, count))
+        } else {
+            store_clone
+                .get(&locale, &key)
+                .or_else(|| store_clone.get(&default_lang, &key))
+        };
+
+        match result {
+            Some(template_str) => {
+                // Apply variable interpolation
+                let mut output = template_str;
+                for (k, v) in &var_refs {
+                    output = output.replace(&format!("{{{k}}}"), v);
+                }
+                Ok(output)
+            }
+            None => {
+                // Return the key itself as fallback (common i18n convention)
+                Ok(key)
+            }
+        }
+    });
+}
+```
+
+**Step 3: Update modo-i18n/src/lib.rs**
+
+Add behind the feature flag:
+
+```rust
+#[cfg(feature = "templates")]
+pub mod template;
+
+#[cfg(feature = "templates")]
+pub use template::register_template_functions;
+```
+
+**Step 4: Write integration test**
+
+Create `modo-i18n/tests/template_integration.rs`:
+
+```rust
+#![cfg(feature = "templates")]
+
+use minijinja::{Environment, context};
+use modo_i18n::{I18nConfig, load, register_template_functions};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn setup(name: &str) -> (Arc<modo_i18n::TranslationStore>, PathBuf) {
+    let dir = std::env::temp_dir().join(format!("modo_i18n_tmpl_test_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    let en = dir.join("en");
+    fs::create_dir_all(&en).unwrap();
+    fs::write(
+        en.join("common.yml"),
+        r#"
+greeting: "Hello, {name}!"
+title: "Welcome"
+items_count:
+  zero: "No items"
+  one: "One item"
+  other: "{count} items"
+"#,
+    )
+    .unwrap();
+
+    let config = I18nConfig {
+        path: dir.to_str().unwrap().to_string(),
+        default_lang: "en".to_string(),
+        ..Default::default()
+    };
+    let store = load(&config).unwrap();
+    (store, dir)
+}
+
+#[test]
+fn t_function_simple_key() {
+    let (store, dir) = setup("simple");
+    let mut env = Environment::new();
+    register_template_functions(&mut env, store);
+
+    env.add_template("test", "{{ t('common.title') }}").unwrap();
+    let tmpl = env.get_template("test").unwrap();
+    let result = tmpl.render(context! { locale => "en" }).unwrap();
+    assert_eq!(result, "Welcome");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn t_function_with_variable() {
+    let (store, dir) = setup("var");
+    let mut env = Environment::new();
+    register_template_functions(&mut env, store);
+
+    env.add_template("test", "{{ t('common.greeting', name='World') }}")
+        .unwrap();
+    let tmpl = env.get_template("test").unwrap();
+    let result = tmpl.render(context! { locale => "en" }).unwrap();
+    assert_eq!(result, "Hello, World!");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn t_function_plural() {
+    let (store, dir) = setup("plural");
+    let mut env = Environment::new();
+    register_template_functions(&mut env, store);
+
+    env.add_template("test", "{{ t('common.items_count', count=0) }} | {{ t('common.items_count', count=1) }} | {{ t('common.items_count', count=5) }}")
+        .unwrap();
+    let tmpl = env.get_template("test").unwrap();
+    let result = tmpl.render(context! { locale => "en" }).unwrap();
+    assert_eq!(result, "No items | One item | 5 items");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn t_function_missing_key_returns_key() {
+    let (store, dir) = setup("missing");
+    let mut env = Environment::new();
+    register_template_functions(&mut env, store);
+
+    env.add_template("test", "{{ t('nonexistent.key') }}")
+        .unwrap();
+    let tmpl = env.get_template("test").unwrap();
+    let result = tmpl.render(context! { locale => "en" }).unwrap();
+    assert_eq!(result, "nonexistent.key");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+```
+
+**Step 5: Run tests**
+
+Run: `cargo test -p modo-i18n --features templates`
+Expected: All new tests pass. Existing tests still pass.
+
+**Step 6: Commit**
+
+```
+feat(modo-i18n): add template function registration for MiniJinja
+```
+
+---
+
+### Task 8: Wire up re-exports in modo umbrella crate
+
+**Files:**
+- Modify: `modo/Cargo.toml`
+- Modify: `modo/src/lib.rs`
+
+**Step 1: Add optional dependency**
+
+In `modo/Cargo.toml` add:
+
+```toml
+modo-templates = { path = "../modo-templates", optional = true }
+modo-templates-macros = { path = "../modo-templates-macros", optional = true }
+
+[features]
+default = []
+templates = ["dep:modo-templates", "dep:modo-templates-macros"]
+```
+
+**Step 2: Add re-exports**
+
+In `modo/src/lib.rs`, add the macro re-export (keep alphabetical order for re-exports section):
+
+```rust
+// At the top, add view to the macro re-exports (conditionally):
+#[cfg(feature = "templates")]
+pub use modo_templates_macros::view;
+
+// In the re-exports section, add (alphabetically):
+#[cfg(feature = "templates")]
+pub use modo_templates;
+```
+
+**Step 3: Verify compilation**
+
+Run: `cargo check -p modo --features templates`
+Expected: PASS
+
+**Step 4: Commit**
+
+```
+feat(modo): re-export modo-templates behind templates feature flag
+```
+
+---
+
+### Task 9: Update middleware to add locale to TemplateContext
+
+**Files:**
+- Modify: `modo-i18n/src/middleware.rs`
+- Modify: `modo-i18n/Cargo.toml`
+
+**Step 1: Update middleware to insert locale into TemplateContext**
+
+In `modo-i18n/src/middleware.rs`, inside the `call` method, after inserting `ResolvedLang` into extensions, add:
+
+```rust
+// If TemplateContext exists (modo-templates context_layer is active),
+// add the locale to it.
+#[cfg(feature = "templates")]
+if let Some(ctx) = parts.extensions.get_mut::<modo_templates::TemplateContext>() {
+    ctx.insert("locale", resolved.clone());
+}
+```
+
+**Step 2: Run all tests**
+
+Run: `cargo test --workspace`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```
+feat(modo-i18n): inject locale into TemplateContext when templates feature enabled
+```
+
+---
+
+### Task 10: End-to-end integration test
+
+**Files:**
+- Create: `modo-templates/tests/e2e.rs`
+
+**Step 1: Write full-stack integration test**
+
+```rust
+use axum::body::Body;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use http::Request;
+use modo_templates::middleware::ContextLayer;
+use modo_templates::render::RenderLayer;
+use modo_templates::{TemplateEngine, View};
+use serde::Serialize;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn setup(name: &str) -> (Arc<TemplateEngine>, PathBuf) {
+    let dir = std::env::temp_dir().join(format!("modo_e2e_test_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+
+    let layouts = dir.join("layouts");
+    let pages = dir.join("pages");
+    let htmx = dir.join("htmx");
+    fs::create_dir_all(&layouts).unwrap();
+    fs::create_dir_all(&pages).unwrap();
+    fs::create_dir_all(&htmx).unwrap();
+
+    fs::write(
+        layouts.join("base.html"),
+        "<html><body>{% block content %}{% endblock %}</body></html>",
+    )
+    .unwrap();
+
+    fs::write(
+        pages.join("home.html"),
+        r#"{% extends "layouts/base.html" %}{% block content %}<h1>{{ title }}</h1><p>url={{ current_url }}</p>{% endblock %}"#,
+    )
+    .unwrap();
+
+    fs::write(htmx.join("home.html"), "<h1>{{ title }}</h1>").unwrap();
+
+    let engine = TemplateEngine::builder()
+        .directory(&dir)
+        .build()
+        .unwrap();
+    (Arc::new(engine), dir)
+}
+
+#[modo_templates::view("pages/home.html", htmx = "htmx/home.html")]
+struct HomePage {
+    title: String,
+}
+
+#[tokio::test]
+async fn full_page_renders_with_layout() {
+    let (engine, dir) = setup("fullpage");
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                HomePage {
+                    title: "Welcome".to_string(),
+                }
+            }),
+        )
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body.contains("<html>"));
+    assert!(body.contains("<h1>Welcome</h1>"));
+    assert!(body.contains("url=/"));
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn htmx_request_renders_partial() {
+    let (engine, dir) = setup("htmxpartial");
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                HomePage {
+                    title: "Welcome".to_string(),
+                }
+            }),
+        )
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(
+            Request::get("/")
+                .header("hx-request", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    // Should NOT contain layout
+    assert!(!body.contains("<html>"));
+    // Should contain partial content
+    assert_eq!(body, "<h1>Welcome</h1>");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+```
+
+**Step 2: Run all tests**
+
+Run: `cargo test --workspace`
+Expected: All tests pass
+
+**Step 3: Run format and lint**
+
+Run: `just fmt && just lint`
+Expected: PASS
+
+**Step 4: Commit**
+
+```
+test(modo-templates): add end-to-end integration tests
+```
+
+---
+
+### Task 11: Update CLAUDE.md and workspace docs
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Add modo-templates conventions**
+
+Under `## Architecture`, update the `modo-templates` entry:
+
+```
+- `modo-templates/` — MiniJinja template engine (views, render layer, context injection)
+- `modo-templates-macros/` — `#[view("path", htmx = "path")]` proc macro
+```
+
+Under `## Conventions`, add:
+
+```
+- Views: `#[modo::view("pages/home.html")]` or `#[modo::view("page.html", htmx = "htmx/frag.html")]`
+- View structs: fields must implement `Serialize`, handler returns struct directly
+- Template context: `TemplateContext` in request extensions, middleware adds via `ctx.insert("key", value)`
+- Template engine: `TemplateEngine::builder().directory("templates").build()`
+- Render layer: `RenderLayer::new(engine)` — renders View responses, merges request context
+- Context layer: `ContextLayer::new()` — outermost, creates TemplateContext with request_id + current_url
+- HTMX views: htmx template rendered on HX-Request, always HTTP 200, non-200 skips render
+- i18n in templates: `{{ t("key", name=val) }}` — register via `modo_i18n::register_template_functions`
+```
+
+**Step 2: Commit**
+
+```
+docs: update CLAUDE.md with modo-templates conventions
+```

--- a/docs/plans/2026-03-08-modo-templates-implementation.md
+++ b/docs/plans/2026-03-08-modo-templates-implementation.md
@@ -332,14 +332,6 @@ pub struct TemplateEngine {
 }
 
 impl TemplateEngine {
-    /// Create a builder from config (follows modo pattern: config → builder → service).
-    pub fn builder(config: &crate::TemplateConfig) -> TemplateEngineBuilder {
-        TemplateEngineBuilder {
-            directory: config.path.clone().into(),
-            strict: config.strict,
-        }
-    }
-
     /// Get a reference to the inner MiniJinja Environment for registering
     /// custom functions, filters, or globals.
     pub fn env(&self) -> &Environment<'static> {
@@ -358,36 +350,17 @@ impl TemplateEngine {
     }
 }
 
-pub struct TemplateEngineBuilder {
-    directory: PathBuf,
-    strict: bool,
-}
+/// Create a template engine from config (follows `modo_i18n::load` pattern).
+pub fn engine(config: &crate::TemplateConfig) -> Result<TemplateEngine, crate::TemplateError> {
+    let mut env = Environment::new();
 
-impl TemplateEngineBuilder {
-    /// Override the template directory from config.
-    pub fn directory(mut self, path: impl Into<PathBuf>) -> Self {
-        self.directory = path.into();
-        self
+    if config.strict {
+        env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
     }
 
-    /// Override strict mode from config.
-    pub fn strict(mut self, strict: bool) -> Self {
-        self.strict = strict;
-        self
-    }
+    env.set_loader(minijinja::path_loader(&config.path));
 
-    /// Build the template engine.
-    pub fn build(self) -> Result<TemplateEngine, crate::TemplateError> {
-        let mut env = Environment::new();
-
-        if self.strict {
-            env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
-        }
-
-        env.set_loader(minijinja::path_loader(&self.directory));
-
-        Ok(TemplateEngine { env })
-    }
+    Ok(TemplateEngine { env })
 }
 
 #[cfg(test)]
@@ -423,8 +396,7 @@ mod tests {
     #[test]
     fn render_simple_template() {
         let dir = setup_templates("simple");
-        let engine = TemplateEngine::builder(&test_config(&dir))
-            .build()
+        let engine = crate::engine(&test_config(&dir))
             .unwrap();
 
         let result = engine
@@ -438,8 +410,7 @@ mod tests {
     #[test]
     fn render_with_inheritance() {
         let dir = setup_templates("inherit");
-        let engine = TemplateEngine::builder(&test_config(&dir))
-            .build()
+        let engine = crate::engine(&test_config(&dir))
             .unwrap();
 
         let result = engine
@@ -453,8 +424,7 @@ mod tests {
     #[test]
     fn strict_mode_rejects_undefined() {
         let dir = setup_templates("strict");
-        let engine = TemplateEngine::builder(&test_config(&dir))
-            .build()
+        let engine = crate::engine(&test_config(&dir))
             .unwrap();
 
         let result = engine.render(
@@ -469,8 +439,7 @@ mod tests {
     #[test]
     fn template_not_found_error() {
         let dir = setup_templates("notfound");
-        let engine = TemplateEngine::builder(&test_config(&dir))
-            .build()
+        let engine = crate::engine(&test_config(&dir))
             .unwrap();
 
         let result = engine.render("nonexistent.html", minijinja::context! {}.into());
@@ -496,7 +465,7 @@ Add to `modo-templates/src/lib.rs`:
 ```rust
 pub mod engine;
 
-pub use engine::{TemplateEngine, TemplateEngineBuilder};
+pub use engine::{TemplateEngine, engine};
 ```
 
 **Step 4: Commit**
@@ -1069,10 +1038,11 @@ fn setup(name: &str) -> (Arc<TemplateEngine>, PathBuf) {
     fs::write(dir.join("hello.html"), "Hello {{ name }}! url={{ current_url }}").unwrap();
     fs::write(dir.join("hello_htmx.html"), "partial: {{ name }}").unwrap();
 
-    let engine = TemplateEngine::builder()
-        .directory(&dir)
-        .build()
-        .unwrap();
+    let config = modo_templates::TemplateConfig {
+        path: dir.to_str().unwrap().to_string(),
+        ..Default::default()
+    };
+    let engine = modo_templates::engine(&config).unwrap();
     (Arc::new(engine), dir)
 }
 
@@ -1585,10 +1555,11 @@ fn setup(name: &str) -> (Arc<TemplateEngine>, PathBuf) {
 
     fs::write(htmx.join("home.html"), "<h1>{{ title }}</h1>").unwrap();
 
-    let engine = TemplateEngine::builder()
-        .directory(&dir)
-        .build()
-        .unwrap();
+    let config = modo_templates::TemplateConfig {
+        path: dir.to_str().unwrap().to_string(),
+        ..Default::default()
+    };
+    let engine = modo_templates::engine(&config).unwrap();
     (Arc::new(engine), dir)
 }
 
@@ -1706,7 +1677,7 @@ Under `## Conventions`, add:
 
 ```
 - Templates config: `TemplateConfig { path, strict }` — YAML-deserializable with serde defaults
-- Template engine: `TemplateEngine::builder(&config).build()` — config → builder → service pattern
+- Template engine: `modo_templates::engine(&config)?` — config → engine (follows `modo_i18n::load` pattern)
 - Views: `#[modo::view("pages/home.html")]` or `#[modo::view("page.html", htmx = "htmx/frag.html")]`
 - View structs: fields must implement `Serialize`, handler returns struct directly
 - Template context: `TemplateContext` in request extensions, middleware adds via `ctx.insert("key", value)`

--- a/docs/plans/2026-03-08-modo-templates-implementation.md
+++ b/docs/plans/2026-03-08-modo-templates-implementation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add MiniJinja-based template engine to modo with view structs, auto-rendered request context, HTMX partial support, and i18n integration.
 
-**Architecture:** Two crates — `modo-templates` (runtime: engine, context map, render layer, View type) and `modo-templates-macros` (proc macro: `#[view]`). The render layer is axum middleware that intercepts View responses, merges request context from extensions, and renders via MiniJinja. Other crates (csrf, i18n, flash) add their values to a shared `TemplateContext` in request extensions.
+**Architecture:** Two crates — `modo-templates` (runtime: config, engine, context map, render layer, View type) and `modo-templates-macros` (proc macro: `#[view]`). The render layer is axum middleware that intercepts View responses, merges request context from extensions, and renders via MiniJinja. Other crates (csrf, i18n, flash) add their values to a shared `TemplateContext` in request extensions. Template layers are auto-registered in `app.rs` when the engine is registered as a service — no manual `.layer()` calls needed.
 
 **Tech Stack:** MiniJinja (template engine), minijinja-embed (compile-time embedding), serde (context serialization), syn/quote (proc macro), axum/tower (middleware)
 
@@ -82,15 +82,63 @@ feat(modo-templates-macros): scaffold proc macro crate
 
 ---
 
-### Task 2: Scaffold modo-templates crate with TemplateContext and errors
+### Task 2: Scaffold modo-templates crate with TemplateConfig, TemplateContext, and errors
 
 **Files:**
 - Create: `modo-templates/Cargo.toml`
 - Create: `modo-templates/src/lib.rs`
+- Create: `modo-templates/src/config.rs`
 - Create: `modo-templates/src/error.rs`
 - Create: `modo-templates/src/context.rs`
 
-**Step 1: Write test for TemplateContext**
+**Step 1: Create config.rs (follows DatabaseConfig/SessionConfig/I18nConfig pattern)**
+
+```rust
+use serde::Deserialize;
+
+/// Template engine configuration, deserialized from YAML via `modo::config::load()`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct TemplateConfig {
+    /// Directory containing template files.
+    pub path: String,
+    /// When true, accessing undefined variables in templates is an error.
+    pub strict: bool,
+}
+
+impl Default for TemplateConfig {
+    fn default() -> Self {
+        Self {
+            path: "templates".to_string(),
+            strict: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = TemplateConfig::default();
+        assert_eq!(config.path, "templates");
+        assert!(config.strict);
+    }
+
+    #[test]
+    fn partial_yaml_deserialization() {
+        let yaml = r#"
+path: "views"
+"#;
+        let config: TemplateConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.path, "views");
+        assert!(config.strict); // default preserved
+    }
+}
+```
+
+**Step 2: Write test for TemplateContext**
 
 Create `modo-templates/src/context.rs` with tests at the bottom:
 
@@ -215,6 +263,7 @@ modo-templates-macros = { path = "../modo-templates-macros" }
 
 minijinja = { version = "2", features = ["loader"] }
 serde = { version = "1", features = ["derive"] }
+serde_yaml_ng = "0.10"
 axum = "0.8"
 http = "1"
 tower = { version = "0.5", features = ["util"] }
@@ -231,9 +280,11 @@ serde = { version = "1", features = ["derive"] }
 **Step 4: Create lib.rs**
 
 ```rust
+pub mod config;
 pub mod context;
 pub mod error;
 
+pub use config::TemplateConfig;
 pub use context::TemplateContext;
 pub use error::TemplateError;
 
@@ -250,12 +301,12 @@ pub use minijinja::context;
 Add `"modo-templates"` to workspace `Cargo.toml` members list.
 
 Run: `cargo test -p modo-templates`
-Expected: 2 tests pass (insert_and_get, into_values_returns_all)
+Expected: 4 tests pass (2 config + 2 context)
 
 **Step 6: Commit**
 
 ```
-feat(modo-templates): scaffold crate with TemplateContext and errors
+feat(modo-templates): scaffold crate with TemplateConfig, TemplateContext, and errors
 ```
 
 ---
@@ -281,10 +332,11 @@ pub struct TemplateEngine {
 }
 
 impl TemplateEngine {
-    pub fn builder() -> TemplateEngineBuilder {
+    /// Create a builder from config (follows modo pattern: config → builder → service).
+    pub fn builder(config: &crate::TemplateConfig) -> TemplateEngineBuilder {
         TemplateEngineBuilder {
-            directory: None,
-            strict: true,
+            directory: config.path.clone().into(),
+            strict: config.strict,
         }
     }
 
@@ -307,19 +359,18 @@ impl TemplateEngine {
 }
 
 pub struct TemplateEngineBuilder {
-    directory: Option<PathBuf>,
+    directory: PathBuf,
     strict: bool,
 }
 
 impl TemplateEngineBuilder {
-    /// Set the directory to load templates from.
+    /// Override the template directory from config.
     pub fn directory(mut self, path: impl Into<PathBuf>) -> Self {
-        self.directory = Some(path.into());
+        self.directory = path.into();
         self
     }
 
-    /// Set strict undefined behavior (default: true).
-    /// When true, accessing undefined variables in templates is an error.
+    /// Override strict mode from config.
     pub fn strict(mut self, strict: bool) -> Self {
         self.strict = strict;
         self
@@ -333,10 +384,7 @@ impl TemplateEngineBuilder {
             env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
         }
 
-        if let Some(dir) = self.directory {
-            let dir = dir.clone();
-            env.set_loader(minijinja::path_loader(&dir));
-        }
+        env.set_loader(minijinja::path_loader(&self.directory));
 
         Ok(TemplateEngine { env })
     }
@@ -365,11 +413,17 @@ mod tests {
         dir
     }
 
+    fn test_config(dir: &std::path::Path) -> crate::TemplateConfig {
+        crate::TemplateConfig {
+            path: dir.to_str().unwrap().to_string(),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn render_simple_template() {
         let dir = setup_templates("simple");
-        let engine = TemplateEngine::builder()
-            .directory(&dir)
+        let engine = TemplateEngine::builder(&test_config(&dir))
             .build()
             .unwrap();
 
@@ -384,8 +438,7 @@ mod tests {
     #[test]
     fn render_with_inheritance() {
         let dir = setup_templates("inherit");
-        let engine = TemplateEngine::builder()
-            .directory(&dir)
+        let engine = TemplateEngine::builder(&test_config(&dir))
             .build()
             .unwrap();
 
@@ -400,9 +453,7 @@ mod tests {
     #[test]
     fn strict_mode_rejects_undefined() {
         let dir = setup_templates("strict");
-        let engine = TemplateEngine::builder()
-            .directory(&dir)
-            .strict(true)
+        let engine = TemplateEngine::builder(&test_config(&dir))
             .build()
             .unwrap();
 
@@ -418,8 +469,7 @@ mod tests {
     #[test]
     fn template_not_found_error() {
         let dir = setup_templates("notfound");
-        let engine = TemplateEngine::builder()
-            .directory(&dir)
+        let engine = TemplateEngine::builder(&test_config(&dir))
             .build()
             .unwrap();
 
@@ -1372,11 +1422,12 @@ feat(modo-i18n): add template function registration for MiniJinja
 
 ---
 
-### Task 8: Wire up re-exports in modo umbrella crate
+### Task 8: Wire up re-exports and auto-registration in modo umbrella crate
 
 **Files:**
 - Modify: `modo/Cargo.toml`
 - Modify: `modo/src/lib.rs`
+- Modify: `modo/src/app.rs`
 
 **Step 1: Add optional dependency**
 
@@ -1405,15 +1456,52 @@ pub use modo_templates_macros::view;
 pub use modo_templates;
 ```
 
-**Step 3: Verify compilation**
+**Step 3: Add auto-registration in app.rs**
+
+In `modo/src/app.rs`, inside `run()`, add template layer auto-registration:
+
+Before user layers (render_layer = innermost):
+
+```rust
+// --- Template render layer (innermost — closest to handler) ---
+#[cfg(feature = "templates")]
+let template_engine: Option<std::sync::Arc<modo_templates::TemplateEngine>> = self
+    .services
+    .get(&TypeId::of::<modo_templates::TemplateEngine>())
+    .and_then(|s| s.clone().downcast::<modo_templates::TemplateEngine>().ok());
+
+#[cfg(feature = "templates")]
+if let Some(ref engine) = template_engine {
+    router = router.layer(modo_templates::RenderLayer::new(engine.clone()));
+}
+```
+
+After user layers (context_layer = outermost of context-writing middleware):
+
+```rust
+// --- User global layers (innermost of framework layers) ---
+for layer_fn in self.layers {
+    router = layer_fn(router);
+}
+
+// --- Template context layer (wraps user layers, creates TemplateContext) ---
+#[cfg(feature = "templates")]
+if template_engine.is_some() {
+    router = router.layer(modo_templates::ContextLayer::new());
+}
+```
+
+This guarantees the stack: `context_layer > user layers (csrf, i18n) > render_layer > handler`
+
+**Step 4: Verify compilation**
 
 Run: `cargo check -p modo --features templates`
 Expected: PASS
 
-**Step 4: Commit**
+**Step 5: Commit**
 
 ```
-feat(modo): re-export modo-templates behind templates feature flag
+feat(modo): auto-register template layers when engine is a service
 ```
 
 ---
@@ -1617,12 +1705,12 @@ Under `## Architecture`, update the `modo-templates` entry:
 Under `## Conventions`, add:
 
 ```
+- Templates config: `TemplateConfig { path, strict }` — YAML-deserializable with serde defaults
+- Template engine: `TemplateEngine::builder(&config).build()` — config → builder → service pattern
 - Views: `#[modo::view("pages/home.html")]` or `#[modo::view("page.html", htmx = "htmx/frag.html")]`
 - View structs: fields must implement `Serialize`, handler returns struct directly
 - Template context: `TemplateContext` in request extensions, middleware adds via `ctx.insert("key", value)`
-- Template engine: `TemplateEngine::builder().directory("templates").build()`
-- Render layer: `RenderLayer::new(engine)` — renders View responses, merges request context
-- Context layer: `ContextLayer::new()` — outermost, creates TemplateContext with request_id + current_url
+- Template layers: auto-registered when `TemplateEngine` is a service — no manual `.layer()` needed
 - HTMX views: htmx template rendered on HX-Request, always HTTP 200, non-200 skips render
 - i18n in templates: `{{ t("key", name=val) }}` — register via `modo_i18n::register_template_functions`
 ```

--- a/examples/templates/Cargo.toml
+++ b/examples/templates/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "templates-example"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+modo = { path = "../../modo", features = ["templates"] }
+modo-templates = { path = "../../modo-templates" }
+chrono = "0.4"

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -24,7 +24,7 @@ async fn main(app: modo::app::AppBuilder) -> Result<(), Box<dyn std::error::Erro
 
     // Production: embed templates into the binary (requires minijinja-embed).
     // #[cfg(not(debug_assertions))]
-    // minijinja_embed::load_templates!(&mut engine.env_mut());
+    // minijinja_embed::load_templates!(engine.env_mut());
 
     // Custom template function — demonstrates env_mut().add_function() API
     engine

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -4,6 +4,7 @@ use modo_templates::{TemplateConfig, engine};
 struct HomePage {
     time: String,
     date: String,
+    time_hour: u32,
 }
 
 #[modo::handler(GET, "/")]
@@ -12,6 +13,7 @@ async fn home() -> HomePage {
     HomePage {
         time: now.format("%H:%M:%S").to_string(),
         date: now.format("%A, %B %d, %Y").to_string(),
+        time_hour: chrono::Timelike::hour(&now),
     }
 }
 
@@ -19,6 +21,10 @@ async fn home() -> HomePage {
 async fn main(app: modo::app::AppBuilder) -> Result<(), Box<dyn std::error::Error>> {
     let config = TemplateConfig::default();
     let mut engine = engine(&config)?;
+
+    // Production: embed templates into the binary (requires minijinja-embed).
+    // #[cfg(not(debug_assertions))]
+    // minijinja_embed::load_templates!(&mut engine.env_mut());
 
     // Custom template function — demonstrates env_mut().add_function() API
     engine

--- a/examples/templates/src/main.rs
+++ b/examples/templates/src/main.rs
@@ -1,0 +1,43 @@
+use modo_templates::{TemplateConfig, engine};
+
+#[modo::view("pages/home.html", htmx = "partials/clock.html")]
+struct HomePage {
+    time: String,
+    date: String,
+}
+
+#[modo::handler(GET, "/")]
+async fn home() -> HomePage {
+    let now = chrono::Local::now();
+    HomePage {
+        time: now.format("%H:%M:%S").to_string(),
+        date: now.format("%A, %B %d, %Y").to_string(),
+    }
+}
+
+#[modo::main]
+async fn main(app: modo::app::AppBuilder) -> Result<(), Box<dyn std::error::Error>> {
+    let config = TemplateConfig::default();
+    let mut engine = engine(&config)?;
+
+    // Custom template function — demonstrates env_mut().add_function() API
+    engine
+        .env_mut()
+        .add_function("greeting", |hour: u32| -> String {
+            match hour {
+                0..=11 => "Good morning".to_string(),
+                12..=17 => "Good afternoon".to_string(),
+                _ => "Good evening".to_string(),
+            }
+        });
+
+    app.security_headers(modo::SecurityHeadersConfig {
+        content_security_policy: Some(
+            "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'".to_string(),
+        ),
+        ..Default::default()
+    })
+    .service(engine)
+    .run()
+    .await
+}

--- a/examples/templates/templates/layouts/base.html
+++ b/examples/templates/templates/layouts/base.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}modo{% endblock %}</title>
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #f5f5f7;
+            color: #1d1d1f;
+        }
+        .container {
+            max-width: 480px;
+            width: 100%;
+            padding: 2.5rem;
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+            text-align: center;
+        }
+        h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.5rem; }
+        .subtitle { color: #86868b; font-size: 0.9rem; margin-bottom: 2rem; }
+        .clock { font-size: 4rem; font-weight: 300; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; padding: 1rem 0; }
+        .date { color: #6e6e73; font-size: 1rem; margin-bottom: 2rem; }
+        .divider { border: none; border-top: 1px solid #e5e5ea; margin: 1.5rem 0; }
+        .meta { color: #86868b; font-size: 0.75rem; text-align: left; }
+        .meta p { margin-bottom: 0.25rem; }
+        .meta code { background: #f5f5f7; padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.7rem; }
+    </style>
+</head>
+<body>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/examples/templates/templates/layouts/base.html
+++ b/examples/templates/templates/layouts/base.html
@@ -24,6 +24,7 @@
             box-shadow: 0 2px 12px rgba(0,0,0,0.08);
             text-align: center;
         }
+        .greeting { color: #6e6e73; font-size: 1.1rem; margin-bottom: 0.25rem; }
         h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.5rem; }
         .subtitle { color: #86868b; font-size: 0.9rem; margin-bottom: 2rem; }
         .clock { font-size: 4rem; font-weight: 300; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; padding: 1rem 0; }

--- a/examples/templates/templates/pages/home.html
+++ b/examples/templates/templates/pages/home.html
@@ -1,0 +1,24 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}Live Clock — modo-templates{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h1>Live Clock</h1>
+    <p class="subtitle">Powered by <strong>modo-templates</strong> + HTMX polling</p>
+
+    <div id="clock"
+         hx-get="/"
+         hx-trigger="every 1s"
+         hx-swap="innerHTML">
+        {% include "partials/clock.html" %}
+    </div>
+
+    <hr class="divider">
+
+    <div class="meta">
+        <p>request_id: <code>{{ request_id }}</code></p>
+        <p>current_url: <code>{{ current_url }}</code></p>
+    </div>
+</div>
+{% endblock %}

--- a/examples/templates/templates/pages/home.html
+++ b/examples/templates/templates/pages/home.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 <div class="container">
+    <p class="greeting">{{ greeting(time_hour) }}</p>
     <h1>Live Clock</h1>
     <p class="subtitle">Powered by <strong>modo-templates</strong> + HTMX polling</p>
 

--- a/examples/templates/templates/partials/clock.html
+++ b/examples/templates/templates/partials/clock.html
@@ -1,0 +1,2 @@
+<div class="clock">{{ time }}</div>
+<p class="date">{{ date }}</p>

--- a/modo-i18n/Cargo.toml
+++ b/modo-i18n/Cargo.toml
@@ -17,7 +17,15 @@ serde_yaml_ng = "0.10"
 futures-util = "0.3"
 tracing = "0.1"
 
+modo-templates = { path = "../modo-templates", optional = true }
+minijinja = { version = "2", optional = true }
+
+[features]
+default = []
+templates = ["dep:modo-templates", "dep:minijinja"]
+
 [dev-dependencies]
+minijinja = "2"
 tokio = { version = "1", features = ["full"] }
 tower = { version = "0.5", features = ["util"] }
 http = "1"

--- a/modo-i18n/src/lib.rs
+++ b/modo-i18n/src/lib.rs
@@ -5,6 +5,8 @@ pub mod extractor;
 pub mod locale;
 pub mod middleware;
 pub mod store;
+#[cfg(feature = "templates")]
+pub mod template;
 
 pub use config::I18nConfig;
 pub use entry::Entry;
@@ -12,6 +14,9 @@ pub use error::I18nError;
 pub use extractor::I18n;
 pub use middleware::{layer, layer_with_source};
 pub use store::{TranslationStore, load};
+
+#[cfg(feature = "templates")]
+pub use template::register_template_functions;
 
 // Re-export macro
 pub use modo_i18n_macros::t;

--- a/modo-i18n/src/middleware.rs
+++ b/modo-i18n/src/middleware.rs
@@ -140,6 +140,13 @@ where
             // Insert resolved language into extensions
             parts.extensions.insert(ResolvedLang(resolved.clone()));
 
+            // If TemplateContext exists (modo-templates context_layer is active),
+            // add the locale to it.
+            #[cfg(feature = "templates")]
+            if let Some(ctx) = parts.extensions.get_mut::<modo_templates::TemplateContext>() {
+                ctx.insert("locale", resolved.clone());
+            }
+
             // Reassemble request
             let request = Request::from_parts(parts, body);
 

--- a/modo-i18n/src/middleware.rs
+++ b/modo-i18n/src/middleware.rs
@@ -143,7 +143,10 @@ where
             // If TemplateContext exists (modo-templates context_layer is active),
             // add the locale to it.
             #[cfg(feature = "templates")]
-            if let Some(ctx) = parts.extensions.get_mut::<modo_templates::TemplateContext>() {
+            if let Some(ctx) = parts
+                .extensions
+                .get_mut::<modo_templates::TemplateContext>()
+            {
                 ctx.insert("locale", resolved.clone());
             }
 

--- a/modo-i18n/src/template.rs
+++ b/modo-i18n/src/template.rs
@@ -30,6 +30,19 @@ pub fn register_template_functions(env: &mut Environment<'static>, store: Arc<Tr
             let mut count: Option<u64> = None;
 
             for k in kwargs.args() {
+                if k == "count" {
+                    // Try native numeric types first (template passes integer),
+                    // fall back to String parse for string-typed count values.
+                    if let Ok(n) = kwargs.get::<u64>(k) {
+                        count = Some(n);
+                        vars.push((k.to_string(), n.to_string()));
+                        continue;
+                    } else if let Ok(n) = kwargs.get::<i64>(k) {
+                        count = u64::try_from(n).ok();
+                        vars.push((k.to_string(), n.to_string()));
+                        continue;
+                    }
+                }
                 let v: String = kwargs
                     .get::<String>(k)
                     .map_err(|e: Error| Error::new(ErrorKind::InvalidOperation, e.to_string()))?;

--- a/modo-i18n/src/template.rs
+++ b/modo-i18n/src/template.rs
@@ -1,0 +1,69 @@
+use crate::store::TranslationStore;
+use minijinja::value::Kwargs;
+use minijinja::{Environment, Error, ErrorKind, State};
+use std::sync::Arc;
+
+/// Register i18n template functions (`t`) on the MiniJinja environment.
+///
+/// The `t` function reads `locale` from the template render context
+/// (set by the i18n middleware via `TemplateContext`).
+///
+/// Template usage:
+/// ```jinja
+/// {{ t("auth.login.title") }}
+/// {{ t("greeting", name="Alice") }}
+/// {{ t("items_count", count=5) }}
+/// ```
+pub fn register_template_functions(env: &mut Environment<'static>, store: Arc<TranslationStore>) {
+    env.add_function(
+        "t",
+        move |state: &State, key: String, kwargs: Kwargs| -> Result<String, Error> {
+            let locale = state
+                .lookup("locale")
+                .map(|v: minijinja::Value| v.to_string())
+                .unwrap_or_else(|| store.config().default_lang.clone());
+
+            let default_lang = store.config().default_lang.clone();
+
+            // Extract keyword arguments
+            let mut vars: Vec<(String, String)> = Vec::new();
+            let mut count: Option<u64> = None;
+
+            for k in kwargs.args() {
+                let v: String = kwargs.get::<String>(k).map_err(|e: Error| {
+                    Error::new(ErrorKind::InvalidOperation, e.to_string())
+                })?;
+                if k == "count" {
+                    count = v.parse().ok();
+                }
+                vars.push((k.to_string(), v));
+            }
+
+            // Try requested locale, fall back to default
+            let result = if let Some(count) = count {
+                store
+                    .get_plural(&locale, &key, count)
+                    .or_else(|| store.get_plural(&default_lang, &key, count))
+            } else {
+                store
+                    .get(&locale, &key)
+                    .or_else(|| store.get(&default_lang, &key))
+            };
+
+            match result {
+                Some(template_str) => {
+                    // Apply variable interpolation
+                    let mut output = template_str;
+                    for (k, v) in &vars {
+                        output = output.replace(&format!("{{{k}}}"), v);
+                    }
+                    Ok(output)
+                }
+                None => {
+                    // Return the key itself as fallback (common i18n convention)
+                    Ok(key)
+                }
+            }
+        },
+    );
+}

--- a/modo-i18n/src/template.rs
+++ b/modo-i18n/src/template.rs
@@ -30,9 +30,9 @@ pub fn register_template_functions(env: &mut Environment<'static>, store: Arc<Tr
             let mut count: Option<u64> = None;
 
             for k in kwargs.args() {
-                let v: String = kwargs.get::<String>(k).map_err(|e: Error| {
-                    Error::new(ErrorKind::InvalidOperation, e.to_string())
-                })?;
+                let v: String = kwargs
+                    .get::<String>(k)
+                    .map_err(|e: Error| Error::new(ErrorKind::InvalidOperation, e.to_string()))?;
                 if k == "count" {
                     count = v.parse().ok();
                 }

--- a/modo-i18n/tests/template_integration.rs
+++ b/modo-i18n/tests/template_integration.rs
@@ -38,8 +38,7 @@ fn t_function_simple_key() {
     let mut env = Environment::new();
     register_template_functions(&mut env, store);
 
-    env.add_template("test", "{{ t('common.title') }}")
-        .unwrap();
+    env.add_template("test", "{{ t('common.title') }}").unwrap();
     let tmpl = env.get_template("test").unwrap();
     let result = tmpl.render(context! { locale => "en" }).unwrap();
     assert_eq!(result, "Welcome");

--- a/modo-i18n/tests/template_integration.rs
+++ b/modo-i18n/tests/template_integration.rs
@@ -1,0 +1,93 @@
+#![cfg(feature = "templates")]
+
+use minijinja::{Environment, context};
+use modo_i18n::{I18nConfig, load, register_template_functions};
+use std::fs;
+use std::path::PathBuf;
+
+fn setup(name: &str) -> (std::sync::Arc<modo_i18n::TranslationStore>, PathBuf) {
+    let dir = std::env::temp_dir().join(format!("modo_i18n_tmpl_test_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    let en = dir.join("en");
+    fs::create_dir_all(&en).unwrap();
+    fs::write(
+        en.join("common.yml"),
+        r#"
+greeting: "Hello, {name}!"
+title: "Welcome"
+items_count:
+  zero: "No items"
+  one: "One item"
+  other: "{count} items"
+"#,
+    )
+    .unwrap();
+
+    let config = I18nConfig {
+        path: dir.to_str().unwrap().to_string(),
+        default_lang: "en".to_string(),
+        ..Default::default()
+    };
+    let store = load(&config).unwrap();
+    (store, dir)
+}
+
+#[test]
+fn t_function_simple_key() {
+    let (store, dir) = setup("simple");
+    let mut env = Environment::new();
+    register_template_functions(&mut env, store);
+
+    env.add_template("test", "{{ t('common.title') }}")
+        .unwrap();
+    let tmpl = env.get_template("test").unwrap();
+    let result = tmpl.render(context! { locale => "en" }).unwrap();
+    assert_eq!(result, "Welcome");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn t_function_with_variable() {
+    let (store, dir) = setup("var");
+    let mut env = Environment::new();
+    register_template_functions(&mut env, store);
+
+    env.add_template("test", "{{ t('common.greeting', name='World') }}")
+        .unwrap();
+    let tmpl = env.get_template("test").unwrap();
+    let result = tmpl.render(context! { locale => "en" }).unwrap();
+    assert_eq!(result, "Hello, World!");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn t_function_plural() {
+    let (store, dir) = setup("plural");
+    let mut env = Environment::new();
+    register_template_functions(&mut env, store);
+
+    env.add_template("test", "{{ t('common.items_count', count=0) }} | {{ t('common.items_count', count=1) }} | {{ t('common.items_count', count=5) }}")
+        .unwrap();
+    let tmpl = env.get_template("test").unwrap();
+    let result = tmpl.render(context! { locale => "en" }).unwrap();
+    assert_eq!(result, "No items | One item | 5 items");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn t_function_missing_key_returns_key() {
+    let (store, dir) = setup("missing");
+    let mut env = Environment::new();
+    register_template_functions(&mut env, store);
+
+    env.add_template("test", "{{ t('nonexistent.key') }}")
+        .unwrap();
+    let tmpl = env.get_template("test").unwrap();
+    let result = tmpl.render(context! { locale => "en" }).unwrap();
+    assert_eq!(result, "nonexistent.key");
+
+    fs::remove_dir_all(&dir).unwrap();
+}

--- a/modo-templates-macros/Cargo.toml
+++ b/modo-templates-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "modo-templates-macros"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"

--- a/modo-templates-macros/src/lib.rs
+++ b/modo-templates-macros/src/lib.rs
@@ -76,11 +76,12 @@ fn view_impl(
     };
 
     Ok(quote! {
-        #[derive(::serde::Serialize)]
+        #[derive(::modo_templates::serde::Serialize)]
+        #[serde(crate = "::modo_templates::serde")]
         #input
 
-        impl ::axum::response::IntoResponse for #struct_name {
-            fn into_response(self) -> ::axum::response::Response {
+        impl ::modo_templates::axum::response::IntoResponse for #struct_name {
+            fn into_response(self) -> ::modo_templates::axum::response::Response {
                 let user_context = ::modo_templates::minijinja::Value::from_serialize(&self);
                 let view = #view_construction;
                 view.into_response()

--- a/modo-templates-macros/src/lib.rs
+++ b/modo-templates-macros/src/lib.rs
@@ -1,0 +1,26 @@
+use proc_macro::TokenStream;
+
+/// Marks a struct as a view with an associated template.
+///
+/// Usage:
+/// ```ignore
+/// #[view("pages/home.html")]
+/// struct HomePage { items: Vec<Item> }
+///
+/// #[view("pages/login.html", htmx = "htmx/login_form.html")]
+/// struct LoginPage { form_errors: Vec<String> }
+/// ```
+#[proc_macro_attribute]
+pub fn view(attr: TokenStream, item: TokenStream) -> TokenStream {
+    match view_impl(attr.into(), item.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn view_impl(
+    _attr: proc_macro2::TokenStream,
+    _item: proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
+    todo!("implement in Task 4")
+}

--- a/modo-templates-macros/src/lib.rs
+++ b/modo-templates-macros/src/lib.rs
@@ -1,4 +1,41 @@
 use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{Ident, ItemStruct, LitStr, Token};
+
+struct ViewAttr {
+    template: LitStr,
+    htmx_template: Option<LitStr>,
+}
+
+impl Parse for ViewAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let template: LitStr = input.parse()?;
+        let mut htmx_template = None;
+
+        while input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+            let key: Ident = input.parse()?;
+            if key == "htmx" {
+                input.parse::<Token![=]>()?;
+                htmx_template = Some(input.parse::<LitStr>()?);
+            } else {
+                return Err(syn::Error::new_spanned(
+                    key,
+                    "unknown attribute, expected `htmx`",
+                ));
+            }
+        }
+
+        Ok(ViewAttr {
+            template,
+            htmx_template,
+        })
+    }
+}
 
 /// Marks a struct as a view with an associated template.
 ///
@@ -19,8 +56,35 @@ pub fn view(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn view_impl(
-    _attr: proc_macro2::TokenStream,
-    _item: proc_macro2::TokenStream,
+    attr: proc_macro2::TokenStream,
+    item: proc_macro2::TokenStream,
 ) -> syn::Result<proc_macro2::TokenStream> {
-    todo!("implement in Task 4")
+    let attr = syn::parse2::<ViewAttr>(attr)?;
+    let input = syn::parse2::<ItemStruct>(item)?;
+
+    let struct_name = &input.ident;
+    let template_path = &attr.template;
+
+    let view_construction = match &attr.htmx_template {
+        Some(htmx_lit) => quote! {
+            ::modo_templates::View::new(#template_path, user_context)
+                .with_htmx(#htmx_lit)
+        },
+        None => quote! {
+            ::modo_templates::View::new(#template_path, user_context)
+        },
+    };
+
+    Ok(quote! {
+        #[derive(::serde::Serialize)]
+        #input
+
+        impl ::axum::response::IntoResponse for #struct_name {
+            fn into_response(self) -> ::axum::response::Response {
+                let user_context = ::modo_templates::minijinja::Value::from_serialize(&self);
+                let view = #view_construction;
+                view.into_response()
+            }
+        }
+    })
 }

--- a/modo-templates/Cargo.toml
+++ b/modo-templates/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 license.workspace = true
 
 [dependencies]
-modo = { path = "../modo" }
 modo-templates-macros = { path = "../modo-templates-macros" }
 
 minijinja = { version = "2", features = ["loader"] }

--- a/modo-templates/Cargo.toml
+++ b/modo-templates/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "modo-templates"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[dependencies]
+modo-templates-macros = { path = "../modo-templates-macros" }
+
+minijinja = { version = "2", features = ["loader"] }
+serde = { version = "1", features = ["derive"] }
+serde_yaml_ng = "0.10"
+axum = "0.8"
+http = "1"
+tower = { version = "0.5", features = ["util"] }
+futures-util = "0.3"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.5", features = ["util"] }
+http = "1"
+serde = { version = "1", features = ["derive"] }

--- a/modo-templates/Cargo.toml
+++ b/modo-templates/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license.workspace = true
 
 [dependencies]
+modo = { path = "../modo" }
 modo-templates-macros = { path = "../modo-templates-macros" }
 
 minijinja = { version = "2", features = ["loader"] }

--- a/modo-templates/src/config.rs
+++ b/modo-templates/src/config.rs
@@ -1,0 +1,42 @@
+use serde::Deserialize;
+
+/// Template engine configuration, deserialized from YAML via `modo::config::load()`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct TemplateConfig {
+    /// Directory containing template files.
+    pub path: String,
+    /// When true, accessing undefined variables in templates is an error.
+    pub strict: bool,
+}
+
+impl Default for TemplateConfig {
+    fn default() -> Self {
+        Self {
+            path: "templates".to_string(),
+            strict: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = TemplateConfig::default();
+        assert_eq!(config.path, "templates");
+        assert!(config.strict);
+    }
+
+    #[test]
+    fn partial_yaml_deserialization() {
+        let yaml = r#"
+path: "views"
+"#;
+        let config: TemplateConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.path, "views");
+        assert!(config.strict); // default preserved
+    }
+}

--- a/modo-templates/src/context.rs
+++ b/modo-templates/src/context.rs
@@ -1,0 +1,57 @@
+use minijinja::Value;
+use std::collections::BTreeMap;
+
+/// Request-scoped template context stored in request extensions.
+/// Middleware layers add their values here; the render layer merges
+/// this with the view's user context before rendering.
+#[derive(Debug, Clone, Default)]
+pub struct TemplateContext {
+    values: BTreeMap<String, Value>,
+}
+
+impl TemplateContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, key: impl Into<String>, value: impl Into<Value>) {
+        self.values.insert(key.into(), value.into());
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.values.get(key)
+    }
+
+    /// Consume into the inner map for merging with user context.
+    pub fn into_values(self) -> BTreeMap<String, Value> {
+        self.values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_get() {
+        let mut ctx = TemplateContext::new();
+        ctx.insert("locale", "en");
+        ctx.insert("request_id", "abc-123");
+
+        assert_eq!(ctx.get("locale").unwrap().to_string(), "en");
+        assert_eq!(ctx.get("request_id").unwrap().to_string(), "abc-123");
+        assert!(ctx.get("missing").is_none());
+    }
+
+    #[test]
+    fn into_values_returns_all() {
+        let mut ctx = TemplateContext::new();
+        ctx.insert("a", "1");
+        ctx.insert("b", "2");
+
+        let values = ctx.into_values();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values["a"].to_string(), "1");
+        assert_eq!(values["b"].to_string(), "2");
+    }
+}

--- a/modo-templates/src/engine.rs
+++ b/modo-templates/src/engine.rs
@@ -25,7 +25,8 @@ impl TemplateEngine {
 
     /// Render a template by name with the given context value.
     ///
-    /// Dev: acquires a write lock, clears cached templates, and re-reads from disk.
+    /// Dev: acquires a write lock to clear cached templates, then drops it and
+    /// acquires a read lock for template loading + rendering (concurrent reads).
     /// Prod: acquires a read lock and serves from embedded templates only.
     pub fn render(
         &self,
@@ -33,8 +34,8 @@ impl TemplateEngine {
         ctx: minijinja::Value,
     ) -> Result<String, crate::TemplateError> {
         if cfg!(debug_assertions) {
-            let mut env = self.env.write().unwrap();
-            env.clear_templates();
+            self.env.write().unwrap().clear_templates();
+            let env = self.env.read().unwrap();
             let tmpl = env.get_template(name)?;
             Ok(tmpl.render(ctx)?)
         } else {

--- a/modo-templates/src/engine.rs
+++ b/modo-templates/src/engine.rs
@@ -1,34 +1,56 @@
+use std::sync::RwLock;
+
 use minijinja::Environment;
 
 /// Wraps MiniJinja's `Environment` for use as a modo service.
+///
+/// In dev (`debug_assertions`), templates are re-read from disk on every render
+/// via `clear_templates()` + the configured `path_loader`.
+///
+/// In prod, no filesystem loader is set — templates must be embedded into the
+/// binary using `minijinja-embed`. Call `engine.env_mut()` during setup to load
+/// them via `minijinja_embed::load_templates!(engine.env_mut())`.
+#[derive(Debug)]
 pub struct TemplateEngine {
-    env: Environment<'static>,
+    env: RwLock<Environment<'static>>,
 }
 
 impl TemplateEngine {
-    /// Get a reference to the inner MiniJinja Environment for registering
-    /// custom functions, filters, or globals.
-    pub fn env(&self) -> &Environment<'static> {
-        &self.env
-    }
-
-    /// Get a mutable reference to the inner MiniJinja Environment.
+    /// Mutable access to the inner MiniJinja Environment during setup
+    /// (before service registration). Uses `get_mut()` — no lock overhead
+    /// since `&mut self` guarantees exclusivity.
     pub fn env_mut(&mut self) -> &mut Environment<'static> {
-        &mut self.env
+        self.env.get_mut().unwrap()
     }
 
     /// Render a template by name with the given context value.
+    ///
+    /// Dev: acquires a write lock, clears cached templates, and re-reads from disk.
+    /// Prod: acquires a read lock and serves from embedded templates only.
     pub fn render(
         &self,
         name: &str,
         ctx: minijinja::Value,
     ) -> Result<String, crate::TemplateError> {
-        let tmpl = self.env.get_template(name)?;
-        Ok(tmpl.render(ctx)?)
+        if cfg!(debug_assertions) {
+            let mut env = self.env.write().unwrap();
+            env.clear_templates();
+            let tmpl = env.get_template(name)?;
+            Ok(tmpl.render(ctx)?)
+        } else {
+            let env = self.env.read().unwrap();
+            let tmpl = env.get_template(name)?;
+            Ok(tmpl.render(ctx)?)
+        }
     }
 }
 
 /// Create a template engine from config (follows `modo_i18n::load` pattern).
+///
+/// In dev (`debug_assertions`), sets a filesystem `path_loader` so templates
+/// auto-reload on every render. In prod, no loader is set — use
+/// `minijinja-embed` to compile templates into the binary and load them
+/// via `engine.env_mut()` before registering the engine as a service.
 pub fn engine(config: &crate::TemplateConfig) -> Result<TemplateEngine, crate::TemplateError> {
     let mut env = Environment::new();
 
@@ -36,9 +58,14 @@ pub fn engine(config: &crate::TemplateConfig) -> Result<TemplateEngine, crate::T
         env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
     }
 
+    // Dev only: load templates from filesystem (auto-reload via clear_templates in render).
+    // Prod: no path_loader — templates must be embedded via minijinja-embed.
+    #[cfg(debug_assertions)]
     env.set_loader(minijinja::path_loader(&config.path));
 
-    Ok(TemplateEngine { env })
+    Ok(TemplateEngine {
+        env: RwLock::new(env),
+    })
 }
 
 #[cfg(test)]
@@ -114,6 +141,46 @@ mod tests {
 
         let result = engine.render("nonexistent.html", minijinja::context! {});
         assert!(matches!(result, Err(crate::TemplateError::NotFound { .. })));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn dev_auto_reload_picks_up_changes() {
+        let dir = setup_templates("reload");
+        let engine = crate::engine(&test_config(&dir)).unwrap();
+
+        let result = engine
+            .render("hello.html", minijinja::context! { name => "World" })
+            .unwrap();
+        assert_eq!(result, "Hello World!");
+
+        // Modify template on disk
+        fs::write(dir.join("hello.html"), "Hi {{ name }}!").unwrap();
+
+        // Next render should pick up the change (dev mode clears cache)
+        let result = engine
+            .render("hello.html", minijinja::context! { name => "World" })
+            .unwrap();
+        assert_eq!(result, "Hi World!");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn env_mut_accessible_during_setup() {
+        let dir = setup_templates("envmut");
+        fs::write(dir.join("custom.html"), "{{ greet(name) }}").unwrap();
+
+        let mut engine = crate::engine(&test_config(&dir)).unwrap();
+        engine
+            .env_mut()
+            .add_function("greet", |name: String| format!("Hello, {name}!"));
+
+        let result = engine
+            .render("custom.html", minijinja::context! { name => "Alice" })
+            .unwrap();
+        assert_eq!(result, "Hello, Alice!");
 
         fs::remove_dir_all(&dir).unwrap();
     }

--- a/modo-templates/src/engine.rs
+++ b/modo-templates/src/engine.rs
@@ -1,0 +1,123 @@
+use minijinja::Environment;
+
+/// Wraps MiniJinja's `Environment` for use as a modo service.
+pub struct TemplateEngine {
+    env: Environment<'static>,
+}
+
+impl TemplateEngine {
+    /// Get a reference to the inner MiniJinja Environment for registering
+    /// custom functions, filters, or globals.
+    pub fn env(&self) -> &Environment<'static> {
+        &self.env
+    }
+
+    /// Get a mutable reference to the inner MiniJinja Environment.
+    pub fn env_mut(&mut self) -> &mut Environment<'static> {
+        &mut self.env
+    }
+
+    /// Render a template by name with the given context value.
+    pub fn render(&self, name: &str, ctx: minijinja::Value) -> Result<String, crate::TemplateError> {
+        let tmpl = self.env.get_template(name)?;
+        Ok(tmpl.render(ctx)?)
+    }
+}
+
+/// Create a template engine from config (follows `modo_i18n::load` pattern).
+pub fn engine(config: &crate::TemplateConfig) -> Result<TemplateEngine, crate::TemplateError> {
+    let mut env = Environment::new();
+
+    if config.strict {
+        env.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+    }
+
+    env.set_loader(minijinja::path_loader(&config.path));
+
+    Ok(TemplateEngine { env })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn setup_templates(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("modo_tmpl_test_{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("hello.html"), "Hello {{ name }}!").unwrap();
+        fs::write(
+            dir.join("layout.html"),
+            "{% block content %}{% endblock %}",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("page.html"),
+            r#"{% extends "layout.html" %}{% block content %}Page: {{ title }}{% endblock %}"#,
+        )
+        .unwrap();
+        dir
+    }
+
+    fn test_config(dir: &std::path::Path) -> crate::TemplateConfig {
+        crate::TemplateConfig {
+            path: dir.to_str().unwrap().to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn render_simple_template() {
+        let dir = setup_templates("simple");
+        let engine = crate::engine(&test_config(&dir)).unwrap();
+
+        let result = engine
+            .render("hello.html", minijinja::context! { name => "World" }.into())
+            .unwrap();
+        assert_eq!(result, "Hello World!");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn render_with_inheritance() {
+        let dir = setup_templates("inherit");
+        let engine = crate::engine(&test_config(&dir)).unwrap();
+
+        let result = engine
+            .render("page.html", minijinja::context! { title => "Home" }.into())
+            .unwrap();
+        assert_eq!(result, "Page: Home");
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn strict_mode_rejects_undefined() {
+        let dir = setup_templates("strict");
+        let engine = crate::engine(&test_config(&dir)).unwrap();
+
+        let result = engine.render(
+            "hello.html",
+            minijinja::context! {}.into(), // name is missing
+        );
+        assert!(result.is_err());
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn template_not_found_error() {
+        let dir = setup_templates("notfound");
+        let engine = crate::engine(&test_config(&dir)).unwrap();
+
+        let result = engine.render("nonexistent.html", minijinja::context! {}.into());
+        assert!(matches!(
+            result,
+            Err(crate::TemplateError::NotFound { .. })
+        ));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/modo-templates/src/engine.rs
+++ b/modo-templates/src/engine.rs
@@ -18,7 +18,11 @@ impl TemplateEngine {
     }
 
     /// Render a template by name with the given context value.
-    pub fn render(&self, name: &str, ctx: minijinja::Value) -> Result<String, crate::TemplateError> {
+    pub fn render(
+        &self,
+        name: &str,
+        ctx: minijinja::Value,
+    ) -> Result<String, crate::TemplateError> {
         let tmpl = self.env.get_template(name)?;
         Ok(tmpl.render(ctx)?)
     }
@@ -47,11 +51,7 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join("hello.html"), "Hello {{ name }}!").unwrap();
-        fs::write(
-            dir.join("layout.html"),
-            "{% block content %}{% endblock %}",
-        )
-        .unwrap();
+        fs::write(dir.join("layout.html"), "{% block content %}{% endblock %}").unwrap();
         fs::write(
             dir.join("page.html"),
             r#"{% extends "layout.html" %}{% block content %}Page: {{ title }}{% endblock %}"#,
@@ -73,7 +73,7 @@ mod tests {
         let engine = crate::engine(&test_config(&dir)).unwrap();
 
         let result = engine
-            .render("hello.html", minijinja::context! { name => "World" }.into())
+            .render("hello.html", minijinja::context! { name => "World" })
             .unwrap();
         assert_eq!(result, "Hello World!");
 
@@ -86,7 +86,7 @@ mod tests {
         let engine = crate::engine(&test_config(&dir)).unwrap();
 
         let result = engine
-            .render("page.html", minijinja::context! { title => "Home" }.into())
+            .render("page.html", minijinja::context! { title => "Home" })
             .unwrap();
         assert_eq!(result, "Page: Home");
 
@@ -100,7 +100,7 @@ mod tests {
 
         let result = engine.render(
             "hello.html",
-            minijinja::context! {}.into(), // name is missing
+            minijinja::context! {}, // name is missing
         );
         assert!(result.is_err());
 
@@ -112,11 +112,8 @@ mod tests {
         let dir = setup_templates("notfound");
         let engine = crate::engine(&test_config(&dir)).unwrap();
 
-        let result = engine.render("nonexistent.html", minijinja::context! {}.into());
-        assert!(matches!(
-            result,
-            Err(crate::TemplateError::NotFound { .. })
-        ));
+        let result = engine.render("nonexistent.html", minijinja::context! {});
+        assert!(matches!(result, Err(crate::TemplateError::NotFound { .. })));
 
         fs::remove_dir_all(&dir).unwrap();
     }

--- a/modo-templates/src/engine.rs
+++ b/modo-templates/src/engine.rs
@@ -39,8 +39,8 @@ pub fn engine(config: &crate::TemplateConfig) -> Result<TemplateEngine, crate::T
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
+    use std::path::PathBuf;
 
     fn setup_templates(name: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("modo_tmpl_test_{name}"));

--- a/modo-templates/src/error.rs
+++ b/modo-templates/src/error.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum TemplateError {
+    /// Template not found in the engine.
+    NotFound { name: String },
+    /// MiniJinja render error.
+    Render { source: minijinja::Error },
+    /// Engine not registered as a service.
+    EngineNotRegistered,
+}
+
+impl fmt::Display for TemplateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound { name } => write!(f, "template not found: {name}"),
+            Self::Render { source } => write!(f, "template render error: {source}"),
+            Self::EngineNotRegistered => write!(f, "TemplateEngine not registered as a service"),
+        }
+    }
+}
+
+impl std::error::Error for TemplateError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Render { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl From<minijinja::Error> for TemplateError {
+    fn from(err: minijinja::Error) -> Self {
+        if err.kind() == minijinja::ErrorKind::TemplateNotFound {
+            Self::NotFound {
+                name: err.template_source().unwrap_or("unknown").to_string(),
+            }
+        } else {
+            Self::Render { source: err }
+        }
+    }
+}

--- a/modo-templates/src/error.rs
+++ b/modo-templates/src/error.rs
@@ -33,10 +33,24 @@ impl From<minijinja::Error> for TemplateError {
     fn from(err: minijinja::Error) -> Self {
         if err.kind() == minijinja::ErrorKind::TemplateNotFound {
             Self::NotFound {
-                name: err.template_source().unwrap_or("unknown").to_string(),
+                name: extract_template_name(&err),
             }
         } else {
             Self::Render { source: err }
         }
     }
+}
+
+/// Extracts the template name from a TemplateNotFound error's detail.
+/// MiniJinja's detail format: `template "NAME" does not exist`
+fn extract_template_name(err: &minijinja::Error) -> String {
+    if let Some(detail) = err.detail() {
+        if let Some(start) = detail.find('"')
+            && let Some(end) = detail[start + 1..].find('"')
+        {
+            return detail[start + 1..start + 1 + end].to_string();
+        }
+        return detail.to_string();
+    }
+    "unknown".to_string()
 }

--- a/modo-templates/src/lib.rs
+++ b/modo-templates/src/lib.rs
@@ -3,6 +3,7 @@ pub mod context;
 pub mod engine;
 pub mod error;
 pub mod middleware;
+pub mod render;
 pub mod view;
 
 pub use config::TemplateConfig;
@@ -10,6 +11,7 @@ pub use context::TemplateContext;
 pub use engine::{TemplateEngine, engine};
 pub use error::TemplateError;
 pub use middleware::ContextLayer;
+pub use render::RenderLayer;
 pub use view::View;
 
 // Re-export macro

--- a/modo-templates/src/lib.rs
+++ b/modo-templates/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod config;
+pub mod context;
+pub mod error;
+
+pub use config::TemplateConfig;
+pub use context::TemplateContext;
+pub use error::TemplateError;
+
+// Re-export macro
+pub use modo_templates_macros::view;
+
+// Re-export minijinja essentials for macro-generated code
+pub use minijinja;
+pub use minijinja::context;

--- a/modo-templates/src/lib.rs
+++ b/modo-templates/src/lib.rs
@@ -17,6 +17,8 @@ pub use view::View;
 // Re-export macro
 pub use modo_templates_macros::view;
 
-// Re-export minijinja essentials for macro-generated code
+// Re-export dependencies for macro-generated code
+pub use axum;
 pub use minijinja;
 pub use minijinja::context;
+pub use serde;

--- a/modo-templates/src/lib.rs
+++ b/modo-templates/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod context;
+pub mod engine;
 pub mod error;
 
 pub use config::TemplateConfig;
 pub use context::TemplateContext;
+pub use engine::{TemplateEngine, engine};
 pub use error::TemplateError;
 
 // Re-export macro

--- a/modo-templates/src/lib.rs
+++ b/modo-templates/src/lib.rs
@@ -2,12 +2,14 @@ pub mod config;
 pub mod context;
 pub mod engine;
 pub mod error;
+pub mod middleware;
 pub mod view;
 
 pub use config::TemplateConfig;
 pub use context::TemplateContext;
 pub use engine::{TemplateEngine, engine};
 pub use error::TemplateError;
+pub use middleware::ContextLayer;
 pub use view::View;
 
 // Re-export macro

--- a/modo-templates/src/lib.rs
+++ b/modo-templates/src/lib.rs
@@ -2,11 +2,13 @@ pub mod config;
 pub mod context;
 pub mod engine;
 pub mod error;
+pub mod view;
 
 pub use config::TemplateConfig;
 pub use context::TemplateContext;
 pub use engine::{TemplateEngine, engine};
 pub use error::TemplateError;
+pub use view::View;
 
 // Re-export macro
 pub use modo_templates_macros::view;

--- a/modo-templates/src/middleware.rs
+++ b/modo-templates/src/middleware.rs
@@ -56,11 +56,6 @@ where
             let mut ctx = TemplateContext::new();
             ctx.insert("current_url", parts.uri.to_string());
 
-            // Read request_id from extensions if set by request_id middleware
-            if let Some(request_id) = parts.extensions.get::<modo::RequestId>() {
-                ctx.insert("request_id", request_id.to_string());
-            }
-
             parts.extensions.insert(ctx);
 
             let request = Request::from_parts(parts, body);

--- a/modo-templates/src/middleware.rs
+++ b/modo-templates/src/middleware.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 use tower::{Layer, Service};
 
 /// Layer that creates a `TemplateContext` in request extensions
-/// with built-in values (request_id, current_url).
+/// with built-in values (current_url).
 /// Must be applied outermost of all context-writing middleware.
 #[derive(Clone, Default)]
 pub struct ContextLayer;

--- a/modo-templates/src/middleware.rs
+++ b/modo-templates/src/middleware.rs
@@ -31,10 +31,7 @@ pub struct ContextMiddleware<S> {
 
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ContextMiddleware<S>
 where
-    S: Service<Request<ReqBody>, Response = axum::http::Response<ResBody>>
-        + Clone
-        + Send
-        + 'static,
+    S: Service<Request<ReqBody>, Response = axum::http::Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send + 'static,
     ReqBody: Send + 'static,
     ResBody: Send + 'static,

--- a/modo-templates/src/middleware.rs
+++ b/modo-templates/src/middleware.rs
@@ -1,0 +1,70 @@
+use crate::context::TemplateContext;
+use axum::http::Request;
+use futures_util::future::BoxFuture;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+/// Layer that creates a `TemplateContext` in request extensions
+/// with built-in values (request_id, current_url).
+/// Must be applied outermost of all context-writing middleware.
+#[derive(Clone, Default)]
+pub struct ContextLayer;
+
+impl ContextLayer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for ContextLayer {
+    type Service = ContextMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ContextMiddleware { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct ContextMiddleware<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ContextMiddleware<S>
+where
+    S: Service<Request<ReqBody>, Response = axum::http::Response<ResBody>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let (mut parts, body) = request.into_parts();
+
+            let mut ctx = TemplateContext::new();
+            ctx.insert("current_url", parts.uri.to_string());
+
+            // Read request_id from extensions if set by request_id middleware
+            if let Some(request_id) = parts.extensions.get::<modo::RequestId>() {
+                ctx.insert("request_id", request_id.to_string());
+            }
+
+            parts.extensions.insert(ctx);
+
+            let request = Request::from_parts(parts, body);
+            inner.call(request).await
+        })
+    }
+}

--- a/modo-templates/src/render.rs
+++ b/modo-templates/src/render.rs
@@ -1,0 +1,131 @@
+use crate::context::TemplateContext;
+use crate::engine::TemplateEngine;
+use crate::view::View;
+use axum::body::Body;
+use axum::http::Request;
+use axum::response::{Html, IntoResponse, Response};
+use futures_util::future::BoxFuture;
+use http::StatusCode;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+use tracing::error;
+
+/// Layer that intercepts View responses and renders them via the TemplateEngine.
+/// Merges request TemplateContext with the view's user context.
+#[derive(Clone)]
+pub struct RenderLayer {
+    engine: Arc<TemplateEngine>,
+}
+
+impl RenderLayer {
+    pub fn new(engine: Arc<TemplateEngine>) -> Self {
+        Self { engine }
+    }
+}
+
+impl<S> Layer<S> for RenderLayer {
+    type Service = RenderMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RenderMiddleware {
+            inner,
+            engine: self.engine.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RenderMiddleware<S> {
+    inner: S,
+    engine: Arc<TemplateEngine>,
+}
+
+impl<S> Service<Request<Body>> for RenderMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<std::convert::Infallible> + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        let engine = self.engine.clone();
+        let mut inner = self.inner.clone();
+
+        // Capture request context and HTMX header before passing to handler
+        let template_ctx = request
+            .extensions()
+            .get::<TemplateContext>()
+            .cloned()
+            .unwrap_or_default();
+        let is_htmx = request.headers().get("hx-request").is_some();
+
+        Box::pin(async move {
+            let mut response = inner.call(request).await?;
+
+            // Only process responses that contain a View
+            let Some(view) = response.extensions_mut().remove::<View>() else {
+                return Ok(response);
+            };
+
+            let status = response.status();
+
+            // HTMX rule: non-200 status -> don't render, pass through
+            if is_htmx && status != StatusCode::OK {
+                return Ok(response);
+            }
+
+            // Pick template: htmx template for HTMX requests, full template otherwise
+            let template_name = if is_htmx {
+                view.htmx_template.as_deref().unwrap_or(&view.template)
+            } else {
+                &view.template
+            };
+
+            // Merge request context with user context
+            let merged = merge_contexts(template_ctx, view.user_context);
+
+            match engine.render(template_name, merged) {
+                Ok(html) => {
+                    let mut resp = Html(html).into_response();
+                    // HTMX responses are always 200
+                    if is_htmx {
+                        *resp.status_mut() = StatusCode::OK;
+                    } else {
+                        *resp.status_mut() = status;
+                    }
+                    Ok(resp)
+                }
+                Err(err) => {
+                    error!(template = template_name, error = %err, "template render failed");
+                    Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+                }
+            }
+        })
+    }
+}
+
+/// Merge request-scoped context (locale, csrf, etc.) with user context (struct fields).
+/// User context values take precedence over request context on key collision.
+fn merge_contexts(request_ctx: TemplateContext, user_ctx: minijinja::Value) -> minijinja::Value {
+    let mut map = request_ctx.into_values();
+
+    // user_ctx is a struct serialized to Value — iterate its keys
+    if let Ok(keys) = user_ctx.try_iter() {
+        for key in keys {
+            let k_str: String = key.to_string();
+            if let Ok(val) = user_ctx.get_attr(&k_str) {
+                map.insert(k_str, val);
+            }
+        }
+    }
+
+    minijinja::Value::from_serialize(&map)
+}

--- a/modo-templates/src/render.rs
+++ b/modo-templates/src/render.rs
@@ -9,7 +9,7 @@ use http::StatusCode;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tower::{Layer, Service};
-use tracing::error;
+use tracing::{error, warn};
 
 /// Layer that intercepts View responses and renders them via the TemplateEngine.
 /// Merges request TemplateContext with the view's user context.
@@ -60,11 +60,13 @@ where
         let mut inner = self.inner.clone();
 
         // Capture request context and HTMX header before passing to handler
-        let template_ctx = request
-            .extensions()
-            .get::<TemplateContext>()
-            .cloned()
-            .unwrap_or_default();
+        let template_ctx = match request.extensions().get::<TemplateContext>().cloned() {
+            Some(ctx) => ctx,
+            None => {
+                warn!("TemplateContext not found in request extensions; was ContextLayer applied?");
+                TemplateContext::default()
+            }
+        };
         let is_htmx = request.headers().get("hx-request").is_some();
 
         Box::pin(async move {
@@ -105,7 +107,15 @@ where
                 }
                 Err(err) => {
                     error!(template = template_name, error = %err, "template render failed");
-                    Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+                    let body = if cfg!(debug_assertions) {
+                        format!(
+                            "<h1>Template Render Error</h1><pre>{}</pre>",
+                            html_escape(&err.to_string())
+                        )
+                    } else {
+                        "<h1>Internal Server Error</h1>".to_string()
+                    };
+                    Ok((StatusCode::INTERNAL_SERVER_ERROR, Html(body)).into_response())
                 }
             }
         })
@@ -128,4 +138,11 @@ fn merge_contexts(request_ctx: TemplateContext, user_ctx: minijinja::Value) -> m
     }
 
     minijinja::Value::from_serialize(&map)
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
 }

--- a/modo-templates/src/view.rs
+++ b/modo-templates/src/view.rs
@@ -12,6 +12,8 @@ pub struct View {
     pub htmx_template: Option<String>,
     /// Serialized user context (struct fields).
     pub user_context: Value,
+    /// HTTP status code for the response.
+    pub status: StatusCode,
 }
 
 impl View {
@@ -20,11 +22,17 @@ impl View {
             template: template.into(),
             htmx_template: None,
             user_context,
+            status: StatusCode::OK,
         }
     }
 
     pub fn with_htmx(mut self, htmx_template: impl Into<String>) -> Self {
         self.htmx_template = Some(htmx_template.into());
+        self
+    }
+
+    pub fn with_status(mut self, status: StatusCode) -> Self {
+        self.status = status;
         self
     }
 }
@@ -33,7 +41,7 @@ impl View {
 impl IntoResponse for View {
     fn into_response(self) -> Response {
         let mut response = Response::new(axum::body::Body::empty());
-        *response.status_mut() = StatusCode::OK;
+        *response.status_mut() = self.status;
         response.extensions_mut().insert(self);
         response
     }

--- a/modo-templates/src/view.rs
+++ b/modo-templates/src/view.rs
@@ -1,0 +1,40 @@
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+use minijinja::Value;
+
+/// A pending template render. Created by the `#[view]` macro's `IntoResponse` impl.
+/// The render layer middleware picks this up from response extensions and renders it.
+#[derive(Debug, Clone)]
+pub struct View {
+    /// Primary template path (full page).
+    pub template: String,
+    /// Optional HTMX template path (fragment).
+    pub htmx_template: Option<String>,
+    /// Serialized user context (struct fields).
+    pub user_context: Value,
+}
+
+impl View {
+    pub fn new(template: impl Into<String>, user_context: Value) -> Self {
+        Self {
+            template: template.into(),
+            htmx_template: None,
+            user_context,
+        }
+    }
+
+    pub fn with_htmx(mut self, htmx_template: impl Into<String>) -> Self {
+        self.htmx_template = Some(htmx_template.into());
+        self
+    }
+}
+
+/// Marker response: stashes the View in response extensions for the render layer.
+impl IntoResponse for View {
+    fn into_response(self) -> Response {
+        let mut response = Response::new(axum::body::Body::empty());
+        *response.status_mut() = StatusCode::OK;
+        response.extensions_mut().insert(self);
+        response
+    }
+}

--- a/modo-templates/tests/context_layer.rs
+++ b/modo-templates/tests/context_layer.rs
@@ -8,11 +8,8 @@ use tower::ServiceExt;
 
 async fn handler(Extension(ctx): Extension<TemplateContext>) -> String {
     format!(
-        "url={} id={}",
+        "url={}",
         ctx.get("current_url")
-            .map(|v| v.to_string())
-            .unwrap_or_default(),
-        ctx.get("request_id")
             .map(|v| v.to_string())
             .unwrap_or_default(),
     )

--- a/modo-templates/tests/context_layer.rs
+++ b/modo-templates/tests/context_layer.rs
@@ -1,0 +1,37 @@
+use axum::body::Body;
+use axum::routing::get;
+use axum::{Extension, Router};
+use http::Request;
+use modo_templates::TemplateContext;
+use modo_templates::middleware::ContextLayer;
+use tower::ServiceExt;
+
+async fn handler(Extension(ctx): Extension<TemplateContext>) -> String {
+    format!(
+        "url={} id={}",
+        ctx.get("current_url")
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        ctx.get("request_id")
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+    )
+}
+
+#[tokio::test]
+async fn context_layer_sets_current_url() {
+    let app = Router::new()
+        .route("/hello", get(handler))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/hello").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body.contains("url=/hello"));
+}

--- a/modo-templates/tests/e2e.rs
+++ b/modo-templates/tests/e2e.rs
@@ -1,0 +1,120 @@
+use axum::Router;
+use axum::body::Body;
+use axum::routing::get;
+use http::Request;
+use modo_templates::middleware::ContextLayer;
+use modo_templates::render::RenderLayer;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn setup(name: &str) -> (Arc<modo_templates::TemplateEngine>, PathBuf) {
+    let dir = std::env::temp_dir().join(format!("modo_e2e_test_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+
+    let layouts = dir.join("layouts");
+    let pages = dir.join("pages");
+    let htmx = dir.join("htmx");
+    fs::create_dir_all(&layouts).unwrap();
+    fs::create_dir_all(&pages).unwrap();
+    fs::create_dir_all(&htmx).unwrap();
+
+    fs::write(
+        layouts.join("base.html"),
+        "<html><body>{% block content %}{% endblock %}</body></html>",
+    )
+    .unwrap();
+
+    fs::write(
+        pages.join("home.html"),
+        r#"{% extends "layouts/base.html" %}{% block content %}<h1>{{ title }}</h1><p>url={{ current_url|safe }}</p>{% endblock %}"#,
+    )
+    .unwrap();
+
+    fs::write(htmx.join("home.html"), "<h1>{{ title }}</h1>").unwrap();
+
+    let config = modo_templates::TemplateConfig {
+        path: dir.to_str().unwrap().to_string(),
+        ..Default::default()
+    };
+    let engine = modo_templates::engine(&config).unwrap();
+    (Arc::new(engine), dir)
+}
+
+#[modo_templates::view("pages/home.html", htmx = "htmx/home.html")]
+struct HomePage {
+    title: String,
+}
+
+#[tokio::test]
+async fn full_page_renders_with_layout() {
+    let (engine, dir) = setup("fullpage");
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                HomePage {
+                    title: "Welcome".to_string(),
+                }
+            }),
+        )
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body.contains("<html>"));
+    assert!(body.contains("<h1>Welcome</h1>"));
+    assert!(body.contains("url=/"));
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn htmx_request_renders_partial() {
+    let (engine, dir) = setup("htmxpartial");
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                HomePage {
+                    title: "Welcome".to_string(),
+                }
+            }),
+        )
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(
+            Request::get("/")
+                .header("hx-request", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    // Should NOT contain layout
+    assert!(!body.contains("<html>"));
+    // Should contain partial content
+    assert_eq!(body, "<h1>Welcome</h1>");
+
+    fs::remove_dir_all(&dir).unwrap();
+}

--- a/modo-templates/tests/render_layer.rs
+++ b/modo-templates/tests/render_layer.rs
@@ -1,0 +1,125 @@
+use axum::body::Body;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use http::Request;
+use modo_templates::middleware::ContextLayer;
+use modo_templates::render::RenderLayer;
+use modo_templates::View;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn setup(name: &str) -> (Arc<modo_templates::TemplateEngine>, PathBuf) {
+    let dir = std::env::temp_dir().join(format!("modo_render_test_{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("hello.html"),
+        "Hello {{ name }}! url={{ current_url|safe }}",
+    )
+    .unwrap();
+    fs::write(dir.join("hello_htmx.html"), "partial: {{ name }}").unwrap();
+
+    let config = modo_templates::TemplateConfig {
+        path: dir.to_str().unwrap().to_string(),
+        ..Default::default()
+    };
+    let engine = modo_templates::engine(&config).unwrap();
+    (Arc::new(engine), dir)
+}
+
+#[tokio::test]
+async fn renders_view_with_merged_context() {
+    let (engine, dir) = setup("merged");
+
+    async fn handler() -> impl IntoResponse {
+        View::new(
+            "hello.html",
+            minijinja::context! { name => "World" }.into(),
+        )
+    }
+
+    let app = Router::new()
+        .route("/test", get(handler))
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/test").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert_eq!(body, "Hello World! url=/test");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn htmx_request_uses_htmx_template() {
+    let (engine, dir) = setup("htmx");
+
+    async fn handler() -> impl IntoResponse {
+        View::new(
+            "hello.html",
+            minijinja::context! { name => "World" }.into(),
+        )
+        .with_htmx("hello_htmx.html")
+    }
+
+    let app = Router::new()
+        .route("/test", get(handler))
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(
+            Request::get("/test")
+                .header("hx-request", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert_eq!(body, "partial: World");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[tokio::test]
+async fn non_view_response_passes_through() {
+    let (engine, dir) = setup("passthrough");
+
+    async fn handler() -> &'static str {
+        "plain text"
+    }
+
+    let app = Router::new()
+        .route("/test", get(handler))
+        .layer(RenderLayer::new(engine))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/test").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(String::from_utf8(body.to_vec()).unwrap(), "plain text");
+
+    fs::remove_dir_all(&dir).unwrap();
+}

--- a/modo-templates/tests/render_layer.rs
+++ b/modo-templates/tests/render_layer.rs
@@ -1,11 +1,11 @@
+use axum::Router;
 use axum::body::Body;
 use axum::response::IntoResponse;
 use axum::routing::get;
-use axum::Router;
 use http::Request;
+use modo_templates::View;
 use modo_templates::middleware::ContextLayer;
 use modo_templates::render::RenderLayer;
-use modo_templates::View;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -35,10 +35,7 @@ async fn renders_view_with_merged_context() {
     let (engine, dir) = setup("merged");
 
     async fn handler() -> impl IntoResponse {
-        View::new(
-            "hello.html",
-            minijinja::context! { name => "World" }.into(),
-        )
+        View::new("hello.html", minijinja::context! { name => "World" })
     }
 
     let app = Router::new()
@@ -66,11 +63,8 @@ async fn htmx_request_uses_htmx_template() {
     let (engine, dir) = setup("htmx");
 
     async fn handler() -> impl IntoResponse {
-        View::new(
-            "hello.html",
-            minijinja::context! { name => "World" }.into(),
-        )
-        .with_htmx("hello_htmx.html")
+        View::new("hello.html", minijinja::context! { name => "World" })
+            .with_htmx("hello_htmx.html")
     }
 
     let app = Router::new()

--- a/modo-templates/tests/view_macro.rs
+++ b/modo-templates/tests/view_macro.rs
@@ -23,10 +23,7 @@ fn view_macro_creates_into_response() {
     let response = page.into_response();
 
     // View should be stashed in extensions
-    let view = response
-        .extensions()
-        .get::<modo_templates::View>()
-        .unwrap();
+    let view = response.extensions().get::<modo_templates::View>().unwrap();
     assert_eq!(view.template, "pages/home.html");
     assert!(view.htmx_template.is_none());
 }
@@ -40,13 +37,7 @@ fn view_macro_with_htmx() {
     };
     let response = page.into_response();
 
-    let view = response
-        .extensions()
-        .get::<modo_templates::View>()
-        .unwrap();
+    let view = response.extensions().get::<modo_templates::View>().unwrap();
     assert_eq!(view.template, "pages/login.html");
-    assert_eq!(
-        view.htmx_template.as_deref(),
-        Some("htmx/login_form.html")
-    );
+    assert_eq!(view.htmx_template.as_deref(), Some("htmx/login_form.html"));
 }

--- a/modo-templates/tests/view_macro.rs
+++ b/modo-templates/tests/view_macro.rs
@@ -1,0 +1,52 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct Item {
+    name: String,
+}
+
+#[modo_templates::view("pages/home.html")]
+pub struct HomePage {
+    pub items: Vec<Item>,
+}
+
+#[modo_templates::view("pages/login.html", htmx = "htmx/login_form.html")]
+pub struct LoginPage {
+    pub form_errors: Vec<String>,
+}
+
+#[test]
+fn view_macro_creates_into_response() {
+    use axum::response::IntoResponse;
+
+    let page = HomePage { items: vec![] };
+    let response = page.into_response();
+
+    // View should be stashed in extensions
+    let view = response
+        .extensions()
+        .get::<modo_templates::View>()
+        .unwrap();
+    assert_eq!(view.template, "pages/home.html");
+    assert!(view.htmx_template.is_none());
+}
+
+#[test]
+fn view_macro_with_htmx() {
+    use axum::response::IntoResponse;
+
+    let page = LoginPage {
+        form_errors: vec!["bad email".to_string()],
+    };
+    let response = page.into_response();
+
+    let view = response
+        .extensions()
+        .get::<modo_templates::View>()
+        .unwrap();
+    assert_eq!(view.template, "pages/login.html");
+    assert_eq!(
+        view.htmx_template.as_deref(),
+        Some("htmx/login_form.html")
+    );
+}

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -42,6 +42,14 @@ ulid = "1"
 # Misc
 chrono = { version = "0.4", features = ["serde"] }
 
+# Templates (optional)
+modo-templates = { path = "../modo-templates", optional = true }
+modo-templates-macros = { path = "../modo-templates-macros", optional = true }
+
+[features]
+default = []
+templates = ["dep:modo-templates", "dep:modo-templates-macros"]
+
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -339,12 +339,47 @@ impl AppBuilder {
         // Stack order: CORS > Maintenance > Catch Panic > Request ID >
         //   Sensitive Headers > Tracing > Client IP > Timeout > Trailing Slash >
         //   Compression > Body Limit > Security Headers > Error Handler >
-        //   Rate Limiter > User Layers > Module/Handler MW (innermost)
+        //   Rate Limiter > Context Layer > User Layers > Render Layer >
+        //   Module/Handler MW (innermost)
         // =====================================================================
+
+        // --- Template render layer (innermost — closest to handler) ---
+        #[cfg(feature = "templates")]
+        let template_engine: Option<std::sync::Arc<modo_templates::TemplateEngine>> = state
+            .services
+            .get::<modo_templates::TemplateEngine>();
+
+        #[cfg(feature = "templates")]
+        if let Some(ref engine) = template_engine {
+            router = router.layer(modo_templates::RenderLayer::new(engine.clone()));
+        }
 
         // --- User global layers (innermost of framework layers) ---
         for layer_fn in self.layers {
             router = layer_fn(router);
+        }
+
+        // --- Template context layer (wraps user layers, creates TemplateContext) ---
+        #[cfg(feature = "templates")]
+        if template_engine.is_some() {
+            // Inject request_id into TemplateContext (runs after ContextLayer creates it)
+            router = router.layer(axum::middleware::from_fn(
+                |request: axum::http::Request<axum::body::Body>, next: axum::middleware::Next| async move {
+                    let (mut parts, body) = request.into_parts();
+                    let rid_str = parts
+                        .extensions
+                        .get::<crate::request_id::RequestId>()
+                        .map(|rid| rid.to_string());
+                    if let Some(rid_str) = rid_str {
+                        if let Some(ctx) = parts.extensions.get_mut::<modo_templates::TemplateContext>() {
+                            ctx.insert("request_id", rid_str);
+                        }
+                    }
+                    let request = axum::http::Request::from_parts(parts, body);
+                    next.run(request).await
+                },
+            ));
+            router = router.layer(modo_templates::ContextLayer::new());
         }
 
         // --- Rate limiter (global) ---

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -339,7 +339,7 @@ impl AppBuilder {
         // Stack order: CORS > Maintenance > Catch Panic > Request ID >
         //   Sensitive Headers > Tracing > Client IP > Timeout > Trailing Slash >
         //   Compression > Body Limit > Security Headers > Error Handler >
-        //   Rate Limiter > Context Layer > User Layers > Render Layer >
+        //   Rate Limiter > Context Layer > Request ID Injector > User Layers > Render Layer >
         //   Module/Handler MW (innermost)
         // =====================================================================
 

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -345,9 +345,8 @@ impl AppBuilder {
 
         // --- Template render layer (innermost — closest to handler) ---
         #[cfg(feature = "templates")]
-        let template_engine: Option<std::sync::Arc<modo_templates::TemplateEngine>> = state
-            .services
-            .get::<modo_templates::TemplateEngine>();
+        let template_engine: Option<std::sync::Arc<modo_templates::TemplateEngine>> =
+            state.services.get::<modo_templates::TemplateEngine>();
 
         #[cfg(feature = "templates")]
         if let Some(ref engine) = template_engine {
@@ -363,22 +362,26 @@ impl AppBuilder {
         #[cfg(feature = "templates")]
         if template_engine.is_some() {
             // Inject request_id into TemplateContext (runs after ContextLayer creates it)
-            router = router.layer(axum::middleware::from_fn(
-                |request: axum::http::Request<axum::body::Body>, next: axum::middleware::Next| async move {
-                    let (mut parts, body) = request.into_parts();
-                    let rid_str = parts
-                        .extensions
-                        .get::<crate::request_id::RequestId>()
-                        .map(|rid| rid.to_string());
-                    if let Some(rid_str) = rid_str {
-                        if let Some(ctx) = parts.extensions.get_mut::<modo_templates::TemplateContext>() {
+            router =
+                router.layer(axum::middleware::from_fn(
+                    |request: axum::http::Request<axum::body::Body>,
+                     next: axum::middleware::Next| async move {
+                        let (mut parts, body) = request.into_parts();
+                        let rid_str = parts
+                            .extensions
+                            .get::<crate::request_id::RequestId>()
+                            .map(|rid| rid.to_string());
+                        if let Some(rid_str) = rid_str
+                            && let Some(ctx) = parts
+                                .extensions
+                                .get_mut::<modo_templates::TemplateContext>()
+                        {
                             ctx.insert("request_id", rid_str);
                         }
-                    }
-                    let request = axum::http::Request::from_parts(parts, body);
-                    next.run(request).await
-                },
-            ));
+                        let request = axum::http::Request::from_parts(parts, body);
+                        next.run(request).await
+                    },
+                ));
             router = router.layer(modo_templates::ContextLayer::new());
         }
 

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -1,4 +1,6 @@
 pub use modo_macros::{Sanitize, Validate, error_handler, handler, main, module};
+#[cfg(feature = "templates")]
+pub use modo_templates_macros::view;
 
 pub mod app;
 pub mod config;
@@ -24,6 +26,8 @@ pub use axum;
 pub use axum_extra;
 pub use chrono;
 pub use inventory;
+#[cfg(feature = "templates")]
+pub use modo_templates;
 pub use serde;
 pub use serde_json;
 pub use tokio;


### PR DESCRIPTION
## Summary

- Add `modo-templates` and `modo-templates-macros` crates for MiniJinja-based template rendering
- `#[view("template.html", htmx = "partial.html")]` proc macro for type-safe view structs with automatic `IntoResponse` impl
- Tower middleware stack: `ContextLayer` (injects `current_url`, `request_id`) + `RenderLayer` (intercepts View responses, renders templates)
- HTMX partial rendering support — automatically switches to htmx template on `HX-Request` header
- i18n integration: `t()` template function with variable interpolation and plural support (`modo-i18n` `templates` feature)
- Auto-registration in `modo` umbrella crate when `TemplateEngine` is registered as a service

## Changes

- **New crate `modo-templates-macros`**: `#[view]` proc macro
- **New crate `modo-templates`**: TemplateConfig, TemplateContext, TemplateEngine, View, ContextLayer, RenderLayer
- **Modified `modo-i18n`**: `template.rs` with `register_template_functions()`, locale injection into TemplateContext
- **Modified `modo`**: auto-register template layers in `app.rs`, re-exports behind `templates` feature
- **Updated `CLAUDE.md`**: MiniJinja conventions, template crate descriptions

## Test plan

- [x] `cargo test -p modo-templates` — unit tests (config, context, engine) + integration tests (view macro, context layer, render layer, e2e)
- [x] `cargo test -p modo-i18n --features templates` — i18n template function tests
- [x] `cargo check -p modo --features templates` — umbrella crate compiles with templates
- [x] `just check` — fmt + clippy + full workspace tests pass