### PR TITLE
feat(modo-db-macros): expand soft delete query helpers

### DIFF
--- a/modo-db-macros/src/entity.rs
+++ b/modo-db-macros/src/entity.rs
@@ -625,13 +625,40 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
 
     let soft_delete_helpers = if struct_attrs.soft_delete {
         quote! {
-            pub fn find_active() -> modo_db::sea_orm::Select<Entity> {
+            /// Returns a select query that filters out soft-deleted records (`deleted_at IS NULL`).
+            pub fn find() -> modo_db::sea_orm::Select<Entity> {
                 use modo_db::sea_orm::EntityTrait;
                 use modo_db::sea_orm::QueryFilter;
                 use modo_db::sea_orm::ColumnTrait;
                 Entity::find().filter(Column::DeletedAt.is_null())
             }
 
+            /// Returns a select query for a single record by primary key, excluding soft-deleted records.
+            pub fn find_by_id<T>(id: T) -> modo_db::sea_orm::Select<Entity>
+            where
+                T: Into<<<Entity as modo_db::sea_orm::EntityTrait>::PrimaryKey as modo_db::sea_orm::PrimaryKeyTrait>::ValueType>,
+            {
+                use modo_db::sea_orm::EntityTrait;
+                use modo_db::sea_orm::QueryFilter;
+                use modo_db::sea_orm::ColumnTrait;
+                Entity::find_by_id(id).filter(Column::DeletedAt.is_null())
+            }
+
+            /// Returns a select query that includes all records, including soft-deleted ones.
+            pub fn with_deleted() -> modo_db::sea_orm::Select<Entity> {
+                use modo_db::sea_orm::EntityTrait;
+                Entity::find()
+            }
+
+            /// Returns a select query that returns only soft-deleted records (`deleted_at IS NOT NULL`).
+            pub fn only_deleted() -> modo_db::sea_orm::Select<Entity> {
+                use modo_db::sea_orm::EntityTrait;
+                use modo_db::sea_orm::QueryFilter;
+                use modo_db::sea_orm::ColumnTrait;
+                Entity::find().filter(Column::DeletedAt.is_not_null())
+            }
+
+            /// Sets `deleted_at` to the current timestamp, marking the record as soft-deleted.
             pub async fn soft_delete<C: modo_db::sea_orm::ConnectionTrait>(
                 mut model: ActiveModel,
                 db: &C,
@@ -641,6 +668,17 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                 model.update(db).await
             }
 
+            /// Clears `deleted_at`, restoring a soft-deleted record.
+            pub async fn restore<C: modo_db::sea_orm::ConnectionTrait>(
+                mut model: ActiveModel,
+                db: &C,
+            ) -> std::result::Result<Model, modo_db::sea_orm::DbErr> {
+                use modo_db::sea_orm::ActiveModelTrait;
+                model.deleted_at = modo_db::sea_orm::ActiveValue::Set(None);
+                model.update(db).await
+            }
+
+            /// Permanently deletes the record from the database (hard delete).
             pub async fn force_delete<C: modo_db::sea_orm::ConnectionTrait>(
                 model: Model,
                 db: &C,

--- a/modo-db/tests/entity_macro.rs
+++ b/modo-db/tests/entity_macro.rs
@@ -107,9 +107,21 @@ fn test_soft_delete_entity_has_deleted_at() {
 
 #[test]
 fn test_soft_delete_helpers_exist() {
-    let _ = test_item::find_active;
+    let _ = test_item::find;
+    let _ = test_item::find_by_id::<i32>;
+    let _ = test_item::with_deleted;
+    let _ = test_item::only_deleted;
     let _ = test_item::soft_delete::<sea_orm::DatabaseConnection>;
+    let _ = test_item::restore::<sea_orm::DatabaseConnection>;
     let _ = test_item::force_delete::<sea_orm::DatabaseConnection>;
+}
+
+#[test]
+fn test_soft_delete_query_scopes_return_select() {
+    let _: sea_orm::Select<test_item::Entity> = test_item::find();
+    let _: sea_orm::Select<test_item::Entity> = test_item::find_by_id(1);
+    let _: sea_orm::Select<test_item::Entity> = test_item::with_deleted();
+    let _: sea_orm::Select<test_item::Entity> = test_item::only_deleted();
 }
 
 // --- Entity with composite index ---


### PR DESCRIPTION
## Summary

Expands the soft-delete entity macro to provide a richer set of query helpers and a restore operation, replacing the limited `find_active` method with a complete set of scoped queries.

### Changes

- Rename `find_active` to `find` — excludes soft-deleted records by default
- Add `find_by_id(id)` — single-record lookup excluding soft-deleted records
- Add `with_deleted()` — returns all records including soft-deleted ones
- Add `only_deleted()` — returns only soft-deleted records
- Add `restore(model, db)` — clears `deleted_at` to un-delete a record
- Add doc comments to all generated soft-delete methods
- Extend `entity_macro` tests to cover the new query scopes

### Breaking Changes

`find_active()` has been renamed to `find()` — callers using `find_active` must be updated.

## Test plan

- [x] `just check` passes (fmt, clippy -D warnings, all tests)
- [x] `test_soft_delete_helpers_exist` verifies all 7 functions exist
- [x] `test_soft_delete_query_scopes_return_select` verifies `find`, `find_by_id`, `with_deleted`, `only_deleted` return `Select<Entity>`