### PR TITLE
feat(modo-auth): add Argon2id password hashing service

### DIFF
--- a/modo-auth/Cargo.toml
+++ b/modo-auth/Cargo.toml
@@ -7,9 +7,12 @@ license.workspace = true
 [dependencies]
 modo = { path = "../modo" }
 modo-session = { path = "../modo-session" }
+argon2 = "0.5"
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+serde_yaml_ng = "0.10"
 modo-db = { path = "../modo-db" }
 axum = "0.8"
 axum-extra = { version = "0.10", features = ["cookie-signed"] }

--- a/modo-auth/Cargo.toml
+++ b/modo-auth/Cargo.toml
@@ -9,6 +9,7 @@ modo = { path = "../modo" }
 modo-session = { path = "../modo-session" }
 argon2 = "0.5"
 serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/modo-auth/src/lib.rs
+++ b/modo-auth/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod extractor;
+pub mod password;
 pub mod provider;
 
 pub use extractor::{Auth, OptionalAuth};
+pub use password::{PasswordConfig, PasswordHasher};
 pub use provider::{UserProvider, UserProviderService};

--- a/modo-auth/src/password.rs
+++ b/modo-auth/src/password.rs
@@ -1,0 +1,161 @@
+use argon2::{
+    Algorithm, Argon2, Params, Version,
+    password_hash::{
+        PasswordHash, PasswordHasher as _, PasswordVerifier, SaltString, rand_core::OsRng,
+    },
+};
+use serde::Deserialize;
+
+/// Configuration for Argon2id password hashing.
+///
+/// Defaults follow OWASP recommendations for Argon2id.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct PasswordConfig {
+    pub memory_cost_kib: u32,
+    pub time_cost: u32,
+    pub parallelism: u32,
+}
+
+impl Default for PasswordConfig {
+    fn default() -> Self {
+        Self {
+            memory_cost_kib: 19456, // 19 MiB
+            time_cost: 2,
+            parallelism: 1,
+        }
+    }
+}
+
+/// Argon2id password hashing service.
+///
+/// Construct with config, register as a service via `app.service(hasher)`,
+/// and extract in handlers via `Service<PasswordHasher>`.
+#[derive(Debug, Clone)]
+pub struct PasswordHasher {
+    config: PasswordConfig,
+}
+
+impl PasswordHasher {
+    pub fn new(config: PasswordConfig) -> Self {
+        Self { config }
+    }
+
+    /// Hash a password using Argon2id with a random salt.
+    ///
+    /// Returns a PHC-formatted string that embeds algorithm, params, salt, and hash.
+    pub fn hash_password(&self, password: &str) -> Result<String, modo::Error> {
+        let params = Params::new(
+            self.config.memory_cost_kib,
+            self.config.time_cost,
+            self.config.parallelism,
+            None,
+        )
+        .map_err(|e| modo::Error::internal(format!("invalid argon2 params: {e}")))?;
+
+        let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+        let salt = SaltString::generate(&mut OsRng);
+
+        argon2
+            .hash_password(password.as_bytes(), &salt)
+            .map(|h| h.to_string())
+            .map_err(|e| modo::Error::internal(format!("password hashing failed: {e}")))
+    }
+
+    /// Verify a password against a PHC-formatted hash string.
+    ///
+    /// Returns `Ok(true)` on match, `Ok(false)` on mismatch.
+    /// Returns `Err` only for malformed hash strings.
+    ///
+    /// Note: uses the params embedded in the hash, not `self.config`.
+    pub fn verify_password(&self, password: &str, hash: &str) -> Result<bool, modo::Error> {
+        let parsed = PasswordHash::new(hash)
+            .map_err(|e| modo::Error::internal(format!("invalid password hash: {e}")))?;
+
+        match Argon2::default().verify_password(password.as_bytes(), &parsed) {
+            Ok(()) => Ok(true),
+            Err(argon2::password_hash::Error::Password) => Ok(false),
+            Err(e) => Err(modo::Error::internal(format!(
+                "password verification failed: {e}"
+            ))),
+        }
+    }
+}
+
+impl Default for PasswordHasher {
+    fn default() -> Self {
+        Self::new(PasswordConfig::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_and_verify_roundtrip() {
+        let hasher = PasswordHasher::default();
+        let hash = hasher
+            .hash_password("correct-horse-battery-staple")
+            .unwrap();
+        assert!(
+            hasher
+                .verify_password("correct-horse-battery-staple", &hash)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn verify_wrong_password() {
+        let hasher = PasswordHasher::default();
+        let hash = hasher.hash_password("correct-password").unwrap();
+        assert!(!hasher.verify_password("wrong-password", &hash).unwrap());
+    }
+
+    #[test]
+    fn verify_invalid_hash() {
+        let hasher = PasswordHasher::default();
+        assert!(
+            hasher
+                .verify_password("password", "not-a-valid-hash")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn hash_produces_unique_outputs() {
+        let hasher = PasswordHasher::default();
+        let h1 = hasher.hash_password("same-password").unwrap();
+        let h2 = hasher.hash_password("same-password").unwrap();
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn default_config_values() {
+        let config = PasswordConfig::default();
+        assert_eq!(config.memory_cost_kib, 19456);
+        assert_eq!(config.time_cost, 2);
+        assert_eq!(config.parallelism, 1);
+    }
+
+    #[test]
+    fn partial_yaml_deserialization() {
+        let yaml = "memory_cost_kib: 32768";
+        let config: PasswordConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.memory_cost_kib, 32768);
+        assert_eq!(config.time_cost, 2); // default
+        assert_eq!(config.parallelism, 1); // default
+    }
+
+    #[test]
+    fn hash_with_custom_config() {
+        let config = PasswordConfig {
+            memory_cost_kib: 8192,
+            time_cost: 1,
+            parallelism: 1,
+        };
+        let hasher = PasswordHasher::new(config);
+        let hash = hasher.hash_password("test-password").unwrap();
+        assert!(hasher.verify_password("test-password", &hash).unwrap());
+    }
+}

--- a/modo-auth/src/password.rs
+++ b/modo-auth/src/password.rs
@@ -37,8 +37,17 @@ pub struct PasswordHasher {
 }
 
 impl PasswordHasher {
-    pub fn new(config: PasswordConfig) -> Self {
-        Self { config }
+    pub fn new(config: PasswordConfig) -> Result<Self, modo::Error> {
+        // Validate by attempting to build Argon2 params eagerly
+        Params::new(
+            config.memory_cost_kib,
+            config.time_cost,
+            config.parallelism,
+            None,
+        )
+        .map_err(|e| modo::Error::internal(format!("invalid argon2 params: {e}")))?;
+
+        Ok(Self { config })
     }
 
     /// Hash a password using Argon2id with a random salt.
@@ -102,7 +111,7 @@ impl PasswordHasher {
 
 impl Default for PasswordHasher {
     fn default() -> Self {
-        Self::new(PasswordConfig::default())
+        Self::new(PasswordConfig::default()).expect("default PasswordConfig is valid")
     }
 }
 
@@ -157,6 +166,16 @@ mod tests {
     }
 
     #[test]
+    fn invalid_config_rejected() {
+        let config = PasswordConfig {
+            memory_cost_kib: 0,
+            time_cost: 0,
+            parallelism: 0,
+        };
+        assert!(PasswordHasher::new(config).is_err());
+    }
+
+    #[test]
     fn default_config_values() {
         let config = PasswordConfig::default();
         assert_eq!(config.memory_cost_kib, 19456);
@@ -180,7 +199,7 @@ mod tests {
             time_cost: 1,
             parallelism: 1,
         };
-        let hasher = PasswordHasher::new(config);
+        let hasher = PasswordHasher::new(config).unwrap();
         let hash = hasher.hash_password("test-password").await.unwrap();
         assert!(
             hasher

--- a/modo-auth/src/password.rs
+++ b/modo-auth/src/password.rs
@@ -33,13 +33,12 @@ impl Default for PasswordConfig {
 /// and extract in handlers via `Service<PasswordHasher>`.
 #[derive(Debug, Clone)]
 pub struct PasswordHasher {
-    config: PasswordConfig,
+    params: Params,
 }
 
 impl PasswordHasher {
     pub fn new(config: PasswordConfig) -> Result<Self, modo::Error> {
-        // Validate by attempting to build Argon2 params eagerly
-        Params::new(
+        let params = Params::new(
             config.memory_cost_kib,
             config.time_cost,
             config.parallelism,
@@ -47,7 +46,7 @@ impl PasswordHasher {
         )
         .map_err(|e| modo::Error::internal(format!("invalid argon2 params: {e}")))?;
 
-        Ok(Self { config })
+        Ok(Self { params })
     }
 
     /// Hash a password using Argon2id with a random salt.
@@ -55,18 +54,10 @@ impl PasswordHasher {
     /// Returns a PHC-formatted string that embeds algorithm, params, salt, and hash.
     /// Runs on a blocking thread to avoid stalling the Tokio runtime.
     pub async fn hash_password(&self, password: &str) -> Result<String, modo::Error> {
-        let config = self.config.clone();
+        let params = self.params.clone();
         let password = password.to_owned();
 
         tokio::task::spawn_blocking(move || {
-            let params = Params::new(
-                config.memory_cost_kib,
-                config.time_cost,
-                config.parallelism,
-                None,
-            )
-            .map_err(|e| modo::Error::internal(format!("invalid argon2 params: {e}")))?;
-
             let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
             let salt = SaltString::generate(&mut OsRng);
 
@@ -84,7 +75,7 @@ impl PasswordHasher {
     /// Returns `Ok(true)` on match, `Ok(false)` on mismatch.
     /// Returns `Err` only for malformed hash strings.
     ///
-    /// Note: uses the params embedded in the hash, not `self.config`.
+    /// Note: uses the params embedded in the hash, not `self.params`.
     /// Runs on a blocking thread to avoid stalling the Tokio runtime.
     pub async fn verify_password(&self, password: &str, hash: &str) -> Result<bool, modo::Error> {
         let password = password.to_owned();

--- a/modo-auth/src/password.rs
+++ b/modo-auth/src/password.rs
@@ -44,22 +44,30 @@ impl PasswordHasher {
     /// Hash a password using Argon2id with a random salt.
     ///
     /// Returns a PHC-formatted string that embeds algorithm, params, salt, and hash.
-    pub fn hash_password(&self, password: &str) -> Result<String, modo::Error> {
-        let params = Params::new(
-            self.config.memory_cost_kib,
-            self.config.time_cost,
-            self.config.parallelism,
-            None,
-        )
-        .map_err(|e| modo::Error::internal(format!("invalid argon2 params: {e}")))?;
+    /// Runs on a blocking thread to avoid stalling the Tokio runtime.
+    pub async fn hash_password(&self, password: &str) -> Result<String, modo::Error> {
+        let config = self.config.clone();
+        let password = password.to_owned();
 
-        let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
-        let salt = SaltString::generate(&mut OsRng);
+        tokio::task::spawn_blocking(move || {
+            let params = Params::new(
+                config.memory_cost_kib,
+                config.time_cost,
+                config.parallelism,
+                None,
+            )
+            .map_err(|e| modo::Error::internal(format!("invalid argon2 params: {e}")))?;
 
-        argon2
-            .hash_password(password.as_bytes(), &salt)
-            .map(|h| h.to_string())
-            .map_err(|e| modo::Error::internal(format!("password hashing failed: {e}")))
+            let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+            let salt = SaltString::generate(&mut OsRng);
+
+            argon2
+                .hash_password(password.as_bytes(), &salt)
+                .map(|h| h.to_string())
+                .map_err(|e| modo::Error::internal(format!("password hashing failed: {e}")))
+        })
+        .await
+        .map_err(|e| modo::Error::internal(format!("password hashing task failed: {e}")))?
     }
 
     /// Verify a password against a PHC-formatted hash string.
@@ -68,17 +76,27 @@ impl PasswordHasher {
     /// Returns `Err` only for malformed hash strings.
     ///
     /// Note: uses the params embedded in the hash, not `self.config`.
-    pub fn verify_password(&self, password: &str, hash: &str) -> Result<bool, modo::Error> {
-        let parsed = PasswordHash::new(hash)
-            .map_err(|e| modo::Error::internal(format!("invalid password hash: {e}")))?;
+    /// Runs on a blocking thread to avoid stalling the Tokio runtime.
+    pub async fn verify_password(&self, password: &str, hash: &str) -> Result<bool, modo::Error> {
+        let password = password.to_owned();
+        let hash = hash.to_owned();
 
-        match Argon2::default().verify_password(password.as_bytes(), &parsed) {
-            Ok(()) => Ok(true),
-            Err(argon2::password_hash::Error::Password) => Ok(false),
-            Err(e) => Err(modo::Error::internal(format!(
-                "password verification failed: {e}"
-            ))),
-        }
+        tokio::task::spawn_blocking(move || {
+            let parsed = PasswordHash::new(&hash)
+                .map_err(|e| modo::Error::internal(format!("invalid password hash: {e}")))?;
+
+            match Argon2::new(Algorithm::Argon2id, Version::V0x13, Params::default())
+                .verify_password(password.as_bytes(), &parsed)
+            {
+                Ok(()) => Ok(true),
+                Err(argon2::password_hash::Error::Password) => Ok(false),
+                Err(e) => Err(modo::Error::internal(format!(
+                    "password verification failed: {e}"
+                ))),
+            }
+        })
+        .await
+        .map_err(|e| modo::Error::internal(format!("password verification task failed: {e}")))?
     }
 }
 
@@ -92,41 +110,49 @@ impl Default for PasswordHasher {
 mod tests {
     use super::*;
 
-    #[test]
-    fn hash_and_verify_roundtrip() {
+    #[tokio::test]
+    async fn hash_and_verify_roundtrip() {
         let hasher = PasswordHasher::default();
         let hash = hasher
             .hash_password("correct-horse-battery-staple")
+            .await
             .unwrap();
         assert!(
             hasher
                 .verify_password("correct-horse-battery-staple", &hash)
+                .await
                 .unwrap()
         );
     }
 
-    #[test]
-    fn verify_wrong_password() {
+    #[tokio::test]
+    async fn verify_wrong_password() {
         let hasher = PasswordHasher::default();
-        let hash = hasher.hash_password("correct-password").unwrap();
-        assert!(!hasher.verify_password("wrong-password", &hash).unwrap());
+        let hash = hasher.hash_password("correct-password").await.unwrap();
+        assert!(
+            !hasher
+                .verify_password("wrong-password", &hash)
+                .await
+                .unwrap()
+        );
     }
 
-    #[test]
-    fn verify_invalid_hash() {
+    #[tokio::test]
+    async fn verify_invalid_hash() {
         let hasher = PasswordHasher::default();
         assert!(
             hasher
                 .verify_password("password", "not-a-valid-hash")
+                .await
                 .is_err()
         );
     }
 
-    #[test]
-    fn hash_produces_unique_outputs() {
+    #[tokio::test]
+    async fn hash_produces_unique_outputs() {
         let hasher = PasswordHasher::default();
-        let h1 = hasher.hash_password("same-password").unwrap();
-        let h2 = hasher.hash_password("same-password").unwrap();
+        let h1 = hasher.hash_password("same-password").await.unwrap();
+        let h2 = hasher.hash_password("same-password").await.unwrap();
         assert_ne!(h1, h2);
     }
 
@@ -147,15 +173,20 @@ mod tests {
         assert_eq!(config.parallelism, 1); // default
     }
 
-    #[test]
-    fn hash_with_custom_config() {
+    #[tokio::test]
+    async fn hash_with_custom_config() {
         let config = PasswordConfig {
             memory_cost_kib: 8192,
             time_cost: 1,
             parallelism: 1,
         };
         let hasher = PasswordHasher::new(config);
-        let hash = hasher.hash_password("test-password").unwrap();
-        assert!(hasher.verify_password("test-password", &hash).unwrap());
+        let hash = hasher.hash_password("test-password").await.unwrap();
+        assert!(
+            hasher
+                .verify_password("test-password", &hash)
+                .await
+                .unwrap()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds a PasswordHasher service to modo-auth using Argon2id with OWASP-recommended defaults, enabling handlers to hash and verify passwords via the service extractor pattern.

### Changes

- Add `PasswordConfig` struct with serde defaults (19 MiB memory, 2 iterations, parallelism 1) matching OWASP Argon2id recommendations
- Add `PasswordHasher` service with `hash_password` and `verify_password` methods producing PHC-formatted strings
- Re-export `PasswordConfig` and `PasswordHasher` from `modo-auth` crate root
- Add `argon2` dependency and `serde_yaml_ng` dev-dependency for partial YAML deserialization tests
- Add six unit tests covering roundtrip, wrong password, invalid hash, unique salt output, default config values, and custom config