### PR TITLE
feat(modo-csrf): add CSRF protection crate and integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "modo-templates", "modo-templates-macros", "examples/*"]
+members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "modo-templates", "modo-templates-macros", "modo-csrf", "examples/*"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/modo-csrf/Cargo.toml
+++ b/modo-csrf/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "modo-csrf"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[dependencies]
+axum = "0.8"
+http = "1"
+rand = "0.9"
+hmac = "0.12"
+sha2 = "0.10"
+subtle = "2"
+serde = { version = "1", features = ["derive"] }
+form_urlencoded = "1"
+tracing = "0.1"
+
+modo-templates = { path = "../modo-templates", optional = true }
+minijinja = { version = "2", optional = true }
+
+[features]
+default = []
+templates = ["dep:modo-templates", "dep:minijinja"]
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+serde_yaml_ng = "0.10"

--- a/modo-csrf/src/config.rs
+++ b/modo-csrf/src/config.rs
@@ -1,0 +1,57 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct CsrfConfig {
+    pub cookie_name: String,
+    pub field_name: String,
+    pub header_name: String,
+    pub cookie_max_age: u64,
+    pub token_length: usize,
+    pub secure: bool,
+}
+
+impl Default for CsrfConfig {
+    fn default() -> Self {
+        Self {
+            cookie_name: "_csrf".to_string(),
+            field_name: "_csrf_token".to_string(),
+            header_name: "x-csrf-token".to_string(),
+            cookie_max_age: 86400,
+            token_length: 32,
+            secure: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = CsrfConfig::default();
+        assert_eq!(config.cookie_name, "_csrf");
+        assert_eq!(config.field_name, "_csrf_token");
+        assert_eq!(config.header_name, "x-csrf-token");
+        assert_eq!(config.cookie_max_age, 86400);
+        assert_eq!(config.token_length, 32);
+        assert!(!config.secure);
+    }
+
+    #[test]
+    fn partial_yaml_deserialization() {
+        let yaml = r#"
+cookie_name: "my_csrf"
+secure: true
+"#;
+        let config: CsrfConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.cookie_name, "my_csrf");
+        assert!(config.secure);
+        // Defaults preserved
+        assert_eq!(config.field_name, "_csrf_token");
+        assert_eq!(config.header_name, "x-csrf-token");
+        assert_eq!(config.cookie_max_age, 86400);
+        assert_eq!(config.token_length, 32);
+    }
+}

--- a/modo-csrf/src/config.rs
+++ b/modo-csrf/src/config.rs
@@ -9,6 +9,7 @@ pub struct CsrfConfig {
     pub cookie_max_age: u64,
     pub token_length: usize,
     pub secure: bool,
+    pub max_body_bytes: usize,
 }
 
 impl Default for CsrfConfig {
@@ -19,7 +20,8 @@ impl Default for CsrfConfig {
             header_name: "x-csrf-token".to_string(),
             cookie_max_age: 86400,
             token_length: 32,
-            secure: false,
+            secure: true,
+            max_body_bytes: 1_048_576,
         }
     }
 }
@@ -36,18 +38,21 @@ mod tests {
         assert_eq!(config.header_name, "x-csrf-token");
         assert_eq!(config.cookie_max_age, 86400);
         assert_eq!(config.token_length, 32);
-        assert!(!config.secure);
+        assert!(config.secure);
+        assert_eq!(config.max_body_bytes, 1_048_576);
     }
 
     #[test]
     fn partial_yaml_deserialization() {
         let yaml = r#"
 cookie_name: "my_csrf"
-secure: true
+secure: false
+max_body_bytes: 2097152
 "#;
         let config: CsrfConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(config.cookie_name, "my_csrf");
-        assert!(config.secure);
+        assert!(!config.secure);
+        assert_eq!(config.max_body_bytes, 2_097_152);
         // Defaults preserved
         assert_eq!(config.field_name, "_csrf_token");
         assert_eq!(config.header_name, "x-csrf-token");

--- a/modo-csrf/src/lib.rs
+++ b/modo-csrf/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod config;
+pub mod middleware;
+#[cfg(feature = "templates")]
+pub mod template;
+pub mod token;
+
+pub use config::CsrfConfig;
+pub use middleware::{CsrfState, CsrfToken, csrf_protection};
+#[cfg(feature = "templates")]
+pub use template::register_template_functions;

--- a/modo-csrf/src/middleware.rs
+++ b/modo-csrf/src/middleware.rs
@@ -1,0 +1,463 @@
+use crate::config::CsrfConfig;
+use crate::token;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Method, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use http::header;
+
+/// Trait for extracting CSRF config and secret from application state.
+///
+/// Implement this for your app state type to use `csrf_protection` middleware.
+pub trait CsrfState {
+    fn csrf_config(&self) -> CsrfConfig;
+    fn csrf_secret(&self) -> &[u8];
+}
+
+/// CSRF token inserted into request extensions by the middleware.
+///
+/// Handlers can extract this to get the raw token value.
+#[derive(Debug, Clone)]
+pub struct CsrfToken(pub String);
+
+/// Double-submit cookie CSRF protection middleware.
+///
+/// For safe methods (GET, HEAD, OPTIONS, TRACE): generates a token, sets it
+/// in a signed cookie, and injects it into request extensions.
+///
+/// For mutating methods (POST, PUT, PATCH, DELETE): validates that the token
+/// submitted via header or form field matches the cookie token.
+pub async fn csrf_protection<S>(
+    State(state): State<S>,
+    request: Request<Body>,
+    next: Next,
+) -> Response
+where
+    S: CsrfState + Clone + Send + Sync + 'static,
+{
+    let config = state.csrf_config();
+    let key = state.csrf_secret();
+    let method = request.method().clone();
+
+    if is_safe_method(&method) {
+        handle_safe_request(request, next, &config, key).await
+    } else {
+        handle_mutating_request(request, next, &config, key).await
+    }
+}
+
+fn is_safe_method(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE
+    )
+}
+
+async fn handle_safe_request(
+    request: Request<Body>,
+    next: Next,
+    config: &CsrfConfig,
+    key: &[u8],
+) -> Response {
+    let (mut parts, body) = request.into_parts();
+
+    // Try to read existing valid token from cookie
+    let existing_token = read_cookie(&parts.headers, &config.cookie_name)
+        .and_then(|signed| token::verify(&signed, key));
+
+    let (raw_token, needs_cookie) = match existing_token {
+        Some(t) => (t, false),
+        None => (token::generate(config.token_length), true),
+    };
+
+    // Insert token into extensions for handlers
+    parts.extensions.insert(CsrfToken(raw_token.clone()));
+
+    // Insert into TemplateContext if available
+    #[cfg(feature = "templates")]
+    if let Some(ctx) = parts
+        .extensions
+        .get_mut::<modo_templates::TemplateContext>()
+    {
+        ctx.insert("csrf_token", raw_token.clone());
+    }
+
+    let request = Request::from_parts(parts, body);
+    let mut response = next.run(request).await;
+
+    if needs_cookie {
+        let signed = token::sign(&raw_token, key);
+        let cookie = build_set_cookie(
+            &config.cookie_name,
+            &signed,
+            config.cookie_max_age,
+            config.secure,
+        );
+        if let Ok(val) = cookie.parse() {
+            response.headers_mut().append(header::SET_COOKIE, val);
+        }
+    }
+
+    response
+}
+
+async fn handle_mutating_request(
+    request: Request<Body>,
+    next: Next,
+    config: &CsrfConfig,
+    key: &[u8],
+) -> Response {
+    let (parts, body) = request.into_parts();
+
+    // 1. Read and verify cookie token
+    let cookie_token = match read_cookie(&parts.headers, &config.cookie_name)
+        .and_then(|signed| token::verify(&signed, key))
+    {
+        Some(t) => t,
+        None => {
+            tracing::warn!("CSRF validation failed: missing or invalid cookie");
+            return StatusCode::FORBIDDEN.into_response();
+        }
+    };
+
+    // 2. Extract submitted token from header first
+    let submitted = parts
+        .headers
+        .get(&config.header_name)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    // 3. If no header, try form body (only for url-encoded)
+    let (submitted, body) = if submitted.is_some() {
+        (submitted, body)
+    } else {
+        extract_from_form_body(&parts.headers, body, &config.field_name).await
+    };
+
+    let submitted = match submitted {
+        Some(t) => t,
+        None => {
+            tracing::warn!("CSRF validation failed: no token in header or form body");
+            return StatusCode::FORBIDDEN.into_response();
+        }
+    };
+
+    // 4. Constant-time compare
+    if !constant_time_eq(cookie_token.as_bytes(), submitted.as_bytes()) {
+        tracing::warn!("CSRF validation failed: token mismatch");
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
+    let request = Request::from_parts(parts, body);
+    next.run(request).await
+}
+
+/// Extract the CSRF token from a url-encoded form body, returning both the
+/// token (if found) and the reconstructed body for downstream handlers.
+async fn extract_from_form_body(
+    headers: &http::HeaderMap,
+    body: Body,
+    field_name: &str,
+) -> (Option<String>, Body) {
+    let is_form = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("application/x-www-form-urlencoded"));
+
+    if !is_form {
+        return (None, body);
+    }
+
+    // Buffer the body
+    let bytes = match axum::body::to_bytes(body, 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => return (None, Body::empty()),
+    };
+
+    // Parse url-encoded form
+    let token = form_urlencoded::parse(&bytes)
+        .find(|(key, _)| key == field_name)
+        .map(|(_, val)| val.into_owned());
+
+    // Reconstruct body for downstream
+    (token, Body::from(bytes))
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    use subtle::ConstantTimeEq;
+    a.ct_eq(b).into()
+}
+
+// --- Cookie helpers ---
+
+fn read_cookie(headers: &http::HeaderMap, cookie_name: &str) -> Option<String> {
+    let prefix = format!("{cookie_name}=");
+    headers.get_all(header::COOKIE).iter().find_map(|val| {
+        let val = val.to_str().ok()?;
+        for pair in val.split(';') {
+            let pair = pair.trim();
+            if let Some(value) = pair.strip_prefix(&prefix)
+                && !value.is_empty()
+            {
+                return Some(value.to_string());
+            }
+        }
+        None
+    })
+}
+
+fn build_set_cookie(name: &str, value: &str, max_age: u64, secure: bool) -> String {
+    let secure_flag = if secure { "; Secure" } else { "" };
+    format!("{name}={value}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age}{secure_flag}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::routing::{get, post};
+    use http::Request;
+    use tower::ServiceExt;
+
+    #[derive(Clone)]
+    struct TestState {
+        config: CsrfConfig,
+        secret: Vec<u8>,
+    }
+
+    impl CsrfState for TestState {
+        fn csrf_config(&self) -> CsrfConfig {
+            self.config.clone()
+        }
+        fn csrf_secret(&self) -> &[u8] {
+            &self.secret
+        }
+    }
+
+    fn test_state() -> TestState {
+        TestState {
+            config: CsrfConfig::default(),
+            secret: b"test-secret-key-for-csrf".to_vec(),
+        }
+    }
+
+    fn test_app(state: TestState) -> Router {
+        Router::new()
+            .route(
+                "/form",
+                get(|_req: axum::http::Request<Body>| async { "ok" }),
+            )
+            .route(
+                "/submit",
+                post(|_req: axum::http::Request<Body>| async { "ok" }),
+            )
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                csrf_protection::<TestState>,
+            ))
+            .with_state(state)
+    }
+
+    fn extract_set_cookie(response: &Response) -> Option<String> {
+        response
+            .headers()
+            .get(header::SET_COOKIE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+    }
+
+    #[tokio::test]
+    async fn get_with_no_cookie_sets_cookie_and_injects_token() {
+        let app = test_app(test_state());
+        let request = Request::builder().uri("/form").body(Body::empty()).unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let set_cookie = extract_set_cookie(&response).expect("should set cookie");
+        assert!(set_cookie.contains("_csrf="));
+        assert!(set_cookie.contains("HttpOnly"));
+        assert!(set_cookie.contains("SameSite=Lax"));
+        assert!(set_cookie.contains("Path=/"));
+    }
+
+    #[tokio::test]
+    async fn get_with_valid_cookie_does_not_set_new_cookie() {
+        let state = test_state();
+        let raw_token = token::generate(state.config.token_length);
+        let signed = token::sign(&raw_token, &state.secret);
+
+        let app = test_app(state);
+        let request = Request::builder()
+            .uri("/form")
+            .header(header::COOKIE, format!("_csrf={signed}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(extract_set_cookie(&response).is_none());
+    }
+
+    #[tokio::test]
+    async fn post_with_valid_cookie_and_matching_header_succeeds() {
+        let state = test_state();
+        let raw_token = token::generate(state.config.token_length);
+        let signed = token::sign(&raw_token, &state.secret);
+
+        let app = test_app(state);
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/submit")
+            .header(header::COOKIE, format!("_csrf={signed}"))
+            .header("x-csrf-token", &raw_token)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_with_valid_cookie_and_matching_form_field_succeeds() {
+        let state = test_state();
+        let raw_token = token::generate(state.config.token_length);
+        let signed = token::sign(&raw_token, &state.secret);
+        let form_body = format!("name=test&_csrf_token={raw_token}");
+
+        let app = test_app(state);
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/submit")
+            .header(header::COOKIE, format!("_csrf={signed}"))
+            .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(Body::from(form_body))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_with_wrong_token_returns_403() {
+        let state = test_state();
+        let raw_token = token::generate(state.config.token_length);
+        let signed = token::sign(&raw_token, &state.secret);
+
+        let app = test_app(state.clone());
+        let wrong_token = token::generate(state.config.token_length);
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/submit")
+            .header(header::COOKIE, format!("_csrf={signed}"))
+            .header("x-csrf-token", &wrong_token)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn post_with_no_cookie_returns_403() {
+        let app = test_app(test_state());
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/submit")
+            .header("x-csrf-token", "some-token")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn post_with_tampered_cookie_hmac_returns_403() {
+        let state = test_state();
+        let raw_token = token::generate(state.config.token_length);
+        let mut signed = token::sign(&raw_token, &state.secret);
+        // Tamper the last char
+        let last = signed.pop().unwrap();
+        signed.push(if last == 'a' { 'b' } else { 'a' });
+
+        let app = test_app(state);
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/submit")
+            .header(header::COOKIE, format!("_csrf={signed}"))
+            .header("x-csrf-token", &raw_token)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn post_with_no_submitted_token_returns_403() {
+        let state = test_state();
+        let raw_token = token::generate(state.config.token_length);
+        let signed = token::sign(&raw_token, &state.secret);
+
+        let app = test_app(state);
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/submit")
+            .header(header::COOKIE, format!("_csrf={signed}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn head_skips_validation() {
+        let app = test_app(test_state());
+        let request = Request::builder()
+            .method(Method::HEAD)
+            .uri("/form")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn build_set_cookie_format() {
+        let cookie = build_set_cookie("_csrf", "token123", 86400, false);
+        assert_eq!(
+            cookie,
+            "_csrf=token123; HttpOnly; SameSite=Lax; Path=/; Max-Age=86400"
+        );
+    }
+
+    #[test]
+    fn build_set_cookie_secure() {
+        let cookie = build_set_cookie("_csrf", "token123", 86400, true);
+        assert!(cookie.contains("; Secure"));
+    }
+
+    #[test]
+    fn read_cookie_finds_value() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            "other=x; _csrf=mytoken; foo=bar".parse().unwrap(),
+        );
+        assert_eq!(read_cookie(&headers, "_csrf").unwrap(), "mytoken");
+    }
+
+    #[test]
+    fn read_cookie_returns_none_when_missing() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(header::COOKIE, "other=x".parse().unwrap());
+        assert!(read_cookie(&headers, "_csrf").is_none());
+    }
+}

--- a/modo-csrf/src/middleware.rs
+++ b/modo-csrf/src/middleware.rs
@@ -81,6 +81,7 @@ async fn handle_safe_request(
         .get_mut::<modo_templates::TemplateContext>()
     {
         ctx.insert("csrf_token", raw_token.clone());
+        ctx.insert("csrf_field_name", config.field_name.clone());
     }
 
     let request = Request::from_parts(parts, body);
@@ -108,7 +109,7 @@ async fn handle_mutating_request(
     config: &CsrfConfig,
     key: &[u8],
 ) -> Response {
-    let (parts, body) = request.into_parts();
+    let (mut parts, body) = request.into_parts();
 
     // 1. Read and verify cookie token
     let cookie_token = match read_cookie(&parts.headers, &config.cookie_name)
@@ -132,7 +133,13 @@ async fn handle_mutating_request(
     let (submitted, body) = if submitted.is_some() {
         (submitted, body)
     } else {
-        extract_from_form_body(&parts.headers, body, &config.field_name).await
+        extract_from_form_body(
+            &parts.headers,
+            body,
+            &config.field_name,
+            config.max_body_bytes,
+        )
+        .await
     };
 
     let submitted = match submitted {
@@ -149,6 +156,18 @@ async fn handle_mutating_request(
         return StatusCode::FORBIDDEN.into_response();
     }
 
+    // 5. Inject token so handlers re-rendering forms (e.g. validation errors) can access it
+    parts.extensions.insert(CsrfToken(cookie_token.clone()));
+
+    #[cfg(feature = "templates")]
+    if let Some(ctx) = parts
+        .extensions
+        .get_mut::<modo_templates::TemplateContext>()
+    {
+        ctx.insert("csrf_token", cookie_token.clone());
+        ctx.insert("csrf_field_name", config.field_name.clone());
+    }
+
     let request = Request::from_parts(parts, body);
     next.run(request).await
 }
@@ -159,6 +178,7 @@ async fn extract_from_form_body(
     headers: &http::HeaderMap,
     body: Body,
     field_name: &str,
+    max_body_bytes: usize,
 ) -> (Option<String>, Body) {
     let is_form = headers
         .get(header::CONTENT_TYPE)
@@ -170,7 +190,7 @@ async fn extract_from_form_body(
     }
 
     // Buffer the body
-    let bytes = match axum::body::to_bytes(body, 1024 * 1024).await {
+    let bytes = match axum::body::to_bytes(body, max_body_bytes).await {
         Ok(b) => b,
         Err(_) => return (None, Body::empty()),
     };

--- a/modo-csrf/src/template.rs
+++ b/modo-csrf/src/template.rs
@@ -1,0 +1,45 @@
+use minijinja::{Environment, Error, ErrorKind, State};
+
+/// Register CSRF template functions on the MiniJinja environment.
+///
+/// Registers:
+/// - `csrf_field()` — returns `<input type="hidden" ...>` HTML for forms
+/// - `csrf_token()` — returns the raw token string (for meta tags / JS)
+///
+/// Both read `csrf_token` from the template render context, injected by
+/// the CSRF middleware via `TemplateContext`.
+pub fn register_template_functions(env: &mut Environment<'static>) {
+    env.add_function("csrf_field", |state: &State| -> Result<String, Error> {
+        let token = state
+            .lookup("csrf_token")
+            .map(|v: minijinja::Value| v.to_string())
+            .unwrap_or_default();
+
+        if token.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidOperation,
+                "csrf_token not found in template context — is the CSRF middleware active?",
+            ));
+        }
+
+        Ok(format!(
+            r#"<input type="hidden" name="_csrf_token" value="{token}">"#
+        ))
+    });
+
+    env.add_function("csrf_token", |state: &State| -> Result<String, Error> {
+        let token = state
+            .lookup("csrf_token")
+            .map(|v: minijinja::Value| v.to_string())
+            .unwrap_or_default();
+
+        if token.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidOperation,
+                "csrf_token not found in template context — is the CSRF middleware active?",
+            ));
+        }
+
+        Ok(token)
+    });
+}

--- a/modo-csrf/src/template.rs
+++ b/modo-csrf/src/template.rs
@@ -25,7 +25,12 @@ pub fn register_template_functions(env: &mut Environment<'static>) {
         let field_name = state
             .lookup("csrf_field_name")
             .map(|v: minijinja::Value| v.to_string())
-            .unwrap_or_else(|| "_csrf_token".to_string());
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidOperation,
+                    "csrf_field_name not found in template context — is the CSRF middleware active?",
+                )
+            })?;
 
         let escaped = html_escape(&token);
         Ok(format!(

--- a/modo-csrf/src/template.rs
+++ b/modo-csrf/src/template.rs
@@ -22,8 +22,14 @@ pub fn register_template_functions(env: &mut Environment<'static>) {
             ));
         }
 
+        let field_name = state
+            .lookup("csrf_field_name")
+            .map(|v: minijinja::Value| v.to_string())
+            .unwrap_or_else(|| "_csrf_token".to_string());
+
+        let escaped = html_escape(&token);
         Ok(format!(
-            r#"<input type="hidden" name="_csrf_token" value="{token}">"#
+            r#"<input type="hidden" name="{field_name}" value="{escaped}">"#
         ))
     });
 
@@ -42,4 +48,18 @@ pub fn register_template_functions(env: &mut Environment<'static>) {
 
         Ok(token)
     });
+}
+
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '"' => out.push_str("&quot;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
 }

--- a/modo-csrf/src/token.rs
+++ b/modo-csrf/src/token.rs
@@ -1,0 +1,152 @@
+use hmac::{Hmac, Mac};
+use rand::RngCore;
+use sha2::Sha256;
+use std::fmt::Write;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Generate a random token of `len` bytes, returned as a hex string.
+pub fn generate(len: usize) -> String {
+    let mut bytes = vec![0u8; len];
+    rand::rng().fill_bytes(&mut bytes);
+    let mut hex = String::with_capacity(len * 2);
+    for b in &bytes {
+        write!(hex, "{b:02x}").expect("writing to String cannot fail");
+    }
+    hex
+}
+
+/// Sign a token with HMAC-SHA256. Returns `{token}.{hmac_hex}`.
+///
+/// If `key` is empty (dev mode), returns the raw token unsigned.
+pub fn sign(token: &str, key: &[u8]) -> String {
+    if key.is_empty() {
+        return token.to_string();
+    }
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
+    mac.update(token.as_bytes());
+    let result = mac.finalize().into_bytes();
+    let mut sig = String::with_capacity(result.len() * 2);
+    for b in &result {
+        write!(sig, "{b:02x}").expect("writing to String cannot fail");
+    }
+    format!("{token}.{sig}")
+}
+
+/// Verify an HMAC-signed token. Returns the raw token on success.
+///
+/// If `key` is empty (dev mode), returns the input as-is (no signature expected).
+pub fn verify(signed: &str, key: &[u8]) -> Option<String> {
+    if key.is_empty() {
+        return Some(signed.to_string());
+    }
+    let (token, sig_hex) = signed.rsplit_once('.')?;
+    if token.is_empty() || sig_hex.is_empty() {
+        return None;
+    }
+
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
+    mac.update(token.as_bytes());
+    let expected = mac.finalize().into_bytes();
+
+    let sig_bytes = hex_decode(sig_hex)?;
+    if sig_bytes.len() != expected.len() {
+        return None;
+    }
+
+    if sig_bytes.ct_eq(&expected).into() {
+        Some(token.to_string())
+    } else {
+        None
+    }
+}
+
+fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(s.len() / 2);
+    for chunk in s.as_bytes().chunks(2) {
+        let hi = hex_digit(chunk[0])?;
+        let lo = hex_digit(chunk[1])?;
+        bytes.push((hi << 4) | lo);
+    }
+    Some(bytes)
+}
+
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_produces_correct_length() {
+        let token = generate(32);
+        assert_eq!(token.len(), 64); // 32 bytes = 64 hex chars
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn generate_produces_unique_tokens() {
+        let a = generate(32);
+        let b = generate(32);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn sign_verify_roundtrip() {
+        let key = b"test-secret-key";
+        let token = generate(32);
+        let signed = sign(&token, key);
+        let verified = verify(&signed, key).unwrap();
+        assert_eq!(verified, token);
+    }
+
+    #[test]
+    fn verify_rejects_tampered_hmac() {
+        let key = b"test-secret-key";
+        let token = generate(32);
+        let signed = sign(&token, key);
+        // Tamper with the last character of the signature
+        let mut tampered = signed.clone();
+        let last = tampered.pop().unwrap();
+        tampered.push(if last == 'a' { 'b' } else { 'a' });
+        assert!(verify(&tampered, key).is_none());
+    }
+
+    #[test]
+    fn verify_rejects_wrong_key() {
+        let token = generate(32);
+        let signed = sign(&token, b"key-a");
+        assert!(verify(&signed, b"key-b").is_none());
+    }
+
+    #[test]
+    fn verify_rejects_missing_signature() {
+        assert!(verify("tokenonly", b"key").is_none());
+    }
+
+    #[test]
+    fn verify_rejects_empty_parts() {
+        assert!(verify(".abcd", b"key").is_none());
+        assert!(verify("abcd.", b"key").is_none());
+    }
+
+    #[test]
+    fn empty_key_skips_signing() {
+        let token = generate(32);
+        let signed = sign(&token, b"");
+        assert_eq!(signed, token); // No dot, no signature
+        let verified = verify(&signed, b"").unwrap();
+        assert_eq!(verified, token);
+    }
+}

--- a/modo-csrf/src/token.rs
+++ b/modo-csrf/src/token.rs
@@ -22,6 +22,10 @@ pub fn generate(len: usize) -> String {
 /// If `key` is empty (dev mode), returns the raw token unsigned.
 pub fn sign(token: &str, key: &[u8]) -> String {
     if key.is_empty() {
+        static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+        WARN_ONCE.call_once(|| {
+            tracing::warn!("CSRF HMAC signing key is empty — tokens are unsigned (dev mode only)");
+        });
         return token.to_string();
     }
     let mut mac = HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
@@ -39,6 +43,12 @@ pub fn sign(token: &str, key: &[u8]) -> String {
 /// If `key` is empty (dev mode), returns the input as-is (no signature expected).
 pub fn verify(signed: &str, key: &[u8]) -> Option<String> {
     if key.is_empty() {
+        static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+        WARN_ONCE.call_once(|| {
+            tracing::warn!(
+                "CSRF HMAC verification key is empty — signature check skipped (dev mode only)"
+            );
+        });
         return Some(signed.to_string());
     }
     let (token, sig_hex) = signed.rsplit_once('.')?;

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -46,9 +46,13 @@ chrono = { version = "0.4", features = ["serde"] }
 modo-templates = { path = "../modo-templates", optional = true }
 modo-templates-macros = { path = "../modo-templates-macros", optional = true }
 
+# CSRF (optional)
+modo-csrf = { path = "../modo-csrf", optional = true }
+
 [features]
 default = []
 templates = ["dep:modo-templates", "dep:modo-templates-macros"]
+csrf = ["dep:modo-csrf"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -28,6 +28,8 @@ pub use axum;
 pub use axum_extra;
 pub use chrono;
 pub use inventory;
+#[cfg(feature = "csrf")]
+pub use modo_csrf;
 #[cfg(feature = "templates")]
 pub use modo_templates;
 pub use serde;

--- a/modo/src/middleware/csrf.rs
+++ b/modo/src/middleware/csrf.rs
@@ -1,0 +1,12 @@
+impl modo_csrf::CsrfState for crate::app::AppState {
+    fn csrf_config(&self) -> modo_csrf::CsrfConfig {
+        self.services
+            .get::<modo_csrf::CsrfConfig>()
+            .map(|c| (*c).clone())
+            .unwrap_or_default()
+    }
+
+    fn csrf_secret(&self) -> &[u8] {
+        self.server_config.secret_key.as_bytes()
+    }
+}

--- a/modo/src/middleware/mod.rs
+++ b/modo/src/middleware/mod.rs
@@ -1,5 +1,7 @@
 mod catch_panic;
 mod client_ip;
+#[cfg(feature = "csrf")]
+mod csrf;
 mod maintenance;
 pub(crate) mod rate_limit;
 mod security_headers;
@@ -8,6 +10,8 @@ mod trailing_slash;
 pub use catch_panic::PanicHandler;
 pub use client_ip::{ClientIp, client_ip_middleware};
 pub use maintenance::maintenance_middleware;
+#[cfg(feature = "csrf")]
+pub use modo_csrf::csrf_protection;
 pub use rate_limit::{
     RateLimitInfo, RateLimiterState, by_header, by_ip, by_path, rate_limit_middleware,
     spawn_cleanup_task,


### PR DESCRIPTION
## Summary

Introduces `modo-csrf`, a new standalone crate providing double-submit cookie CSRF protection, and integrates it into the core `modo` crate as an optional `csrf` feature.

### Changes

- Add `modo-csrf` crate with HMAC-signed double-submit cookie middleware, configurable via `CsrfConfig` (cookie name, header name, form field name, token length, max age, secure flag)
- Implement `CsrfState` trait for `AppState` so the middleware can pull config and secret key from the service registry
- Expose `modo_csrf::csrf_protection` as `modo::middleware::csrf_protection` when the `csrf` feature is enabled
- Add optional MiniJinja template integration (`templates` feature) that injects the CSRF token into `TemplateContext` automatically
- Token validation uses constant-time comparison (`subtle` crate) to guard against timing attacks; full test suite covers all paths (missing cookie, tampered HMAC, wrong token, form-body extraction)

### Breaking Changes

None. The `csrf` feature is opt-in and existing builds are unaffected.