### PR TITLE
feat: add modo-tenant multi-tenancy with RBAC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - `modo-templates/` — MiniJinja template engine (views, render layer, context injection)
 - `modo-templates-macros/` — `#[view("path", htmx = "path")]` proc macro
 - `modo-csrf/` — CSRF protection (double-submit cookie, HMAC-signed tokens)
+- `modo-tenant/` — multi-tenancy with RBAC (tenant resolution, member/role management, extractors, guards)
+- `modo-tenant-macros/` — `#[allow_roles]` / `#[deny_roles]` proc macros
 
 ## Commands
 
@@ -69,6 +71,16 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - Jobs: `#[modo_jobs::job(queue = "...", priority = N, max_attempts = N, timeout = "5m")]`
 - Cron jobs: `#[modo_jobs::job(cron = "0 0 * * * *", timeout = "5m")]` — in-memory only
 - Upload storage: `UploadConfig { backend, path, s3 }` — YAML-deserializable, `modo_upload::storage(&config)?` returns `Box<dyn FileStorage>`
+- Tenant resolution: implement `HasTenantId` + `TenantResolver` traits, wrap in `TenantResolverService::new(resolver)`, register as service
+- Tenant extractors: `Tenant<T>` (required, 404 if missing), `OptionalTenant<T>` (optional), both cache via `ResolvedTenant<T>` extension
+- Member provider: implement `MemberProvider` trait (`find_member`, `list_tenants`, `role`), wrap in `MemberProviderService::new(provider)`
+- Member extractor: `Member<T, M>` — requires tenant + auth + membership (404/401/403), caches via `ResolvedMember<M>`
+- Tenant context: `TenantContext<T, M, U>` — composite extractor providing tenant, member, user, tenants list, and role
+- Built-in resolvers: `SubdomainResolver`, `HeaderResolver`, `PathPrefixResolver` — all take a lookup closure
+- Role guards: `#[allow_roles("admin", "owner")]` / `#[deny_roles("viewer")]` — proc macros emitting `#[middleware(...)]`
+- Role guard functions: `modo_tenant::guard::require_roles::<T, M>(&["admin"])` / `exclude_roles::<T, M>(&["viewer"])` — middleware factories
+- Template context layer: `TenantContextLayer<T, M>` — auto-injects `tenant`, `member`, `tenants`, `role` into `TemplateContext` (feature = "templates")
+- User context layer: `modo_auth::context_layer::UserContextLayer<U>` — auto-injects `user` into `TemplateContext` (feature = "templates")
 
 ## Gotchas
 
@@ -83,3 +95,6 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - Use official documentation only when researching dependencies
 - Session IDs: ULID (no UUID anywhere)
 - Testing Tower middleware: use `Router::new().route(...).layer(mw).oneshot(request)` pattern — no AppState needed, handler reads `Extension<T>` from extensions
+- Type-erased services: use object-safe bridge trait (`XxxDyn`) + `Arc<dyn XxxDyn<T>>` wrapper — see `TenantResolverService` / `MemberProviderService` pattern
+- Tenant `MemberProvider::role()` needs explicit lifetime: `fn role<'a>(&'a self, member: &'a M) -> &'a str`
+- Session user ID access: use `modo_session::user_id_from_extensions(&parts.extensions)` — returns `Option<String>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,8 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - Member extractor: `Member<T, M>` — requires tenant + auth + membership (404/401/403), caches via `ResolvedMember<M>`
 - Tenant context: `TenantContext<T, M, U>` — composite extractor providing tenant, member, user, tenants list, and role
 - Built-in resolvers: `SubdomainResolver`, `HeaderResolver`, `PathPrefixResolver` — all take a lookup closure
-- Role guards: `#[allow_roles("admin", "owner")]` / `#[deny_roles("viewer")]` — proc macros emitting `#[middleware(...)]`
-- Role guard functions: `modo_tenant::guard::require_roles::<T, M>(&["admin"])` / `exclude_roles::<T, M>(&["viewer"])` — middleware factories
+- Role guards: `#[allow_roles(MyTenant, MyMember, "admin", "owner")]` / `#[deny_roles(MyTenant, MyMember, "viewer")]` — first two args are tenant/member types
+- Role guard functions: `modo_tenant::guard::require_roles::<T, M>(&["admin"])` / `exclude_roles::<T, M>(&["viewer"])` — middleware factories, use with `from_fn`
 - Template context layer: `TenantContextLayer<T, M>` — auto-injects `tenant`, `member`, `tenants`, `role` into `TemplateContext` (feature = "templates")
 - User context layer: `modo_auth::context_layer::UserContextLayer<U>` — auto-injects `user` into `TemplateContext` (feature = "templates")
 
@@ -98,3 +98,4 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - Type-erased services: use object-safe bridge trait (`XxxDyn`) + `Arc<dyn XxxDyn<T>>` wrapper — see `TenantResolverService` / `MemberProviderService` pattern
 - Tenant `MemberProvider::role()` needs explicit lifetime: `fn role<'a>(&'a self, member: &'a M) -> &'a str`
 - Session user ID access: use `modo_session::user_id_from_extensions(&parts.extensions)` — returns `Option<String>`
+- AppState in middleware: modo injects `AppState` into request extensions globally — handler-level middleware reads via `parts.extensions.get::<AppState>()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-email", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-upload", "modo-upload-macros", "modo-templates", "modo-templates-macros", "modo-csrf", "examples/*"]
+members = ["modo", "modo-macros", "modo-db", "modo-db-macros", "modo-email", "modo-i18n", "modo-i18n-macros", "modo-jobs", "modo-jobs-macros", "modo-session", "modo-auth", "modo-tenant", "modo-tenant-macros", "modo-upload", "modo-upload-macros", "modo-templates", "modo-templates-macros", "modo-csrf", "examples/*"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/modo-auth/Cargo.toml
+++ b/modo-auth/Cargo.toml
@@ -7,9 +7,17 @@ license.workspace = true
 [dependencies]
 modo = { path = "../modo" }
 modo-session = { path = "../modo-session" }
+modo-templates = { path = "../modo-templates", optional = true }
 argon2 = "0.5"
+futures-util = "0.3"
+minijinja = { version = "2", optional = true }
 serde = { version = "1", features = ["derive"] }
+tower = { version = "0.5", features = ["util"] }
 tokio = { version = "1", features = ["rt"] }
+
+[features]
+default = []
+templates = ["dep:modo-templates", "dep:minijinja"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/modo-auth/src/context_layer.rs
+++ b/modo-auth/src/context_layer.rs
@@ -112,15 +112,13 @@ where
             // Try to get user_id from session extensions
             let user_id = modo_session::user_id_from_extensions(&parts.extensions);
 
-            if let Some(user_id) = user_id {
-                if let Ok(Some(user)) = user_svc.find_by_id(&user_id).await {
-                    if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
-                        ctx.insert("user", minijinja::Value::from_serialize(&user));
-                    }
-                    parts
-                        .extensions
-                        .insert(ResolvedUser(Arc::new(user)));
+            if let Some(user_id) = user_id
+                && let Ok(Some(user)) = user_svc.find_by_id(&user_id).await
+            {
+                if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
+                    ctx.insert("user", minijinja::Value::from_serialize(&user));
                 }
+                parts.extensions.insert(ResolvedUser(Arc::new(user)));
             }
 
             let request = Request::from_parts(parts, body);

--- a/modo-auth/src/context_layer.rs
+++ b/modo-auth/src/context_layer.rs
@@ -1,0 +1,130 @@
+#[cfg(feature = "templates")]
+use crate::provider::UserProviderService;
+
+#[cfg(feature = "templates")]
+use futures_util::future::BoxFuture;
+#[cfg(feature = "templates")]
+use modo::axum::http::Request;
+#[cfg(feature = "templates")]
+use modo_templates::TemplateContext;
+#[cfg(feature = "templates")]
+use std::sync::Arc;
+#[cfg(feature = "templates")]
+use std::task::{Context, Poll};
+#[cfg(feature = "templates")]
+use tower::{Layer, Service};
+
+/// Cached resolved user in request extensions.
+#[cfg(feature = "templates")]
+pub struct ResolvedUser<U>(pub Arc<U>);
+
+#[cfg(feature = "templates")]
+impl<U> Clone for ResolvedUser<U> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+/// Layer that injects the authenticated user into TemplateContext.
+/// Graceful: injects nothing if not authenticated.
+#[cfg(feature = "templates")]
+pub struct UserContextLayer<U>
+where
+    U: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    user_svc: UserProviderService<U>,
+}
+
+#[cfg(feature = "templates")]
+impl<U> Clone for UserContextLayer<U>
+where
+    U: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            user_svc: self.user_svc.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "templates")]
+impl<U> UserContextLayer<U>
+where
+    U: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    pub fn new(user_svc: UserProviderService<U>) -> Self {
+        Self { user_svc }
+    }
+}
+
+#[cfg(feature = "templates")]
+impl<S, U> Layer<S> for UserContextLayer<U>
+where
+    U: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    type Service = UserContextMiddleware<S, U>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        UserContextMiddleware {
+            inner,
+            user_svc: self.user_svc.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "templates")]
+#[derive(Clone)]
+pub struct UserContextMiddleware<S, U>
+where
+    U: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    inner: S,
+    user_svc: UserProviderService<U>,
+}
+
+#[cfg(feature = "templates")]
+impl<S, ReqBody, ResBody, U> Service<Request<ReqBody>> for UserContextMiddleware<S, U>
+where
+    S: Service<Request<ReqBody>, Response = modo::axum::http::Response<ResBody>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+    U: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let user_svc = self.user_svc.clone();
+
+        Box::pin(async move {
+            let (mut parts, body) = request.into_parts();
+
+            // Try to get user_id from session extensions
+            let user_id = modo_session::user_id_from_extensions(&parts.extensions);
+
+            if let Some(user_id) = user_id {
+                if let Ok(Some(user)) = user_svc.find_by_id(&user_id).await {
+                    if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
+                        ctx.insert("user", minijinja::Value::from_serialize(&user));
+                    }
+                    parts
+                        .extensions
+                        .insert(ResolvedUser(Arc::new(user)));
+                }
+            }
+
+            let request = Request::from_parts(parts, body);
+            inner.call(request).await
+        })
+    }
+}

--- a/modo-auth/src/lib.rs
+++ b/modo-auth/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod context_layer;
 pub mod extractor;
 pub mod password;
 pub mod provider;
@@ -5,3 +6,6 @@ pub mod provider;
 pub use extractor::{Auth, OptionalAuth};
 pub use password::{PasswordConfig, PasswordHasher};
 pub use provider::{UserProvider, UserProviderService};
+
+#[cfg(feature = "templates")]
+pub use context_layer::{ResolvedUser, UserContextLayer};

--- a/modo-session/src/lib.rs
+++ b/modo-session/src/lib.rs
@@ -15,7 +15,7 @@ pub mod cleanup;
 pub use config::SessionConfig;
 pub use manager::SessionManager;
 pub use meta::SessionMeta;
-pub use middleware::layer;
+pub use middleware::{layer, user_id_from_extensions};
 pub use store::SessionStore;
 pub use types::{SessionData, SessionId, SessionToken};
 

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -212,17 +212,18 @@ where
 /// Extract the current user ID from request extensions without going through
 /// the full `SessionManager` extractor. Useful for middleware/layers.
 ///
-/// Returns `None` if no session middleware is active, no session exists, or
-/// the session lock is currently held.
+/// Uses `try_lock()` to avoid deadlocks when `SessionManager::set()` or
+/// `remove_key()` hold the mutex across `.await`. Returns `None` if no session
+/// exists or the lock is contended (logged as a warning).
 pub fn user_id_from_extensions(extensions: &http::Extensions) -> Option<String> {
     extensions
         .get::<Arc<SessionManagerState>>()
-        .and_then(|state| {
-            state
-                .current_session
-                .try_lock()
-                .ok()
-                .and_then(|guard| guard.as_ref().map(|s| s.user_id.clone()))
+        .and_then(|state| match state.current_session.try_lock() {
+            Ok(guard) => guard.as_ref().map(|s| s.user_id.clone()),
+            Err(_) => {
+                tracing::warn!("user_id_from_extensions: session lock contended, returning None");
+                None
+            }
         })
 }
 

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -209,6 +209,23 @@ where
     }
 }
 
+/// Extract the current user ID from request extensions without going through
+/// the full `SessionManager` extractor. Useful for middleware/layers.
+///
+/// Returns `None` if no session middleware is active, no session exists, or
+/// the session lock is currently held.
+pub fn user_id_from_extensions(extensions: &http::Extensions) -> Option<String> {
+    extensions
+        .get::<Arc<SessionManagerState>>()
+        .and_then(|state| {
+            state
+                .current_session
+                .try_lock()
+                .ok()
+                .and_then(|guard| guard.as_ref().map(|s| s.user_id.clone()))
+        })
+}
+
 // --- Cookie helpers ---
 
 fn read_session_cookie(headers: &http::HeaderMap, cookie_name: &str) -> Option<SessionToken> {

--- a/modo-tenant-macros/Cargo.toml
+++ b/modo-tenant-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "modo-tenant-macros"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"

--- a/modo-tenant-macros/src/lib.rs
+++ b/modo-tenant-macros/src/lib.rs
@@ -1,0 +1,13 @@
+use proc_macro::TokenStream;
+
+/// Placeholder — implemented in Task 8.
+#[proc_macro_attribute]
+pub fn allow_roles(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+
+/// Placeholder — implemented in Task 8.
+#[proc_macro_attribute]
+pub fn deny_roles(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}

--- a/modo-tenant-macros/src/lib.rs
+++ b/modo-tenant-macros/src/lib.rs
@@ -1,13 +1,17 @@
 use proc_macro::TokenStream;
 
-/// Placeholder — implemented in Task 8.
+mod roles;
+
 #[proc_macro_attribute]
-pub fn allow_roles(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
+pub fn allow_roles(attr: TokenStream, item: TokenStream) -> TokenStream {
+    roles::expand_allow_roles(attr.into(), item.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
 }
 
-/// Placeholder — implemented in Task 8.
 #[proc_macro_attribute]
-pub fn deny_roles(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
+pub fn deny_roles(attr: TokenStream, item: TokenStream) -> TokenStream {
+    roles::expand_deny_roles(attr.into(), item.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
 }

--- a/modo-tenant-macros/src/roles.rs
+++ b/modo-tenant-macros/src/roles.rs
@@ -1,34 +1,54 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{ItemFn, LitStr, Result, Token};
+use syn::{ItemFn, LitStr, Path, Result, Token};
 
-pub struct RoleList(pub Vec<LitStr>);
+pub struct RolesArgs {
+    pub tenant_type: Path,
+    pub member_type: Path,
+    pub roles: Vec<LitStr>,
+}
 
-impl syn::parse::Parse for RoleList {
+impl syn::parse::Parse for RolesArgs {
     fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+        let tenant_type: Path = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let member_type: Path = input.parse()?;
+        input.parse::<Token![,]>()?;
         let roles = input.parse_terminated(|input| input.parse::<LitStr>(), Token![,])?;
-        Ok(RoleList(roles.into_iter().collect()))
+        Ok(RolesArgs {
+            tenant_type,
+            member_type,
+            roles: roles.into_iter().collect(),
+        })
     }
 }
 
 pub fn expand_allow_roles(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
-    let roles: RoleList = syn::parse2(attr)?;
+    let args: RolesArgs = syn::parse2(attr)?;
     let func: ItemFn = syn::parse2(item)?;
-    let role_strs: Vec<&LitStr> = roles.0.iter().collect();
+    let role_strs: Vec<&LitStr> = args.roles.iter().collect();
+    let tenant_type = &args.tenant_type;
+    let member_type = &args.member_type;
 
     Ok(quote! {
-        #[middleware(modo_tenant::guard::require_roles(&[#(#role_strs),*]))]
+        #[middleware(modo::axum::middleware::from_fn(
+            modo_tenant::guard::require_roles::<#tenant_type, #member_type>(&[#(#role_strs),*])
+        ))]
         #func
     })
 }
 
 pub fn expand_deny_roles(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
-    let roles: RoleList = syn::parse2(attr)?;
+    let args: RolesArgs = syn::parse2(attr)?;
     let func: ItemFn = syn::parse2(item)?;
-    let role_strs: Vec<&LitStr> = roles.0.iter().collect();
+    let role_strs: Vec<&LitStr> = args.roles.iter().collect();
+    let tenant_type = &args.tenant_type;
+    let member_type = &args.member_type;
 
     Ok(quote! {
-        #[middleware(modo_tenant::guard::exclude_roles(&[#(#role_strs),*]))]
+        #[middleware(modo::axum::middleware::from_fn(
+            modo_tenant::guard::exclude_roles::<#tenant_type, #member_type>(&[#(#role_strs),*])
+        ))]
         #func
     })
 }

--- a/modo-tenant-macros/src/roles.rs
+++ b/modo-tenant-macros/src/roles.rs
@@ -1,0 +1,34 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{ItemFn, LitStr, Result, Token};
+
+pub struct RoleList(pub Vec<LitStr>);
+
+impl syn::parse::Parse for RoleList {
+    fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+        let roles = input.parse_terminated(|input| input.parse::<LitStr>(), Token![,])?;
+        Ok(RoleList(roles.into_iter().collect()))
+    }
+}
+
+pub fn expand_allow_roles(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
+    let roles: RoleList = syn::parse2(attr)?;
+    let func: ItemFn = syn::parse2(item)?;
+    let role_strs: Vec<&LitStr> = roles.0.iter().collect();
+
+    Ok(quote! {
+        #[middleware(modo_tenant::guard::require_roles(&[#(#role_strs),*]))]
+        #func
+    })
+}
+
+pub fn expand_deny_roles(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
+    let roles: RoleList = syn::parse2(attr)?;
+    let func: ItemFn = syn::parse2(item)?;
+    let role_strs: Vec<&LitStr> = roles.0.iter().collect();
+
+    Ok(quote! {
+        #[middleware(modo_tenant::guard::exclude_roles(&[#(#role_strs),*]))]
+        #func
+    })
+}

--- a/modo-tenant/Cargo.toml
+++ b/modo-tenant/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 modo = { path = "../modo" }
+modo-auth = { path = "../modo-auth" }
 modo-session = { path = "../modo-session" }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"

--- a/modo-tenant/Cargo.toml
+++ b/modo-tenant/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "modo-tenant"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[dependencies]
+modo = { path = "../modo" }
+modo-session = { path = "../modo-session" }
+serde = { version = "1", features = ["derive"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+axum = "0.8"
+axum-extra = { version = "0.10", features = ["cookie-signed"] }
+tower = { version = "0.5", features = ["util"] }
+http = "1"
+serde_json = "1"

--- a/modo-tenant/Cargo.toml
+++ b/modo-tenant/Cargo.toml
@@ -15,11 +15,11 @@ serde = { version = "1", features = ["derive"] }
 tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 futures-util = "0.3"
-minijinja = "2"
+minijinja = { version = "2", optional = true }
 
 [features]
 default = []
-templates = ["dep:modo-templates"]
+templates = ["dep:modo-templates", "dep:minijinja"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/modo-tenant/Cargo.toml
+++ b/modo-tenant/Cargo.toml
@@ -10,8 +10,16 @@ modo = { path = "../modo" }
 modo-auth = { path = "../modo-auth" }
 modo-session = { path = "../modo-session" }
 modo-tenant-macros = { path = "../modo-tenant-macros" }
+modo-templates = { path = "../modo-templates", optional = true }
 serde = { version = "1", features = ["derive"] }
+tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
+futures-util = "0.3"
+minijinja = "2"
+
+[features]
+default = []
+templates = ["dep:modo-templates"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/modo-tenant/Cargo.toml
+++ b/modo-tenant/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2024"
 license.workspace = true
 
 [dependencies]
+http = "1"
 modo = { path = "../modo" }
 modo-auth = { path = "../modo-auth" }
 modo-session = { path = "../modo-session" }
+modo-tenant-macros = { path = "../modo-tenant-macros" }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 

--- a/modo-tenant/src/cache.rs
+++ b/modo-tenant/src/cache.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+/// Cached resolved tenant in request extensions.
+pub struct ResolvedTenant<T>(pub Arc<T>);
+
+impl<T> Clone for ResolvedTenant<T> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+/// Cached resolved member in request extensions.
+pub struct ResolvedMember<M>(pub Arc<M>);
+
+impl<M> Clone for ResolvedMember<M> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+/// Cached resolved role in request extensions.
+#[derive(Clone)]
+pub struct ResolvedRole(pub String);
+
+/// Cached resolved tenants list in request extensions.
+pub struct ResolvedTenants<T>(pub Arc<Vec<T>>);
+
+impl<T> Clone for ResolvedTenants<T> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}

--- a/modo-tenant/src/context_layer.rs
+++ b/modo-tenant/src/context_layer.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "templates")]
+use crate::HasTenantId;
+#[cfg(feature = "templates")]
 use crate::cache::{ResolvedMember, ResolvedRole, ResolvedTenant, ResolvedTenants};
 #[cfg(feature = "templates")]
 use crate::member::MemberProviderService;
 #[cfg(feature = "templates")]
 use crate::resolver::TenantResolverService;
-#[cfg(feature = "templates")]
-use crate::HasTenantId;
 
 #[cfg(feature = "templates")]
 use futures_util::future::BoxFuture;
@@ -93,8 +93,7 @@ where
 }
 
 #[cfg(feature = "templates")]
-impl<S, ReqBody, ResBody, T, M> Service<Request<ReqBody>>
-    for TenantContextMiddleware<S, T, M>
+impl<S, ReqBody, ResBody, T, M> Service<Request<ReqBody>> for TenantContextMiddleware<S, T, M>
 where
     S: Service<Request<ReqBody>, Response = modo::axum::http::Response<ResBody>>
         + Clone
@@ -129,9 +128,7 @@ where
                 } else {
                     match tenant_svc.resolve(&parts).await {
                         Ok(Some(t)) => {
-                            parts
-                                .extensions
-                                .insert(ResolvedTenant(Arc::new(t.clone())));
+                            parts.extensions.insert(ResolvedTenant(Arc::new(t.clone())));
                             Some(t)
                         }
                         _ => None,
@@ -139,10 +136,10 @@ where
                 };
 
             // Inject tenant into template context
-            if let Some(ref t) = tenant {
-                if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
-                    ctx.insert("tenant", minijinja::Value::from_serialize(t));
-                }
+            if let Some(ref t) = tenant
+                && let Some(ctx) = parts.extensions.get_mut::<TemplateContext>()
+            {
+                ctx.insert("tenant", minijinja::Value::from_serialize(t));
             }
 
             // If user is authenticated and tenant is resolved, load member + tenants
@@ -151,37 +148,26 @@ where
 
                 if let Some(user_id) = user_id {
                     // Load member
-                    if let Ok(Some(member)) = member_svc
-                        .find_member(&user_id, tenant.tenant_id())
-                        .await
+                    if let Ok(Some(member)) =
+                        member_svc.find_member(&user_id, tenant.tenant_id()).await
                     {
                         let role = member_svc.role(&member).to_string();
 
                         if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
-                            ctx.insert(
-                                "member",
-                                minijinja::Value::from_serialize(&member),
-                            );
+                            ctx.insert("member", minijinja::Value::from_serialize(&member));
                             ctx.insert("role", role.clone());
                         }
 
-                        parts
-                            .extensions
-                            .insert(ResolvedMember(Arc::new(member)));
+                        parts.extensions.insert(ResolvedMember(Arc::new(member)));
                         parts.extensions.insert(ResolvedRole(role));
                     }
 
                     // Load tenants list
                     if let Ok(tenants) = member_svc.list_tenants(&user_id).await {
                         if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
-                            ctx.insert(
-                                "tenants",
-                                minijinja::Value::from_serialize(&tenants),
-                            );
+                            ctx.insert("tenants", minijinja::Value::from_serialize(&tenants));
                         }
-                        parts
-                            .extensions
-                            .insert(ResolvedTenants(Arc::new(tenants)));
+                        parts.extensions.insert(ResolvedTenants(Arc::new(tenants)));
                     }
                 }
             }

--- a/modo-tenant/src/context_layer.rs
+++ b/modo-tenant/src/context_layer.rs
@@ -1,0 +1,193 @@
+#[cfg(feature = "templates")]
+use crate::cache::{ResolvedMember, ResolvedRole, ResolvedTenant, ResolvedTenants};
+#[cfg(feature = "templates")]
+use crate::member::MemberProviderService;
+#[cfg(feature = "templates")]
+use crate::resolver::TenantResolverService;
+#[cfg(feature = "templates")]
+use crate::HasTenantId;
+
+#[cfg(feature = "templates")]
+use futures_util::future::BoxFuture;
+#[cfg(feature = "templates")]
+use modo::axum::http::Request;
+#[cfg(feature = "templates")]
+use modo_templates::TemplateContext;
+#[cfg(feature = "templates")]
+use std::sync::Arc;
+#[cfg(feature = "templates")]
+use std::task::{Context, Poll};
+#[cfg(feature = "templates")]
+use tower::{Layer, Service};
+
+/// Layer that injects tenant, member, tenants, and role into TemplateContext.
+/// Graceful: skips if no tenant or no auth.
+#[cfg(feature = "templates")]
+pub struct TenantContextLayer<T, M>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    tenant_svc: TenantResolverService<T>,
+    member_svc: MemberProviderService<M, T>,
+}
+
+#[cfg(feature = "templates")]
+impl<T, M> Clone for TenantContextLayer<T, M>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            tenant_svc: self.tenant_svc.clone(),
+            member_svc: self.member_svc.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "templates")]
+impl<T, M> TenantContextLayer<T, M>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    pub fn new(
+        tenant_svc: TenantResolverService<T>,
+        member_svc: MemberProviderService<M, T>,
+    ) -> Self {
+        Self {
+            tenant_svc,
+            member_svc,
+        }
+    }
+}
+
+#[cfg(feature = "templates")]
+impl<S, T, M> Layer<S> for TenantContextLayer<T, M>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    type Service = TenantContextMiddleware<S, T, M>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TenantContextMiddleware {
+            inner,
+            tenant_svc: self.tenant_svc.clone(),
+            member_svc: self.member_svc.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "templates")]
+#[derive(Clone)]
+pub struct TenantContextMiddleware<S, T, M>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    inner: S,
+    tenant_svc: TenantResolverService<T>,
+    member_svc: MemberProviderService<M, T>,
+}
+
+#[cfg(feature = "templates")]
+impl<S, ReqBody, ResBody, T, M> Service<Request<ReqBody>>
+    for TenantContextMiddleware<S, T, M>
+where
+    S: Service<Request<ReqBody>, Response = modo::axum::http::Response<ResBody>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let tenant_svc = self.tenant_svc.clone();
+        let member_svc = self.member_svc.clone();
+
+        Box::pin(async move {
+            let (mut parts, body) = request.into_parts();
+
+            // Resolve tenant (cached or fresh)
+            let tenant: Option<T> =
+                if let Some(cached) = parts.extensions.get::<ResolvedTenant<T>>() {
+                    Some((*cached.0).clone())
+                } else {
+                    match tenant_svc.resolve(&parts).await {
+                        Ok(Some(t)) => {
+                            parts
+                                .extensions
+                                .insert(ResolvedTenant(Arc::new(t.clone())));
+                            Some(t)
+                        }
+                        _ => None,
+                    }
+                };
+
+            // Inject tenant into template context
+            if let Some(ref t) = tenant {
+                if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
+                    ctx.insert("tenant", minijinja::Value::from_serialize(t));
+                }
+            }
+
+            // If user is authenticated and tenant is resolved, load member + tenants
+            if let Some(ref tenant) = tenant {
+                let user_id = modo_session::user_id_from_extensions(&parts.extensions);
+
+                if let Some(user_id) = user_id {
+                    // Load member
+                    if let Ok(Some(member)) = member_svc
+                        .find_member(&user_id, tenant.tenant_id())
+                        .await
+                    {
+                        let role = member_svc.role(&member).to_string();
+
+                        if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
+                            ctx.insert(
+                                "member",
+                                minijinja::Value::from_serialize(&member),
+                            );
+                            ctx.insert("role", role.clone());
+                        }
+
+                        parts
+                            .extensions
+                            .insert(ResolvedMember(Arc::new(member)));
+                        parts.extensions.insert(ResolvedRole(role));
+                    }
+
+                    // Load tenants list
+                    if let Ok(tenants) = member_svc.list_tenants(&user_id).await {
+                        if let Some(ctx) = parts.extensions.get_mut::<TemplateContext>() {
+                            ctx.insert(
+                                "tenants",
+                                minijinja::Value::from_serialize(&tenants),
+                            );
+                        }
+                        parts
+                            .extensions
+                            .insert(ResolvedTenants(Arc::new(tenants)));
+                    }
+                }
+            }
+
+            let request = Request::from_parts(parts, body);
+            inner.call(request).await
+        })
+    }
+}

--- a/modo-tenant/src/context_layer.rs
+++ b/modo-tenant/src/context_layer.rs
@@ -131,7 +131,11 @@ where
                             parts.extensions.insert(ResolvedTenant(Arc::new(t.clone())));
                             Some(t)
                         }
-                        _ => None,
+                        Ok(None) => None,
+                        Err(e) => {
+                            tracing::warn!("TenantContextLayer: tenant resolution failed: {e}");
+                            None
+                        }
                     }
                 };
 

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -1,0 +1,224 @@
+use crate::cache::ResolvedTenant;
+use crate::resolver::TenantResolverService;
+use crate::HasTenantId;
+use modo::app::AppState;
+use modo::axum::extract::FromRequestParts;
+use modo::axum::http::request::Parts;
+use modo::{Error, HttpError};
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// Extractor that requires a resolved tenant. Returns 404 if not found.
+#[derive(Clone)]
+pub struct Tenant<T: Clone + Send + Sync + 'static>(pub T);
+
+impl<T: Clone + Send + Sync + 'static> Deref for Tenant<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Resolve tenant from cache or via resolver service, caching the result.
+pub(crate) async fn resolve_tenant<T>(
+    parts: &mut Parts,
+    state: &AppState,
+) -> Result<Option<T>, Error>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+{
+    // Check cache first
+    if let Some(cached) = parts.extensions.get::<ResolvedTenant<T>>() {
+        return Ok(Some((*cached.0).clone()));
+    }
+
+    let resolver = state
+        .services
+        .get::<TenantResolverService<T>>()
+        .ok_or_else(|| {
+            Error::internal(format!(
+                "TenantResolverService<{}> not registered",
+                std::any::type_name::<T>()
+            ))
+        })?;
+
+    let tenant = resolver.resolve(parts).await?;
+
+    if let Some(ref t) = tenant {
+        parts
+            .extensions
+            .insert(ResolvedTenant(Arc::new(t.clone())));
+    }
+
+    Ok(tenant)
+}
+
+impl<T> FromRequestParts<AppState> for Tenant<T>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let tenant = resolve_tenant::<T>(parts, state)
+            .await?
+            .ok_or_else(|| Error::from(HttpError::NotFound))?;
+        Ok(Tenant(tenant))
+    }
+}
+
+/// Extractor that optionally resolves a tenant. Never rejects due to missing tenant.
+#[derive(Clone)]
+pub struct OptionalTenant<T: Clone + Send + Sync + 'static>(pub Option<T>);
+
+impl<T: Clone + Send + Sync + 'static> Deref for OptionalTenant<T> {
+    type Target = Option<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> FromRequestParts<AppState> for OptionalTenant<T>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let tenant = resolve_tenant::<T>(parts, state).await?;
+        Ok(OptionalTenant(tenant))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolver::TenantResolverService;
+    use modo::app::{AppState, ServiceRegistry};
+    use modo::axum::body::Body;
+    use modo::axum::http::{Request, StatusCode};
+    use modo::axum::routing::get;
+    use modo::axum::Router;
+    use tower::ServiceExt;
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct TestTenant {
+        id: String,
+        name: String,
+    }
+
+    impl crate::HasTenantId for TestTenant {
+        fn tenant_id(&self) -> &str {
+            &self.id
+        }
+    }
+
+    struct TestResolver;
+
+    impl crate::TenantResolver for TestResolver {
+        type Tenant = TestTenant;
+
+        async fn resolve(
+            &self,
+            parts: &modo::axum::http::request::Parts,
+        ) -> Result<Option<Self::Tenant>, modo::Error> {
+            let host = parts
+                .headers
+                .get("host")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            if host.starts_with("acme.") {
+                Ok(Some(TestTenant {
+                    id: "t-1".to_string(),
+                    name: "Acme".to_string(),
+                }))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    fn app_state_with_resolver() -> AppState {
+        let services = ServiceRegistry::new().with(TenantResolverService::new(TestResolver));
+        AppState {
+            services,
+            server_config: Default::default(),
+            cookie_key: axum_extra::extract::cookie::Key::generate(),
+        }
+    }
+
+    #[tokio::test]
+    async fn tenant_extractor_returns_tenant() {
+        let state = app_state_with_resolver();
+        let app = Router::new()
+            .route("/", get(|t: Tenant<TestTenant>| async move { t.name.clone() }))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "acme.test.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn tenant_extractor_returns_404_when_missing() {
+        let state = app_state_with_resolver();
+        let app = Router::new()
+            .route("/", get(|_t: Tenant<TestTenant>| async { "ok" }))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "unknown.test.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn optional_tenant_returns_none_when_missing() {
+        let state = app_state_with_resolver();
+        let app = Router::new()
+            .route(
+                "/",
+                get(|t: OptionalTenant<TestTenant>| async move {
+                    if t.0.is_some() {
+                        "found"
+                    } else {
+                        "none"
+                    }
+                }),
+            )
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "unknown.test.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -1,7 +1,7 @@
+use crate::HasTenantId;
 use crate::cache::{ResolvedMember, ResolvedRole, ResolvedTenant, ResolvedTenants};
 use crate::member::MemberProviderService;
 use crate::resolver::TenantResolverService;
-use crate::HasTenantId;
 use modo::app::AppState;
 use modo::axum::extract::FromRequestParts;
 use modo::axum::http::request::Parts;
@@ -48,9 +48,7 @@ where
     let tenant = resolver.resolve(parts).await?;
 
     if let Some(ref t) = tenant {
-        parts
-            .extensions
-            .insert(ResolvedTenant(Arc::new(t.clone())));
+        parts.extensions.insert(ResolvedTenant(Arc::new(t.clone())));
     }
 
     Ok(tenant)
@@ -340,10 +338,10 @@ mod tests {
     use super::*;
     use crate::resolver::TenantResolverService;
     use modo::app::{AppState, ServiceRegistry};
+    use modo::axum::Router;
     use modo::axum::body::Body;
     use modo::axum::http::{Request, StatusCode};
     use modo::axum::routing::get;
-    use modo::axum::Router;
     use tower::ServiceExt;
 
     #[derive(Clone, Debug, PartialEq, serde::Serialize)]
@@ -396,7 +394,10 @@ mod tests {
     async fn tenant_extractor_returns_tenant() {
         let state = app_state_with_resolver();
         let app = Router::new()
-            .route("/", get(|t: Tenant<TestTenant>| async move { t.name.clone() }))
+            .route(
+                "/",
+                get(|t: Tenant<TestTenant>| async move { t.name.clone() }),
+            )
             .with_state(state);
 
         let resp = app
@@ -439,11 +440,7 @@ mod tests {
             .route(
                 "/",
                 get(|t: OptionalTenant<TestTenant>| async move {
-                    if t.0.is_some() {
-                        "found"
-                    } else {
-                        "none"
-                    }
+                    if t.0.is_some() { "found" } else { "none" }
                 }),
             )
             .with_state(state);

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -1,10 +1,12 @@
-use crate::cache::ResolvedTenant;
+use crate::cache::{ResolvedMember, ResolvedRole, ResolvedTenant};
+use crate::member::MemberProviderService;
 use crate::resolver::TenantResolverService;
 use crate::HasTenantId;
 use modo::app::AppState;
 use modo::axum::extract::FromRequestParts;
 use modo::axum::http::request::Parts;
 use modo::{Error, HttpError};
+use modo_session::SessionManager;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -93,6 +95,124 @@ where
     ) -> Result<Self, Self::Rejection> {
         let tenant = resolve_tenant::<T>(parts, state).await?;
         Ok(OptionalTenant(tenant))
+    }
+}
+
+/// Extractor that requires tenant + auth + membership.
+/// Returns 404 (no tenant), 401 (no auth), or 403 (not a member).
+pub struct Member<T: HasTenantId + Clone + Send + Sync + 'static, M: Clone + Send + Sync + 'static>
+{
+    tenant: T,
+    inner: M,
+    role: String,
+}
+
+impl<T: HasTenantId + Clone + Send + Sync + 'static, M: Clone + Send + Sync + 'static> Clone
+    for Member<T, M>
+{
+    fn clone(&self) -> Self {
+        Self {
+            tenant: self.tenant.clone(),
+            inner: self.inner.clone(),
+            role: self.role.clone(),
+        }
+    }
+}
+
+impl<T: HasTenantId + Clone + Send + Sync + 'static, M: Clone + Send + Sync + 'static>
+    Member<T, M>
+{
+    pub fn tenant(&self) -> &T {
+        &self.tenant
+    }
+
+    pub fn role(&self) -> &str {
+        &self.role
+    }
+
+    pub fn into_inner(self) -> M {
+        self.inner
+    }
+}
+
+impl<T: HasTenantId + Clone + Send + Sync + 'static, M: Clone + Send + Sync + 'static> Deref
+    for Member<T, M>
+{
+    type Target = M;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T, M> FromRequestParts<AppState> for Member<T, M>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // 1. Resolve tenant (cached or fresh)
+        let tenant = resolve_tenant::<T>(parts, state)
+            .await?
+            .ok_or_else(|| Error::from(HttpError::NotFound))?;
+
+        // 2. Check member cache
+        if let Some(cached_member) = parts.extensions.get::<ResolvedMember<M>>() {
+            let role = parts
+                .extensions
+                .get::<ResolvedRole>()
+                .map(|r| r.0.clone())
+                .unwrap_or_default();
+            return Ok(Member {
+                tenant,
+                inner: (*cached_member.0).clone(),
+                role,
+            });
+        }
+
+        // 3. Get user_id from session
+        let session = SessionManager::from_request_parts(parts, state)
+            .await
+            .map_err(|_| Error::internal("Member<T, M> requires session middleware"))?;
+        let user_id = session
+            .user_id()
+            .await
+            .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
+
+        // 4. Look up member
+        let provider = state
+            .services
+            .get::<MemberProviderService<M, T>>()
+            .ok_or_else(|| {
+                Error::internal(format!(
+                    "MemberProviderService<{}, {}> not registered",
+                    std::any::type_name::<M>(),
+                    std::any::type_name::<T>()
+                ))
+            })?;
+
+        let member = provider
+            .find_member(&user_id, tenant.tenant_id())
+            .await?
+            .ok_or_else(|| Error::from(HttpError::Forbidden))?;
+
+        let role = provider.role(&member).to_string();
+
+        // 5. Cache
+        parts
+            .extensions
+            .insert(ResolvedMember(Arc::new(member.clone())));
+        parts.extensions.insert(ResolvedRole(role.clone()));
+
+        Ok(Member {
+            tenant,
+            inner: member,
+            role,
+        })
     }
 }
 
@@ -220,5 +340,32 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct TestMember {
+        user_id: String,
+        tenant_id: String,
+        role: String,
+    }
+
+    #[test]
+    fn member_accessors() {
+        let member = Member::<TestTenant, TestMember> {
+            tenant: TestTenant {
+                id: "t-1".to_string(),
+                name: "Acme".to_string(),
+            },
+            inner: TestMember {
+                user_id: "u-1".to_string(),
+                tenant_id: "t-1".to_string(),
+                role: "admin".to_string(),
+            },
+            role: "admin".to_string(),
+        };
+
+        assert_eq!(member.tenant().tenant_id(), "t-1");
+        assert_eq!(member.role(), "admin");
+        assert_eq!(member.user_id, "u-1"); // Deref to M
     }
 }

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -1,4 +1,4 @@
-use crate::cache::{ResolvedMember, ResolvedRole, ResolvedTenant};
+use crate::cache::{ResolvedMember, ResolvedRole, ResolvedTenant, ResolvedTenants};
 use crate::member::MemberProviderService;
 use crate::resolver::TenantResolverService;
 use crate::HasTenantId;
@@ -6,6 +6,7 @@ use modo::app::AppState;
 use modo::axum::extract::FromRequestParts;
 use modo::axum::http::request::Parts;
 use modo::{Error, HttpError};
+use modo_auth::UserProviderService;
 use modo_session::SessionManager;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -216,6 +217,124 @@ where
     }
 }
 
+/// Full tenant context — everything needed for authenticated tenant pages.
+pub struct TenantContext<
+    T: HasTenantId + Clone + Send + Sync + 'static,
+    M: Clone + Send + Sync + 'static,
+    U: Clone + Send + Sync + 'static,
+> {
+    tenant: T,
+    member: M,
+    user: U,
+    tenants: Vec<T>,
+    role: String,
+}
+
+impl<T: HasTenantId + Clone + Send + Sync, M: Clone + Send + Sync, U: Clone + Send + Sync> Clone
+    for TenantContext<T, M, U>
+{
+    fn clone(&self) -> Self {
+        Self {
+            tenant: self.tenant.clone(),
+            member: self.member.clone(),
+            user: self.user.clone(),
+            tenants: self.tenants.clone(),
+            role: self.role.clone(),
+        }
+    }
+}
+
+impl<T: HasTenantId + Clone + Send + Sync, M: Clone + Send + Sync, U: Clone + Send + Sync>
+    TenantContext<T, M, U>
+{
+    pub fn tenant(&self) -> &T {
+        &self.tenant
+    }
+
+    pub fn member(&self) -> &M {
+        &self.member
+    }
+
+    pub fn user(&self) -> &U {
+        &self.user
+    }
+
+    pub fn tenants(&self) -> &[T] {
+        &self.tenants
+    }
+
+    pub fn role(&self) -> &str {
+        &self.role
+    }
+}
+
+impl<T, M, U> FromRequestParts<AppState> for TenantContext<T, M, U>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+    U: Clone + Send + Sync + 'static,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // Resolve member (which resolves tenant internally)
+        let member_ext = Member::<T, M>::from_request_parts(parts, state).await?;
+
+        // Load user
+        let session = SessionManager::from_request_parts(parts, state)
+            .await
+            .map_err(|_| Error::internal("TenantContext requires session middleware"))?;
+        let user_id = session
+            .user_id()
+            .await
+            .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
+
+        let user_provider = state
+            .services
+            .get::<UserProviderService<U>>()
+            .ok_or_else(|| {
+                Error::internal(format!(
+                    "UserProviderService<{}> not registered",
+                    std::any::type_name::<U>()
+                ))
+            })?;
+        let user = user_provider
+            .find_by_id(&user_id)
+            .await?
+            .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
+
+        // Load tenants list (cached or fresh)
+        let tenants = if let Some(cached) = parts.extensions.get::<ResolvedTenants<T>>() {
+            (*cached.0).clone()
+        } else {
+            let provider = state
+                .services
+                .get::<MemberProviderService<M, T>>()
+                .ok_or_else(|| Error::internal("MemberProviderService not registered"))?;
+            let list = provider.list_tenants(&user_id).await?;
+            parts
+                .extensions
+                .insert(ResolvedTenants(Arc::new(list.clone())));
+            list
+        };
+
+        Ok(TenantContext {
+            tenant: member_ext.tenant.clone(),
+            member: member_ext.into_inner(),
+            user,
+            tenants,
+            role: parts
+                .extensions
+                .get::<ResolvedRole>()
+                .map(|r| r.0.clone())
+                .unwrap_or_default(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,6 +466,42 @@ mod tests {
         user_id: String,
         tenant_id: String,
         role: String,
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct TestUser {
+        id: String,
+        name: String,
+    }
+
+    #[test]
+    fn tenant_context_accessors() {
+        let ctx = TenantContext::<TestTenant, TestMember, TestUser> {
+            tenant: TestTenant {
+                id: "t-1".to_string(),
+                name: "Acme".to_string(),
+            },
+            member: TestMember {
+                user_id: "u-1".to_string(),
+                tenant_id: "t-1".to_string(),
+                role: "admin".to_string(),
+            },
+            user: TestUser {
+                id: "u-1".to_string(),
+                name: "Alice".to_string(),
+            },
+            tenants: vec![TestTenant {
+                id: "t-1".to_string(),
+                name: "Acme".to_string(),
+            }],
+            role: "admin".to_string(),
+        };
+
+        assert_eq!(ctx.tenant().tenant_id(), "t-1");
+        assert_eq!(ctx.member().user_id, "u-1");
+        assert_eq!(ctx.user().name, "Alice");
+        assert_eq!(ctx.tenants().len(), 1);
+        assert_eq!(ctx.role(), "admin");
     }
 
     #[test]

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -282,12 +282,7 @@ where
         let member_ext = Member::<T, M>::from_request_parts(parts, state).await?;
 
         // Load user
-        let session = SessionManager::from_request_parts(parts, state)
-            .await
-            .map_err(|_| Error::internal("TenantContext requires session middleware"))?;
-        let user_id = session
-            .user_id()
-            .await
+        let user_id = modo_session::user_id_from_extensions(&parts.extensions)
             .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
 
         let user_provider = state
@@ -519,5 +514,71 @@ mod tests {
         assert_eq!(member.tenant().tenant_id(), "t-1");
         assert_eq!(member.role(), "admin");
         assert_eq!(member.user_id, "u-1"); // Deref to M
+    }
+
+    #[tokio::test]
+    async fn member_extractor_returns_cached_member() {
+        use crate::cache::{ResolvedMember, ResolvedRole};
+        use crate::member::MemberProviderService;
+
+        // Dummy member provider (never called — cache hit path)
+        struct NoOpMemberProvider;
+        impl crate::member::MemberProvider for NoOpMemberProvider {
+            type Member = TestMember;
+            type Tenant = TestTenant;
+
+            async fn find_member(
+                &self,
+                _user_id: &str,
+                _tenant_id: &str,
+            ) -> Result<Option<Self::Member>, modo::Error> {
+                panic!("should not be called on cache hit");
+            }
+
+            async fn list_tenants(&self, _user_id: &str) -> Result<Vec<Self::Tenant>, modo::Error> {
+                panic!("should not be called on cache hit");
+            }
+
+            fn role<'a>(&'a self, member: &'a Self::Member) -> &'a str {
+                &member.role
+            }
+        }
+
+        let services = ServiceRegistry::new()
+            .with(TenantResolverService::new(TestResolver))
+            .with(MemberProviderService::new(NoOpMemberProvider));
+        let state = AppState {
+            services,
+            server_config: Default::default(),
+            cookie_key: axum_extra::extract::cookie::Key::generate(),
+        };
+
+        let app = Router::new()
+            .route(
+                "/",
+                get(|member: Member<TestTenant, TestMember>| async move {
+                    format!("{}:{}", member.user_id, member.role())
+                }),
+            )
+            .with_state(state);
+
+        let cached_member = TestMember {
+            user_id: "u-1".to_string(),
+            tenant_id: "t-1".to_string(),
+            role: "admin".to_string(),
+        };
+
+        let mut req = Request::builder()
+            .header("host", "acme.test.com")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut()
+            .insert(ResolvedMember(Arc::new(cached_member)));
+        req.extensions_mut()
+            .insert(ResolvedRole("admin".to_string()));
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/modo-tenant/src/guard.rs
+++ b/modo-tenant/src/guard.rs
@@ -1,7 +1,7 @@
+use crate::HasTenantId;
 use crate::cache::{ResolvedMember, ResolvedRole, ResolvedTenant};
 use crate::member::MemberProviderService;
 use crate::resolver::TenantResolverService;
-use crate::HasTenantId;
 use modo::{Error, HttpError};
 use std::sync::Arc;
 
@@ -89,8 +89,8 @@ pub fn require_roles<T, M>(
 ) -> std::pin::Pin<
     Box<dyn std::future::Future<Output = modo::axum::response::Response> + Send>,
 > + Clone
-       + Send
-       + Sync
++ Send
++ Sync
 where
     T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
     M: Clone + Send + Sync + serde::Serialize + 'static,
@@ -119,7 +119,7 @@ where
                     (Some(t), Some(m)) => (t, m),
                     _ => {
                         return Error::internal("Role guard: services not registered")
-                            .into_response()
+                            .into_response();
                     }
                 }
             } else {
@@ -150,8 +150,8 @@ pub fn exclude_roles<T, M>(
 ) -> std::pin::Pin<
     Box<dyn std::future::Future<Output = modo::axum::response::Response> + Send>,
 > + Clone
-       + Send
-       + Sync
++ Send
++ Sync
 where
     T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
     M: Clone + Send + Sync + serde::Serialize + 'static,
@@ -172,7 +172,7 @@ where
                     (Some(t), Some(m)) => (t, m),
                     _ => {
                         return Error::internal("Role guard: services not registered")
-                            .into_response()
+                            .into_response();
                     }
                 }
             } else {
@@ -206,19 +206,13 @@ mod tests {
     #[test]
     fn allowed_rejects_non_matching_role() {
         let err = check_allowed("viewer", &["admin", "owner"]).unwrap_err();
-        assert_eq!(
-            err.status_code(),
-            modo::axum::http::StatusCode::FORBIDDEN
-        );
+        assert_eq!(err.status_code(), modo::axum::http::StatusCode::FORBIDDEN);
     }
 
     #[test]
     fn denied_blocks_matching_role() {
         let err = check_denied("viewer", &["viewer"]).unwrap_err();
-        assert_eq!(
-            err.status_code(),
-            modo::axum::http::StatusCode::FORBIDDEN
-        );
+        assert_eq!(err.status_code(), modo::axum::http::StatusCode::FORBIDDEN);
     }
 
     #[test]

--- a/modo-tenant/src/guard.rs
+++ b/modo-tenant/src/guard.rs
@@ -75,10 +75,12 @@ where
 
 /// Middleware function: allow only specified roles.
 ///
-/// Usage with modo handler macro:
+/// Reads `AppState` from request extensions (injected by modo's global middleware).
+///
+/// Usage:
 /// ```ignore
+/// #[allow_roles(MyTenant, MyMember, "admin", "owner")]
 /// #[modo::handler(GET, "/admin")]
-/// #[middleware(modo_tenant::guard::require_roles::<MyTenant, MyMember>(&["admin", "owner"]))]
 /// async fn admin_page() -> &'static str { "admin" }
 /// ```
 pub fn require_roles<T, M>(
@@ -102,17 +104,15 @@ where
         Box::pin(async move {
             let (mut parts, body) = req.into_parts();
 
-            let state = parts
-                .extensions
-                .get::<modo::app::AppState>()
-                .cloned()
-                .or_else(|| {
-                    // Try to get from the extensions that axum injects
-                    None
-                });
+            let state = match parts.extensions.get::<modo::app::AppState>().cloned() {
+                Some(s) => s,
+                None => {
+                    return Error::internal("Role guard: AppState not in extensions")
+                        .into_response();
+                }
+            };
 
-            // Get services from state or extensions
-            let (tenant_svc, member_svc) = if let Some(ref state) = state {
+            let (tenant_svc, member_svc) = {
                 let t = state.services.get::<TenantResolverService<T>>();
                 let m = state.services.get::<MemberProviderService<M, T>>();
                 match (t, m) {
@@ -122,8 +122,6 @@ where
                             .into_response();
                     }
                 }
-            } else {
-                return Error::internal("Role guard: AppState not available").into_response();
             };
 
             match resolve_role::<T, M>(&mut parts.extensions, &tenant_svc, &member_svc).await {
@@ -142,6 +140,15 @@ where
 }
 
 /// Middleware function: deny specified roles.
+///
+/// Reads `AppState` from request extensions (injected by modo's global middleware).
+///
+/// Usage:
+/// ```ignore
+/// #[deny_roles(MyTenant, MyMember, "viewer")]
+/// #[modo::handler(GET, "/admin")]
+/// async fn admin_page() -> &'static str { "admin" }
+/// ```
 pub fn exclude_roles<T, M>(
     roles: &'static [&'static str],
 ) -> impl Fn(
@@ -163,9 +170,15 @@ where
         Box::pin(async move {
             let (mut parts, body) = req.into_parts();
 
-            let state = parts.extensions.get::<modo::app::AppState>().cloned();
+            let state = match parts.extensions.get::<modo::app::AppState>().cloned() {
+                Some(s) => s,
+                None => {
+                    return Error::internal("Role guard: AppState not in extensions")
+                        .into_response();
+                }
+            };
 
-            let (tenant_svc, member_svc) = if let Some(ref state) = state {
+            let (tenant_svc, member_svc) = {
                 let t = state.services.get::<TenantResolverService<T>>();
                 let m = state.services.get::<MemberProviderService<M, T>>();
                 match (t, m) {
@@ -175,8 +188,6 @@ where
                             .into_response();
                     }
                 }
-            } else {
-                return Error::internal("Role guard: AppState not available").into_response();
             };
 
             match resolve_role::<T, M>(&mut parts.extensions, &tenant_svc, &member_svc).await {
@@ -197,6 +208,16 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::TenantResolver;
+    use crate::cache::ResolvedTenant;
+    use crate::member::MemberProvider;
+    use crate::resolver::TenantResolverService;
+    use modo::app::{AppState, ServiceRegistry};
+    use modo::axum::Router;
+    use modo::axum::body::Body;
+    use modo::axum::http::{Request, StatusCode};
+    use modo::axum::routing::get;
+    use tower::ServiceExt;
 
     #[test]
     fn allowed_passes_matching_role() {
@@ -206,17 +227,158 @@ mod tests {
     #[test]
     fn allowed_rejects_non_matching_role() {
         let err = check_allowed("viewer", &["admin", "owner"]).unwrap_err();
-        assert_eq!(err.status_code(), modo::axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(err.status_code(), StatusCode::FORBIDDEN);
     }
 
     #[test]
     fn denied_blocks_matching_role() {
         let err = check_denied("viewer", &["viewer"]).unwrap_err();
-        assert_eq!(err.status_code(), modo::axum::http::StatusCode::FORBIDDEN);
+        assert_eq!(err.status_code(), StatusCode::FORBIDDEN);
     }
 
     #[test]
     fn denied_passes_non_matching_role() {
         assert!(check_denied("admin", &["viewer"]).is_ok());
+    }
+
+    // -- Integration test types --
+
+    #[derive(Clone, Debug, serde::Serialize)]
+    struct TestTenant {
+        id: String,
+    }
+
+    impl crate::HasTenantId for TestTenant {
+        fn tenant_id(&self) -> &str {
+            &self.id
+        }
+    }
+
+    #[derive(Clone, Debug, serde::Serialize)]
+    struct TestMember {
+        role: String,
+    }
+
+    struct TestResolver;
+
+    impl TenantResolver for TestResolver {
+        type Tenant = TestTenant;
+
+        async fn resolve(
+            &self,
+            _parts: &modo::axum::http::request::Parts,
+        ) -> Result<Option<Self::Tenant>, modo::Error> {
+            Ok(None)
+        }
+    }
+
+    struct TestMemberProvider;
+
+    impl MemberProvider for TestMemberProvider {
+        type Member = TestMember;
+        type Tenant = TestTenant;
+
+        async fn find_member(
+            &self,
+            _user_id: &str,
+            _tenant_id: &str,
+        ) -> Result<Option<Self::Member>, modo::Error> {
+            Ok(None)
+        }
+
+        async fn list_tenants(&self, _user_id: &str) -> Result<Vec<Self::Tenant>, modo::Error> {
+            Ok(vec![])
+        }
+
+        fn role<'a>(&'a self, member: &'a Self::Member) -> &'a str {
+            &member.role
+        }
+    }
+
+    fn test_state() -> AppState {
+        let services = ServiceRegistry::new()
+            .with(TenantResolverService::new(TestResolver))
+            .with(MemberProviderService::new(TestMemberProvider));
+        AppState {
+            services,
+            server_config: Default::default(),
+            cookie_key: axum_extra::extract::cookie::Key::generate(),
+        }
+    }
+
+    /// Build a request with AppState, ResolvedRole, and ResolvedTenant pre-populated.
+    fn test_request(state: &AppState, role: &str) -> Request<Body> {
+        let mut req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        req.extensions_mut().insert(state.clone());
+        req.extensions_mut().insert(ResolvedRole(role.to_string()));
+        req.extensions_mut()
+            .insert(ResolvedTenant(Arc::new(TestTenant {
+                id: "t-1".to_string(),
+            })));
+        req
+    }
+
+    #[tokio::test]
+    async fn require_roles_middleware_allows_matching_role() {
+        let state = test_state();
+        let app = Router::<AppState>::new()
+            .route("/", get(|| async { "ok" }))
+            .route_layer(modo::axum::middleware::from_fn(require_roles::<
+                TestTenant,
+                TestMember,
+            >(&[
+                "admin", "owner",
+            ])))
+            .with_state(state.clone());
+
+        let resp = app.oneshot(test_request(&state, "admin")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn require_roles_middleware_rejects_non_matching_role() {
+        let state = test_state();
+        let app = Router::<AppState>::new()
+            .route("/", get(|| async { "ok" }))
+            .route_layer(modo::axum::middleware::from_fn(require_roles::<
+                TestTenant,
+                TestMember,
+            >(&[
+                "admin", "owner",
+            ])))
+            .with_state(state.clone());
+
+        let resp = app.oneshot(test_request(&state, "viewer")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn exclude_roles_middleware_allows_non_matching_role() {
+        let state = test_state();
+        let app = Router::<AppState>::new()
+            .route("/", get(|| async { "ok" }))
+            .route_layer(modo::axum::middleware::from_fn(exclude_roles::<
+                TestTenant,
+                TestMember,
+            >(&["viewer"])))
+            .with_state(state.clone());
+
+        let resp = app.oneshot(test_request(&state, "admin")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn exclude_roles_middleware_rejects_matching_role() {
+        let state = test_state();
+        let app = Router::<AppState>::new()
+            .route("/", get(|| async { "ok" }))
+            .route_layer(modo::axum::middleware::from_fn(exclude_roles::<
+                TestTenant,
+                TestMember,
+            >(&["viewer"])))
+            .with_state(state.clone());
+
+        let resp = app.oneshot(test_request(&state, "viewer")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/modo-tenant/src/guard.rs
+++ b/modo-tenant/src/guard.rs
@@ -1,0 +1,228 @@
+use crate::cache::{ResolvedMember, ResolvedRole, ResolvedTenant};
+use crate::member::MemberProviderService;
+use crate::resolver::TenantResolverService;
+use crate::HasTenantId;
+use modo::{Error, HttpError};
+use std::sync::Arc;
+
+/// Check that the resolved role is in the allowed list.
+pub fn check_allowed(role: &str, allowed: &[&str]) -> Result<(), Error> {
+    if allowed.contains(&role) {
+        Ok(())
+    } else {
+        Err(HttpError::Forbidden.into())
+    }
+}
+
+/// Check that the resolved role is NOT in the denied list.
+pub fn check_denied(role: &str, denied: &[&str]) -> Result<(), Error> {
+    if denied.contains(&role) {
+        Err(HttpError::Forbidden.into())
+    } else {
+        Ok(())
+    }
+}
+
+/// Resolve the current user's role for the current tenant from request extensions.
+///
+/// Checks cached `ResolvedRole` first, then resolves tenant + member if needed.
+/// Requires session middleware and both `TenantResolverService` and `MemberProviderService`
+/// to be registered.
+pub async fn resolve_role<T, M>(
+    extensions: &mut http::Extensions,
+    _tenant_svc: &TenantResolverService<T>,
+    member_svc: &MemberProviderService<M, T>,
+) -> Result<String, Error>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    // Check cache first
+    if let Some(cached) = extensions.get::<ResolvedRole>() {
+        return Ok(cached.0.clone());
+    }
+
+    // Resolve tenant
+    let tenant = if let Some(cached) = extensions.get::<ResolvedTenant<T>>() {
+        (*cached.0).clone()
+    } else {
+        // Build temporary Parts for the resolver
+        // We can't call resolve on extensions alone — need request parts.
+        // This path should rarely hit since TenantContextLayer/extractors cache the tenant.
+        return Err(Error::internal(
+            "Role guard requires tenant to be resolved first (use Tenant<T> extractor or TenantContextLayer)",
+        ));
+    };
+
+    // Get user_id from session
+    let user_id = modo_session::user_id_from_extensions(extensions)
+        .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
+
+    // Resolve member
+    let member = member_svc
+        .find_member(&user_id, tenant.tenant_id())
+        .await?
+        .ok_or_else(|| Error::from(HttpError::Forbidden))?;
+
+    let role = member_svc.role(&member).to_string();
+
+    // Cache
+    extensions.insert(ResolvedMember(Arc::new(member)));
+    extensions.insert(ResolvedRole(role.clone()));
+
+    Ok(role)
+}
+
+/// Middleware function: allow only specified roles.
+///
+/// Usage with modo handler macro:
+/// ```ignore
+/// #[modo::handler(GET, "/admin")]
+/// #[middleware(modo_tenant::guard::require_roles::<MyTenant, MyMember>(&["admin", "owner"]))]
+/// async fn admin_page() -> &'static str { "admin" }
+/// ```
+pub fn require_roles<T, M>(
+    roles: &'static [&'static str],
+) -> impl Fn(
+    modo::axum::http::Request<modo::axum::body::Body>,
+    modo::axum::middleware::Next,
+) -> std::pin::Pin<
+    Box<dyn std::future::Future<Output = modo::axum::response::Response> + Send>,
+> + Clone
+       + Send
+       + Sync
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    use modo::axum::response::IntoResponse;
+
+    move |req: modo::axum::http::Request<modo::axum::body::Body>,
+          next: modo::axum::middleware::Next| {
+        Box::pin(async move {
+            let (mut parts, body) = req.into_parts();
+
+            let state = parts
+                .extensions
+                .get::<modo::app::AppState>()
+                .cloned()
+                .or_else(|| {
+                    // Try to get from the extensions that axum injects
+                    None
+                });
+
+            // Get services from state or extensions
+            let (tenant_svc, member_svc) = if let Some(ref state) = state {
+                let t = state.services.get::<TenantResolverService<T>>();
+                let m = state.services.get::<MemberProviderService<M, T>>();
+                match (t, m) {
+                    (Some(t), Some(m)) => (t, m),
+                    _ => {
+                        return Error::internal("Role guard: services not registered")
+                            .into_response()
+                    }
+                }
+            } else {
+                return Error::internal("Role guard: AppState not available").into_response();
+            };
+
+            match resolve_role::<T, M>(&mut parts.extensions, &tenant_svc, &member_svc).await {
+                Ok(role) => {
+                    if let Err(e) = check_allowed(&role, roles) {
+                        return e.into_response();
+                    }
+                }
+                Err(e) => return e.into_response(),
+            }
+
+            let req = modo::axum::http::Request::from_parts(parts, body);
+            next.run(req).await
+        })
+    }
+}
+
+/// Middleware function: deny specified roles.
+pub fn exclude_roles<T, M>(
+    roles: &'static [&'static str],
+) -> impl Fn(
+    modo::axum::http::Request<modo::axum::body::Body>,
+    modo::axum::middleware::Next,
+) -> std::pin::Pin<
+    Box<dyn std::future::Future<Output = modo::axum::response::Response> + Send>,
+> + Clone
+       + Send
+       + Sync
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    M: Clone + Send + Sync + serde::Serialize + 'static,
+{
+    use modo::axum::response::IntoResponse;
+
+    move |req: modo::axum::http::Request<modo::axum::body::Body>,
+          next: modo::axum::middleware::Next| {
+        Box::pin(async move {
+            let (mut parts, body) = req.into_parts();
+
+            let state = parts.extensions.get::<modo::app::AppState>().cloned();
+
+            let (tenant_svc, member_svc) = if let Some(ref state) = state {
+                let t = state.services.get::<TenantResolverService<T>>();
+                let m = state.services.get::<MemberProviderService<M, T>>();
+                match (t, m) {
+                    (Some(t), Some(m)) => (t, m),
+                    _ => {
+                        return Error::internal("Role guard: services not registered")
+                            .into_response()
+                    }
+                }
+            } else {
+                return Error::internal("Role guard: AppState not available").into_response();
+            };
+
+            match resolve_role::<T, M>(&mut parts.extensions, &tenant_svc, &member_svc).await {
+                Ok(role) => {
+                    if let Err(e) = check_denied(&role, roles) {
+                        return e.into_response();
+                    }
+                }
+                Err(e) => return e.into_response(),
+            }
+
+            let req = modo::axum::http::Request::from_parts(parts, body);
+            next.run(req).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowed_passes_matching_role() {
+        assert!(check_allowed("admin", &["admin", "owner"]).is_ok());
+    }
+
+    #[test]
+    fn allowed_rejects_non_matching_role() {
+        let err = check_allowed("viewer", &["admin", "owner"]).unwrap_err();
+        assert_eq!(
+            err.status_code(),
+            modo::axum::http::StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn denied_blocks_matching_role() {
+        let err = check_denied("viewer", &["viewer"]).unwrap_err();
+        assert_eq!(
+            err.status_code(),
+            modo::axum::http::StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn denied_passes_non_matching_role() {
+        assert!(check_denied("admin", &["viewer"]).is_ok());
+    }
+}

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -3,6 +3,6 @@ pub mod extractor;
 pub mod member;
 pub mod resolver;
 
-pub use extractor::{Member, OptionalTenant, Tenant};
+pub use extractor::{Member, OptionalTenant, Tenant, TenantContext};
 pub use member::{MemberProvider, MemberProviderService};
 pub use resolver::{HasTenantId, TenantResolver, TenantResolverService};

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod resolver;
 
-pub use resolver::HasTenantId;
+pub use resolver::{HasTenantId, TenantResolver, TenantResolverService};

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod resolver;
+
+pub use resolver::HasTenantId;

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -3,6 +3,6 @@ pub mod extractor;
 pub mod member;
 pub mod resolver;
 
-pub use extractor::{OptionalTenant, Tenant};
+pub use extractor::{Member, OptionalTenant, Tenant};
 pub use member::{MemberProvider, MemberProviderService};
 pub use resolver::{HasTenantId, TenantResolver, TenantResolverService};

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -1,5 +1,8 @@
+pub mod cache;
+pub mod extractor;
 pub mod member;
 pub mod resolver;
 
+pub use extractor::{OptionalTenant, Tenant};
 pub use member::{MemberProvider, MemberProviderService};
 pub use resolver::{HasTenantId, TenantResolver, TenantResolverService};

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -2,7 +2,9 @@ pub mod cache;
 pub mod extractor;
 pub mod member;
 pub mod resolver;
+pub mod resolvers;
 
 pub use extractor::{Member, OptionalTenant, Tenant, TenantContext};
 pub use member::{MemberProvider, MemberProviderService};
 pub use resolver::{HasTenantId, TenantResolver, TenantResolverService};
+pub use resolvers::{HeaderResolver, PathPrefixResolver, SubdomainResolver};

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod member;
 pub mod resolver;
 
+pub use member::{MemberProvider, MemberProviderService};
 pub use resolver::{HasTenantId, TenantResolver, TenantResolverService};

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod cache;
 pub mod extractor;
+pub mod guard;
 pub mod member;
 pub mod resolver;
 pub mod resolvers;
 
 pub use extractor::{Member, OptionalTenant, Tenant, TenantContext};
 pub use member::{MemberProvider, MemberProviderService};
+pub use modo_tenant_macros::{allow_roles, deny_roles};
 pub use resolver::{HasTenantId, TenantResolver, TenantResolverService};
 pub use resolvers::{HeaderResolver, PathPrefixResolver, SubdomainResolver};

--- a/modo-tenant/src/lib.rs
+++ b/modo-tenant/src/lib.rs
@@ -1,10 +1,14 @@
 pub mod cache;
+#[cfg(feature = "templates")]
+pub mod context_layer;
 pub mod extractor;
 pub mod guard;
 pub mod member;
 pub mod resolver;
 pub mod resolvers;
 
+#[cfg(feature = "templates")]
+pub use context_layer::TenantContextLayer;
 pub use extractor::{Member, OptionalTenant, Tenant, TenantContext};
 pub use member::{MemberProvider, MemberProviderService};
 pub use modo_tenant_macros::{allow_roles, deny_roles};

--- a/modo-tenant/src/member.rs
+++ b/modo-tenant/src/member.rs
@@ -147,10 +147,7 @@ mod tests {
             }
         }
 
-        async fn list_tenants(
-            &self,
-            user_id: &str,
-        ) -> Result<Vec<Self::Tenant>, modo::Error> {
+        async fn list_tenants(&self, user_id: &str) -> Result<Vec<Self::Tenant>, modo::Error> {
             if user_id == "u-1" {
                 Ok(vec![
                     TestTenant {

--- a/modo-tenant/src/member.rs
+++ b/modo-tenant/src/member.rs
@@ -1,0 +1,204 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Loads membership records and tenant lists for a user.
+pub trait MemberProvider: Send + Sync + 'static {
+    type Member: Clone + Send + Sync + serde::Serialize + 'static;
+    type Tenant: Clone + Send + Sync + crate::HasTenantId + serde::Serialize + 'static;
+
+    fn find_member(
+        &self,
+        user_id: &str,
+        tenant_id: &str,
+    ) -> impl Future<Output = Result<Option<Self::Member>, modo::Error>> + Send;
+
+    fn list_tenants(
+        &self,
+        user_id: &str,
+    ) -> impl Future<Output = Result<Vec<Self::Tenant>, modo::Error>> + Send;
+
+    fn role<'a>(&'a self, member: &'a Self::Member) -> &'a str;
+}
+
+// Object-safe bridge
+trait MemberProviderDyn<M, T>: Send + Sync {
+    fn find_member<'a>(
+        &'a self,
+        user_id: &'a str,
+        tenant_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<M>, modo::Error>> + Send + 'a>>;
+
+    fn list_tenants<'a>(
+        &'a self,
+        user_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<T>, modo::Error>> + Send + 'a>>;
+
+    fn role<'a>(&'a self, member: &'a M) -> &'a str;
+}
+
+impl<P: MemberProvider> MemberProviderDyn<P::Member, P::Tenant> for P {
+    fn find_member<'a>(
+        &'a self,
+        user_id: &'a str,
+        tenant_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<P::Member>, modo::Error>> + Send + 'a>> {
+        Box::pin(MemberProvider::find_member(self, user_id, tenant_id))
+    }
+
+    fn list_tenants<'a>(
+        &'a self,
+        user_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<P::Tenant>, modo::Error>> + Send + 'a>> {
+        Box::pin(MemberProvider::list_tenants(self, user_id))
+    }
+
+    fn role<'a>(&'a self, member: &'a P::Member) -> &'a str {
+        MemberProvider::role(self, member)
+    }
+}
+
+/// Type-erased wrapper stored in the service registry.
+pub struct MemberProviderService<M: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static>
+{
+    inner: Arc<dyn MemberProviderDyn<M, T>>,
+}
+
+impl<M: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> Clone
+    for MemberProviderService<M, T>
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<M: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static>
+    MemberProviderService<M, T>
+{
+    pub fn new<P: MemberProvider<Member = M, Tenant = T>>(provider: P) -> Self {
+        Self {
+            inner: Arc::new(provider),
+        }
+    }
+
+    pub async fn find_member(
+        &self,
+        user_id: &str,
+        tenant_id: &str,
+    ) -> Result<Option<M>, modo::Error> {
+        self.inner.find_member(user_id, tenant_id).await
+    }
+
+    pub async fn list_tenants(&self, user_id: &str) -> Result<Vec<T>, modo::Error> {
+        self.inner.list_tenants(user_id).await
+    }
+
+    pub fn role<'a>(&'a self, member: &'a M) -> &'a str {
+        self.inner.role(member)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct TestMember {
+        user_id: String,
+        tenant_id: String,
+        role: String,
+    }
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct TestTenant {
+        id: String,
+        name: String,
+    }
+
+    impl crate::HasTenantId for TestTenant {
+        fn tenant_id(&self) -> &str {
+            &self.id
+        }
+    }
+
+    struct TestMemberProvider;
+
+    impl MemberProvider for TestMemberProvider {
+        type Member = TestMember;
+        type Tenant = TestTenant;
+
+        async fn find_member(
+            &self,
+            user_id: &str,
+            tenant_id: &str,
+        ) -> Result<Option<Self::Member>, modo::Error> {
+            if user_id == "u-1" && tenant_id == "t-1" {
+                Ok(Some(TestMember {
+                    user_id: "u-1".to_string(),
+                    tenant_id: "t-1".to_string(),
+                    role: "admin".to_string(),
+                }))
+            } else if user_id == "error" {
+                Err(modo::Error::internal("db error"))
+            } else {
+                Ok(None)
+            }
+        }
+
+        async fn list_tenants(
+            &self,
+            user_id: &str,
+        ) -> Result<Vec<Self::Tenant>, modo::Error> {
+            if user_id == "u-1" {
+                Ok(vec![
+                    TestTenant {
+                        id: "t-1".to_string(),
+                        name: "Acme".to_string(),
+                    },
+                    TestTenant {
+                        id: "t-2".to_string(),
+                        name: "Beta".to_string(),
+                    },
+                ])
+            } else {
+                Ok(vec![])
+            }
+        }
+
+        fn role<'a>(&'a self, member: &'a Self::Member) -> &'a str {
+            &member.role
+        }
+    }
+
+    #[tokio::test]
+    async fn member_provider_finds_member() {
+        let svc = MemberProviderService::new(TestMemberProvider);
+        let member = svc.find_member("u-1", "t-1").await.unwrap();
+        assert!(member.is_some());
+        let m = member.unwrap();
+        assert_eq!(svc.role(&m), "admin");
+    }
+
+    #[tokio::test]
+    async fn member_provider_returns_none_for_non_member() {
+        let svc = MemberProviderService::new(TestMemberProvider);
+        let member = svc.find_member("u-1", "t-999").await.unwrap();
+        assert!(member.is_none());
+    }
+
+    #[tokio::test]
+    async fn member_provider_lists_tenants() {
+        let svc = MemberProviderService::new(TestMemberProvider);
+        let tenants = svc.list_tenants("u-1").await.unwrap();
+        assert_eq!(tenants.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn member_provider_propagates_errors() {
+        let svc = MemberProviderService::new(TestMemberProvider);
+        let result = svc.find_member("error", "t-1").await;
+        assert!(result.is_err());
+    }
+}

--- a/modo-tenant/src/resolver.rs
+++ b/modo-tenant/src/resolver.rs
@@ -1,0 +1,4 @@
+/// Trait that tenant types must implement to expose their ID.
+pub trait HasTenantId {
+    fn tenant_id(&self) -> &str;
+}

--- a/modo-tenant/src/resolver.rs
+++ b/modo-tenant/src/resolver.rs
@@ -1,4 +1,145 @@
+use modo::axum::http::request::Parts;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
 /// Trait that tenant types must implement to expose their ID.
 pub trait HasTenantId {
     fn tenant_id(&self) -> &str;
+}
+
+/// Pluggable tenant resolution from HTTP request parts.
+pub trait TenantResolver: Send + Sync + 'static {
+    type Tenant: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static;
+
+    fn resolve(
+        &self,
+        parts: &Parts,
+    ) -> impl Future<Output = Result<Option<Self::Tenant>, modo::Error>> + Send;
+}
+
+// Object-safe bridge trait for type erasure
+trait TenantResolverDyn<T>: Send + Sync {
+    fn resolve<'a>(
+        &'a self,
+        parts: &'a Parts,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<T>, modo::Error>> + Send + 'a>>;
+}
+
+impl<R: TenantResolver> TenantResolverDyn<R::Tenant> for R {
+    fn resolve<'a>(
+        &'a self,
+        parts: &'a Parts,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<R::Tenant>, modo::Error>> + Send + 'a>> {
+        Box::pin(TenantResolver::resolve(self, parts))
+    }
+}
+
+/// Type-erased wrapper stored in the service registry.
+pub struct TenantResolverService<T: Clone + Send + Sync + 'static> {
+    inner: Arc<dyn TenantResolverDyn<T>>,
+}
+
+impl<T: Clone + Send + Sync + 'static> Clone for TenantResolverService<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T: Clone + Send + Sync + 'static> TenantResolverService<T> {
+    pub fn new<R: TenantResolver<Tenant = T>>(resolver: R) -> Self {
+        Self {
+            inner: Arc::new(resolver),
+        }
+    }
+
+    pub async fn resolve(&self, parts: &Parts) -> Result<Option<T>, modo::Error> {
+        self.inner.resolve(parts).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use modo::axum::http::request::Parts;
+    use modo::axum::http::Request;
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct TestTenant {
+        id: String,
+        name: String,
+    }
+
+    impl HasTenantId for TestTenant {
+        fn tenant_id(&self) -> &str {
+            &self.id
+        }
+    }
+
+    struct TestResolver;
+
+    impl TenantResolver for TestResolver {
+        type Tenant = TestTenant;
+
+        async fn resolve(
+            &self,
+            parts: &Parts,
+        ) -> Result<Option<Self::Tenant>, modo::Error> {
+            let host = parts
+                .headers
+                .get("host")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            if host == "acme.test.com" {
+                Ok(Some(TestTenant {
+                    id: "t-1".to_string(),
+                    name: "Acme".to_string(),
+                }))
+            } else if host == "error.test.com" {
+                Err(modo::Error::internal("db error"))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    fn test_parts(host: &str) -> Parts {
+        let req = Request::builder()
+            .header("host", host)
+            .body(())
+            .unwrap();
+        req.into_parts().0
+    }
+
+    #[tokio::test]
+    async fn resolver_service_finds_tenant() {
+        let svc = TenantResolverService::new(TestResolver);
+        let parts = test_parts("acme.test.com");
+        let tenant = svc.resolve(&parts).await.unwrap();
+        assert_eq!(
+            tenant,
+            Some(TestTenant {
+                id: "t-1".to_string(),
+                name: "Acme".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn resolver_service_returns_none_for_unknown() {
+        let svc = TenantResolverService::new(TestResolver);
+        let parts = test_parts("unknown.test.com");
+        let tenant = svc.resolve(&parts).await.unwrap();
+        assert_eq!(tenant, None);
+    }
+
+    #[tokio::test]
+    async fn resolver_service_propagates_errors() {
+        let svc = TenantResolverService::new(TestResolver);
+        let parts = test_parts("error.test.com");
+        let result = svc.resolve(&parts).await;
+        assert!(result.is_err());
+    }
 }

--- a/modo-tenant/src/resolver.rs
+++ b/modo-tenant/src/resolver.rs
@@ -63,8 +63,8 @@ impl<T: Clone + Send + Sync + 'static> TenantResolverService<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use modo::axum::http::request::Parts;
     use modo::axum::http::Request;
+    use modo::axum::http::request::Parts;
 
     #[derive(Clone, Debug, PartialEq, serde::Serialize)]
     struct TestTenant {
@@ -83,10 +83,7 @@ mod tests {
     impl TenantResolver for TestResolver {
         type Tenant = TestTenant;
 
-        async fn resolve(
-            &self,
-            parts: &Parts,
-        ) -> Result<Option<Self::Tenant>, modo::Error> {
+        async fn resolve(&self, parts: &Parts) -> Result<Option<Self::Tenant>, modo::Error> {
             let host = parts
                 .headers
                 .get("host")
@@ -106,10 +103,7 @@ mod tests {
     }
 
     fn test_parts(host: &str) -> Parts {
-        let req = Request::builder()
-            .header("host", host)
-            .body(())
-            .unwrap();
+        let req = Request::builder().header("host", host).body(()).unwrap();
         req.into_parts().0
     }
 

--- a/modo-tenant/src/resolvers/header.rs
+++ b/modo-tenant/src/resolvers/header.rs
@@ -62,8 +62,7 @@ mod tests {
 
     #[tokio::test]
     async fn reads_header() {
-        let resolver =
-            HeaderResolver::new("x-tenant-id", |id| async move { Ok(Some(T { id })) });
+        let resolver = HeaderResolver::new("x-tenant-id", |id| async move { Ok(Some(T { id })) });
         let parts = Request::builder()
             .header("x-tenant-id", "acme")
             .body(())
@@ -73,13 +72,17 @@ mod tests {
         let result = crate::TenantResolver::resolve(&resolver, &parts)
             .await
             .unwrap();
-        assert_eq!(result, Some(T { id: "acme".to_string() }));
+        assert_eq!(
+            result,
+            Some(T {
+                id: "acme".to_string()
+            })
+        );
     }
 
     #[tokio::test]
     async fn returns_none_without_header() {
-        let resolver =
-            HeaderResolver::new("x-tenant-id", |id| async move { Ok(Some(T { id })) });
+        let resolver = HeaderResolver::new("x-tenant-id", |id| async move { Ok(Some(T { id })) });
         let parts = Request::builder().body(()).unwrap().into_parts().0;
         let result = crate::TenantResolver::resolve(&resolver, &parts)
             .await

--- a/modo-tenant/src/resolvers/header.rs
+++ b/modo-tenant/src/resolvers/header.rs
@@ -1,0 +1,89 @@
+use crate::{HasTenantId, TenantResolver};
+use modo::axum::http::request::Parts;
+use std::future::Future;
+use std::marker::PhantomData;
+
+pub struct HeaderResolver<T, F> {
+    header_name: String,
+    lookup: F,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, F, Fut> HeaderResolver<T, F>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    F: Fn(String) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Option<T>, modo::Error>> + Send,
+{
+    pub fn new(header_name: impl Into<String>, lookup: F) -> Self {
+        Self {
+            header_name: header_name.into(),
+            lookup,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, F, Fut> TenantResolver for HeaderResolver<T, F>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    F: Fn(String) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Option<T>, modo::Error>> + Send,
+{
+    type Tenant = T;
+
+    async fn resolve(&self, parts: &Parts) -> Result<Option<T>, modo::Error> {
+        let value = match parts
+            .headers
+            .get(&self.header_name)
+            .and_then(|v| v.to_str().ok())
+        {
+            Some(v) if !v.is_empty() => v.to_string(),
+            _ => return Ok(None),
+        };
+        (self.lookup)(value).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use modo::axum::http::Request;
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct T {
+        id: String,
+    }
+    impl crate::HasTenantId for T {
+        fn tenant_id(&self) -> &str {
+            &self.id
+        }
+    }
+
+    #[tokio::test]
+    async fn reads_header() {
+        let resolver =
+            HeaderResolver::new("x-tenant-id", |id| async move { Ok(Some(T { id })) });
+        let parts = Request::builder()
+            .header("x-tenant-id", "acme")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = crate::TenantResolver::resolve(&resolver, &parts)
+            .await
+            .unwrap();
+        assert_eq!(result, Some(T { id: "acme".to_string() }));
+    }
+
+    #[tokio::test]
+    async fn returns_none_without_header() {
+        let resolver =
+            HeaderResolver::new("x-tenant-id", |id| async move { Ok(Some(T { id })) });
+        let parts = Request::builder().body(()).unwrap().into_parts().0;
+        let result = crate::TenantResolver::resolve(&resolver, &parts)
+            .await
+            .unwrap();
+        assert_eq!(result, None);
+    }
+}

--- a/modo-tenant/src/resolvers/mod.rs
+++ b/modo-tenant/src/resolvers/mod.rs
@@ -1,0 +1,7 @@
+pub mod header;
+pub mod path_prefix;
+pub mod subdomain;
+
+pub use header::HeaderResolver;
+pub use path_prefix::PathPrefixResolver;
+pub use subdomain::SubdomainResolver;

--- a/modo-tenant/src/resolvers/path_prefix.rs
+++ b/modo-tenant/src/resolvers/path_prefix.rs
@@ -1,0 +1,90 @@
+use crate::{HasTenantId, TenantResolver};
+use modo::axum::http::request::Parts;
+use std::future::Future;
+use std::marker::PhantomData;
+
+pub struct PathPrefixResolver<T, F> {
+    lookup: F,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, F, Fut> PathPrefixResolver<T, F>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    F: Fn(String) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Option<T>, modo::Error>> + Send,
+{
+    pub fn new(lookup: F) -> Self {
+        Self {
+            lookup,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, F, Fut> TenantResolver for PathPrefixResolver<T, F>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    F: Fn(String) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Option<T>, modo::Error>> + Send,
+{
+    type Tenant = T;
+
+    async fn resolve(&self, parts: &Parts) -> Result<Option<T>, modo::Error> {
+        let path = parts.uri.path();
+        let mut segments = path.splitn(3, '/').filter(|s| !s.is_empty());
+
+        let identifier = match segments.next() {
+            Some(id) if !id.is_empty() => id.to_string(),
+            _ => return Ok(None),
+        };
+
+        (self.lookup)(identifier).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use modo::axum::http::Request;
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct T {
+        id: String,
+    }
+    impl crate::HasTenantId for T {
+        fn tenant_id(&self) -> &str {
+            &self.id
+        }
+    }
+
+    #[tokio::test]
+    async fn extracts_first_segment() {
+        let resolver = PathPrefixResolver::new(|slug| async move { Ok(Some(T { id: slug })) });
+        let parts = Request::builder()
+            .uri("/acme/dashboard")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = crate::TenantResolver::resolve(&resolver, &parts)
+            .await
+            .unwrap();
+        assert_eq!(result, Some(T { id: "acme".to_string() }));
+    }
+
+    #[tokio::test]
+    async fn returns_none_for_root() {
+        let resolver = PathPrefixResolver::new(|slug| async move { Ok(Some(T { id: slug })) });
+        let parts = Request::builder()
+            .uri("/")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = crate::TenantResolver::resolve(&resolver, &parts)
+            .await
+            .unwrap();
+        assert_eq!(result, None);
+    }
+}

--- a/modo-tenant/src/resolvers/path_prefix.rs
+++ b/modo-tenant/src/resolvers/path_prefix.rs
@@ -70,18 +70,18 @@ mod tests {
         let result = crate::TenantResolver::resolve(&resolver, &parts)
             .await
             .unwrap();
-        assert_eq!(result, Some(T { id: "acme".to_string() }));
+        assert_eq!(
+            result,
+            Some(T {
+                id: "acme".to_string()
+            })
+        );
     }
 
     #[tokio::test]
     async fn returns_none_for_root() {
         let resolver = PathPrefixResolver::new(|slug| async move { Ok(Some(T { id: slug })) });
-        let parts = Request::builder()
-            .uri("/")
-            .body(())
-            .unwrap()
-            .into_parts()
-            .0;
+        let parts = Request::builder().uri("/").body(()).unwrap().into_parts().0;
         let result = crate::TenantResolver::resolve(&resolver, &parts)
             .await
             .unwrap();

--- a/modo-tenant/src/resolvers/path_prefix.rs
+++ b/modo-tenant/src/resolvers/path_prefix.rs
@@ -3,6 +3,10 @@ use modo::axum::http::request::Parts;
 use std::future::Future;
 use std::marker::PhantomData;
 
+/// Resolves tenants from the first path segment (e.g., `/acme/dashboard` → `"acme"`).
+///
+/// The lookup closure is called for every request's first path segment.
+/// It should return `Ok(None)` quickly for non-tenant slugs (e.g., `"assets"`, `"api"`).
 pub struct PathPrefixResolver<T, F> {
     lookup: F,
     _phantom: PhantomData<T>,

--- a/modo-tenant/src/resolvers/subdomain.rs
+++ b/modo-tenant/src/resolvers/subdomain.rs
@@ -1,0 +1,120 @@
+use crate::{HasTenantId, TenantResolver};
+use modo::axum::http::request::Parts;
+use std::future::Future;
+use std::marker::PhantomData;
+
+pub struct SubdomainResolver<T, F> {
+    base_domain: String,
+    lookup: F,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, F, Fut> SubdomainResolver<T, F>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    F: Fn(String) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Option<T>, modo::Error>> + Send,
+{
+    pub fn new(base_domain: impl Into<String>, lookup: F) -> Self {
+        Self {
+            base_domain: base_domain.into(),
+            lookup,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, F, Fut> TenantResolver for SubdomainResolver<T, F>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
+    F: Fn(String) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Option<T>, modo::Error>> + Send,
+{
+    type Tenant = T;
+
+    async fn resolve(&self, parts: &Parts) -> Result<Option<T>, modo::Error> {
+        let host = match parts.headers.get("host").and_then(|v| v.to_str().ok()) {
+            Some(h) => h.split(':').next().unwrap_or(h),
+            None => return Ok(None),
+        };
+
+        let subdomain = host.strip_suffix(&format!(".{}", self.base_domain));
+        match subdomain {
+            Some(sub) if !sub.is_empty() && sub != "www" => (self.lookup)(sub.to_string()).await,
+            _ => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use modo::axum::http::Request;
+
+    #[derive(Clone, Debug, PartialEq, serde::Serialize)]
+    struct T {
+        id: String,
+    }
+    impl crate::HasTenantId for T {
+        fn tenant_id(&self) -> &str {
+            &self.id
+        }
+    }
+
+    fn parts(host: &str) -> Parts {
+        Request::builder()
+            .header("host", host)
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0
+    }
+
+    #[tokio::test]
+    async fn extracts_subdomain() {
+        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
+            Ok(Some(T { id: slug }))
+        });
+        let p = parts("acme.myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p)
+            .await
+            .unwrap();
+        assert_eq!(result, Some(T { id: "acme".to_string() }));
+    }
+
+    #[tokio::test]
+    async fn returns_none_for_bare_domain() {
+        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
+            Ok(Some(T { id: slug }))
+        });
+        let p = parts("myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p)
+            .await
+            .unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn returns_none_for_www() {
+        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
+            Ok(Some(T { id: slug }))
+        });
+        let p = parts("www.myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p)
+            .await
+            .unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn returns_none_when_no_host() {
+        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
+            Ok(Some(T { id: slug }))
+        });
+        let p = Request::builder().body(()).unwrap().into_parts().0;
+        let result = crate::TenantResolver::resolve(&resolver, &p)
+            .await
+            .unwrap();
+        assert_eq!(result, None);
+    }
+}

--- a/modo-tenant/src/resolvers/subdomain.rs
+++ b/modo-tenant/src/resolvers/subdomain.rs
@@ -72,49 +72,42 @@ mod tests {
 
     #[tokio::test]
     async fn extracts_subdomain() {
-        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
-            Ok(Some(T { id: slug }))
-        });
+        let resolver =
+            SubdomainResolver::new("myapp.com", |slug| async move { Ok(Some(T { id: slug })) });
         let p = parts("acme.myapp.com");
-        let result = crate::TenantResolver::resolve(&resolver, &p)
-            .await
-            .unwrap();
-        assert_eq!(result, Some(T { id: "acme".to_string() }));
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
+        assert_eq!(
+            result,
+            Some(T {
+                id: "acme".to_string()
+            })
+        );
     }
 
     #[tokio::test]
     async fn returns_none_for_bare_domain() {
-        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
-            Ok(Some(T { id: slug }))
-        });
+        let resolver =
+            SubdomainResolver::new("myapp.com", |slug| async move { Ok(Some(T { id: slug })) });
         let p = parts("myapp.com");
-        let result = crate::TenantResolver::resolve(&resolver, &p)
-            .await
-            .unwrap();
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
         assert_eq!(result, None);
     }
 
     #[tokio::test]
     async fn returns_none_for_www() {
-        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
-            Ok(Some(T { id: slug }))
-        });
+        let resolver =
+            SubdomainResolver::new("myapp.com", |slug| async move { Ok(Some(T { id: slug })) });
         let p = parts("www.myapp.com");
-        let result = crate::TenantResolver::resolve(&resolver, &p)
-            .await
-            .unwrap();
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
         assert_eq!(result, None);
     }
 
     #[tokio::test]
     async fn returns_none_when_no_host() {
-        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
-            Ok(Some(T { id: slug }))
-        });
+        let resolver =
+            SubdomainResolver::new("myapp.com", |slug| async move { Ok(Some(T { id: slug })) });
         let p = Request::builder().body(()).unwrap().into_parts().0;
-        let result = crate::TenantResolver::resolve(&resolver, &p)
-            .await
-            .unwrap();
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
         assert_eq!(result, None);
     }
 }

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -403,6 +403,21 @@ impl AppBuilder {
         //   Module/Handler MW (innermost)
         // =====================================================================
 
+        // --- Inject AppState into extensions (for handler-level middleware) ---
+        {
+            let st = state.clone();
+            router = router.layer(axum::middleware::from_fn(
+                move |mut req: axum::http::Request<axum::body::Body>,
+                      next: axum::middleware::Next| {
+                    let st = st.clone();
+                    async move {
+                        req.extensions_mut().insert(st);
+                        next.run(req).await
+                    }
+                },
+            ));
+        }
+
         // --- Template render layer (innermost — closest to handler) ---
         #[cfg(feature = "templates")]
         let template_engine: Option<std::sync::Arc<modo_templates::TemplateEngine>> =


### PR DESCRIPTION
## Summary
- Add `modo-tenant` and `modo-tenant-macros` crates providing multi-tenancy with role-based access control
- Tenant resolution via pluggable `TenantResolver` trait with built-in resolvers: `SubdomainResolver`, `HeaderResolver`, `PathPrefixResolver`
- Member/role management via `MemberProvider` trait with type-erased `MemberProviderService`
- Axum extractors: `Tenant<T>`, `OptionalTenant<T>`, `Member<T, M>`, `TenantContext<T, M, U>` — all with extension caching
- Role guard proc macros: `#[allow_roles("admin", "owner")]` / `#[deny_roles("viewer")]` and middleware factories `require_roles` / `exclude_roles`
- Template context layers: `TenantContextLayer<T, M>` injects tenant/member/tenants/role; `UserContextLayer<U>` (in modo-auth) injects user
- Add `user_id_from_extensions()` public helper to modo-session for cross-crate session access

## Test Plan
- [x] All 22 new unit tests pass (resolver, member, extractors, guards, subdomain/header/path resolvers)
- [x] Full workspace `just check` passes (fmt-check + clippy + all tests)
- [x] No warnings with `-D warnings`
- [x] CLAUDE.md updated with modo-tenant conventions and gotchas