### PR TITLE
feat: add modo-email crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "modo-templates", "modo-templates-macros", "modo-csrf", "examples/*"]
+members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-email", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "modo-templates", "modo-templates-macros", "modo-csrf", "examples/*"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/docs/plans/2026-03-09-modo-email-design.md
+++ b/docs/plans/2026-03-09-modo-email-design.md
@@ -1,0 +1,416 @@
+# modo-email Design
+
+Email sending module for the modo framework. Pluggable transports, Markdown-based templates, multi-tenant sender customization.
+
+## Goals
+
+- Adapter pattern for email providers (SMTP + Resend for v1)
+- Markdown templates with custom elements (buttons via `[button|Text](url)` syntax)
+- Responsive HTML email output with plain text fallback
+- Centralized YAML config following existing modo patterns
+- Multi-tenant sender customization (same provider, different sender identity and brand context)
+- Serializable payload struct for async sending via modo-jobs (job handler is app-level, not framework)
+- `TemplateProvider` trait for custom template sources (DB-backed, API, etc.)
+- README with documentation and usage examples
+
+## Crate Structure
+
+```
+modo-email/
+  Cargo.toml
+  README.md
+  src/
+    lib.rs              # public API re-exports
+    config.rs           # EmailConfig (YAML-deserializable)
+    mailer.rs           # Mailer service
+    message.rs          # SendEmail, SendEmailPayload, SenderProfile, MailMessage
+    transport/
+      mod.rs            # MailTransport trait + factory
+      smtp.rs           # SMTP backend (lettre) — default feature
+      resend.rs         # Resend HTTP API — "resend" feature
+    template/
+      mod.rs            # TemplateProvider trait, EmailTemplate
+      filesystem.rs     # Default: loads .md files from directory
+      markdown.rs       # Markdown -> HTML renderer (button support)
+      layout.rs         # Wraps rendered HTML in responsive base layout
+```
+
+## Feature Flags
+
+- `smtp` (default) — SMTP transport via `lettre`
+- `resend` — Resend HTTP API via `reqwest`
+
+## Core Traits
+
+### MailTransport
+
+Pluggable email delivery backend. Uses `#[async_trait]` because trait objects (`Box<dyn MailTransport>`) require object safety.
+
+```rust
+#[async_trait::async_trait]
+pub trait MailTransport: Send + Sync + 'static {
+    async fn send(&self, message: &MailMessage) -> Result<(), Error>;
+}
+```
+
+### TemplateProvider
+
+Pluggable template source. Sync — filesystem reads are sync, DB-backed providers can cache on init.
+
+```rust
+pub trait TemplateProvider: Send + Sync + 'static {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, Error>;
+}
+```
+
+Default `FilesystemProvider` resolution order:
+1. `{path}/{locale}/{name}.md` — if locale provided
+2. `{path}/{name}.md` — locale-less fallback (also serves single-language projects)
+3. Error — template not found
+
+## Config
+
+YAML-deserializable, follows existing modo patterns (`UploadConfig`, `TemplateConfig`).
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct EmailConfig {
+    pub transport: TransportBackend,    // smtp (default) or resend
+    pub templates_path: String,         // "emails"
+    pub default_from_name: String,      // "My App"
+    pub default_from_email: String,     // "noreply@example.com"
+    pub default_reply_to: Option<String>,
+
+    #[cfg(feature = "smtp")]
+    pub smtp: SmtpConfig,
+
+    #[cfg(feature = "resend")]
+    pub resend: ResendConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SmtpConfig {
+    pub host: String,       // "localhost"
+    pub port: u16,          // 587
+    pub username: String,
+    pub password: String,
+    pub tls: bool,          // true
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResendConfig {
+    pub api_key: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub enum TransportBackend {
+    #[default]
+    Smtp,
+    Resend,
+}
+```
+
+YAML example:
+
+```yaml
+email:
+  transport: smtp
+  templates_path: emails
+  default_from_name: "My App"
+  default_from_email: "noreply@myapp.com"
+  smtp:
+    host: "smtp.gmail.com"
+    port: 587
+    username: "${SMTP_USER}"
+    password: "${SMTP_PASS}"
+    tls: true
+```
+
+## Types
+
+### SenderProfile
+
+Typed sender identity for multi-tenant override.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SenderProfile {
+    pub from_name: String,
+    pub from_email: String,
+    pub reply_to: Option<String>,
+}
+```
+
+### SendEmail
+
+Builder for constructing an email request.
+
+```rust
+pub struct SendEmail {
+    template: String,
+    to: String,
+    locale: Option<String>,
+    sender: Option<SenderProfile>,
+    context: HashMap<String, Value>,
+}
+
+impl SendEmail {
+    pub fn new(template: &str, to: &str) -> Self;
+    pub fn locale(mut self, locale: &str) -> Self;
+    pub fn sender(mut self, sender: &SenderProfile) -> Self;
+    pub fn var(mut self, key: &str, value: impl Into<Value>) -> Self;
+    pub fn context(mut self, ctx: &HashMap<String, Value>) -> Self;
+}
+```
+
+### SendEmailPayload
+
+Serializable twin of `SendEmail` for job queue serialization.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendEmailPayload {
+    pub template: String,
+    pub to: String,
+    pub locale: Option<String>,
+    pub sender: Option<SenderProfile>,
+    pub context: HashMap<String, Value>,
+}
+
+impl From<SendEmail> for SendEmailPayload { ... }
+impl From<SendEmailPayload> for SendEmail { ... }
+```
+
+### MailMessage
+
+Final rendered email ready for delivery.
+
+```rust
+pub struct MailMessage {
+    pub from: String,           // "Acme Corp <noreply@acme.com>"
+    pub reply_to: Option<String>,
+    pub to: String,
+    pub subject: String,
+    pub html: String,           // full responsive HTML
+    pub text: String,           // plain text fallback
+}
+```
+
+### EmailTemplate
+
+Raw template content before rendering.
+
+```rust
+pub struct EmailTemplate {
+    pub subject: String,            // "Welcome, {{user_name}}!"
+    pub body: String,               // Markdown with {{variable}} placeholders
+    pub layout: Option<String>,     // layout override name, defaults to "default"
+}
+```
+
+## Mailer Service
+
+Central service tying transport, templates, and rendering together.
+
+```rust
+pub struct Mailer {
+    transport: Box<dyn MailTransport>,
+    templates: Box<dyn TemplateProvider>,
+    default_sender: SenderProfile,
+    layout_engine: LayoutEngine,
+}
+
+impl Mailer {
+    /// Render and send an email.
+    pub async fn send(&self, email: SendEmail) -> Result<(), Error>;
+
+    /// Render without sending. Useful for previews and testing.
+    pub fn render(&self, email: &SendEmail) -> Result<MailMessage, Error>;
+}
+```
+
+### Factory Functions
+
+```rust
+/// Create a Mailer with the default FilesystemProvider.
+pub fn mailer(config: &EmailConfig) -> Result<Mailer, Error>;
+
+/// Create a Mailer with a custom TemplateProvider.
+pub fn mailer_with(config: &EmailConfig, provider: Box<dyn TemplateProvider>) -> Result<Mailer, Error>;
+```
+
+## Template Rendering Pipeline
+
+Four stages:
+
+1. **Template loading** — `TemplateProvider.get(name, locale)` returns `EmailTemplate`
+2. **Variable substitution** — simple `{{key}}` string replacement on subject and body (NOT MiniJinja, safe for end-user content). Unresolved variables left as-is.
+3. **Markdown to HTML** — `pulldown-cmark` parses Markdown. Custom element detection in the event stream: link text matching `{type}|{label}` renders as a custom element. Starting with `button` type.
+4. **Layout wrapping** — rendered HTML injected into a MiniJinja base layout template (developer-controlled). Layout receives `{{content}}`, `{{subject}}`, and all brand context variables. Plain text version generated from Markdown source (not from HTML).
+
+### Template File Format
+
+Markdown with YAML frontmatter:
+
+```markdown
+---
+subject: "Welcome to {{product_name}}, {{user_name}}!"
+layout: default
+---
+
+Hi **{{user_name}}**,
+
+Thanks for signing up for **{{product_name}}**.
+
+[button|Get Started]({{dashboard_url}})
+
+If you have questions, reach out at {{support_email}}.
+```
+
+### Directory Structure
+
+Single-language:
+
+```
+emails/
+  layouts/
+    default.html
+  welcome.md
+  password_reset.md
+```
+
+Multi-language (locale directories with fallback to root):
+
+```
+emails/
+  layouts/
+    default.html
+  welcome.md              <- fallback
+  de/
+    welcome.md
+  fr/
+    welcome.md
+```
+
+### Button Rendering
+
+`[button|Get Started](https://example.com)` is parsed by pulldown-cmark as a standard link with text `"button|Get Started"`. The renderer detects the `button|` prefix, strips it, and outputs a responsive table-based HTML button with MSO conditionals for Outlook. Button accent color comes from `brand_color` in the context, with a sensible default.
+
+### Layout
+
+The `default.html` layout ships as a built-in default (developer can override by placing `layouts/default.html` in their templates directory):
+
+- Single-column, max-width 600px centered
+- Inline CSS (email clients ignore `<style>` inconsistently)
+- MSO conditionals for Outlook
+- Dark mode via `@media (prefers-color-scheme: dark)` (progressive enhancement)
+- Mobile-first: fluid width on small screens, fixed max-width on desktop
+
+### Plain Text Generation
+
+Derived from Markdown source (not from HTML):
+- Headings: UPPERCASE
+- Links: `Text (url)`
+- Buttons: same as links
+- Bold/italic: stripped
+
+## Usage Examples
+
+### Setup
+
+```rust
+#[derive(Deserialize, Default)]
+struct AppConfig {
+    server: ServerConfig,
+    email: EmailConfig,
+}
+
+#[modo::main]
+async fn main(app: AppBuilder, config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
+    let mailer = modo_email::mailer(&config.email)?;
+    app.server_config(config.server)
+        .service(mailer)
+        .run()
+        .await
+}
+```
+
+### Simple send
+
+```rust
+#[modo::handler(POST, "/invite")]
+async fn invite(mailer: Service<Mailer>, form: Form<InviteForm>) -> Result<&'static str, Error> {
+    mailer.send(
+        SendEmail::new("invite", &form.email)
+            .var("inviter", &form.inviter_name)
+    ).await?;
+    Ok("Invitation sent")
+}
+```
+
+### Multi-tenant with branding
+
+```rust
+mailer.send(
+    SendEmail::new("welcome", "user@example.com")
+        .locale("de")
+        .sender(&tenant.sender_profile)
+        .context(&tenant.brand_context)
+        .var("user_name", "Hans")
+).await?;
+```
+
+### Async via modo-jobs (app-level)
+
+```rust
+#[job(queue = "email", max_attempts = 3, timeout = "30s")]
+async fn send_email(payload: SendEmailPayload, mailer: Service<Mailer>) -> Result<(), Error> {
+    mailer.send(payload.into()).await
+}
+
+// Enqueue from handler
+SendEmailJob::enqueue(&queue, &SendEmailPayload::from(email)).await?;
+```
+
+### Custom TemplateProvider
+
+```rust
+struct DbTemplateProvider { db: DbPool }
+
+impl TemplateProvider for DbTemplateProvider {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, Error> {
+        // Load from database
+    }
+}
+
+let mailer = modo_email::mailer_with(&config.email, Box::new(db_provider))?;
+```
+
+### Preview without sending
+
+```rust
+let msg = mailer.render(&email)?;
+println!("{}", msg.html);
+```
+
+## Dependencies
+
+| Crate | Purpose | Feature |
+|-------|---------|---------|
+| `modo` | Core framework types | always |
+| `pulldown-cmark` | Markdown parsing | always |
+| `minijinja` | Layout rendering | always |
+| `serde` | Serialization | always |
+| `serde_json` | Value type for context | always |
+| `serde_yaml` | Frontmatter parsing | always |
+| `async-trait` | Object-safe async traits | always |
+| `lettre` | SMTP transport | `smtp` |
+| `reqwest` | HTTP client for Resend | `resend` |
+
+## Deliverables
+
+- `modo-email/` crate with full implementation
+- `modo-email/README.md` with documentation and usage examples
+- Built-in responsive `default.html` layout
+- Integration test suite

--- a/docs/plans/2026-03-09-modo-email-implementation.md
+++ b/docs/plans/2026-03-09-modo-email-implementation.md
@@ -1,0 +1,1935 @@
+# modo-email Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a pluggable email sending module with Markdown templates, responsive HTML output, and multi-tenant sender support.
+
+**Architecture:** `Mailer` service wraps a `MailTransport` trait (SMTP/Resend) and `TemplateProvider` trait (filesystem default). Markdown templates with `{{var}}` substitution are rendered to HTML via `pulldown-cmark`, wrapped in a MiniJinja layout, and delivered through the configured transport.
+
+**Tech Stack:** pulldown-cmark (Markdown), minijinja (layouts), lettre (SMTP), reqwest (Resend HTTP API), serde_yaml_ng (frontmatter), async-trait (object-safe async traits)
+
+**Design doc:** `docs/plans/2026-03-09-modo-email-design.md`
+
+---
+
+### Task 1: Scaffold Crate
+
+**Files:**
+- Create: `modo-email/Cargo.toml`
+- Create: `modo-email/src/lib.rs`
+- Modify: `Cargo.toml` (workspace root)
+
+**Step 1: Create Cargo.toml**
+
+```toml
+[package]
+name = "modo-email"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[features]
+default = ["smtp"]
+smtp = ["dep:lettre"]
+resend = ["dep:reqwest"]
+
+[dependencies]
+modo = { path = "../modo" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml_ng = "0.10"
+async-trait = "0.1"
+pulldown-cmark = "0.12"
+minijinja = { version = "2", features = ["loader"] }
+tracing = "0.1"
+lettre = { version = "0.11", features = ["tokio1-native-tls", "builder", "smtp-transport"], optional = true }
+reqwest = { version = "0.12", features = ["json"], optional = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+tempfile = "3"
+```
+
+**Step 2: Create src/lib.rs with module stubs**
+
+```rust
+mod config;
+mod mailer;
+mod message;
+mod template;
+mod transport;
+
+pub use config::{EmailConfig, TransportBackend};
+pub use mailer::Mailer;
+pub use message::{MailMessage, SendEmail, SendEmailPayload, SenderProfile};
+pub use template::{EmailTemplate, TemplateProvider};
+pub use transport::MailTransport;
+
+#[cfg(feature = "smtp")]
+pub use config::SmtpConfig;
+#[cfg(feature = "resend")]
+pub use config::ResendConfig;
+```
+
+Create empty module files:
+- `modo-email/src/config.rs`
+- `modo-email/src/mailer.rs`
+- `modo-email/src/message.rs`
+- `modo-email/src/template/mod.rs`
+- `modo-email/src/template/filesystem.rs`
+- `modo-email/src/template/markdown.rs`
+- `modo-email/src/template/layout.rs`
+- `modo-email/src/transport/mod.rs`
+- `modo-email/src/transport/smtp.rs`
+- `modo-email/src/transport/resend.rs`
+
+**Step 3: Add to workspace**
+
+Add `"modo-email"` to the `members` list in the root `Cargo.toml`.
+
+**Step 4: Verify it compiles**
+
+Run: `cargo check -p modo-email`
+Expected: PASS (empty modules)
+
+**Step 5: Commit**
+
+```bash
+git add modo-email/ Cargo.toml
+git commit -m "chore: scaffold modo-email crate"
+```
+
+---
+
+### Task 2: Config Types
+
+**Files:**
+- Modify: `modo-email/src/config.rs`
+
+**Step 1: Write tests for config**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = EmailConfig::default();
+        assert_eq!(config.templates_path, "emails");
+        assert_eq!(config.default_from_name, "");
+        assert_eq!(config.default_from_email, "");
+        assert!(config.default_reply_to.is_none());
+        assert_eq!(config.transport, TransportBackend::Smtp);
+    }
+
+    #[test]
+    fn partial_yaml_deserialization() {
+        let yaml = r#"
+templates_path: "mail"
+default_from_name: "Acme"
+default_from_email: "hi@acme.com"
+"#;
+        let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.templates_path, "mail");
+        assert_eq!(config.default_from_name, "Acme");
+        assert_eq!(config.default_from_email, "hi@acme.com");
+        assert_eq!(config.transport, TransportBackend::Smtp);
+    }
+
+    #[test]
+    fn transport_backend_deserialization() {
+        let yaml = "transport: resend";
+        let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.transport, TransportBackend::Resend);
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p modo-email`
+Expected: FAIL — types don't exist
+
+**Step 3: Implement config types**
+
+```rust
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransportBackend {
+    #[default]
+    Smtp,
+    Resend,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct EmailConfig {
+    pub transport: TransportBackend,
+    pub templates_path: String,
+    pub default_from_name: String,
+    pub default_from_email: String,
+    pub default_reply_to: Option<String>,
+
+    #[cfg(feature = "smtp")]
+    pub smtp: SmtpConfig,
+
+    #[cfg(feature = "resend")]
+    pub resend: ResendConfig,
+}
+
+impl Default for EmailConfig {
+    fn default() -> Self {
+        Self {
+            transport: TransportBackend::default(),
+            templates_path: "emails".to_string(),
+            default_from_name: String::new(),
+            default_from_email: String::new(),
+            default_reply_to: None,
+            #[cfg(feature = "smtp")]
+            smtp: SmtpConfig::default(),
+            #[cfg(feature = "resend")]
+            resend: ResendConfig::default(),
+        }
+    }
+}
+
+#[cfg(feature = "smtp")]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SmtpConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub tls: bool,
+}
+
+#[cfg(feature = "smtp")]
+impl Default for SmtpConfig {
+    fn default() -> Self {
+        Self {
+            host: "localhost".to_string(),
+            port: 587,
+            username: String::new(),
+            password: String::new(),
+            tls: true,
+        }
+    }
+}
+
+#[cfg(feature = "resend")]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ResendConfig {
+    pub api_key: String,
+}
+
+#[cfg(feature = "resend")]
+impl Default for ResendConfig {
+    fn default() -> Self {
+        Self {
+            api_key: String::new(),
+        }
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p modo-email`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add modo-email/src/config.rs
+git commit -m "feat(modo-email): add config types"
+```
+
+---
+
+### Task 3: Core Message Types
+
+**Files:**
+- Modify: `modo-email/src/message.rs`
+
+**Step 1: Write tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sender_profile_serialization_roundtrip() {
+        let profile = SenderProfile {
+            from_name: "Acme".to_string(),
+            from_email: "hi@acme.com".to_string(),
+            reply_to: Some("support@acme.com".to_string()),
+        };
+        let json = serde_json::to_string(&profile).unwrap();
+        let back: SenderProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.from_name, "Acme");
+        assert_eq!(back.reply_to, Some("support@acme.com".to_string()));
+    }
+
+    #[test]
+    fn sender_profile_format_address() {
+        let profile = SenderProfile {
+            from_name: "Acme Corp".to_string(),
+            from_email: "hi@acme.com".to_string(),
+            reply_to: None,
+        };
+        assert_eq!(profile.format_address(), "Acme Corp <hi@acme.com>");
+    }
+
+    #[test]
+    fn send_email_builder() {
+        let email = SendEmail::new("welcome", "user@test.com")
+            .locale("de")
+            .var("name", "Hans")
+            .var("code", "1234");
+        assert_eq!(email.template, "welcome");
+        assert_eq!(email.to, "user@test.com");
+        assert_eq!(email.locale.as_deref(), Some("de"));
+        assert_eq!(email.context.len(), 2);
+    }
+
+    #[test]
+    fn send_email_context_merge() {
+        let mut brand = HashMap::new();
+        brand.insert("logo".to_string(), serde_json::json!("https://logo.png"));
+        brand.insert("color".to_string(), serde_json::json!("#ff0000"));
+
+        let email = SendEmail::new("welcome", "u@t.com")
+            .context(&brand)
+            .var("name", "Alice");
+        assert_eq!(email.context.len(), 3);
+    }
+
+    #[test]
+    fn payload_roundtrip() {
+        let email = SendEmail::new("welcome", "u@t.com")
+            .locale("en")
+            .var("name", "Alice");
+        let payload = SendEmailPayload::from(email);
+        let json = serde_json::to_string(&payload).unwrap();
+        let back: SendEmailPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.template, "welcome");
+        assert_eq!(back.locale.as_deref(), Some("en"));
+
+        let email_back = SendEmail::from(back);
+        assert_eq!(email_back.to, "u@t.com");
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p modo-email`
+Expected: FAIL
+
+**Step 3: Implement types**
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SenderProfile {
+    pub from_name: String,
+    pub from_email: String,
+    pub reply_to: Option<String>,
+}
+
+impl SenderProfile {
+    pub fn format_address(&self) -> String {
+        format!("{} <{}>", self.from_name, self.from_email)
+    }
+}
+
+pub struct MailMessage {
+    pub from: String,
+    pub reply_to: Option<String>,
+    pub to: String,
+    pub subject: String,
+    pub html: String,
+    pub text: String,
+}
+
+pub struct SendEmail {
+    pub(crate) template: String,
+    pub(crate) to: String,
+    pub(crate) locale: Option<String>,
+    pub(crate) sender: Option<SenderProfile>,
+    pub(crate) context: HashMap<String, serde_json::Value>,
+}
+
+impl SendEmail {
+    pub fn new(template: &str, to: &str) -> Self {
+        Self {
+            template: template.to_string(),
+            to: to.to_string(),
+            locale: None,
+            sender: None,
+            context: HashMap::new(),
+        }
+    }
+
+    pub fn locale(mut self, locale: &str) -> Self {
+        self.locale = Some(locale.to_string());
+        self
+    }
+
+    pub fn sender(mut self, sender: &SenderProfile) -> Self {
+        self.sender = Some(sender.clone());
+        self
+    }
+
+    pub fn var(mut self, key: &str, value: impl Into<serde_json::Value>) -> Self {
+        self.context.insert(key.to_string(), value.into());
+        self
+    }
+
+    pub fn context(mut self, ctx: &HashMap<String, serde_json::Value>) -> Self {
+        self.context.extend(ctx.clone());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendEmailPayload {
+    pub template: String,
+    pub to: String,
+    pub locale: Option<String>,
+    pub sender: Option<SenderProfile>,
+    pub context: HashMap<String, serde_json::Value>,
+}
+
+impl From<SendEmail> for SendEmailPayload {
+    fn from(e: SendEmail) -> Self {
+        Self {
+            template: e.template,
+            to: e.to,
+            locale: e.locale,
+            sender: e.sender,
+            context: e.context,
+        }
+    }
+}
+
+impl From<SendEmailPayload> for SendEmail {
+    fn from(p: SendEmailPayload) -> Self {
+        Self {
+            template: p.template,
+            to: p.to,
+            locale: p.locale,
+            sender: p.sender,
+            context: p.context,
+        }
+    }
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p modo-email`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add modo-email/src/message.rs
+git commit -m "feat(modo-email): add message types, builder, and payload"
+```
+
+---
+
+### Task 4: MailTransport Trait + SMTP Backend
+
+**Files:**
+- Modify: `modo-email/src/transport/mod.rs`
+- Modify: `modo-email/src/transport/smtp.rs`
+
+**Step 1: Define the trait**
+
+In `transport/mod.rs`:
+
+```rust
+#[cfg(feature = "smtp")]
+pub mod smtp;
+#[cfg(feature = "resend")]
+pub mod resend;
+
+use crate::message::MailMessage;
+
+#[async_trait::async_trait]
+pub trait MailTransport: Send + Sync + 'static {
+    async fn send(&self, message: &MailMessage) -> Result<(), modo::Error>;
+}
+```
+
+**Step 2: Implement SMTP transport**
+
+In `transport/smtp.rs`:
+
+```rust
+use super::MailTransport;
+use crate::config::SmtpConfig;
+use crate::message::MailMessage;
+use lettre::message::{header::ContentType, MultiPart, SinglePart};
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
+
+pub struct SmtpTransport {
+    mailer: AsyncSmtpTransport<Tokio1Executor>,
+}
+
+impl SmtpTransport {
+    pub fn new(config: &SmtpConfig) -> Result<Self, modo::Error> {
+        let creds = Credentials::new(config.username.clone(), config.password.clone());
+
+        let builder = if config.tls {
+            AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)
+        } else {
+            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.host)
+                .port(config.port)
+                .into()  // adjust as needed per lettre API
+        };
+
+        let mailer = builder
+            .map_err(|e| modo::Error::internal(format!("SMTP config error: {e}")))?
+            .credentials(creds)
+            .port(config.port)
+            .build();
+
+        Ok(Self { mailer })
+    }
+}
+
+#[async_trait::async_trait]
+impl MailTransport for SmtpTransport {
+    async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
+        let mut builder = Message::builder()
+            .from(message.from.parse().map_err(|e| {
+                modo::Error::internal(format!("Invalid from address: {e}"))
+            })?)
+            .to(message.to.parse().map_err(|e| {
+                modo::Error::internal(format!("Invalid to address: {e}"))
+            })?)
+            .subject(&message.subject);
+
+        if let Some(ref reply_to) = message.reply_to {
+            builder = builder.reply_to(reply_to.parse().map_err(|e| {
+                modo::Error::internal(format!("Invalid reply-to address: {e}"))
+            })?);
+        }
+
+        let email = builder
+            .multipart(
+                MultiPart::alternative()
+                    .singlepart(
+                        SinglePart::builder()
+                            .header(ContentType::TEXT_PLAIN)
+                            .body(message.text.clone()),
+                    )
+                    .singlepart(
+                        SinglePart::builder()
+                            .header(ContentType::TEXT_HTML)
+                            .body(message.html.clone()),
+                    ),
+            )
+            .map_err(|e| modo::Error::internal(format!("Failed to build email: {e}")))?;
+
+        self.mailer
+            .send(email)
+            .await
+            .map_err(|e| modo::Error::internal(format!("SMTP send failed: {e}")))?;
+
+        Ok(())
+    }
+}
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cargo check -p modo-email`
+Expected: PASS
+
+Note: SMTP transport is tested via integration tests in Task 14. Unit-testing requires a real SMTP server or mock, which adds complexity. The trait boundary is the testable seam.
+
+**Step 4: Commit**
+
+```bash
+git add modo-email/src/transport/
+git commit -m "feat(modo-email): add MailTransport trait and SMTP backend"
+```
+
+---
+
+### Task 5: Resend HTTP Transport
+
+**Files:**
+- Modify: `modo-email/src/transport/resend.rs`
+
+**Step 1: Implement Resend transport**
+
+```rust
+use super::MailTransport;
+use crate::config::ResendConfig;
+use crate::message::MailMessage;
+
+pub struct ResendTransport {
+    client: reqwest::Client,
+    api_key: String,
+}
+
+impl ResendTransport {
+    pub fn new(config: &ResendConfig) -> Result<Self, modo::Error> {
+        let client = reqwest::Client::new();
+        Ok(Self {
+            client,
+            api_key: config.api_key.clone(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl MailTransport for ResendTransport {
+    async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
+        let mut body = serde_json::json!({
+            "from": message.from,
+            "to": [message.to],
+            "subject": message.subject,
+            "html": message.html,
+            "text": message.text,
+        });
+
+        if let Some(ref reply_to) = message.reply_to {
+            body["reply_to"] = serde_json::json!(reply_to);
+        }
+
+        let resp = self
+            .client
+            .post("https://api.resend.com/emails")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| modo::Error::internal(format!("Resend request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(modo::Error::internal(format!(
+                "Resend API error ({status}): {text}"
+            )));
+        }
+
+        Ok(())
+    }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `cargo check -p modo-email --features resend`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add modo-email/src/transport/resend.rs
+git commit -m "feat(modo-email): add Resend HTTP transport"
+```
+
+---
+
+### Task 6: TemplateProvider Trait + EmailTemplate + Frontmatter Parsing
+
+**Files:**
+- Modify: `modo-email/src/template/mod.rs`
+
+**Step 1: Write tests for frontmatter parsing**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_template_with_frontmatter() {
+        let raw = "---\nsubject: \"Hello {{name}}\"\nlayout: custom\n---\n\nBody here.";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Hello {{name}}");
+        assert_eq!(tpl.layout.as_deref(), Some("custom"));
+        assert_eq!(tpl.body.trim(), "Body here.");
+    }
+
+    #[test]
+    fn parse_template_default_layout() {
+        let raw = "---\nsubject: \"Hi\"\n---\n\nContent.";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Hi");
+        assert!(tpl.layout.is_none());
+    }
+
+    #[test]
+    fn parse_template_missing_subject() {
+        let raw = "---\nlayout: default\n---\n\nNo subject.";
+        let result = EmailTemplate::parse(raw);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_template_no_frontmatter() {
+        let raw = "Just markdown, no frontmatter.";
+        let result = EmailTemplate::parse(raw);
+        assert!(result.is_err());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p modo-email`
+Expected: FAIL
+
+**Step 3: Implement**
+
+```rust
+pub mod filesystem;
+pub mod layout;
+pub mod markdown;
+
+use serde::Deserialize;
+
+pub struct EmailTemplate {
+    pub subject: String,
+    pub body: String,
+    pub layout: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Frontmatter {
+    subject: String,
+    layout: Option<String>,
+}
+
+impl EmailTemplate {
+    pub fn parse(raw: &str) -> Result<Self, modo::Error> {
+        let raw = raw.trim();
+        if !raw.starts_with("---") {
+            return Err(modo::Error::internal(
+                "Email template must start with YAML frontmatter (---)",
+            ));
+        }
+
+        let after_first = &raw[3..];
+        let end = after_first.find("---").ok_or_else(|| {
+            modo::Error::internal("Email template frontmatter missing closing ---")
+        })?;
+
+        let yaml = &after_first[..end];
+        let body = &after_first[end + 3..];
+
+        let fm: Frontmatter = serde_yaml_ng::from_str(yaml)
+            .map_err(|e| modo::Error::internal(format!("Invalid frontmatter: {e}")))?;
+
+        Ok(Self {
+            subject: fm.subject,
+            body: body.to_string(),
+            layout: fm.layout,
+        })
+    }
+}
+
+pub trait TemplateProvider: Send + Sync + 'static {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, modo::Error>;
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p modo-email`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add modo-email/src/template/mod.rs
+git commit -m "feat(modo-email): add TemplateProvider trait and frontmatter parsing"
+```
+
+---
+
+### Task 7: FilesystemProvider
+
+**Files:**
+- Modify: `modo-email/src/template/filesystem.rs`
+
+**Step 1: Write tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::template::TemplateProvider;
+    use std::fs;
+
+    #[test]
+    fn load_template_no_locale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        fs::write(
+            path.join("welcome.md"),
+            "---\nsubject: \"Hi\"\n---\n\nHello!",
+        ).unwrap();
+
+        let provider = FilesystemProvider::new(path.to_str().unwrap());
+        let tpl = provider.get("welcome", "").unwrap();
+        assert_eq!(tpl.subject, "Hi");
+    }
+
+    #[test]
+    fn load_template_with_locale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        fs::create_dir_all(path.join("de")).unwrap();
+        fs::write(
+            path.join("de/welcome.md"),
+            "---\nsubject: \"Hallo\"\n---\n\nHallo!",
+        ).unwrap();
+        fs::write(
+            path.join("welcome.md"),
+            "---\nsubject: \"Hi\"\n---\n\nHello!",
+        ).unwrap();
+
+        let provider = FilesystemProvider::new(path.to_str().unwrap());
+        let tpl = provider.get("welcome", "de").unwrap();
+        assert_eq!(tpl.subject, "Hallo");
+    }
+
+    #[test]
+    fn locale_fallback_to_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        fs::write(
+            path.join("welcome.md"),
+            "---\nsubject: \"Hi\"\n---\n\nHello!",
+        ).unwrap();
+
+        let provider = FilesystemProvider::new(path.to_str().unwrap());
+        let tpl = provider.get("welcome", "fr").unwrap();
+        assert_eq!(tpl.subject, "Hi");
+    }
+
+    #[test]
+    fn template_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = FilesystemProvider::new(dir.path().to_str().unwrap());
+        let result = provider.get("missing", "");
+        assert!(result.is_err());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p modo-email`
+Expected: FAIL
+
+**Step 3: Implement**
+
+```rust
+use super::{EmailTemplate, TemplateProvider};
+use std::path::{Path, PathBuf};
+
+pub struct FilesystemProvider {
+    base_dir: PathBuf,
+}
+
+impl FilesystemProvider {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+        }
+    }
+
+    fn resolve_path(&self, name: &str, locale: &str) -> Option<PathBuf> {
+        // 1. Try {base}/{locale}/{name}.md
+        if !locale.is_empty() {
+            let localized = self.base_dir.join(locale).join(format!("{name}.md"));
+            if localized.is_file() {
+                return Some(localized);
+            }
+        }
+
+        // 2. Try {base}/{name}.md
+        let root = self.base_dir.join(format!("{name}.md"));
+        if root.is_file() {
+            return Some(root);
+        }
+
+        None
+    }
+}
+
+impl TemplateProvider for FilesystemProvider {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, modo::Error> {
+        let path = self.resolve_path(name, locale).ok_or_else(|| {
+            modo::Error::internal(format!("Email template not found: {name}"))
+        })?;
+
+        let raw = std::fs::read_to_string(&path).map_err(|e| {
+            modo::Error::internal(format!("Failed to read template {}: {e}", path.display()))
+        })?;
+
+        EmailTemplate::parse(&raw)
+    }
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p modo-email`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add modo-email/src/template/filesystem.rs
+git commit -m "feat(modo-email): add filesystem template provider with locale fallback"
+```
+
+---
+
+### Task 8: Variable Substitution
+
+**Files:**
+- Create: `modo-email/src/template/vars.rs`
+- Modify: `modo-email/src/template/mod.rs` (add `pub mod vars;`)
+
+**Step 1: Write tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn replace_simple_vars() {
+        let mut ctx = HashMap::new();
+        ctx.insert("name".to_string(), json!("Alice"));
+        ctx.insert("code".to_string(), json!("1234"));
+
+        let result = substitute("Hello {{name}}, code: {{code}}", &ctx);
+        assert_eq!(result, "Hello Alice, code: 1234");
+    }
+
+    #[test]
+    fn unresolved_vars_left_as_is() {
+        let ctx = HashMap::new();
+        let result = substitute("Hello {{name}}", &ctx);
+        assert_eq!(result, "Hello {{name}}");
+    }
+
+    #[test]
+    fn whitespace_in_braces() {
+        let mut ctx = HashMap::new();
+        ctx.insert("name".to_string(), json!("Bob"));
+        let result = substitute("Hello {{ name }}", &ctx);
+        assert_eq!(result, "Hello Bob");
+    }
+
+    #[test]
+    fn non_string_values() {
+        let mut ctx = HashMap::new();
+        ctx.insert("count".to_string(), json!(42));
+        ctx.insert("active".to_string(), json!(true));
+        let result = substitute("Count: {{count}}, active: {{active}}", &ctx);
+        assert_eq!(result, "Count: 42, active: true");
+    }
+
+    #[test]
+    fn empty_input() {
+        let ctx = HashMap::new();
+        assert_eq!(substitute("", &ctx), "");
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p modo-email`
+Expected: FAIL
+
+**Step 3: Implement**
+
+```rust
+use std::collections::HashMap;
+
+pub fn substitute(input: &str, context: &HashMap<String, serde_json::Value>) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '{' && chars.peek() == Some(&'{') {
+            chars.next(); // consume second {
+            let mut key = String::new();
+            let mut found_close = false;
+
+            for ch in chars.by_ref() {
+                if ch == '}' {
+                    // Check for second }
+                    if chars.peek() == Some(&'}') {
+                        chars.next();
+                        found_close = true;
+                        break;
+                    }
+                    key.push(ch);
+                    continue;
+                }
+                key.push(ch);
+            }
+
+            let key = key.trim();
+            if found_close {
+                if let Some(val) = context.get(key) {
+                    match val {
+                        serde_json::Value::String(s) => result.push_str(s),
+                        other => result.push_str(&other.to_string()),
+                    }
+                } else {
+                    result.push_str("{{");
+                    result.push_str(key);
+                    result.push_str("}}");
+                }
+            } else {
+                result.push_str("{{");
+                result.push_str(key);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p modo-email`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add modo-email/src/template/vars.rs modo-email/src/template/mod.rs
+git commit -m "feat(modo-email): add template variable substitution"
+```
+
+---
+
+### Task 9: Markdown Renderer with Button Support
+
+**Files:**
+- Modify: `modo-email/src/template/markdown.rs`
+
+**Step 1: Write tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_basic_markdown() {
+        let html = render_markdown("Hello **world**");
+        assert!(html.contains("<strong>world</strong>"));
+    }
+
+    #[test]
+    fn render_link_as_link() {
+        let html = render_markdown("[Click](https://example.com)");
+        assert!(html.contains("<a"));
+        assert!(html.contains("href=\"https://example.com\""));
+        assert!(html.contains("Click"));
+    }
+
+    #[test]
+    fn render_button_link() {
+        let html = render_markdown("[button|Get Started](https://example.com)");
+        assert!(html.contains("Get Started"));
+        assert!(html.contains("https://example.com"));
+        assert!(html.contains("role=\"presentation\""));
+        assert!(!html.contains("button|"));
+    }
+
+    #[test]
+    fn render_normal_link_with_pipe() {
+        let html = render_markdown("[some|text](https://example.com)");
+        // "some" is not a known element type, render as normal link
+        assert!(html.contains("some|text"));
+        assert!(html.contains("<a"));
+    }
+
+    #[test]
+    fn plain_text_from_markdown() {
+        let text = render_plain_text("Hello **world**\n\n[button|Click](https://url.com)\n\n[Link](https://other.com)");
+        assert!(text.contains("Hello world"));
+        assert!(text.contains("Click (https://url.com)"));
+        assert!(text.contains("Link (https://other.com)"));
+        assert!(!text.contains("button|"));
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p modo-email`
+Expected: FAIL
+
+**Step 3: Implement**
+
+```rust
+use pulldown_cmark::{Event, LinkType, Options, Parser, Tag, TagEnd};
+
+const BUTTON_PREFIX: &str = "button|";
+
+const DEFAULT_BUTTON_COLOR: &str = "#4F46E5";
+
+pub fn render_markdown(markdown: &str) -> String {
+    render_markdown_with_color(markdown, DEFAULT_BUTTON_COLOR)
+}
+
+pub fn render_markdown_with_color(markdown: &str, button_color: &str) -> String {
+    let opts = Options::empty();
+    let parser = Parser::new_ext(markdown, opts);
+
+    let mut html = String::new();
+    let mut in_button_link = false;
+    let mut button_url = String::new();
+    let mut button_text = String::new();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Link { link_type: LinkType::Inline, dest_url, .. }) => {
+                // We don't know yet if it's a button — buffer until we see text
+                button_url = dest_url.to_string();
+                in_button_link = true;
+                button_text.clear();
+            }
+            Event::Text(text) if in_button_link => {
+                button_text.push_str(&text);
+            }
+            Event::End(TagEnd::Link) if in_button_link => {
+                in_button_link = false;
+                if button_text.starts_with(BUTTON_PREFIX) {
+                    let label = &button_text[BUTTON_PREFIX.len()..];
+                    html.push_str(&render_button(label, &button_url, button_color));
+                } else {
+                    // Normal link
+                    html.push_str(&format!(
+                        "<a href=\"{}\" style=\"color:{button_color}\">{}</a>",
+                        button_url, button_text,
+                    ));
+                }
+            }
+            _ if in_button_link => {
+                // Non-text event inside a link — treat as normal link
+                // (shouldn't happen with simple markdown, but handle gracefully)
+            }
+            _ => {
+                // Default: use pulldown-cmark's HTML push
+                pulldown_cmark::html::push_html(&mut html, std::iter::once(event));
+            }
+        }
+    }
+
+    html
+}
+
+fn render_button(label: &str, url: &str, color: &str) -> String {
+    format!(
+        r#"<table role="presentation" cellpadding="0" cellspacing="0" style="margin:16px auto"><tr><td style="background-color:{color};border-radius:6px;padding:12px 24px;text-align:center"><a href="{url}" style="color:#ffffff;text-decoration:none;font-weight:bold;font-size:16px;display:inline-block">{label}</a></td></tr></table>"#,
+    )
+}
+
+pub fn render_plain_text(markdown: &str) -> String {
+    let opts = Options::empty();
+    let parser = Parser::new_ext(markdown, opts);
+
+    let mut text = String::new();
+    let mut in_link = false;
+    let mut link_text = String::new();
+    let mut link_url = String::new();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                in_link = true;
+                link_url = dest_url.to_string();
+                link_text.clear();
+            }
+            Event::Text(t) if in_link => {
+                link_text.push_str(&t);
+            }
+            Event::End(TagEnd::Link) => {
+                in_link = false;
+                let display = if link_text.starts_with(BUTTON_PREFIX) {
+                    &link_text[BUTTON_PREFIX.len()..]
+                } else {
+                    &link_text
+                };
+                text.push_str(&format!("{display} ({link_url})"));
+            }
+            Event::Text(t) => text.push_str(&t),
+            Event::SoftBreak | Event::HardBreak => text.push('\n'),
+            Event::Start(Tag::Paragraph) => {}
+            Event::End(TagEnd::Paragraph) => text.push_str("\n\n"),
+            Event::Start(Tag::Heading { .. }) => {}
+            Event::End(TagEnd::Heading(_)) => text.push_str("\n\n"),
+            _ => {}
+        }
+    }
+
+    text.trim().to_string()
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p modo-email`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add modo-email/src/template/markdown.rs
+git commit -m "feat(modo-email): add Markdown renderer with button link support"
+```
+
+---
+
+### Task 10: Layout Engine + Built-in Default Layout
+
+**Files:**
+- Modify: `modo-email/src/template/layout.rs`
+
+**Step 1: Write tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::fs;
+
+    #[test]
+    fn render_with_builtin_layout() {
+        let engine = LayoutEngine::builtin_only();
+        let mut ctx = HashMap::new();
+        ctx.insert("content".to_string(), serde_json::json!("<p>Hello</p>"));
+        ctx.insert("subject".to_string(), serde_json::json!("Test"));
+
+        let html = engine.render("default", &ctx).unwrap();
+        assert!(html.contains("<p>Hello</p>"));
+        assert!(html.contains("Test")); // subject in <title>
+        assert!(html.contains("max-width")); // responsive wrapper
+    }
+
+    #[test]
+    fn custom_layout_overrides_builtin() {
+        let dir = tempfile::tempdir().unwrap();
+        let layouts_dir = dir.path().join("layouts");
+        fs::create_dir_all(&layouts_dir).unwrap();
+        fs::write(
+            layouts_dir.join("default.html"),
+            "<html><body>CUSTOM: {{content}}</body></html>",
+        ).unwrap();
+
+        let engine = LayoutEngine::new(dir.path().to_str().unwrap());
+        let mut ctx = HashMap::new();
+        ctx.insert("content".to_string(), serde_json::json!("<p>Hi</p>"));
+
+        let html = engine.render("default", &ctx).unwrap();
+        assert!(html.contains("CUSTOM: <p>Hi</p>"));
+    }
+
+    #[test]
+    fn missing_layout_errors() {
+        let engine = LayoutEngine::builtin_only();
+        let ctx = HashMap::new();
+        let result = engine.render("nonexistent", &ctx);
+        assert!(result.is_err());
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p modo-email`
+Expected: FAIL
+
+**Step 3: Create the built-in default layout**
+
+Hard-coded as a const string in the module. This is the responsive HTML email wrapper:
+
+```rust
+pub(crate) const DEFAULT_LAYOUT: &str = r#"<!DOCTYPE html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>{{subject}}</title>
+<style>
+  @media (prefers-color-scheme: dark) {
+    body { background-color: #1a1a1a !important; }
+    .email-wrapper { background-color: #2d2d2d !important; }
+    .email-body { color: #e0e0e0 !important; }
+  }
+  @media only screen and (max-width: 620px) {
+    .email-wrapper { width: 100% !important; padding: 16px !important; }
+  }
+</style>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5">
+<tr><td align="center" style="padding:32px 16px">
+  <!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+  <table role="presentation" class="email-wrapper" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background-color:#ffffff;border-radius:8px;overflow:hidden">
+    {% if logo_url %}
+    <tr><td style="padding:24px 32px 0;text-align:center">
+      <img src="{{logo_url}}" alt="{{product_name | default(value="")}}" style="max-height:48px;width:auto">
+    </td></tr>
+    {% endif %}
+    <tr><td class="email-body" style="padding:32px;color:#1f2937;font-size:16px;line-height:1.6">
+      {{content}}
+    </td></tr>
+    <tr><td style="padding:16px 32px 32px;color:#6b7280;font-size:13px;text-align:center;border-top:1px solid #e5e7eb">
+      {{footer_text | default(value="")}}
+    </td></tr>
+  </table>
+  <!--[if mso]></td></tr></table><![endif]-->
+</td></tr>
+</table>
+</body>
+</html>"#;
+```
+
+**Step 4: Implement LayoutEngine**
+
+```rust
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+pub(crate) const DEFAULT_LAYOUT: &str = /* as above */;
+
+pub struct LayoutEngine {
+    env: minijinja::Environment<'static>,
+}
+
+impl LayoutEngine {
+    pub fn new(templates_path: &str) -> Self {
+        let mut env = minijinja::Environment::new();
+        // Register built-in default
+        env.add_template_owned("__builtin__/default.html".to_string(), DEFAULT_LAYOUT.to_string())
+            .expect("built-in layout is valid");
+
+        // Load custom layouts from {templates_path}/layouts/
+        let layouts_dir = Path::new(templates_path).join("layouts");
+        if layouts_dir.is_dir() {
+            if let Ok(entries) = std::fs::read_dir(&layouts_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().is_some_and(|e| e == "html") {
+                        if let (Some(stem), Ok(content)) = (
+                            path.file_stem().and_then(|s| s.to_str()),
+                            std::fs::read_to_string(&path),
+                        ) {
+                            env.add_template_owned(
+                                format!("layouts/{stem}.html"),
+                                content,
+                            ).ok();
+                        }
+                    }
+                }
+            }
+        }
+
+        Self { env }
+    }
+
+    pub fn builtin_only() -> Self {
+        let mut env = minijinja::Environment::new();
+        env.add_template_owned("__builtin__/default.html".to_string(), DEFAULT_LAYOUT.to_string())
+            .expect("built-in layout is valid");
+        Self { env }
+    }
+
+    pub fn render(
+        &self,
+        layout_name: &str,
+        context: &HashMap<String, serde_json::Value>,
+    ) -> Result<String, modo::Error> {
+        // Try custom layout first, then builtin
+        let template_name = format!("layouts/{layout_name}.html");
+        let builtin_name = format!("__builtin__/{layout_name}.html");
+
+        let tmpl = self.env.get_template(&template_name)
+            .or_else(|_| self.env.get_template(&builtin_name))
+            .map_err(|_| modo::Error::internal(format!("Layout not found: {layout_name}")))?;
+
+        let ctx = minijinja::Value::from_serialize(context);
+        tmpl.render(ctx)
+            .map_err(|e| modo::Error::internal(format!("Layout render error: {e}")))
+    }
+}
+```
+
+**Step 5: Run tests**
+
+Run: `cargo test -p modo-email`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add modo-email/src/template/layout.rs
+git commit -m "feat(modo-email): add layout engine with built-in responsive default"
+```
+
+---
+
+### Task 11: Mailer Service + Factory Functions
+
+**Files:**
+- Modify: `modo-email/src/mailer.rs`
+- Modify: `modo-email/src/lib.rs` (add factory re-exports)
+
+**Step 1: Write tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::template::TemplateProvider;
+    use crate::transport::MailTransport;
+    use std::sync::{Arc, Mutex};
+
+    struct MockTransport {
+        sent: Arc<Mutex<Vec<MailMessage>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl MailTransport for MockTransport {
+        async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
+            self.sent.lock().unwrap().push(MailMessage {
+                from: message.from.clone(),
+                reply_to: message.reply_to.clone(),
+                to: message.to.clone(),
+                subject: message.subject.clone(),
+                html: message.html.clone(),
+                text: message.text.clone(),
+            });
+            Ok(())
+        }
+    }
+
+    struct MockTemplateProvider;
+
+    impl TemplateProvider for MockTemplateProvider {
+        fn get(&self, _name: &str, _locale: &str) -> Result<crate::template::EmailTemplate, modo::Error> {
+            Ok(crate::template::EmailTemplate {
+                subject: "Hello {{name}}".to_string(),
+                body: "Hi **{{name}}**!\n\n[button|Click](https://example.com)".to_string(),
+                layout: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn send_renders_and_delivers() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let mailer = Mailer::new(
+            Box::new(MockTransport { sent: sent.clone() }),
+            Box::new(MockTemplateProvider),
+            SenderProfile {
+                from_name: "Test".to_string(),
+                from_email: "test@test.com".to_string(),
+                reply_to: None,
+            },
+            LayoutEngine::builtin_only(),
+        );
+
+        mailer.send(
+            SendEmail::new("welcome", "user@test.com")
+                .var("name", "Alice")
+        ).await.unwrap();
+
+        let messages = sent.lock().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].to, "user@test.com");
+        assert_eq!(messages[0].subject, "Hello Alice");
+        assert!(messages[0].html.contains("Alice"));
+        assert!(messages[0].html.contains("role=\"presentation\"")); // button
+        assert!(messages[0].text.contains("Alice"));
+    }
+
+    #[tokio::test]
+    async fn sender_override() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let mailer = Mailer::new(
+            Box::new(MockTransport { sent: sent.clone() }),
+            Box::new(MockTemplateProvider),
+            SenderProfile {
+                from_name: "Default".to_string(),
+                from_email: "default@test.com".to_string(),
+                reply_to: None,
+            },
+            LayoutEngine::builtin_only(),
+        );
+
+        let custom_sender = SenderProfile {
+            from_name: "Tenant".to_string(),
+            from_email: "tenant@custom.com".to_string(),
+            reply_to: Some("support@custom.com".to_string()),
+        };
+
+        mailer.send(
+            SendEmail::new("welcome", "user@test.com")
+                .sender(&custom_sender)
+                .var("name", "Bob")
+        ).await.unwrap();
+
+        let messages = sent.lock().unwrap();
+        assert!(messages[0].from.contains("tenant@custom.com"));
+        assert_eq!(messages[0].reply_to.as_deref(), Some("support@custom.com"));
+    }
+
+    #[test]
+    fn render_returns_message_without_sending() {
+        let mailer = Mailer::new(
+            Box::new(MockTransport { sent: Arc::new(Mutex::new(Vec::new())) }),
+            Box::new(MockTemplateProvider),
+            SenderProfile {
+                from_name: "Test".to_string(),
+                from_email: "test@test.com".to_string(),
+                reply_to: None,
+            },
+            LayoutEngine::builtin_only(),
+        );
+
+        let msg = mailer.render(
+            &SendEmail::new("welcome", "user@test.com")
+                .var("name", "Charlie")
+        ).unwrap();
+
+        assert_eq!(msg.subject, "Hello Charlie");
+        assert!(msg.html.contains("Charlie"));
+        assert!(msg.text.contains("Charlie"));
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p modo-email`
+Expected: FAIL
+
+**Step 3: Implement Mailer**
+
+```rust
+use crate::config::EmailConfig;
+use crate::message::{MailMessage, SendEmail, SenderProfile};
+use crate::template::layout::LayoutEngine;
+use crate::template::markdown;
+use crate::template::vars;
+use crate::template::TemplateProvider;
+use crate::transport::MailTransport;
+use std::collections::HashMap;
+
+pub struct Mailer {
+    transport: Box<dyn MailTransport>,
+    templates: Box<dyn TemplateProvider>,
+    default_sender: SenderProfile,
+    layout_engine: LayoutEngine,
+}
+
+impl Mailer {
+    pub fn new(
+        transport: Box<dyn MailTransport>,
+        templates: Box<dyn TemplateProvider>,
+        default_sender: SenderProfile,
+        layout_engine: LayoutEngine,
+    ) -> Self {
+        Self {
+            transport,
+            templates,
+            default_sender,
+            layout_engine,
+        }
+    }
+
+    pub fn render(&self, email: &SendEmail) -> Result<MailMessage, modo::Error> {
+        let locale = email.locale.as_deref().unwrap_or("");
+        let template = self.templates.get(&email.template, locale)?;
+
+        // Variable substitution on subject and body
+        let subject = vars::substitute(&template.subject, &email.context);
+        let body = vars::substitute(&template.body, &email.context);
+
+        // Extract button color from context, fallback to default
+        let button_color = email.context
+            .get("brand_color")
+            .and_then(|v| v.as_str())
+            .unwrap_or("#4F46E5");
+
+        // Render Markdown to HTML
+        let html_body = markdown::render_markdown_with_color(&body, button_color);
+        let text = markdown::render_plain_text(&body);
+
+        // Wrap in layout
+        let layout_name = template.layout.as_deref().unwrap_or("default");
+        let mut layout_ctx: HashMap<String, serde_json::Value> = email.context.clone();
+        layout_ctx.insert("content".to_string(), serde_json::Value::String(html_body));
+        layout_ctx.insert("subject".to_string(), serde_json::Value::String(subject.clone()));
+
+        let html = self.layout_engine.render(layout_name, &layout_ctx)?;
+
+        // Resolve sender
+        let sender = email.sender.as_ref().unwrap_or(&self.default_sender);
+
+        Ok(MailMessage {
+            from: sender.format_address(),
+            reply_to: sender.reply_to.clone(),
+            to: email.to.clone(),
+            subject,
+            html,
+            text,
+        })
+    }
+
+    pub async fn send(&self, email: SendEmail) -> Result<(), modo::Error> {
+        let message = self.render(&email)?;
+        self.transport.send(&message).await
+    }
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cargo test -p modo-email`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add modo-email/src/mailer.rs
+git commit -m "feat(modo-email): add Mailer service with render and send"
+```
+
+---
+
+### Task 12: Factory Functions + Transport Factory
+
+**Files:**
+- Modify: `modo-email/src/transport/mod.rs` (add factory function)
+- Modify: `modo-email/src/lib.rs` (add `mailer()` and `mailer_with()`)
+
+**Step 1: Add transport factory**
+
+In `transport/mod.rs`, add:
+
+```rust
+use crate::config::EmailConfig;
+
+pub fn transport(config: &EmailConfig) -> Result<Box<dyn MailTransport>, modo::Error> {
+    match config.transport {
+        #[cfg(feature = "smtp")]
+        crate::config::TransportBackend::Smtp => {
+            Ok(Box::new(smtp::SmtpTransport::new(&config.smtp)?))
+        }
+        #[cfg(not(feature = "smtp"))]
+        crate::config::TransportBackend::Smtp => Err(modo::Error::internal(
+            "SMTP transport requires the `smtp` feature",
+        )),
+
+        #[cfg(feature = "resend")]
+        crate::config::TransportBackend::Resend => {
+            Ok(Box::new(resend::ResendTransport::new(&config.resend)?))
+        }
+        #[cfg(not(feature = "resend"))]
+        crate::config::TransportBackend::Resend => Err(modo::Error::internal(
+            "Resend transport requires the `resend` feature",
+        )),
+    }
+}
+```
+
+**Step 2: Add public factory functions in lib.rs**
+
+```rust
+use crate::config::EmailConfig;
+use crate::mailer::Mailer;
+use crate::message::SenderProfile;
+use crate::template::filesystem::FilesystemProvider;
+use crate::template::layout::LayoutEngine;
+use crate::template::TemplateProvider;
+
+/// Create a Mailer with the default FilesystemProvider.
+pub fn mailer(config: &EmailConfig) -> Result<Mailer, modo::Error> {
+    let transport = transport::transport(config)?;
+    let provider = Box::new(FilesystemProvider::new(&config.templates_path));
+    let layout = LayoutEngine::new(&config.templates_path);
+    let sender = SenderProfile {
+        from_name: config.default_from_name.clone(),
+        from_email: config.default_from_email.clone(),
+        reply_to: config.default_reply_to.clone(),
+    };
+    Ok(Mailer::new(transport, provider, sender, layout))
+}
+
+/// Create a Mailer with a custom TemplateProvider.
+pub fn mailer_with(
+    config: &EmailConfig,
+    provider: Box<dyn TemplateProvider>,
+) -> Result<Mailer, modo::Error> {
+    let transport = transport::transport(config)?;
+    let layout = LayoutEngine::new(&config.templates_path);
+    let sender = SenderProfile {
+        from_name: config.default_from_name.clone(),
+        from_email: config.default_from_email.clone(),
+        reply_to: config.default_reply_to.clone(),
+    };
+    Ok(Mailer::new(transport, provider, sender, layout))
+}
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cargo check -p modo-email`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add modo-email/src/transport/mod.rs modo-email/src/lib.rs
+git commit -m "feat(modo-email): add transport factory and public mailer constructors"
+```
+
+---
+
+### Task 13: Final Integration — Wire Up lib.rs Exports
+
+**Files:**
+- Modify: `modo-email/src/lib.rs`
+
+**Step 1: Finalize all public re-exports**
+
+Ensure `lib.rs` exports everything documented in the design. Add `pub use` for `FilesystemProvider`, `LayoutEngine`, `render_markdown`, `render_plain_text` if useful for advanced users.
+
+**Step 2: Run full check**
+
+Run: `cargo check -p modo-email && cargo check -p modo-email --features resend && cargo test -p modo-email`
+Expected: All PASS
+
+**Step 3: Run workspace lint**
+
+Run: `just fmt && just lint`
+Expected: PASS. Fix any warnings (dead code, unused imports, etc.)
+
+**Step 4: Commit**
+
+```bash
+git add modo-email/
+git commit -m "feat(modo-email): finalize public API exports"
+```
+
+---
+
+### Task 14: End-to-End Integration Test
+
+**Files:**
+- Create: `modo-email/tests/integration.rs`
+
+**Step 1: Write integration test with filesystem templates**
+
+```rust
+use modo_email::{EmailConfig, Mailer, SendEmail, SenderProfile};
+use modo_email::template::filesystem::FilesystemProvider;
+use modo_email::template::layout::LayoutEngine;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+// Reuse a simple mock transport for testing
+struct CapturingTransport {
+    messages: Arc<Mutex<Vec<modo_email::MailMessage>>>,
+}
+
+#[async_trait::async_trait]
+impl modo_email::MailTransport for CapturingTransport {
+    async fn send(&self, message: &modo_email::MailMessage) -> Result<(), modo::Error> {
+        self.messages.lock().unwrap().push(modo_email::MailMessage {
+            from: message.from.clone(),
+            reply_to: message.reply_to.clone(),
+            to: message.to.clone(),
+            subject: message.subject.clone(),
+            html: message.html.clone(),
+            text: message.text.clone(),
+        });
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn end_to_end_filesystem_template() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path();
+
+    // Create template
+    std::fs::write(
+        path.join("welcome.md"),
+        "---\nsubject: \"Welcome {{name}}!\"\n---\n\nHi **{{name}}**,\n\nGet started:\n\n[button|Launch Dashboard]({{url}})\n",
+    ).unwrap();
+
+    let messages = Arc::new(Mutex::new(Vec::new()));
+    let provider = Box::new(FilesystemProvider::new(path.to_str().unwrap()));
+    let layout = LayoutEngine::new(path.to_str().unwrap());
+
+    let mailer = Mailer::new(
+        Box::new(CapturingTransport { messages: messages.clone() }),
+        provider,
+        SenderProfile {
+            from_name: "App".to_string(),
+            from_email: "app@test.com".to_string(),
+            reply_to: None,
+        },
+        layout,
+    );
+
+    mailer.send(
+        SendEmail::new("welcome", "user@example.com")
+            .var("name", "Alice")
+            .var("url", "https://app.com/dashboard")
+    ).await.unwrap();
+
+    let msgs = messages.lock().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].subject, "Welcome Alice!");
+    assert!(msgs[0].html.contains("Alice"));
+    assert!(msgs[0].html.contains("Launch Dashboard"));
+    assert!(msgs[0].html.contains("https://app.com/dashboard"));
+    assert!(msgs[0].html.contains("role=\"presentation\"")); // button rendered
+    assert!(msgs[0].text.contains("Launch Dashboard (https://app.com/dashboard)"));
+}
+
+#[tokio::test]
+async fn end_to_end_locale_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path();
+
+    // Root template only
+    std::fs::write(
+        path.join("reset.md"),
+        "---\nsubject: \"Reset password\"\n---\n\nClick below to reset.",
+    ).unwrap();
+
+    let messages = Arc::new(Mutex::new(Vec::new()));
+    let mailer = Mailer::new(
+        Box::new(CapturingTransport { messages: messages.clone() }),
+        Box::new(FilesystemProvider::new(path.to_str().unwrap())),
+        SenderProfile {
+            from_name: "App".to_string(),
+            from_email: "app@test.com".to_string(),
+            reply_to: None,
+        },
+        LayoutEngine::new(path.to_str().unwrap()),
+    );
+
+    // Request "fr" locale — should fallback to root
+    mailer.send(
+        SendEmail::new("reset", "user@example.com").locale("fr")
+    ).await.unwrap();
+
+    let msgs = messages.lock().unwrap();
+    assert_eq!(msgs[0].subject, "Reset password");
+}
+```
+
+**Step 2: Run integration tests**
+
+Run: `cargo test -p modo-email --test integration`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add modo-email/tests/
+git commit -m "test(modo-email): add end-to-end integration tests"
+```
+
+---
+
+### Task 15: README
+
+**Files:**
+- Create: `modo-email/README.md`
+
+Write README with:
+- Overview (what it does)
+- Quick start (config + setup + send)
+- Template format (frontmatter + Markdown + button syntax)
+- Directory structure (single-language and multi-language)
+- Multi-tenant usage (SenderProfile + brand context)
+- Async sending via modo-jobs (app-level example)
+- Custom TemplateProvider example
+- Available transports and feature flags
+- Configuration reference
+
+**Step 1: Write README**
+
+Content based on the design doc's usage examples and configuration reference.
+
+**Step 2: Commit**
+
+```bash
+git add modo-email/README.md
+git commit -m "docs(modo-email): add README with usage examples"
+```
+
+---
+
+### Task 16: Final Verification
+
+**Step 1: Run full workspace check**
+
+```bash
+just fmt && just check
+```
+
+Expected: All PASS
+
+**Step 2: Review all public types match the design doc**
+
+Verify these types are exported from `modo_email`:
+- `EmailConfig`, `TransportBackend`, `SmtpConfig`, `ResendConfig`
+- `Mailer`
+- `SendEmail`, `SendEmailPayload`, `SenderProfile`, `MailMessage`
+- `EmailTemplate`, `TemplateProvider`
+- `MailTransport`
+- `mailer()`, `mailer_with()`
+
+**Step 3: Final commit if any adjustments**
+
+```bash
+git add -A
+git commit -m "chore(modo-email): final cleanup"
+```

--- a/modo-email/Cargo.toml
+++ b/modo-email/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "modo-email"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[features]
+default = ["smtp"]
+smtp = ["dep:lettre"]
+resend = ["dep:reqwest"]
+
+[dependencies]
+modo = { path = "../modo" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml_ng = "0.10"
+async-trait = "0.1"
+pulldown-cmark = "0.12"
+minijinja = { version = "2", features = ["loader"] }
+tracing = "0.1"
+lettre = { version = "0.11", features = ["tokio1-native-tls", "builder", "smtp-transport"], optional = true }
+reqwest = { version = "0.12", features = ["json"], optional = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+tempfile = "3"

--- a/modo-email/README.md
+++ b/modo-email/README.md
@@ -1,0 +1,381 @@
+# modo-email
+
+Email sending for the [modo](https://github.com/dmitrymomot/modo) framework. Markdown templates, responsive HTML output, pluggable transports, multi-tenant sender customization.
+
+## Features
+
+- **Markdown templates** with YAML frontmatter and `{{var}}` substitution
+- **Button syntax** -- `[button|Label](url)` renders as email-safe table-based buttons
+- **Responsive HTML layout** with dark mode support, or bring your own
+- **Plain text fallback** auto-generated from Markdown
+- **Transports** -- SMTP (default) and Resend HTTP API
+- **Multi-tenant** -- per-email `SenderProfile` override and brand context variables
+- **Serializable payload** (`SendEmailPayload`) for async sending via modo-jobs
+- **Custom template sources** -- implement `TemplateProvider` for DB-backed templates, APIs, etc.
+
+## Quick Start
+
+Add to `Cargo.toml`:
+
+```toml
+[dependencies]
+modo-email = { path = "../modo-email" }
+
+# For Resend instead of (or alongside) SMTP:
+# modo-email = { path = "../modo-email", features = ["resend"] }
+```
+
+### Configuration
+
+```yaml
+# config.yaml (or however your app loads config)
+email:
+  transport: smtp          # or "resend"
+  templates_path: "emails"
+  default_from_name: "My App"
+  default_from_email: "hello@myapp.com"
+  default_reply_to: "support@myapp.com"
+  smtp:
+    host: "smtp.example.com"
+    port: 587
+    username: "user"
+    password: "pass"
+    tls: true
+```
+
+All fields have defaults (`templates_path` defaults to `"emails"`, `smtp.port` to `587`, `smtp.tls` to `true`). Only specify what you need to override.
+
+### Setup and Send
+
+```rust
+use modo_email::{mailer, EmailConfig, SendEmail};
+
+// Build the mailer from config (uses FilesystemProvider + configured transport).
+let config: EmailConfig = load_config(); // your config loading
+let mailer = mailer(&config)?;
+
+// Send a templated email.
+mailer
+    .send(
+        SendEmail::new("welcome", "user@example.com")
+            .var("name", "Alice")
+            .var("dashboard_url", "https://app.com/dashboard"),
+    )
+    .await?;
+```
+
+### Render Without Sending
+
+```rust
+let message = mailer.render(
+    &SendEmail::new("welcome", "user@example.com")
+        .var("name", "Alice"),
+)?;
+
+println!("Subject: {}", message.subject);
+println!("HTML: {}", message.html);
+println!("Text: {}", message.text);
+```
+
+## Template Format
+
+Templates are `.md` files with YAML frontmatter:
+
+```markdown
+---
+subject: "Welcome {{name}}!"
+layout: default
+---
+
+Hi **{{name}}**,
+
+Thanks for joining! Here's what you can do next.
+
+[button|Get Started]({{dashboard_url}})
+
+If you have questions, just reply to this email.
+```
+
+### Frontmatter Fields
+
+| Field     | Required | Description                                                       |
+|-----------|----------|-------------------------------------------------------------------|
+| `subject` | Yes      | Email subject line. Supports `{{var}}` placeholders.              |
+| `layout`  | No       | Layout name to wrap the body in. Falls back to `"default"` built-in. |
+
+### Variable Substitution
+
+Use `{{key}}` or `{{ key }}` (whitespace is trimmed). Variables are passed via the builder:
+
+```rust
+SendEmail::new("invoice", "user@example.com")
+    .var("name", "Alice")
+    .var("amount", "$49.00")
+    .var("invoice_url", "https://app.com/invoices/123")
+```
+
+Unresolved placeholders are left as-is in the output.
+
+### Button Syntax
+
+```markdown
+[button|Click Me](https://example.com)
+```
+
+Renders as an email-safe, table-based CTA button with a default indigo (`#4F46E5`) background. Customize the color per-email with the `brand_color` variable:
+
+```rust
+SendEmail::new("welcome", "user@example.com")
+    .var("brand_color", "#E11D48")
+```
+
+Regular Markdown links render as styled inline links:
+
+```markdown
+[View docs](https://docs.example.com)
+```
+
+## Directory Structure
+
+### Single Language
+
+```
+emails/
+  welcome.md
+  reset_password.md
+  invoice.md
+```
+
+### Multi-Language (Locale Subdirectories)
+
+```
+emails/
+  welcome.md              # default / fallback
+  reset_password.md
+  de/
+    welcome.md            # German override
+    reset_password.md
+  fr/
+    welcome.md            # French override
+  layouts/
+    default.html          # custom layout (overrides built-in)
+    minimal.html          # additional named layout
+```
+
+Locale resolution: if `de/welcome.md` exists, it is used; otherwise falls back to `welcome.md`.
+
+```rust
+SendEmail::new("welcome", "user@example.com")
+    .locale("de")
+    .var("name", "Hans")
+```
+
+## Layouts
+
+The built-in `default` layout provides a responsive, dark-mode-aware HTML email wrapper. It supports these context variables:
+
+| Variable       | Description                          |
+|----------------|--------------------------------------|
+| `content`      | Rendered HTML body (injected automatically) |
+| `subject`      | Email subject (injected automatically) |
+| `logo_url`     | Optional logo image URL              |
+| `product_name` | Optional product name (logo alt text) |
+| `footer_text`  | Optional footer text                 |
+
+To override the built-in layout or add custom ones, place `.html` files in `{templates_path}/layouts/`:
+
+```
+emails/layouts/default.html    # overrides built-in default
+emails/layouts/minimal.html    # new named layout
+```
+
+Layouts use [MiniJinja](https://docs.rs/minijinja) syntax. All email context variables are available. Auto-escaping is disabled since the content is pre-rendered HTML.
+
+```html
+<!-- emails/layouts/minimal.html -->
+<html>
+<body style="font-family: sans-serif; padding: 20px;">
+  {{content}}
+</body>
+</html>
+```
+
+Reference it in a template's frontmatter:
+
+```markdown
+---
+subject: "Alert"
+layout: minimal
+---
+```
+
+## Multi-Tenant Usage
+
+### Per-Email Sender Override
+
+```rust
+use modo_email::{SendEmail, SenderProfile};
+
+let tenant_sender = SenderProfile {
+    from_name: "Tenant Corp".to_string(),
+    from_email: "notifications@tenant.com".to_string(),
+    reply_to: Some("support@tenant.com".to_string()),
+};
+
+mailer
+    .send(
+        SendEmail::new("welcome", "user@example.com")
+            .sender(&tenant_sender)
+            .var("name", "Bob"),
+    )
+    .await?;
+```
+
+Without `.sender()`, the mailer uses the default sender from `EmailConfig`.
+
+### Brand Context Variables
+
+Pass brand-specific variables to customize templates and layouts per tenant:
+
+```rust
+use std::collections::HashMap;
+
+let mut brand = HashMap::new();
+brand.insert("logo_url".to_string(), serde_json::json!("https://tenant.com/logo.png"));
+brand.insert("product_name".to_string(), serde_json::json!("Tenant Corp"));
+brand.insert("brand_color".to_string(), serde_json::json!("#E11D48"));
+brand.insert("footer_text".to_string(), serde_json::json!("(c) 2026 Tenant Corp"));
+
+mailer
+    .send(
+        SendEmail::new("welcome", "user@example.com")
+            .context(&brand)
+            .var("name", "Alice"),
+    )
+    .await?;
+```
+
+## Async Sending via modo-jobs
+
+`SendEmailPayload` is a serializable mirror of `SendEmail`, designed for job queue payloads. The job handler lives in your application, not in this crate:
+
+```rust
+use modo_email::{SendEmail, SendEmailPayload, Mailer};
+use modo_jobs::job;
+
+// Enqueue from a handler:
+let payload = SendEmailPayload::from(
+    SendEmail::new("welcome", "user@example.com")
+        .var("name", "Alice")
+        .var("dashboard_url", "https://app.com/dashboard"),
+);
+jobs.enqueue("send_email", &payload).await?;
+
+// Job worker:
+#[job(queue = "email", max_attempts = 3, timeout = "30s")]
+async fn send_email(
+    Service(mailer): Service<Mailer>,
+    Json(payload): Json<SendEmailPayload>,
+) -> Result<(), modo::Error> {
+    let email = SendEmail::from(payload);
+    mailer.send(email).await
+}
+```
+
+## Custom TemplateProvider
+
+Implement the `TemplateProvider` trait to load templates from a database, API, or any other source:
+
+```rust
+use modo_email::{EmailConfig, TemplateProvider, EmailTemplate, mailer_with};
+
+struct DbTemplateProvider {
+    pool: DatabasePool,
+}
+
+impl TemplateProvider for DbTemplateProvider {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, modo::Error> {
+        // Query your database for the template.
+        let raw = self.pool.query_template(name, locale)?;
+
+        // Return a parsed template (or build one manually).
+        EmailTemplate::parse(&raw)
+    }
+}
+
+// Use it:
+let provider = Box::new(DbTemplateProvider { pool });
+let mailer = mailer_with(&config, provider)?;
+```
+
+`EmailTemplate` fields if you want to build one without parsing:
+
+```rust
+EmailTemplate {
+    subject: "Welcome {{name}}!".to_string(),
+    body: "Hi **{{name}}**!".to_string(),
+    layout: Some("default".to_string()),  // None = built-in default
+}
+```
+
+## Transports and Feature Flags
+
+| Feature  | Default | Transport            | Dependency |
+|----------|---------|----------------------|------------|
+| `smtp`   | Yes     | SMTP via lettre      | `lettre`   |
+| `resend` | No      | Resend HTTP API      | `reqwest`  |
+
+Both features can be enabled simultaneously. The active transport is selected by `transport` in config.
+
+```toml
+# SMTP only (default):
+modo-email = { path = "../modo-email" }
+
+# Resend only:
+modo-email = { path = "../modo-email", default-features = false, features = ["resend"] }
+
+# Both available:
+modo-email = { path = "../modo-email", features = ["resend"] }
+```
+
+### Resend Configuration
+
+```yaml
+email:
+  transport: resend
+  templates_path: "emails"
+  default_from_name: "My App"
+  default_from_email: "hello@myapp.com"
+  resend:
+    api_key: "re_..."
+```
+
+## Configuration Reference
+
+### `EmailConfig`
+
+| Field                | Type              | Default       | Description                          |
+|----------------------|-------------------|---------------|--------------------------------------|
+| `transport`          | `smtp` / `resend` | `smtp`        | Which transport backend to use       |
+| `templates_path`     | `String`          | `"emails"`    | Directory containing `.md` templates |
+| `default_from_name`  | `String`          | `""`          | Default sender display name          |
+| `default_from_email` | `String`          | `""`          | Default sender email address         |
+| `default_reply_to`   | `Option<String>`  | `None`        | Default reply-to address             |
+| `smtp`               | `SmtpConfig`      | see below     | SMTP settings (requires `smtp` feature) |
+| `resend`             | `ResendConfig`    | see below     | Resend settings (requires `resend` feature) |
+
+### `SmtpConfig`
+
+| Field      | Type     | Default       | Description                 |
+|------------|----------|---------------|-----------------------------|
+| `host`     | `String` | `"localhost"` | SMTP server hostname        |
+| `port`     | `u16`    | `587`         | SMTP server port            |
+| `username` | `String` | `""`          | SMTP auth username          |
+| `password` | `String` | `""`          | SMTP auth password          |
+| `tls`      | `bool`   | `true`        | Enable TLS (STARTTLS)       |
+
+### `ResendConfig`
+
+| Field     | Type     | Default | Description        |
+|-----------|----------|---------|--------------------|
+| `api_key` | `String` | `""`    | Resend API key     |

--- a/modo-email/src/config.rs
+++ b/modo-email/src/config.rs
@@ -1,0 +1,117 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransportBackend {
+    #[default]
+    Smtp,
+    Resend,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct EmailConfig {
+    pub transport: TransportBackend,
+    pub templates_path: String,
+    pub default_from_name: String,
+    pub default_from_email: String,
+    pub default_reply_to: Option<String>,
+
+    #[cfg(feature = "smtp")]
+    pub smtp: SmtpConfig,
+
+    #[cfg(feature = "resend")]
+    pub resend: ResendConfig,
+}
+
+impl Default for EmailConfig {
+    fn default() -> Self {
+        Self {
+            transport: TransportBackend::default(),
+            templates_path: "emails".to_string(),
+            default_from_name: String::new(),
+            default_from_email: String::new(),
+            default_reply_to: None,
+            #[cfg(feature = "smtp")]
+            smtp: SmtpConfig::default(),
+            #[cfg(feature = "resend")]
+            resend: ResendConfig::default(),
+        }
+    }
+}
+
+#[cfg(feature = "smtp")]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SmtpConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub tls: bool,
+}
+
+#[cfg(feature = "smtp")]
+impl Default for SmtpConfig {
+    fn default() -> Self {
+        Self {
+            host: "localhost".to_string(),
+            port: 587,
+            username: String::new(),
+            password: String::new(),
+            tls: true,
+        }
+    }
+}
+
+#[cfg(feature = "resend")]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ResendConfig {
+    pub api_key: String,
+}
+
+#[cfg(feature = "resend")]
+impl Default for ResendConfig {
+    fn default() -> Self {
+        Self {
+            api_key: String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = EmailConfig::default();
+        assert_eq!(config.templates_path, "emails");
+        assert_eq!(config.default_from_name, "");
+        assert_eq!(config.default_from_email, "");
+        assert!(config.default_reply_to.is_none());
+        assert_eq!(config.transport, TransportBackend::Smtp);
+    }
+
+    #[test]
+    fn partial_yaml_deserialization() {
+        let yaml = r#"
+templates_path: "mail"
+default_from_name: "Acme"
+default_from_email: "hi@acme.com"
+"#;
+        let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.templates_path, "mail");
+        assert_eq!(config.default_from_name, "Acme");
+        assert_eq!(config.default_from_email, "hi@acme.com");
+        assert_eq!(config.transport, TransportBackend::Smtp);
+    }
+
+    #[test]
+    fn transport_backend_deserialization() {
+        let yaml = "transport: resend";
+        let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.transport, TransportBackend::Resend);
+    }
+}

--- a/modo-email/src/config.rs
+++ b/modo-email/src/config.rs
@@ -65,19 +65,10 @@ impl Default for SmtpConfig {
 }
 
 #[cfg(feature = "resend")]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 #[serde(default)]
 pub struct ResendConfig {
     pub api_key: String,
-}
-
-#[cfg(feature = "resend")]
-impl Default for ResendConfig {
-    fn default() -> Self {
-        Self {
-            api_key: String::new(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/modo-email/src/config.rs
+++ b/modo-email/src/config.rs
@@ -48,6 +48,8 @@ pub struct SmtpConfig {
     pub port: u16,
     pub username: String,
     pub password: String,
+    /// When `true`, uses STARTTLS (port 587). When `false`, no TLS at all.
+    /// Implicit TLS / SMTPS (port 465) is not currently supported.
     pub tls: bool,
 }
 

--- a/modo-email/src/lib.rs
+++ b/modo-email/src/lib.rs
@@ -3,3 +3,45 @@ mod mailer;
 mod message;
 mod template;
 mod transport;
+
+pub use config::{EmailConfig, TransportBackend};
+pub use mailer::Mailer;
+pub use message::{MailMessage, SendEmail, SendEmailPayload, SenderProfile};
+pub use template::{EmailTemplate, TemplateProvider};
+pub use transport::MailTransport;
+
+#[cfg(feature = "smtp")]
+pub use config::SmtpConfig;
+#[cfg(feature = "resend")]
+pub use config::ResendConfig;
+
+use template::filesystem::FilesystemProvider;
+use template::layout::LayoutEngine;
+
+/// Create a Mailer with the default FilesystemProvider.
+pub fn mailer(config: &EmailConfig) -> Result<Mailer, modo::Error> {
+    let transport = transport::transport(config)?;
+    let provider = Box::new(FilesystemProvider::new(&config.templates_path));
+    let layout = LayoutEngine::new(&config.templates_path);
+    let sender = SenderProfile {
+        from_name: config.default_from_name.clone(),
+        from_email: config.default_from_email.clone(),
+        reply_to: config.default_reply_to.clone(),
+    };
+    Ok(Mailer::new(transport, provider, sender, layout))
+}
+
+/// Create a Mailer with a custom TemplateProvider.
+pub fn mailer_with(
+    config: &EmailConfig,
+    provider: Box<dyn TemplateProvider>,
+) -> Result<Mailer, modo::Error> {
+    let transport = transport::transport(config)?;
+    let layout = LayoutEngine::new(&config.templates_path);
+    let sender = SenderProfile {
+        from_name: config.default_from_name.clone(),
+        from_email: config.default_from_email.clone(),
+        reply_to: config.default_reply_to.clone(),
+    };
+    Ok(Mailer::new(transport, provider, sender, layout))
+}

--- a/modo-email/src/lib.rs
+++ b/modo-email/src/lib.rs
@@ -1,8 +1,8 @@
 mod config;
 mod mailer;
 mod message;
-mod template;
-mod transport;
+pub mod template;
+pub mod transport;
 
 pub use config::{EmailConfig, TransportBackend};
 pub use mailer::Mailer;
@@ -10,13 +10,13 @@ pub use message::{MailMessage, SendEmail, SendEmailPayload, SenderProfile};
 pub use template::{EmailTemplate, TemplateProvider};
 pub use transport::MailTransport;
 
-#[cfg(feature = "smtp")]
-pub use config::SmtpConfig;
 #[cfg(feature = "resend")]
 pub use config::ResendConfig;
+#[cfg(feature = "smtp")]
+pub use config::SmtpConfig;
 
-use template::filesystem::FilesystemProvider;
-use template::layout::LayoutEngine;
+pub use template::filesystem::FilesystemProvider;
+pub use template::layout::LayoutEngine;
 
 /// Create a Mailer with the default FilesystemProvider.
 pub fn mailer(config: &EmailConfig) -> Result<Mailer, modo::Error> {

--- a/modo-email/src/lib.rs
+++ b/modo-email/src/lib.rs
@@ -1,0 +1,5 @@
+mod config;
+mod mailer;
+mod message;
+mod template;
+mod transport;

--- a/modo-email/src/lib.rs
+++ b/modo-email/src/lib.rs
@@ -18,11 +18,13 @@ pub use config::SmtpConfig;
 pub use template::filesystem::FilesystemProvider;
 pub use template::layout::LayoutEngine;
 
+use std::sync::Arc;
+
 /// Create a Mailer with the default FilesystemProvider.
 pub fn mailer(config: &EmailConfig) -> Result<Mailer, modo::Error> {
     let transport = transport::transport(config)?;
-    let provider = Box::new(FilesystemProvider::new(&config.templates_path));
-    let layout = LayoutEngine::new(&config.templates_path);
+    let provider = Arc::new(FilesystemProvider::new(&config.templates_path));
+    let layout = Arc::new(LayoutEngine::new(&config.templates_path));
     let sender = SenderProfile {
         from_name: config.default_from_name.clone(),
         from_email: config.default_from_email.clone(),
@@ -34,10 +36,10 @@ pub fn mailer(config: &EmailConfig) -> Result<Mailer, modo::Error> {
 /// Create a Mailer with a custom TemplateProvider.
 pub fn mailer_with(
     config: &EmailConfig,
-    provider: Box<dyn TemplateProvider>,
+    provider: Arc<dyn TemplateProvider>,
 ) -> Result<Mailer, modo::Error> {
     let transport = transport::transport(config)?;
-    let layout = LayoutEngine::new(&config.templates_path);
+    let layout = Arc::new(LayoutEngine::new(&config.templates_path));
     let sender = SenderProfile {
         from_name: config.default_from_name.clone(),
         from_email: config.default_from_email.clone(),

--- a/modo-email/src/mailer.rs
+++ b/modo-email/src/mailer.rs
@@ -1,0 +1,204 @@
+use crate::message::{MailMessage, SendEmail, SenderProfile};
+use crate::template::layout::LayoutEngine;
+use crate::template::{markdown, vars, TemplateProvider};
+use crate::transport::MailTransport;
+use std::collections::HashMap;
+
+/// High-level email service that ties together template loading, variable
+/// substitution, Markdown rendering, layout wrapping, and transport delivery.
+pub struct Mailer {
+    transport: Box<dyn MailTransport>,
+    templates: Box<dyn TemplateProvider>,
+    default_sender: SenderProfile,
+    layout_engine: LayoutEngine,
+}
+
+impl Mailer {
+    pub fn new(
+        transport: Box<dyn MailTransport>,
+        templates: Box<dyn TemplateProvider>,
+        default_sender: SenderProfile,
+        layout_engine: LayoutEngine,
+    ) -> Self {
+        Self {
+            transport,
+            templates,
+            default_sender,
+            layout_engine,
+        }
+    }
+
+    /// Render a `SendEmail` into a fully-formed `MailMessage` without sending.
+    pub fn render(&self, email: &SendEmail) -> Result<MailMessage, modo::Error> {
+        let locale = email.locale.as_deref().unwrap_or("");
+        let template = self.templates.get(&email.template, locale)?;
+
+        // Substitute variables in subject and body.
+        let subject = vars::substitute(&template.subject, &email.context);
+        let body = vars::substitute(&template.body, &email.context);
+
+        // Render Markdown body to HTML (with optional custom button color).
+        let button_color = email
+            .context
+            .get("brand_color")
+            .and_then(|v| v.as_str())
+            .unwrap_or("#4F46E5");
+        let html_body = markdown::render_markdown_with_color(&body, button_color);
+        let text = markdown::render_plain_text(&body);
+
+        // Wrap HTML body in a layout.
+        let layout_name = template.layout.as_deref().unwrap_or("default");
+        let mut layout_ctx: HashMap<String, serde_json::Value> = email.context.clone();
+        layout_ctx.insert(
+            "content".to_string(),
+            serde_json::Value::String(html_body),
+        );
+        layout_ctx.insert(
+            "subject".to_string(),
+            serde_json::Value::String(subject.clone()),
+        );
+        let html = self.layout_engine.render(layout_name, &layout_ctx)?;
+
+        // Resolve sender (per-email override or default).
+        let sender = email.sender.as_ref().unwrap_or(&self.default_sender);
+
+        Ok(MailMessage {
+            from: sender.format_address(),
+            reply_to: sender.reply_to.clone(),
+            to: email.to.clone(),
+            subject,
+            html,
+            text,
+        })
+    }
+
+    /// Render and deliver an email via the configured transport.
+    pub async fn send(&self, email: SendEmail) -> Result<(), modo::Error> {
+        let message = self.render(&email)?;
+        self.transport.send(&message).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::template::EmailTemplate;
+    use std::sync::{Arc, Mutex};
+
+    struct MockTransport {
+        sent: Arc<Mutex<Vec<MailMessage>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl MailTransport for MockTransport {
+        async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
+            self.sent.lock().unwrap().push(MailMessage {
+                from: message.from.clone(),
+                reply_to: message.reply_to.clone(),
+                to: message.to.clone(),
+                subject: message.subject.clone(),
+                html: message.html.clone(),
+                text: message.text.clone(),
+            });
+            Ok(())
+        }
+    }
+
+    struct MockTemplateProvider;
+
+    impl TemplateProvider for MockTemplateProvider {
+        fn get(&self, _name: &str, _locale: &str) -> Result<EmailTemplate, modo::Error> {
+            Ok(EmailTemplate {
+                subject: "Hello {{name}}".to_string(),
+                body: "Hi **{{name}}**!\n\n[button|Click](https://example.com)".to_string(),
+                layout: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn send_renders_and_delivers() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let mailer = Mailer::new(
+            Box::new(MockTransport { sent: sent.clone() }),
+            Box::new(MockTemplateProvider),
+            SenderProfile {
+                from_name: "Test".to_string(),
+                from_email: "test@test.com".to_string(),
+                reply_to: None,
+            },
+            LayoutEngine::builtin_only(),
+        );
+
+        mailer
+            .send(SendEmail::new("welcome", "user@test.com").var("name", "Alice"))
+            .await
+            .unwrap();
+
+        let messages = sent.lock().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].to, "user@test.com");
+        assert_eq!(messages[0].subject, "Hello Alice");
+        assert!(messages[0].html.contains("Alice"));
+        assert!(messages[0].html.contains("role=\"presentation\"")); // button
+        assert!(messages[0].text.contains("Alice"));
+    }
+
+    #[tokio::test]
+    async fn sender_override() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let mailer = Mailer::new(
+            Box::new(MockTransport { sent: sent.clone() }),
+            Box::new(MockTemplateProvider),
+            SenderProfile {
+                from_name: "Default".to_string(),
+                from_email: "default@test.com".to_string(),
+                reply_to: None,
+            },
+            LayoutEngine::builtin_only(),
+        );
+
+        let custom_sender = SenderProfile {
+            from_name: "Tenant".to_string(),
+            from_email: "tenant@custom.com".to_string(),
+            reply_to: Some("support@custom.com".to_string()),
+        };
+
+        mailer
+            .send(
+                SendEmail::new("welcome", "user@test.com")
+                    .sender(&custom_sender)
+                    .var("name", "Bob"),
+            )
+            .await
+            .unwrap();
+
+        let messages = sent.lock().unwrap();
+        assert!(messages[0].from.contains("tenant@custom.com"));
+        assert_eq!(messages[0].reply_to.as_deref(), Some("support@custom.com"));
+    }
+
+    #[test]
+    fn render_returns_message_without_sending() {
+        let mailer = Mailer::new(
+            Box::new(MockTransport {
+                sent: Arc::new(Mutex::new(Vec::new())),
+            }),
+            Box::new(MockTemplateProvider),
+            SenderProfile {
+                from_name: "Test".to_string(),
+                from_email: "test@test.com".to_string(),
+                reply_to: None,
+            },
+            LayoutEngine::builtin_only(),
+        );
+
+        let msg = mailer
+            .render(&SendEmail::new("welcome", "user@test.com").var("name", "Charlie"))
+            .unwrap();
+
+        assert_eq!(msg.subject, "Hello Charlie");
+        assert!(msg.html.contains("Charlie"));
+        assert!(msg.text.contains("Charlie"));
+    }
+}

--- a/modo-email/src/mailer.rs
+++ b/modo-email/src/mailer.rs
@@ -1,6 +1,6 @@
 use crate::message::{MailMessage, SendEmail, SenderProfile};
 use crate::template::layout::LayoutEngine;
-use crate::template::{markdown, vars, TemplateProvider};
+use crate::template::{TemplateProvider, markdown, vars};
 use crate::transport::MailTransport;
 use std::collections::HashMap;
 
@@ -49,10 +49,7 @@ impl Mailer {
         // Wrap HTML body in a layout.
         let layout_name = template.layout.as_deref().unwrap_or("default");
         let mut layout_ctx: HashMap<String, serde_json::Value> = email.context.clone();
-        layout_ctx.insert(
-            "content".to_string(),
-            serde_json::Value::String(html_body),
-        );
+        layout_ctx.insert("content".to_string(), serde_json::Value::String(html_body));
         layout_ctx.insert(
             "subject".to_string(),
             serde_json::Value::String(subject.clone()),

--- a/modo-email/src/mailer.rs
+++ b/modo-email/src/mailer.rs
@@ -3,22 +3,27 @@ use crate::template::layout::LayoutEngine;
 use crate::template::{TemplateProvider, markdown, vars};
 use crate::transport::MailTransport;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// High-level email service that ties together template loading, variable
 /// substitution, Markdown rendering, layout wrapping, and transport delivery.
+///
+/// `Mailer` is cheaply cloneable via internal `Arc`s, making it safe to share
+/// across async tasks and register as a modo service.
+#[derive(Clone)]
 pub struct Mailer {
-    transport: Box<dyn MailTransport>,
-    templates: Box<dyn TemplateProvider>,
+    transport: Arc<dyn MailTransport>,
+    templates: Arc<dyn TemplateProvider>,
     default_sender: SenderProfile,
-    layout_engine: LayoutEngine,
+    layout_engine: Arc<LayoutEngine>,
 }
 
 impl Mailer {
     pub fn new(
-        transport: Box<dyn MailTransport>,
-        templates: Box<dyn TemplateProvider>,
+        transport: Arc<dyn MailTransport>,
+        templates: Arc<dyn TemplateProvider>,
         default_sender: SenderProfile,
-        layout_engine: LayoutEngine,
+        layout_engine: Arc<LayoutEngine>,
     ) -> Self {
         Self {
             transport,
@@ -37,12 +42,15 @@ impl Mailer {
         let subject = vars::substitute(&template.subject, &email.context);
         let body = vars::substitute(&template.body, &email.context);
 
-        // Render Markdown body to HTML (with optional custom button color).
+        // Validate brand_color as a CSS hex color; fall back to default if invalid.
         let button_color = email
             .context
             .get("brand_color")
             .and_then(|v| v.as_str())
+            .filter(|s| is_valid_hex_color(s))
             .unwrap_or("#4F46E5");
+
+        // Render Markdown body to HTML (with optional custom button color).
         let html_body = markdown::render_markdown_with_color(&body, button_color);
         let text = markdown::render_plain_text(&body);
 
@@ -70,33 +78,31 @@ impl Mailer {
     }
 
     /// Render and deliver an email via the configured transport.
-    pub async fn send(&self, email: SendEmail) -> Result<(), modo::Error> {
-        let message = self.render(&email)?;
+    pub async fn send(&self, email: &SendEmail) -> Result<(), modo::Error> {
+        let message = self.render(email)?;
         self.transport.send(&message).await
     }
+}
+
+/// Validate that a string is a valid CSS hex color (#RGB or #RRGGBB).
+fn is_valid_hex_color(s: &str) -> bool {
+    let s = s.as_bytes();
+    matches!(s.len(), 4 | 7) && s[0] == b'#' && s[1..].iter().all(|b| b.is_ascii_hexdigit())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::template::EmailTemplate;
-    use std::sync::{Arc, Mutex};
 
     struct MockTransport {
-        sent: Arc<Mutex<Vec<MailMessage>>>,
+        sent: std::sync::Mutex<Vec<MailMessage>>,
     }
 
     #[async_trait::async_trait]
     impl MailTransport for MockTransport {
         async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
-            self.sent.lock().unwrap().push(MailMessage {
-                from: message.from.clone(),
-                reply_to: message.reply_to.clone(),
-                to: message.to.clone(),
-                subject: message.subject.clone(),
-                html: message.html.clone(),
-                text: message.text.clone(),
-            });
+            self.sent.lock().unwrap().push(message.clone());
             Ok(())
         }
     }
@@ -113,28 +119,34 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn send_renders_and_delivers() {
-        let sent = Arc::new(Mutex::new(Vec::new()));
-        let mailer = Mailer::new(
-            Box::new(MockTransport { sent: sent.clone() }),
-            Box::new(MockTemplateProvider),
+    fn test_mailer(transport: Arc<dyn MailTransport>) -> Mailer {
+        Mailer::new(
+            transport,
+            Arc::new(MockTemplateProvider),
             SenderProfile {
                 from_name: "Test".to_string(),
                 from_email: "test@test.com".to_string(),
                 reply_to: None,
             },
-            LayoutEngine::builtin_only(),
-        );
+            Arc::new(LayoutEngine::builtin_only()),
+        )
+    }
+
+    #[tokio::test]
+    async fn send_renders_and_delivers() {
+        let transport = Arc::new(MockTransport {
+            sent: std::sync::Mutex::new(Vec::new()),
+        });
+        let mailer = test_mailer(transport.clone());
 
         mailer
-            .send(SendEmail::new("welcome", "user@test.com").var("name", "Alice"))
+            .send(&SendEmail::new("welcome", "user@test.com").var("name", "Alice"))
             .await
             .unwrap();
 
-        let messages = sent.lock().unwrap();
+        let messages = transport.sent.lock().unwrap();
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].to, "user@test.com");
+        assert_eq!(messages[0].to, vec!["user@test.com"]);
         assert_eq!(messages[0].subject, "Hello Alice");
         assert!(messages[0].html.contains("Alice"));
         assert!(messages[0].html.contains("role=\"presentation\"")); // button
@@ -143,16 +155,18 @@ mod tests {
 
     #[tokio::test]
     async fn sender_override() {
-        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = Arc::new(MockTransport {
+            sent: std::sync::Mutex::new(Vec::new()),
+        });
         let mailer = Mailer::new(
-            Box::new(MockTransport { sent: sent.clone() }),
-            Box::new(MockTemplateProvider),
+            transport.clone(),
+            Arc::new(MockTemplateProvider),
             SenderProfile {
                 from_name: "Default".to_string(),
                 from_email: "default@test.com".to_string(),
                 reply_to: None,
             },
-            LayoutEngine::builtin_only(),
+            Arc::new(LayoutEngine::builtin_only()),
         );
 
         let custom_sender = SenderProfile {
@@ -163,32 +177,24 @@ mod tests {
 
         mailer
             .send(
-                SendEmail::new("welcome", "user@test.com")
+                &SendEmail::new("welcome", "user@test.com")
                     .sender(&custom_sender)
                     .var("name", "Bob"),
             )
             .await
             .unwrap();
 
-        let messages = sent.lock().unwrap();
+        let messages = transport.sent.lock().unwrap();
         assert!(messages[0].from.contains("tenant@custom.com"));
         assert_eq!(messages[0].reply_to.as_deref(), Some("support@custom.com"));
     }
 
     #[test]
     fn render_returns_message_without_sending() {
-        let mailer = Mailer::new(
-            Box::new(MockTransport {
-                sent: Arc::new(Mutex::new(Vec::new())),
-            }),
-            Box::new(MockTemplateProvider),
-            SenderProfile {
-                from_name: "Test".to_string(),
-                from_email: "test@test.com".to_string(),
-                reply_to: None,
-            },
-            LayoutEngine::builtin_only(),
-        );
+        let transport = Arc::new(MockTransport {
+            sent: std::sync::Mutex::new(Vec::new()),
+        });
+        let mailer = test_mailer(transport);
 
         let msg = mailer
             .render(&SendEmail::new("welcome", "user@test.com").var("name", "Charlie"))
@@ -197,5 +203,52 @@ mod tests {
         assert_eq!(msg.subject, "Hello Charlie");
         assert!(msg.html.contains("Charlie"));
         assert!(msg.text.contains("Charlie"));
+    }
+
+    #[test]
+    fn mailer_is_clone() {
+        let transport = Arc::new(MockTransport {
+            sent: std::sync::Mutex::new(Vec::new()),
+        });
+        let mailer = test_mailer(transport);
+        let _clone = mailer.clone();
+    }
+
+    #[test]
+    fn invalid_brand_color_falls_back_to_default() {
+        let transport = Arc::new(MockTransport {
+            sent: std::sync::Mutex::new(Vec::new()),
+        });
+        let mailer = test_mailer(transport);
+
+        let msg = mailer
+            .render(
+                &SendEmail::new("welcome", "user@test.com")
+                    .var("name", "Alice")
+                    .var("brand_color", "red;position:absolute"),
+            )
+            .unwrap();
+
+        // Should use default color, not the injection attempt
+        assert!(msg.html.contains("#4F46E5"));
+        assert!(!msg.html.contains("position:absolute"));
+    }
+
+    #[test]
+    fn valid_brand_color_is_used() {
+        let transport = Arc::new(MockTransport {
+            sent: std::sync::Mutex::new(Vec::new()),
+        });
+        let mailer = test_mailer(transport);
+
+        let msg = mailer
+            .render(
+                &SendEmail::new("welcome", "user@test.com")
+                    .var("name", "Alice")
+                    .var("brand_color", "#ff6600"),
+            )
+            .unwrap();
+
+        assert!(msg.html.contains("#ff6600"));
     }
 }

--- a/modo-email/src/message.rs
+++ b/modo-email/src/message.rs
@@ -11,12 +11,21 @@ pub struct SenderProfile {
 
 impl SenderProfile {
     /// Format as `"Name <email>"` for the From header.
+    ///
+    /// Strips control characters and angle brackets from the name to prevent
+    /// header injection.
     pub fn format_address(&self) -> String {
-        format!("{} <{}>", self.from_name, self.from_email)
+        let safe_name: String = self
+            .from_name
+            .chars()
+            .filter(|c| !c.is_control() && *c != '<' && *c != '>')
+            .collect();
+        format!("{} <{}>", safe_name.trim(), self.from_email)
     }
 }
 
 /// A fully-rendered email ready for transport.
+#[derive(Debug, Clone)]
 pub struct MailMessage {
     pub from: String,
     pub reply_to: Option<String>,
@@ -27,6 +36,7 @@ pub struct MailMessage {
 }
 
 /// Builder for requesting a templated email send.
+#[derive(Debug)]
 pub struct SendEmail {
     pub(crate) template: String,
     pub(crate) to: String,

--- a/modo-email/src/message.rs
+++ b/modo-email/src/message.rs
@@ -1,0 +1,169 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Sender identity for outgoing emails.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SenderProfile {
+    pub from_name: String,
+    pub from_email: String,
+    pub reply_to: Option<String>,
+}
+
+impl SenderProfile {
+    /// Format as `"Name <email>"` for the From header.
+    pub fn format_address(&self) -> String {
+        format!("{} <{}>", self.from_name, self.from_email)
+    }
+}
+
+/// A fully-rendered email ready for transport.
+pub struct MailMessage {
+    pub from: String,
+    pub reply_to: Option<String>,
+    pub to: String,
+    pub subject: String,
+    pub html: String,
+    pub text: String,
+}
+
+/// Builder for requesting a templated email send.
+pub struct SendEmail {
+    pub(crate) template: String,
+    pub(crate) to: String,
+    pub(crate) locale: Option<String>,
+    pub(crate) sender: Option<SenderProfile>,
+    pub(crate) context: HashMap<String, serde_json::Value>,
+}
+
+impl SendEmail {
+    pub fn new(template: &str, to: &str) -> Self {
+        Self {
+            template: template.to_string(),
+            to: to.to_string(),
+            locale: None,
+            sender: None,
+            context: HashMap::new(),
+        }
+    }
+
+    pub fn locale(mut self, locale: &str) -> Self {
+        self.locale = Some(locale.to_string());
+        self
+    }
+
+    pub fn sender(mut self, sender: &SenderProfile) -> Self {
+        self.sender = Some(sender.clone());
+        self
+    }
+
+    pub fn var(mut self, key: &str, value: impl Into<serde_json::Value>) -> Self {
+        self.context.insert(key.to_string(), value.into());
+        self
+    }
+
+    pub fn context(mut self, ctx: &HashMap<String, serde_json::Value>) -> Self {
+        self.context.extend(ctx.clone());
+        self
+    }
+}
+
+/// Serializable version of `SendEmail` for job payloads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendEmailPayload {
+    pub template: String,
+    pub to: String,
+    pub locale: Option<String>,
+    pub sender: Option<SenderProfile>,
+    pub context: HashMap<String, serde_json::Value>,
+}
+
+impl From<SendEmail> for SendEmailPayload {
+    fn from(e: SendEmail) -> Self {
+        Self {
+            template: e.template,
+            to: e.to,
+            locale: e.locale,
+            sender: e.sender,
+            context: e.context,
+        }
+    }
+}
+
+impl From<SendEmailPayload> for SendEmail {
+    fn from(p: SendEmailPayload) -> Self {
+        Self {
+            template: p.template,
+            to: p.to,
+            locale: p.locale,
+            sender: p.sender,
+            context: p.context,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sender_profile_serialization_roundtrip() {
+        let profile = SenderProfile {
+            from_name: "Acme".to_string(),
+            from_email: "hi@acme.com".to_string(),
+            reply_to: Some("support@acme.com".to_string()),
+        };
+        let json = serde_json::to_string(&profile).unwrap();
+        let back: SenderProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.from_name, "Acme");
+        assert_eq!(back.reply_to, Some("support@acme.com".to_string()));
+    }
+
+    #[test]
+    fn sender_profile_format_address() {
+        let profile = SenderProfile {
+            from_name: "Acme Corp".to_string(),
+            from_email: "hi@acme.com".to_string(),
+            reply_to: None,
+        };
+        assert_eq!(profile.format_address(), "Acme Corp <hi@acme.com>");
+    }
+
+    #[test]
+    fn send_email_builder() {
+        let email = SendEmail::new("welcome", "user@test.com")
+            .locale("de")
+            .var("name", "Hans")
+            .var("code", "1234");
+        assert_eq!(email.template, "welcome");
+        assert_eq!(email.to, "user@test.com");
+        assert_eq!(email.locale.as_deref(), Some("de"));
+        assert_eq!(email.context.len(), 2);
+    }
+
+    #[test]
+    fn send_email_context_merge() {
+        let mut brand = HashMap::new();
+        brand.insert("logo".to_string(), serde_json::json!("https://logo.png"));
+        brand.insert("color".to_string(), serde_json::json!("#ff0000"));
+
+        let email = SendEmail::new("welcome", "u@t.com")
+            .context(&brand)
+            .var("name", "Alice");
+        assert_eq!(email.context.len(), 3);
+    }
+
+    #[test]
+    fn payload_roundtrip() {
+        let email = SendEmail::new("welcome", "u@t.com")
+            .locale("en")
+            .var("name", "Alice");
+        let payload = SendEmailPayload::from(email);
+        let json = serde_json::to_string(&payload).unwrap();
+        let back: SendEmailPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.template, "welcome");
+        assert_eq!(back.locale.as_deref(), Some("en"));
+
+        let email_back = SendEmail::from(back);
+        assert_eq!(email_back.to, "u@t.com");
+    }
+}

--- a/modo-email/src/message.rs
+++ b/modo-email/src/message.rs
@@ -12,15 +12,20 @@ pub struct SenderProfile {
 impl SenderProfile {
     /// Format as `"Name <email>"` for the From header.
     ///
-    /// Strips control characters and angle brackets from the name to prevent
-    /// header injection.
+    /// Strips control characters and angle brackets from the name, and control
+    /// characters from the email, to prevent header injection.
     pub fn format_address(&self) -> String {
         let safe_name: String = self
             .from_name
             .chars()
             .filter(|c| !c.is_control() && *c != '<' && *c != '>')
             .collect();
-        format!("{} <{}>", safe_name.trim(), self.from_email)
+        let safe_email: String = self
+            .from_email
+            .chars()
+            .filter(|c| !c.is_control())
+            .collect();
+        format!("{} <{}>", safe_name.trim(), safe_email.trim())
     }
 }
 
@@ -29,17 +34,17 @@ impl SenderProfile {
 pub struct MailMessage {
     pub from: String,
     pub reply_to: Option<String>,
-    pub to: String,
+    pub to: Vec<String>,
     pub subject: String,
     pub html: String,
     pub text: String,
 }
 
 /// Builder for requesting a templated email send.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SendEmail {
     pub(crate) template: String,
-    pub(crate) to: String,
+    pub(crate) to: Vec<String>,
     pub(crate) locale: Option<String>,
     pub(crate) sender: Option<SenderProfile>,
     pub(crate) context: HashMap<String, serde_json::Value>,
@@ -49,11 +54,17 @@ impl SendEmail {
     pub fn new(template: &str, to: &str) -> Self {
         Self {
             template: template.to_string(),
-            to: to.to_string(),
+            to: vec![to.to_string()],
             locale: None,
             sender: None,
             context: HashMap::new(),
         }
+    }
+
+    /// Add an additional recipient.
+    pub fn to(mut self, to: &str) -> Self {
+        self.to.push(to.to_string());
+        self
     }
 
     pub fn locale(mut self, locale: &str) -> Self {
@@ -81,7 +92,7 @@ impl SendEmail {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendEmailPayload {
     pub template: String,
-    pub to: String,
+    pub to: Vec<String>,
     pub locale: Option<String>,
     pub sender: Option<SenderProfile>,
     pub context: HashMap<String, serde_json::Value>,
@@ -139,15 +150,45 @@ mod tests {
     }
 
     #[test]
+    fn sender_profile_sanitizes_name() {
+        let profile = SenderProfile {
+            from_name: "Evil<script>".to_string(),
+            from_email: "hi@acme.com".to_string(),
+            reply_to: None,
+        };
+        assert_eq!(profile.format_address(), "Evilscript <hi@acme.com>");
+    }
+
+    #[test]
+    fn sender_profile_sanitizes_email() {
+        let profile = SenderProfile {
+            from_name: "Acme".to_string(),
+            from_email: "hi@acme.com\r\nBcc: evil@x.com".to_string(),
+            reply_to: None,
+        };
+        let addr = profile.format_address();
+        assert!(!addr.contains('\r'));
+        assert!(!addr.contains('\n'));
+    }
+
+    #[test]
     fn send_email_builder() {
         let email = SendEmail::new("welcome", "user@test.com")
             .locale("de")
             .var("name", "Hans")
             .var("code", "1234");
         assert_eq!(email.template, "welcome");
-        assert_eq!(email.to, "user@test.com");
+        assert_eq!(email.to, vec!["user@test.com"]);
         assert_eq!(email.locale.as_deref(), Some("de"));
         assert_eq!(email.context.len(), 2);
+    }
+
+    #[test]
+    fn send_email_multiple_recipients() {
+        let email = SendEmail::new("welcome", "a@test.com")
+            .to("b@test.com")
+            .to("c@test.com");
+        assert_eq!(email.to, vec!["a@test.com", "b@test.com", "c@test.com"]);
     }
 
     #[test]
@@ -165,6 +206,7 @@ mod tests {
     #[test]
     fn payload_roundtrip() {
         let email = SendEmail::new("welcome", "u@t.com")
+            .to("v@t.com")
             .locale("en")
             .var("name", "Alice");
         let payload = SendEmailPayload::from(email);
@@ -172,8 +214,9 @@ mod tests {
         let back: SendEmailPayload = serde_json::from_str(&json).unwrap();
         assert_eq!(back.template, "welcome");
         assert_eq!(back.locale.as_deref(), Some("en"));
+        assert_eq!(back.to, vec!["u@t.com", "v@t.com"]);
 
         let email_back = SendEmail::from(back);
-        assert_eq!(email_back.to, "u@t.com");
+        assert_eq!(email_back.to, vec!["u@t.com", "v@t.com"]);
     }
 }

--- a/modo-email/src/template/filesystem.rs
+++ b/modo-email/src/template/filesystem.rs
@@ -19,6 +19,17 @@ impl FilesystemProvider {
     }
 
     fn resolve_path(&self, name: &str, locale: &str) -> Option<PathBuf> {
+        // Reject path traversal attempts
+        if name.contains("..")
+            || name.contains('/')
+            || name.contains('\\')
+            || locale.contains("..")
+            || locale.contains('/')
+            || locale.contains('\\')
+        {
+            return None;
+        }
+
         if !locale.is_empty() {
             let localized = self.base_dir.join(locale).join(format!("{name}.md"));
             if localized.is_file() {

--- a/modo-email/src/template/filesystem.rs
+++ b/modo-email/src/template/filesystem.rs
@@ -1,0 +1,116 @@
+use super::{EmailTemplate, TemplateProvider};
+use std::path::PathBuf;
+
+/// Loads email templates from the filesystem with locale-based fallback.
+///
+/// Templates are stored as `.md` files with YAML frontmatter. Localized
+/// variants live in subdirectories named after the locale (e.g. `de/welcome.md`).
+/// When a localized file is not found, the provider falls back to the root
+/// template (`welcome.md`).
+pub struct FilesystemProvider {
+    base_dir: PathBuf,
+}
+
+impl FilesystemProvider {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+        }
+    }
+
+    fn resolve_path(&self, name: &str, locale: &str) -> Option<PathBuf> {
+        if !locale.is_empty() {
+            let localized = self.base_dir.join(locale).join(format!("{name}.md"));
+            if localized.is_file() {
+                return Some(localized);
+            }
+        }
+
+        let root = self.base_dir.join(format!("{name}.md"));
+        if root.is_file() {
+            return Some(root);
+        }
+
+        None
+    }
+}
+
+impl TemplateProvider for FilesystemProvider {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, modo::Error> {
+        let path = self.resolve_path(name, locale).ok_or_else(|| {
+            modo::Error::internal(format!("Email template not found: {name}"))
+        })?;
+
+        let raw = std::fs::read_to_string(&path).map_err(|e| {
+            modo::Error::internal(format!("Failed to read template {}: {e}", path.display()))
+        })?;
+
+        EmailTemplate::parse(&raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::template::TemplateProvider;
+    use std::fs;
+
+    #[test]
+    fn load_template_no_locale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        fs::write(
+            path.join("welcome.md"),
+            "---\nsubject: \"Hi\"\n---\n\nHello!",
+        )
+        .unwrap();
+
+        let provider = FilesystemProvider::new(path.to_str().unwrap());
+        let tpl = provider.get("welcome", "").unwrap();
+        assert_eq!(tpl.subject, "Hi");
+    }
+
+    #[test]
+    fn load_template_with_locale() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        fs::create_dir_all(path.join("de")).unwrap();
+        fs::write(
+            path.join("de/welcome.md"),
+            "---\nsubject: \"Hallo\"\n---\n\nHallo!",
+        )
+        .unwrap();
+        fs::write(
+            path.join("welcome.md"),
+            "---\nsubject: \"Hi\"\n---\n\nHello!",
+        )
+        .unwrap();
+
+        let provider = FilesystemProvider::new(path.to_str().unwrap());
+        let tpl = provider.get("welcome", "de").unwrap();
+        assert_eq!(tpl.subject, "Hallo");
+    }
+
+    #[test]
+    fn locale_fallback_to_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        fs::write(
+            path.join("welcome.md"),
+            "---\nsubject: \"Hi\"\n---\n\nHello!",
+        )
+        .unwrap();
+
+        let provider = FilesystemProvider::new(path.to_str().unwrap());
+        let tpl = provider.get("welcome", "fr").unwrap();
+        assert_eq!(tpl.subject, "Hi");
+    }
+
+    #[test]
+    fn template_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = FilesystemProvider::new(dir.path().to_str().unwrap());
+        let result = provider.get("missing", "");
+        assert!(result.is_err());
+    }
+}

--- a/modo-email/src/template/filesystem.rs
+++ b/modo-email/src/template/filesystem.rs
@@ -37,9 +37,9 @@ impl FilesystemProvider {
 
 impl TemplateProvider for FilesystemProvider {
     fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, modo::Error> {
-        let path = self.resolve_path(name, locale).ok_or_else(|| {
-            modo::Error::internal(format!("Email template not found: {name}"))
-        })?;
+        let path = self
+            .resolve_path(name, locale)
+            .ok_or_else(|| modo::Error::internal(format!("Email template not found: {name}")))?;
 
         let raw = std::fs::read_to_string(&path).map_err(|e| {
             modo::Error::internal(format!("Failed to read template {}: {e}", path.display()))

--- a/modo-email/src/template/layout.rs
+++ b/modo-email/src/template/layout.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+pub(crate) const DEFAULT_LAYOUT: &str = r#"<!DOCTYPE html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>{{subject}}</title>
+<style>
+  @media (prefers-color-scheme: dark) {
+    body { background-color: #1a1a1a !important; }
+    .email-wrapper { background-color: #2d2d2d !important; }
+    .email-body { color: #e0e0e0 !important; }
+  }
+  @media only screen and (max-width: 620px) {
+    .email-wrapper { width: 100% !important; padding: 16px !important; }
+  }
+</style>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5">
+<tr><td align="center" style="padding:32px 16px">
+  <!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+  <table role="presentation" class="email-wrapper" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background-color:#ffffff;border-radius:8px;overflow:hidden">
+    {% if logo_url %}
+    <tr><td style="padding:24px 32px 0;text-align:center">
+      <img src="{{logo_url}}" alt="{{product_name | default(value="")}}" style="max-height:48px;width:auto">
+    </td></tr>
+    {% endif %}
+    <tr><td class="email-body" style="padding:32px;color:#1f2937;font-size:16px;line-height:1.6">
+      {{content}}
+    </td></tr>
+    <tr><td style="padding:16px 32px 32px;color:#6b7280;font-size:13px;text-align:center;border-top:1px solid #e5e7eb">
+      {{footer_text | default(value="")}}
+    </td></tr>
+  </table>
+  <!--[if mso]></td></tr></table><![endif]-->
+</td></tr>
+</table>
+</body>
+</html>"#;
+
+pub struct LayoutEngine {
+    env: minijinja::Environment<'static>,
+}
+
+impl LayoutEngine {
+    pub fn new(templates_path: &str) -> Self {
+        let mut env = Self::base_env();
+
+        let layouts_dir = Path::new(templates_path).join("layouts");
+        if layouts_dir.is_dir()
+            && let Ok(entries) = std::fs::read_dir(&layouts_dir)
+        {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "html")
+                    && let (Some(stem), Ok(content)) = (
+                        path.file_stem().and_then(|s| s.to_str()),
+                        std::fs::read_to_string(&path),
+                    )
+                {
+                    env.add_template_owned(format!("layouts/{stem}.html"), content)
+                        .ok();
+                }
+            }
+        }
+
+        Self { env }
+    }
+
+    pub fn builtin_only() -> Self {
+        Self {
+            env: Self::base_env(),
+        }
+    }
+
+    pub fn render(
+        &self,
+        layout_name: &str,
+        context: &HashMap<String, serde_json::Value>,
+    ) -> Result<String, modo::Error> {
+        let template_name = format!("layouts/{layout_name}.html");
+        let builtin_name = format!("__builtin__/{layout_name}.html");
+
+        let tmpl = self
+            .env
+            .get_template(&template_name)
+            .or_else(|_| self.env.get_template(&builtin_name))
+            .map_err(|_| modo::Error::internal(format!("Layout not found: {layout_name}")))?;
+
+        let ctx = minijinja::Value::from_serialize(context);
+        tmpl.render(&ctx)
+            .map_err(|e| modo::Error::internal(format!("Layout render error: {e}")))
+    }
+
+    /// Creates a base environment with the built-in default layout and
+    /// auto-escaping disabled (email content is pre-rendered HTML).
+    fn base_env() -> minijinja::Environment<'static> {
+        let mut env = minijinja::Environment::new();
+        env.set_auto_escape_callback(|_| minijinja::AutoEscape::None);
+        env.add_template_owned(
+            "__builtin__/default.html".to_string(),
+            DEFAULT_LAYOUT.to_string(),
+        )
+        .expect("built-in layout is valid");
+        env
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn render_with_builtin_layout() {
+        let engine = LayoutEngine::builtin_only();
+        let mut ctx = HashMap::new();
+        ctx.insert("content".to_string(), serde_json::json!("<p>Hello</p>"));
+        ctx.insert("subject".to_string(), serde_json::json!("Test"));
+
+        let html = engine.render("default", &ctx).unwrap();
+        assert!(html.contains("<p>Hello</p>"));
+        assert!(html.contains("Test")); // subject in <title>
+        assert!(html.contains("max-width")); // responsive wrapper
+    }
+
+    #[test]
+    fn custom_layout_overrides_builtin() {
+        let dir = tempfile::tempdir().unwrap();
+        let layouts_dir = dir.path().join("layouts");
+        fs::create_dir_all(&layouts_dir).unwrap();
+        fs::write(
+            layouts_dir.join("default.html"),
+            "<html><body>CUSTOM: {{content}}</body></html>",
+        )
+        .unwrap();
+
+        let engine = LayoutEngine::new(dir.path().to_str().unwrap());
+        let mut ctx = HashMap::new();
+        ctx.insert("content".to_string(), serde_json::json!("<p>Hi</p>"));
+
+        let html = engine.render("default", &ctx).unwrap();
+        assert!(html.contains("CUSTOM: <p>Hi</p>"));
+    }
+
+    #[test]
+    fn missing_layout_errors() {
+        let engine = LayoutEngine::builtin_only();
+        let ctx = HashMap::new();
+        let result = engine.render("nonexistent", &ctx);
+        assert!(result.is_err());
+    }
+}

--- a/modo-email/src/template/markdown.rs
+++ b/modo-email/src/template/markdown.rs
@@ -75,7 +75,7 @@ pub fn render_plain_text(markdown: &str) -> String {
             Event::Text(t) if in_link => {
                 link_text.push_str(&t);
             }
-            Event::End(TagEnd::Link) => {
+            Event::End(TagEnd::Link) if in_link => {
                 in_link = false;
                 let display = link_text.strip_prefix(BUTTON_PREFIX).unwrap_or(&link_text);
                 text.push_str(&format!("{display} ({link_url})"));

--- a/modo-email/src/template/markdown.rs
+++ b/modo-email/src/template/markdown.rs
@@ -1,0 +1,146 @@
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+
+const BUTTON_PREFIX: &str = "button|";
+const DEFAULT_BUTTON_COLOR: &str = "#4F46E5";
+
+/// Render Markdown to HTML, converting `[button|Label](url)` into email-safe button tables.
+pub fn render_markdown(markdown: &str) -> String {
+    render_markdown_with_color(markdown, DEFAULT_BUTTON_COLOR)
+}
+
+/// Render Markdown to HTML with a custom button background color.
+pub fn render_markdown_with_color(markdown: &str, button_color: &str) -> String {
+    let opts = Options::empty();
+    let parser = Parser::new_ext(markdown, opts);
+
+    let mut html = String::new();
+    let mut in_link = false;
+    let mut link_url = String::new();
+    let mut link_text = String::new();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                in_link = true;
+                link_url = dest_url.to_string();
+                link_text.clear();
+            }
+            Event::Text(text) if in_link => {
+                link_text.push_str(&text);
+            }
+            Event::End(TagEnd::Link) if in_link => {
+                in_link = false;
+                if link_text.starts_with(BUTTON_PREFIX) {
+                    let label = &link_text[BUTTON_PREFIX.len()..];
+                    html.push_str(&render_button(label, &link_url, button_color));
+                } else {
+                    html.push_str(&format!(
+                        "<a href=\"{}\" style=\"color:{button_color}\">{}</a>",
+                        link_url, link_text,
+                    ));
+                }
+            }
+            _ if in_link => {}
+            _ => {
+                pulldown_cmark::html::push_html(&mut html, std::iter::once(event));
+            }
+        }
+    }
+
+    html
+}
+
+fn render_button(label: &str, url: &str, color: &str) -> String {
+    format!(
+        r#"<table role="presentation" cellpadding="0" cellspacing="0" style="margin:16px auto"><tr><td style="background-color:{color};border-radius:6px;padding:12px 24px;text-align:center"><a href="{url}" style="color:#ffffff;text-decoration:none;font-weight:bold;font-size:16px;display:inline-block">{label}</a></td></tr></table>"#,
+    )
+}
+
+/// Convert Markdown to plain text, stripping formatting and converting links to `Text (URL)` form.
+pub fn render_plain_text(markdown: &str) -> String {
+    let opts = Options::empty();
+    let parser = Parser::new_ext(markdown, opts);
+
+    let mut text = String::new();
+    let mut in_link = false;
+    let mut link_text = String::new();
+    let mut link_url = String::new();
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                in_link = true;
+                link_url = dest_url.to_string();
+                link_text.clear();
+            }
+            Event::Text(t) if in_link => {
+                link_text.push_str(&t);
+            }
+            Event::End(TagEnd::Link) => {
+                in_link = false;
+                let display = if link_text.starts_with(BUTTON_PREFIX) {
+                    &link_text[BUTTON_PREFIX.len()..]
+                } else {
+                    &link_text
+                };
+                text.push_str(&format!("{display} ({link_url})"));
+            }
+            Event::Text(t) => text.push_str(&t),
+            Event::SoftBreak | Event::HardBreak => text.push('\n'),
+            Event::Start(Tag::Paragraph) => {}
+            Event::End(TagEnd::Paragraph) => text.push_str("\n\n"),
+            Event::Start(Tag::Heading { .. }) => {}
+            Event::End(TagEnd::Heading(_)) => text.push_str("\n\n"),
+            _ => {}
+        }
+    }
+
+    text.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_basic_markdown() {
+        let html = render_markdown("Hello **world**");
+        assert!(html.contains("<strong>world</strong>"));
+    }
+
+    #[test]
+    fn render_link_as_link() {
+        let html = render_markdown("[Click](https://example.com)");
+        assert!(html.contains("<a"));
+        assert!(html.contains("href=\"https://example.com\""));
+        assert!(html.contains("Click"));
+    }
+
+    #[test]
+    fn render_button_link() {
+        let html = render_markdown("[button|Get Started](https://example.com)");
+        assert!(html.contains("Get Started"));
+        assert!(html.contains("https://example.com"));
+        assert!(html.contains("role=\"presentation\""));
+        assert!(!html.contains("button|"));
+    }
+
+    #[test]
+    fn render_normal_link_with_pipe() {
+        let html = render_markdown("[some|text](https://example.com)");
+        // "some" is not a known element type, render as normal link
+        assert!(html.contains("some|text"));
+        assert!(html.contains("<a"));
+    }
+
+    #[test]
+    fn plain_text_from_markdown() {
+        let text = render_plain_text(
+            "Hello **world**\n\n[button|Click](https://url.com)\n\n[Link](https://other.com)",
+        );
+        assert!(text.contains("Hello world"));
+        assert!(text.contains("Click (https://url.com)"));
+        assert!(text.contains("Link (https://other.com)"));
+        assert!(!text.contains("button|"));
+    }
+}

--- a/modo-email/src/template/markdown.rs
+++ b/modo-email/src/template/markdown.rs
@@ -30,8 +30,7 @@ pub fn render_markdown_with_color(markdown: &str, button_color: &str) -> String 
             }
             Event::End(TagEnd::Link) if in_link => {
                 in_link = false;
-                if link_text.starts_with(BUTTON_PREFIX) {
-                    let label = &link_text[BUTTON_PREFIX.len()..];
+                if let Some(label) = link_text.strip_prefix(BUTTON_PREFIX) {
                     html.push_str(&render_button(label, &link_url, button_color));
                 } else {
                     html.push_str(&format!(
@@ -78,11 +77,7 @@ pub fn render_plain_text(markdown: &str) -> String {
             }
             Event::End(TagEnd::Link) => {
                 in_link = false;
-                let display = if link_text.starts_with(BUTTON_PREFIX) {
-                    &link_text[BUTTON_PREFIX.len()..]
-                } else {
-                    &link_text
-                };
+                let display = link_text.strip_prefix(BUTTON_PREFIX).unwrap_or(&link_text);
                 text.push_str(&format!("{display} ({link_url})"));
             }
             Event::Text(t) => text.push_str(&t),

--- a/modo-email/src/template/mod.rs
+++ b/modo-email/src/template/mod.rs
@@ -1,6 +1,7 @@
 pub mod filesystem;
 pub mod layout;
 pub mod markdown;
+pub mod vars;
 
 use serde::Deserialize;
 

--- a/modo-email/src/template/mod.rs
+++ b/modo-email/src/template/mod.rs
@@ -1,0 +1,91 @@
+pub mod filesystem;
+pub mod layout;
+pub mod markdown;
+
+use serde::Deserialize;
+
+/// A parsed email template with subject, body, and optional layout.
+pub struct EmailTemplate {
+    pub subject: String,
+    pub body: String,
+    pub layout: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Frontmatter {
+    subject: String,
+    layout: Option<String>,
+}
+
+impl EmailTemplate {
+    /// Parse a raw template string with YAML frontmatter delimited by `---`.
+    ///
+    /// The frontmatter must contain at least a `subject` field.
+    /// An optional `layout` field specifies which layout to wrap the body in.
+    pub fn parse(raw: &str) -> Result<Self, modo::Error> {
+        let raw = raw.trim();
+        if !raw.starts_with("---") {
+            return Err(modo::Error::internal(
+                "Email template must start with YAML frontmatter (---)",
+            ));
+        }
+
+        let after_first = &raw[3..];
+        let end = after_first.find("---").ok_or_else(|| {
+            modo::Error::internal("Email template frontmatter missing closing ---")
+        })?;
+
+        let yaml = &after_first[..end];
+        let body = &after_first[end + 3..];
+
+        let fm: Frontmatter = serde_yaml_ng::from_str(yaml)
+            .map_err(|e| modo::Error::internal(format!("Invalid frontmatter: {e}")))?;
+
+        Ok(Self {
+            subject: fm.subject,
+            body: body.to_string(),
+            layout: fm.layout,
+        })
+    }
+}
+
+/// Trait for loading email templates by name and locale.
+pub trait TemplateProvider: Send + Sync + 'static {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, modo::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_template_with_frontmatter() {
+        let raw = "---\nsubject: \"Hello {{name}}\"\nlayout: custom\n---\n\nBody here.";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Hello {{name}}");
+        assert_eq!(tpl.layout.as_deref(), Some("custom"));
+        assert_eq!(tpl.body.trim(), "Body here.");
+    }
+
+    #[test]
+    fn parse_template_default_layout() {
+        let raw = "---\nsubject: \"Hi\"\n---\n\nContent.";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Hi");
+        assert!(tpl.layout.is_none());
+    }
+
+    #[test]
+    fn parse_template_missing_subject() {
+        let raw = "---\nlayout: default\n---\n\nNo subject.";
+        let result = EmailTemplate::parse(raw);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_template_no_frontmatter() {
+        let raw = "Just markdown, no frontmatter.";
+        let result = EmailTemplate::parse(raw);
+        assert!(result.is_err());
+    }
+}

--- a/modo-email/src/template/vars.rs
+++ b/modo-email/src/template/vars.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+/// Replace `{{key}}` placeholders in `input` with values from `context`.
+///
+/// - Whitespace inside braces is trimmed: `{{ name }}` matches key `"name"`.
+/// - String values are inserted directly; other JSON types use their `to_string()` representation.
+/// - Unresolved placeholders are left as-is.
+pub fn substitute(input: &str, context: &HashMap<String, serde_json::Value>) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '{' && chars.peek() == Some(&'{') {
+            chars.next(); // consume second {
+            let mut key = String::new();
+            let mut found_close = false;
+
+            while let Some(ch) = chars.next() {
+                if ch == '}' && chars.peek() == Some(&'}') {
+                    chars.next();
+                    found_close = true;
+                    break;
+                }
+                key.push(ch);
+            }
+
+            let key = key.trim();
+            if found_close {
+                if let Some(val) = context.get(key) {
+                    match val {
+                        serde_json::Value::String(s) => result.push_str(s),
+                        other => result.push_str(&other.to_string()),
+                    }
+                } else {
+                    result.push_str("{{");
+                    result.push_str(key);
+                    result.push_str("}}");
+                }
+            } else {
+                result.push_str("{{");
+                result.push_str(key);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn replace_simple_vars() {
+        let mut ctx = HashMap::new();
+        ctx.insert("name".to_string(), json!("Alice"));
+        ctx.insert("code".to_string(), json!("1234"));
+
+        let result = substitute("Hello {{name}}, code: {{code}}", &ctx);
+        assert_eq!(result, "Hello Alice, code: 1234");
+    }
+
+    #[test]
+    fn unresolved_vars_left_as_is() {
+        let ctx = HashMap::new();
+        let result = substitute("Hello {{name}}", &ctx);
+        assert_eq!(result, "Hello {{name}}");
+    }
+
+    #[test]
+    fn whitespace_in_braces() {
+        let mut ctx = HashMap::new();
+        ctx.insert("name".to_string(), json!("Bob"));
+        let result = substitute("Hello {{ name }}", &ctx);
+        assert_eq!(result, "Hello Bob");
+    }
+
+    #[test]
+    fn non_string_values() {
+        let mut ctx = HashMap::new();
+        ctx.insert("count".to_string(), json!(42));
+        ctx.insert("active".to_string(), json!(true));
+        let result = substitute("Count: {{count}}, active: {{active}}", &ctx);
+        assert_eq!(result, "Count: 42, active: true");
+    }
+
+    #[test]
+    fn empty_input() {
+        let ctx = HashMap::new();
+        assert_eq!(substitute("", &ctx), "");
+    }
+}

--- a/modo-email/src/transport/mod.rs
+++ b/modo-email/src/transport/mod.rs
@@ -1,11 +1,35 @@
-#[cfg(feature = "smtp")]
-pub mod smtp;
 #[cfg(feature = "resend")]
 pub mod resend;
+#[cfg(feature = "smtp")]
+pub mod smtp;
 
+use crate::config::EmailConfig;
 use crate::message::MailMessage;
 
 #[async_trait::async_trait]
 pub trait MailTransport: Send + Sync + 'static {
     async fn send(&self, message: &MailMessage) -> Result<(), modo::Error>;
+}
+
+/// Create the appropriate transport backend based on config.
+pub fn transport(config: &EmailConfig) -> Result<Box<dyn MailTransport>, modo::Error> {
+    match config.transport {
+        #[cfg(feature = "smtp")]
+        crate::config::TransportBackend::Smtp => {
+            Ok(Box::new(smtp::SmtpTransport::new(&config.smtp)?))
+        }
+        #[cfg(not(feature = "smtp"))]
+        crate::config::TransportBackend::Smtp => Err(modo::Error::internal(
+            "SMTP transport requires the `smtp` feature",
+        )),
+
+        #[cfg(feature = "resend")]
+        crate::config::TransportBackend::Resend => {
+            Ok(Box::new(resend::ResendTransport::new(&config.resend)?))
+        }
+        #[cfg(not(feature = "resend"))]
+        crate::config::TransportBackend::Resend => Err(modo::Error::internal(
+            "Resend transport requires the `resend` feature",
+        )),
+    }
 }

--- a/modo-email/src/transport/mod.rs
+++ b/modo-email/src/transport/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "smtp")]
+pub mod smtp;
+#[cfg(feature = "resend")]
+pub mod resend;
+
+use crate::message::MailMessage;
+
+#[async_trait::async_trait]
+pub trait MailTransport: Send + Sync + 'static {
+    async fn send(&self, message: &MailMessage) -> Result<(), modo::Error>;
+}

--- a/modo-email/src/transport/mod.rs
+++ b/modo-email/src/transport/mod.rs
@@ -5,6 +5,7 @@ pub mod smtp;
 
 use crate::config::EmailConfig;
 use crate::message::MailMessage;
+use std::sync::Arc;
 
 #[async_trait::async_trait]
 pub trait MailTransport: Send + Sync + 'static {
@@ -12,11 +13,11 @@ pub trait MailTransport: Send + Sync + 'static {
 }
 
 /// Create the appropriate transport backend based on config.
-pub fn transport(config: &EmailConfig) -> Result<Box<dyn MailTransport>, modo::Error> {
+pub fn transport(config: &EmailConfig) -> Result<Arc<dyn MailTransport>, modo::Error> {
     match config.transport {
         #[cfg(feature = "smtp")]
         crate::config::TransportBackend::Smtp => {
-            Ok(Box::new(smtp::SmtpTransport::new(&config.smtp)?))
+            Ok(Arc::new(smtp::SmtpTransport::new(&config.smtp)?))
         }
         #[cfg(not(feature = "smtp"))]
         crate::config::TransportBackend::Smtp => Err(modo::Error::internal(
@@ -25,7 +26,7 @@ pub fn transport(config: &EmailConfig) -> Result<Box<dyn MailTransport>, modo::E
 
         #[cfg(feature = "resend")]
         crate::config::TransportBackend::Resend => {
-            Ok(Box::new(resend::ResendTransport::new(&config.resend)?))
+            Ok(Arc::new(resend::ResendTransport::new(&config.resend)?))
         }
         #[cfg(not(feature = "resend"))]
         crate::config::TransportBackend::Resend => Err(modo::Error::internal(

--- a/modo-email/src/transport/resend.rs
+++ b/modo-email/src/transport/resend.rs
@@ -1,0 +1,54 @@
+use super::MailTransport;
+use crate::config::ResendConfig;
+use crate::message::MailMessage;
+
+pub struct ResendTransport {
+    client: reqwest::Client,
+    api_key: String,
+}
+
+impl ResendTransport {
+    pub fn new(config: &ResendConfig) -> Result<Self, modo::Error> {
+        let client = reqwest::Client::new();
+        Ok(Self {
+            client,
+            api_key: config.api_key.clone(),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl MailTransport for ResendTransport {
+    async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
+        let mut body = serde_json::json!({
+            "from": message.from,
+            "to": [message.to],
+            "subject": message.subject,
+            "html": message.html,
+            "text": message.text,
+        });
+
+        if let Some(ref reply_to) = message.reply_to {
+            body["reply_to"] = serde_json::json!(reply_to);
+        }
+
+        let resp = self
+            .client
+            .post("https://api.resend.com/emails")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| modo::Error::internal(format!("Resend request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(modo::Error::internal(format!(
+                "Resend API error ({status}): {text}"
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/modo-email/src/transport/resend.rs
+++ b/modo-email/src/transport/resend.rs
@@ -22,7 +22,7 @@ impl MailTransport for ResendTransport {
     async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
         let mut body = serde_json::json!({
             "from": message.from,
-            "to": [message.to],
+            "to": message.to,
             "subject": message.subject,
             "html": message.html,
             "text": message.text,

--- a/modo-email/src/transport/smtp.rs
+++ b/modo-email/src/transport/smtp.rs
@@ -1,0 +1,72 @@
+use super::MailTransport;
+use crate::config::SmtpConfig;
+use crate::message::MailMessage;
+use lettre::message::{header::ContentType, MultiPart, SinglePart};
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
+
+pub struct SmtpTransport {
+    mailer: AsyncSmtpTransport<Tokio1Executor>,
+}
+
+impl SmtpTransport {
+    pub fn new(config: &SmtpConfig) -> Result<Self, modo::Error> {
+        let creds = Credentials::new(config.username.clone(), config.password.clone());
+
+        let builder = if config.tls {
+            AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)
+                .map_err(|e| modo::Error::internal(format!("SMTP config error: {e}")))?
+                .port(config.port)
+        } else {
+            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.host)
+                .port(config.port)
+        };
+
+        let mailer = builder.credentials(creds).build();
+
+        Ok(Self { mailer })
+    }
+}
+
+#[async_trait::async_trait]
+impl MailTransport for SmtpTransport {
+    async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
+        let mut builder = Message::builder()
+            .from(message.from.parse().map_err(|e| {
+                modo::Error::internal(format!("Invalid from address: {e}"))
+            })?)
+            .to(message.to.parse().map_err(|e| {
+                modo::Error::internal(format!("Invalid to address: {e}"))
+            })?)
+            .subject(&message.subject);
+
+        if let Some(ref reply_to) = message.reply_to {
+            builder = builder.reply_to(reply_to.parse().map_err(|e| {
+                modo::Error::internal(format!("Invalid reply-to address: {e}"))
+            })?);
+        }
+
+        let email = builder
+            .multipart(
+                MultiPart::alternative()
+                    .singlepart(
+                        SinglePart::builder()
+                            .header(ContentType::TEXT_PLAIN)
+                            .body(message.text.clone()),
+                    )
+                    .singlepart(
+                        SinglePart::builder()
+                            .header(ContentType::TEXT_HTML)
+                            .body(message.html.clone()),
+                    ),
+            )
+            .map_err(|e| modo::Error::internal(format!("Failed to build email: {e}")))?;
+
+        self.mailer
+            .send(email)
+            .await
+            .map_err(|e| modo::Error::internal(format!("SMTP send failed: {e}")))?;
+
+        Ok(())
+    }
+}

--- a/modo-email/src/transport/smtp.rs
+++ b/modo-email/src/transport/smtp.rs
@@ -1,7 +1,7 @@
 use super::MailTransport;
 use crate::config::SmtpConfig;
 use crate::message::MailMessage;
-use lettre::message::{header::ContentType, MultiPart, SinglePart};
+use lettre::message::{MultiPart, SinglePart, header::ContentType};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
 
@@ -18,8 +18,7 @@ impl SmtpTransport {
                 .map_err(|e| modo::Error::internal(format!("SMTP config error: {e}")))?
                 .port(config.port)
         } else {
-            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.host)
-                .port(config.port)
+            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.host).port(config.port)
         };
 
         let mailer = builder.credentials(creds).build();
@@ -32,18 +31,23 @@ impl SmtpTransport {
 impl MailTransport for SmtpTransport {
     async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
         let mut builder = Message::builder()
-            .from(message.from.parse().map_err(|e| {
-                modo::Error::internal(format!("Invalid from address: {e}"))
-            })?)
-            .to(message.to.parse().map_err(|e| {
-                modo::Error::internal(format!("Invalid to address: {e}"))
-            })?)
+            .from(
+                message
+                    .from
+                    .parse()
+                    .map_err(|e| modo::Error::internal(format!("Invalid from address: {e}")))?,
+            )
+            .to(message
+                .to
+                .parse()
+                .map_err(|e| modo::Error::internal(format!("Invalid to address: {e}")))?)
             .subject(&message.subject);
 
         if let Some(ref reply_to) = message.reply_to {
-            builder = builder.reply_to(reply_to.parse().map_err(|e| {
-                modo::Error::internal(format!("Invalid reply-to address: {e}"))
-            })?);
+            builder =
+                builder.reply_to(reply_to.parse().map_err(|e| {
+                    modo::Error::internal(format!("Invalid reply-to address: {e}"))
+                })?);
         }
 
         let email = builder

--- a/modo-email/src/transport/smtp.rs
+++ b/modo-email/src/transport/smtp.rs
@@ -37,11 +37,13 @@ impl MailTransport for SmtpTransport {
                     .parse()
                     .map_err(|e| modo::Error::internal(format!("Invalid from address: {e}")))?,
             )
-            .to(message
-                .to
-                .parse()
-                .map_err(|e| modo::Error::internal(format!("Invalid to address: {e}")))?)
             .subject(&message.subject);
+
+        for recipient in &message.to {
+            builder = builder.to(recipient
+                .parse()
+                .map_err(|e| modo::Error::internal(format!("Invalid to address: {e}")))?);
+        }
 
         if let Some(ref reply_to) = message.reply_to {
             builder =

--- a/modo-email/tests/integration.rs
+++ b/modo-email/tests/integration.rs
@@ -1,0 +1,110 @@
+use modo_email::template::filesystem::FilesystemProvider;
+use modo_email::template::layout::LayoutEngine;
+use modo_email::{MailMessage, MailTransport, Mailer, SendEmail, SenderProfile};
+use std::sync::{Arc, Mutex};
+
+/// A transport that captures sent messages for assertions.
+struct CapturingTransport {
+    messages: Arc<Mutex<Vec<MailMessage>>>,
+}
+
+#[async_trait::async_trait]
+impl MailTransport for CapturingTransport {
+    async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
+        self.messages.lock().unwrap().push(MailMessage {
+            from: message.from.clone(),
+            reply_to: message.reply_to.clone(),
+            to: message.to.clone(),
+            subject: message.subject.clone(),
+            html: message.html.clone(),
+            text: message.text.clone(),
+        });
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn end_to_end_filesystem_template() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path();
+
+    // Create a template with frontmatter, variable placeholders, and a button link.
+    std::fs::write(
+        path.join("welcome.md"),
+        "---\nsubject: \"Welcome {{name}}!\"\n---\n\nHi **{{name}}**,\n\nGet started:\n\n[button|Launch Dashboard]({{url}})\n",
+    )
+    .unwrap();
+
+    let messages = Arc::new(Mutex::new(Vec::new()));
+    let provider = Box::new(FilesystemProvider::new(path.to_str().unwrap()));
+    let layout = LayoutEngine::new(path.to_str().unwrap());
+
+    let mailer = Mailer::new(
+        Box::new(CapturingTransport {
+            messages: messages.clone(),
+        }),
+        provider,
+        SenderProfile {
+            from_name: "App".to_string(),
+            from_email: "app@test.com".to_string(),
+            reply_to: None,
+        },
+        layout,
+    );
+
+    mailer
+        .send(
+            SendEmail::new("welcome", "user@example.com")
+                .var("name", "Alice")
+                .var("url", "https://app.com/dashboard"),
+        )
+        .await
+        .unwrap();
+
+    let msgs = messages.lock().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].subject, "Welcome Alice!");
+    assert!(msgs[0].html.contains("Alice"));
+    assert!(msgs[0].html.contains("Launch Dashboard"));
+    assert!(msgs[0].html.contains("https://app.com/dashboard"));
+    assert!(msgs[0].html.contains("role=\"presentation\"")); // button rendered
+    assert!(msgs[0]
+        .text
+        .contains("Launch Dashboard (https://app.com/dashboard)"));
+}
+
+#[tokio::test]
+async fn end_to_end_locale_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path();
+
+    // Root template only — no locale-specific variant.
+    std::fs::write(
+        path.join("reset.md"),
+        "---\nsubject: \"Reset password\"\n---\n\nClick below to reset.",
+    )
+    .unwrap();
+
+    let messages = Arc::new(Mutex::new(Vec::new()));
+    let mailer = Mailer::new(
+        Box::new(CapturingTransport {
+            messages: messages.clone(),
+        }),
+        Box::new(FilesystemProvider::new(path.to_str().unwrap())),
+        SenderProfile {
+            from_name: "App".to_string(),
+            from_email: "app@test.com".to_string(),
+            reply_to: None,
+        },
+        LayoutEngine::new(path.to_str().unwrap()),
+    );
+
+    // Request "fr" locale — should fall back to root template.
+    mailer
+        .send(SendEmail::new("reset", "user@example.com").locale("fr"))
+        .await
+        .unwrap();
+
+    let msgs = messages.lock().unwrap();
+    assert_eq!(msgs[0].subject, "Reset password");
+}

--- a/modo-email/tests/integration.rs
+++ b/modo-email/tests/integration.rs
@@ -5,20 +5,13 @@ use std::sync::{Arc, Mutex};
 
 /// A transport that captures sent messages for assertions.
 struct CapturingTransport {
-    messages: Arc<Mutex<Vec<MailMessage>>>,
+    messages: Mutex<Vec<MailMessage>>,
 }
 
 #[async_trait::async_trait]
 impl MailTransport for CapturingTransport {
     async fn send(&self, message: &MailMessage) -> Result<(), modo::Error> {
-        self.messages.lock().unwrap().push(MailMessage {
-            from: message.from.clone(),
-            reply_to: message.reply_to.clone(),
-            to: message.to.clone(),
-            subject: message.subject.clone(),
-            html: message.html.clone(),
-            text: message.text.clone(),
-        });
+        self.messages.lock().unwrap().push(message.clone());
         Ok(())
     }
 }
@@ -35,14 +28,15 @@ async fn end_to_end_filesystem_template() {
     )
     .unwrap();
 
-    let messages = Arc::new(Mutex::new(Vec::new()));
-    let provider = Box::new(FilesystemProvider::new(path.to_str().unwrap()));
-    let layout = LayoutEngine::new(path.to_str().unwrap());
+    let transport = Arc::new(CapturingTransport {
+        messages: Mutex::new(Vec::new()),
+    });
+    let provider: Arc<dyn modo_email::TemplateProvider> =
+        Arc::new(FilesystemProvider::new(path.to_str().unwrap()));
+    let layout = Arc::new(LayoutEngine::new(path.to_str().unwrap()));
 
     let mailer = Mailer::new(
-        Box::new(CapturingTransport {
-            messages: messages.clone(),
-        }),
+        transport.clone(),
         provider,
         SenderProfile {
             from_name: "App".to_string(),
@@ -54,14 +48,14 @@ async fn end_to_end_filesystem_template() {
 
     mailer
         .send(
-            SendEmail::new("welcome", "user@example.com")
+            &SendEmail::new("welcome", "user@example.com")
                 .var("name", "Alice")
                 .var("url", "https://app.com/dashboard"),
         )
         .await
         .unwrap();
 
-    let msgs = messages.lock().unwrap();
+    let msgs = transport.messages.lock().unwrap();
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].subject, "Welcome Alice!");
     assert!(msgs[0].html.contains("Alice"));
@@ -87,26 +81,26 @@ async fn end_to_end_locale_fallback() {
     )
     .unwrap();
 
-    let messages = Arc::new(Mutex::new(Vec::new()));
+    let transport = Arc::new(CapturingTransport {
+        messages: Mutex::new(Vec::new()),
+    });
     let mailer = Mailer::new(
-        Box::new(CapturingTransport {
-            messages: messages.clone(),
-        }),
-        Box::new(FilesystemProvider::new(path.to_str().unwrap())),
+        transport.clone(),
+        Arc::new(FilesystemProvider::new(path.to_str().unwrap())),
         SenderProfile {
             from_name: "App".to_string(),
             from_email: "app@test.com".to_string(),
             reply_to: None,
         },
-        LayoutEngine::new(path.to_str().unwrap()),
+        Arc::new(LayoutEngine::new(path.to_str().unwrap())),
     );
 
     // Request "fr" locale — should fall back to root template.
     mailer
-        .send(SendEmail::new("reset", "user@example.com").locale("fr"))
+        .send(&SendEmail::new("reset", "user@example.com").locale("fr"))
         .await
         .unwrap();
 
-    let msgs = messages.lock().unwrap();
+    let msgs = transport.messages.lock().unwrap();
     assert_eq!(msgs[0].subject, "Reset password");
 }

--- a/modo-email/tests/integration.rs
+++ b/modo-email/tests/integration.rs
@@ -68,9 +68,11 @@ async fn end_to_end_filesystem_template() {
     assert!(msgs[0].html.contains("Launch Dashboard"));
     assert!(msgs[0].html.contains("https://app.com/dashboard"));
     assert!(msgs[0].html.contains("role=\"presentation\"")); // button rendered
-    assert!(msgs[0]
-        .text
-        .contains("Launch Dashboard (https://app.com/dashboard)"));
+    assert!(
+        msgs[0]
+            .text
+            .contains("Launch Dashboard (https://app.com/dashboard)")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `modo-email` crate: pluggable email sending with Markdown templates, responsive HTML output, and multi-tenant sender support
- Implements two transport backends: SMTP (via lettre, default) and Resend HTTP API (optional `resend` feature)
- Template system: Markdown files with YAML frontmatter, `{{var}}` substitution, `[button|Label](url)` syntax for email-safe CTA buttons
- Built-in responsive HTML layout with dark mode support, MSO conditionals, and custom layout overrides via MiniJinja
- `Mailer` service with `render()` (preview) and `send()` (deliver), plus `mailer()`/`mailer_with()` factory functions
- `SendEmailPayload` for async job queue integration with modo-jobs
- 34 unit tests + 2 integration tests, all passing; clippy clean with `-D warnings`

## Test Plan

- [x] `cargo test -p modo-email` — 34 unit tests + 2 integration tests pass
- [x] `cargo check -p modo-email --features resend` — compiles with Resend feature
- [x] `just fmt && just check` — full workspace check passes (fmt, clippy, tests)
- [ ] Manual: create sample templates and verify HTML output in email client

---

@claude please review this PR