### PR TITLE
refactor: simplify and harden all workspace crates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - Middleware: plain async functions, attached via `#[middleware(fn_name(params))]`
 - Middleware stacking order: Global (outermost) → Module → Handler (innermost)
 - Services: manually constructed, registered via `.service(instance)`
-- Sessions: `SessionStore::new(&db, config)` + `app.service(store.clone()).layer(modo_session::layer(store))`
+- Sessions: `SessionStore::new(&db, session_config, cookie_config)` + `app.service(store.clone()).layer(modo_session::layer(store))`
 - SessionManager extractor: `authenticate()` / `logout()` / `logout_all()` / `logout_other()` / `revoke(id)` / `rotate()` — handles cookies automatically
 - SessionManager data: `get::<T>(key)` / `set(key, value)` / `remove_key(key)` — immediate store writes
 - Auth: implement `UserProvider` trait, use `Auth<User>` / `OptionalAuth<User>` extractors

--- a/modo-auth/src/cache.rs
+++ b/modo-auth/src/cache.rs
@@ -1,0 +1,14 @@
+use std::sync::Arc;
+
+/// Cached resolved user in request extensions.
+///
+/// Inserted by `UserContextLayer` or auth extractors so that subsequent
+/// `Auth<U>` / `OptionalAuth<U>` calls reuse the already-loaded user
+/// without a second DB lookup.
+pub(crate) struct ResolvedUser<U>(pub(crate) Arc<U>);
+
+impl<U> Clone for ResolvedUser<U> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}

--- a/modo-auth/src/context_layer.rs
+++ b/modo-auth/src/context_layer.rs
@@ -1,33 +1,15 @@
-#[cfg(feature = "templates")]
+use crate::cache::ResolvedUser;
 use crate::provider::UserProviderService;
 
-#[cfg(feature = "templates")]
 use futures_util::future::BoxFuture;
-#[cfg(feature = "templates")]
 use modo::axum::http::Request;
-#[cfg(feature = "templates")]
 use modo::templates::TemplateContext;
-#[cfg(feature = "templates")]
 use std::sync::Arc;
-#[cfg(feature = "templates")]
 use std::task::{Context, Poll};
-#[cfg(feature = "templates")]
 use tower::{Layer, Service};
-
-/// Cached resolved user in request extensions.
-#[cfg(feature = "templates")]
-pub struct ResolvedUser<U>(pub Arc<U>);
-
-#[cfg(feature = "templates")]
-impl<U> Clone for ResolvedUser<U> {
-    fn clone(&self) -> Self {
-        Self(Arc::clone(&self.0))
-    }
-}
 
 /// Layer that injects the authenticated user into TemplateContext.
 /// Graceful: injects nothing if not authenticated.
-#[cfg(feature = "templates")]
 pub struct UserContextLayer<U>
 where
     U: Clone + Send + Sync + serde::Serialize + 'static,
@@ -35,7 +17,6 @@ where
     user_svc: UserProviderService<U>,
 }
 
-#[cfg(feature = "templates")]
 impl<U> Clone for UserContextLayer<U>
 where
     U: Clone + Send + Sync + serde::Serialize + 'static,
@@ -47,7 +28,6 @@ where
     }
 }
 
-#[cfg(feature = "templates")]
 impl<U> UserContextLayer<U>
 where
     U: Clone + Send + Sync + serde::Serialize + 'static,
@@ -57,7 +37,6 @@ where
     }
 }
 
-#[cfg(feature = "templates")]
 impl<S, U> Layer<S> for UserContextLayer<U>
 where
     U: Clone + Send + Sync + serde::Serialize + 'static,
@@ -72,7 +51,6 @@ where
     }
 }
 
-#[cfg(feature = "templates")]
 #[derive(Clone)]
 pub struct UserContextMiddleware<S, U>
 where
@@ -82,7 +60,6 @@ where
     user_svc: UserProviderService<U>,
 }
 
-#[cfg(feature = "templates")]
 impl<S, ReqBody, ResBody, U> Service<Request<ReqBody>> for UserContextMiddleware<S, U>
 where
     S: Service<Request<ReqBody>, Response = modo::axum::http::Response<ResBody>>

--- a/modo-auth/src/extractor.rs
+++ b/modo-auth/src/extractor.rs
@@ -1,3 +1,4 @@
+use crate::cache::ResolvedUser;
 use crate::provider::UserProviderService;
 use modo::app::AppState;
 use modo::axum::extract::FromRequestParts;
@@ -5,6 +6,48 @@ use modo::axum::http::request::Parts;
 use modo::{Error, HttpError};
 use modo_session::SessionManager;
 use std::ops::Deref;
+use std::sync::Arc;
+
+/// Resolve the authenticated user, checking the extension cache first.
+///
+/// Returns `Ok(None)` when no session or user exists.
+/// Returns `Err` for infrastructure failures (missing middleware/service, DB errors).
+async fn resolve_user<U: Clone + Send + Sync + 'static>(
+    parts: &mut Parts,
+    state: &AppState,
+) -> Result<Option<U>, Error> {
+    // Fast path: user already resolved by UserContextLayer or a prior extractor
+    if let Some(cached) = parts.extensions.get::<ResolvedUser<U>>() {
+        return Ok(Some((*cached.0).clone()));
+    }
+
+    let session = SessionManager::from_request_parts(parts, state)
+        .await
+        .map_err(|_| Error::internal("Auth requires session middleware"))?;
+
+    let user_id = match session.user_id().await {
+        Some(id) => id,
+        None => return Ok(None),
+    };
+
+    let provider = state
+        .services
+        .get::<UserProviderService<U>>()
+        .ok_or_else(|| {
+            Error::internal(format!(
+                "UserProviderService<{}> not registered",
+                std::any::type_name::<U>()
+            ))
+        })?;
+
+    let user = provider.find_by_id(&user_id).await?;
+
+    if let Some(ref u) = user {
+        parts.extensions.insert(ResolvedUser(Arc::new(u.clone())));
+    }
+
+    Ok(user)
+}
 
 /// Extractor that requires an authenticated user.
 ///
@@ -28,34 +71,9 @@ impl<U: Clone + Send + Sync + 'static> FromRequestParts<AppState> for Auth<U> {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        // 1. Extract SessionManager from request extensions
-        let session = SessionManager::from_request_parts(parts, state)
-            .await
-            .map_err(|_| Error::internal("Auth<U> requires session middleware"))?;
-
-        // 2. Get user_id from session
-        let user_id = session
-            .user_id()
-            .await
-            .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
-
-        // 3. Look up UserProviderService<U> in service registry
-        let provider = state
-            .services
-            .get::<UserProviderService<U>>()
-            .ok_or_else(|| {
-                Error::internal(format!(
-                    "UserProviderService<{}> not registered",
-                    std::any::type_name::<U>()
-                ))
-            })?;
-
-        // 4. Load user — None means 401, Err means 500
-        let user = provider
-            .find_by_id(&user_id)
+        let user = resolve_user::<U>(parts, state)
             .await?
             .ok_or_else(|| Error::from(HttpError::Unauthorized))?;
-
         Ok(Auth(user))
     }
 }
@@ -83,31 +101,7 @@ impl<U: Clone + Send + Sync + 'static> FromRequestParts<AppState> for OptionalAu
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        // 1. Extract SessionManager — missing middleware is still a 500
-        let session = SessionManager::from_request_parts(parts, state)
-            .await
-            .map_err(|_| Error::internal("OptionalAuth<U> requires session middleware"))?;
-
-        // 2. Get user_id — no session means None (not an error)
-        let user_id = match session.user_id().await {
-            Some(id) => id,
-            None => return Ok(OptionalAuth(None)),
-        };
-
-        // 3. Look up provider — missing provider is still a 500
-        let provider = state
-            .services
-            .get::<UserProviderService<U>>()
-            .ok_or_else(|| {
-                Error::internal(format!(
-                    "UserProviderService<{}> not registered",
-                    std::any::type_name::<U>()
-                ))
-            })?;
-
-        // 4. Load user — Err propagates as 500, None returns OptionalAuth(None)
-        let user = provider.find_by_id(&user_id).await?;
-
+        let user = resolve_user::<U>(parts, state).await?;
         Ok(OptionalAuth(user))
     }
 }

--- a/modo-auth/src/lib.rs
+++ b/modo-auth/src/lib.rs
@@ -1,3 +1,5 @@
+pub(crate) mod cache;
+#[cfg(feature = "templates")]
 pub mod context_layer;
 pub mod extractor;
 pub mod password;
@@ -8,4 +10,4 @@ pub use password::{PasswordConfig, PasswordHasher};
 pub use provider::{UserProvider, UserProviderService};
 
 #[cfg(feature = "templates")]
-pub use context_layer::{ResolvedUser, UserContextLayer};
+pub use context_layer::UserContextLayer;

--- a/modo-auth/src/password.rs
+++ b/modo-auth/src/password.rs
@@ -78,6 +78,7 @@ impl PasswordHasher {
     /// Note: uses the params embedded in the hash, not `self.params`.
     /// Runs on a blocking thread to avoid stalling the Tokio runtime.
     pub async fn verify_password(&self, password: &str, hash: &str) -> Result<bool, modo::Error> {
+        let params = self.params.clone();
         let password = password.to_owned();
         let hash = hash.to_owned();
 
@@ -85,7 +86,9 @@ impl PasswordHasher {
             let parsed = PasswordHash::new(&hash)
                 .map_err(|e| modo::Error::internal(format!("invalid password hash: {e}")))?;
 
-            match Argon2::new(Algorithm::Argon2id, Version::V0x13, Params::default())
+            // Note: argon2's verify_password uses params from the parsed hash,
+            // not from the Argon2 instance — but we pass self.params for consistency.
+            match Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
                 .verify_password(password.as_bytes(), &parsed)
             {
                 Ok(()) => Ok(true),

--- a/modo-auth/src/provider.rs
+++ b/modo-auth/src/provider.rs
@@ -51,6 +51,12 @@ impl<U: Clone + Send + Sync + 'static> Clone for UserProviderService<U> {
     }
 }
 
+impl<U: Clone + Send + Sync + 'static> std::fmt::Debug for UserProviderService<U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "UserProviderService<{}>", std::any::type_name::<U>())
+    }
+}
+
 impl<U: Clone + Send + Sync + 'static> UserProviderService<U> {
     /// Wrap a `UserProvider` implementation for registration in the service registry.
     pub fn new<P: UserProvider<User = U>>(provider: P) -> Self {

--- a/modo-auth/tests/integration.rs
+++ b/modo-auth/tests/integration.rs
@@ -139,7 +139,7 @@ fn request_no_cookie(uri: &str) -> Request<axum::body::Body> {
 #[tokio::test]
 async fn auth_no_session_returns_401() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, SessionConfig::default());
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
     let app = build_app(store);
 
     let resp = app.oneshot(request_no_cookie("/auth")).await.unwrap();
@@ -149,7 +149,7 @@ async fn auth_no_session_returns_401() {
 #[tokio::test]
 async fn auth_valid_session_returns_user() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, SessionConfig::default());
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
     let app = build_app(store.clone());
 
     let cookie = create_session(&store, "user-1").await;
@@ -166,7 +166,7 @@ async fn auth_valid_session_returns_user() {
 #[tokio::test]
 async fn auth_user_not_found_returns_401() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, SessionConfig::default());
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
     let app = build_app(store.clone());
 
     let cookie = create_session(&store, "unknown-user").await;
@@ -180,7 +180,7 @@ async fn auth_user_not_found_returns_401() {
 #[tokio::test]
 async fn auth_provider_error_returns_500() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, SessionConfig::default());
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
     let app = build_app(store.clone());
 
     let cookie = create_session(&store, "error-user").await;
@@ -196,7 +196,7 @@ async fn auth_provider_error_returns_500() {
 #[tokio::test]
 async fn optional_auth_no_session_returns_none() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, SessionConfig::default());
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
     let app = build_app(store);
 
     let resp = app.oneshot(request_no_cookie("/optional")).await.unwrap();
@@ -209,7 +209,7 @@ async fn optional_auth_no_session_returns_none() {
 #[tokio::test]
 async fn optional_auth_valid_session_returns_user() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, SessionConfig::default());
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
     let app = build_app(store.clone());
 
     let cookie = create_session(&store, "user-1").await;
@@ -226,7 +226,7 @@ async fn optional_auth_valid_session_returns_user() {
 #[tokio::test]
 async fn optional_auth_provider_error_returns_500() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, SessionConfig::default());
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
     let app = build_app(store.clone());
 
     let cookie = create_session(&store, "error-user").await;

--- a/modo-db-macros/src/entity.rs
+++ b/modo-db-macros/src/entity.rs
@@ -236,6 +236,7 @@ fn parse_field_attrs(field: &mut syn::Field) -> Result<FieldAttrs> {
                 }
                 "unique" => attrs.unique = true,
                 "indexed" => attrs.indexed = true,
+                // Accepted but unused — Option<T> already implies nullable in SeaORM.
                 "nullable" => {}
                 "column_type" => {
                     let lit: LitStr = meta.value()?.parse()?;
@@ -512,21 +513,11 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
             continue;
         }
 
+        let pascal = to_pascal_case(&f.name.to_string());
         let target = if f.attrs.has_many {
-            f.attrs.via.as_ref().map_or_else(
-                || {
-                    to_pascal_case(&f.name.to_string())
-                        .trim_end_matches('s')
-                        .to_string()
-                },
-                |_via| {
-                    to_pascal_case(&f.name.to_string())
-                        .trim_end_matches('s')
-                        .to_string()
-                },
-            )
+            pascal.trim_end_matches('s').to_string()
         } else {
-            to_pascal_case(&f.name.to_string())
+            pascal
         };
 
         let target_mod = format_ident!("{}", to_snake_case(&target));

--- a/modo-db/Cargo.toml
+++ b/modo-db/Cargo.toml
@@ -22,7 +22,6 @@ sea-orm = { version = "2.0.0-rc", features = [
 inventory = "0.3"
 serde = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-ulid = "1"
 nanoid = "0.4"
 tracing = "0.1"
 thiserror = "2"

--- a/modo-db/src/connect.rs
+++ b/modo-db/src/connect.rs
@@ -17,7 +17,7 @@ pub async fn connect(config: &DatabaseConfig) -> Result<DbPool, modo::Error> {
         .map_err(|e| modo::Error::internal(format!("Database connection failed: {e}")))?;
 
     // Apply backend-specific settings
-    if config.url.starts_with("sqlite://") || config.url.starts_with("sqlite:") {
+    if conn.get_database_backend() == sea_orm::DatabaseBackend::Sqlite {
         apply_sqlite_pragmas(&conn).await?;
     }
 
@@ -53,12 +53,13 @@ async fn apply_sqlite_pragmas(_conn: &sea_orm::DatabaseConnection) -> Result<(),
 
 /// Redact credentials from database URL for logging.
 fn redact_url(url: &str) -> String {
-    if let Some(at_pos) = url.find('@')
-        && let Some(scheme_end) = url.find("://")
-    {
-        let prefix = &url[..scheme_end + 3];
-        let suffix = &url[at_pos..];
-        return format!("{prefix}***{suffix}");
+    if let Some(scheme_end) = url.find("://") {
+        let authority_start = scheme_end + 3;
+        if let Some(relative_at) = url[authority_start..].find('@') {
+            let prefix = &url[..authority_start];
+            let suffix = &url[authority_start + relative_at..];
+            return format!("{prefix}***{suffix}");
+        }
     }
     url.to_string()
 }

--- a/modo-db/src/extractor.rs
+++ b/modo-db/src/extractor.rs
@@ -22,7 +22,7 @@ impl FromRequestParts<AppState> for Db {
         state
             .services
             .get::<DbPool>()
-            .map(|pool| Db(DbPool(pool.connection().clone())))
+            .map(|pool| Db((*pool).clone()))
             .ok_or_else(|| {
                 Error::internal("Database not configured. Register DbPool via app.service(db).")
             })

--- a/modo-db/src/id.rs
+++ b/modo-db/src/id.rs
@@ -1,6 +1,6 @@
 /// Generate a new ULID string (26 chars, Crockford Base32).
 pub fn generate_ulid() -> String {
-    ulid::Ulid::new().to_string()
+    modo::ulid::Ulid::new().to_string()
 }
 
 /// Generate a new NanoID (21 chars, default alphabet).

--- a/modo-db/src/sync.rs
+++ b/modo-db/src/sync.rs
@@ -15,32 +15,32 @@ use tracing::info;
 pub async fn sync_and_migrate(db: &DbPool) -> Result<(), modo::Error> {
     let conn = db.connection();
 
-    // 1. Bootstrap _modo_migrations
+    // 1. Bootstrap _modo_migrations (BIGINT + CURRENT_TIMESTAMP work on both SQLite and Postgres)
     conn.execute_unprepared(
         "CREATE TABLE IF NOT EXISTS _modo_migrations (\
-            version INTEGER PRIMARY KEY, \
+            version BIGINT PRIMARY KEY, \
             description TEXT NOT NULL, \
-            executed_at TEXT NOT NULL DEFAULT (datetime('now'))\
+            executed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP\
         )",
     )
     .await
     .map_err(|e| modo::Error::internal(format!("Failed to bootstrap migrations table: {e}")))?;
 
-    // 2. Collect and register all entities
+    // 2. Collect all entities in a single pass, partitioned by framework vs user
+    let (framework, user): (Vec<_>, Vec<_>) = inventory::iter::<EntityRegistration>
+        .into_iter()
+        .partition(|r| r.is_framework);
+
     let backend = conn.get_database_backend();
     let schema = Schema::new(backend);
     let mut builder = schema.builder();
 
-    // Framework entities first, then user entities
-    for reg in inventory::iter::<EntityRegistration> {
-        if reg.is_framework {
-            builder = (reg.register_fn)(builder);
-        }
+    // Register framework entities first, then user entities
+    for reg in &framework {
+        builder = (reg.register_fn)(builder);
     }
-    for reg in inventory::iter::<EntityRegistration> {
-        if !reg.is_framework {
-            builder = (reg.register_fn)(builder);
-        }
+    for reg in &user {
+        builder = (reg.register_fn)(builder);
     }
 
     // 3. Sync (addition-only — SeaORM handles topo sort)
@@ -51,7 +51,7 @@ pub async fn sync_and_migrate(db: &DbPool) -> Result<(), modo::Error> {
     info!("Schema sync complete");
 
     // 4. Run extra SQL (composite indices, partial unique indices, etc.)
-    for reg in inventory::iter::<EntityRegistration> {
+    for reg in framework.iter().chain(user.iter()) {
         for sql in reg.extra_sql {
             if let Err(e) = conn.execute_unprepared(sql).await {
                 tracing::error!(

--- a/modo-email/Cargo.toml
+++ b/modo-email/Cargo.toml
@@ -17,7 +17,6 @@ serde_yaml_ng = "0.10"
 async-trait = "0.1"
 pulldown-cmark = "0.12"
 minijinja = { version = "2", features = ["loader"] }
-tracing = "0.1"
 lettre = { version = "0.11", features = ["tokio1-native-tls", "builder", "smtp-transport"], optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
 

--- a/modo-email/src/lib.rs
+++ b/modo-email/src/lib.rs
@@ -22,15 +22,8 @@ use std::sync::Arc;
 
 /// Create a Mailer with the default FilesystemProvider.
 pub fn mailer(config: &EmailConfig) -> Result<Mailer, modo::Error> {
-    let transport = transport::transport(config)?;
     let provider = Arc::new(FilesystemProvider::new(&config.templates_path));
-    let layout = Arc::new(LayoutEngine::new(&config.templates_path));
-    let sender = SenderProfile {
-        from_name: config.default_from_name.clone(),
-        from_email: config.default_from_email.clone(),
-        reply_to: config.default_reply_to.clone(),
-    };
-    Ok(Mailer::new(transport, provider, sender, layout))
+    mailer_with(config, provider)
 }
 
 /// Create a Mailer with a custom TemplateProvider.

--- a/modo-email/src/mailer.rs
+++ b/modo-email/src/mailer.rs
@@ -2,7 +2,6 @@ use crate::message::{MailMessage, SendEmail, SenderProfile};
 use crate::template::layout::LayoutEngine;
 use crate::template::{TemplateProvider, markdown, vars};
 use crate::transport::MailTransport;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// High-level email service that ties together template loading, variable
@@ -39,8 +38,8 @@ impl Mailer {
         let template = self.templates.get(&email.template, locale)?;
 
         // Substitute variables in subject and body.
-        let subject = vars::substitute(&template.subject, &email.context);
-        let body = vars::substitute(&template.body, &email.context);
+        let subject = vars::substitute(&template.subject, &email.context)?;
+        let body = vars::substitute(&template.body, &email.context)?;
 
         // Validate brand_color as a CSS hex color; fall back to default if invalid.
         let button_color = email
@@ -48,20 +47,16 @@ impl Mailer {
             .get("brand_color")
             .and_then(|v| v.as_str())
             .filter(|s| is_valid_hex_color(s))
-            .unwrap_or("#4F46E5");
+            .unwrap_or(markdown::DEFAULT_BUTTON_COLOR);
 
-        // Render Markdown body to HTML (with optional custom button color).
-        let html_body = markdown::render_markdown_with_color(&body, button_color);
-        let text = markdown::render_plain_text(&body);
+        // Render Markdown body to HTML and plain text in one pass.
+        let (html_body, text) = markdown::render(&body, button_color);
 
         // Wrap HTML body in a layout.
         let layout_name = template.layout.as_deref().unwrap_or("default");
-        let mut layout_ctx: HashMap<String, serde_json::Value> = email.context.clone();
-        layout_ctx.insert("content".to_string(), serde_json::Value::String(html_body));
-        layout_ctx.insert(
-            "subject".to_string(),
-            serde_json::Value::String(subject.clone()),
-        );
+        let base_ctx = minijinja::Value::from_serialize(&email.context);
+        let extra_ctx = minijinja::context! { content => html_body, subject => &subject };
+        let layout_ctx = minijinja::context! { ..base_ctx, ..extra_ctx };
         let html = self.layout_engine.render(layout_name, &layout_ctx)?;
 
         // Resolve sender (per-email override or default).
@@ -230,7 +225,7 @@ mod tests {
             .unwrap();
 
         // Should use default color, not the injection attempt
-        assert!(msg.html.contains("#4F46E5"));
+        assert!(msg.html.contains(markdown::DEFAULT_BUTTON_COLOR));
         assert!(!msg.html.contains("position:absolute"));
     }
 

--- a/modo-email/src/mailer.rs
+++ b/modo-email/src/mailer.rs
@@ -38,8 +38,8 @@ impl Mailer {
         let template = self.templates.get(&email.template, locale)?;
 
         // Substitute variables in subject and body.
-        let subject = vars::substitute(&template.subject, &email.context)?;
-        let body = vars::substitute(&template.body, &email.context)?;
+        let subject = vars::substitute(&template.subject, &email.context);
+        let body = vars::substitute(&template.body, &email.context);
 
         // Validate brand_color as a CSS hex color; fall back to default if invalid.
         let button_color = email

--- a/modo-email/src/template/filesystem.rs
+++ b/modo-email/src/template/filesystem.rs
@@ -124,4 +124,60 @@ mod tests {
         let result = provider.get("missing", "");
         assert!(result.is_err());
     }
+
+    #[test]
+    fn path_traversal_in_name_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = FilesystemProvider::new(dir.path().to_str().unwrap());
+        let result = provider.get("../secret", "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn path_traversal_in_locale_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = FilesystemProvider::new(dir.path().to_str().unwrap());
+        let result = provider.get("welcome", "../../etc");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn backslash_traversal_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = FilesystemProvider::new(dir.path().to_str().unwrap());
+        let result = provider.get("..\\secret", "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn forward_slash_in_name_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = FilesystemProvider::new(dir.path().to_str().unwrap());
+        let result = provider.get("sub/template", "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_locale_uses_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        fs::write(
+            path.join("welcome.md"),
+            "---\nsubject: \"Root\"\n---\n\nRoot body",
+        )
+        .unwrap();
+
+        let provider = FilesystemProvider::new(path.to_str().unwrap());
+        let tpl = provider.get("welcome", "").unwrap();
+        assert_eq!(tpl.subject, "Root");
+    }
+
+    #[test]
+    fn name_with_md_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = FilesystemProvider::new(dir.path().to_str().unwrap());
+        // "welcome.md" → tries "welcome.md.md" → not found
+        let result = provider.get("welcome.md", "");
+        assert!(result.is_err());
+    }
 }

--- a/modo-email/src/template/layout.rs
+++ b/modo-email/src/template/layout.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::Path;
 
 pub(crate) const DEFAULT_LAYOUT: &str = r#"<!DOCTYPE html>
@@ -80,19 +79,16 @@ impl LayoutEngine {
     pub fn render(
         &self,
         layout_name: &str,
-        context: &HashMap<String, serde_json::Value>,
+        context: &minijinja::Value,
     ) -> Result<String, modo::Error> {
         let template_name = format!("layouts/{layout_name}.html");
-        let builtin_name = format!("__builtin__/{layout_name}.html");
 
         let tmpl = self
             .env
             .get_template(&template_name)
-            .or_else(|_| self.env.get_template(&builtin_name))
             .map_err(|_| modo::Error::internal(format!("Layout not found: {layout_name}")))?;
 
-        let ctx = minijinja::Value::from_serialize(context);
-        tmpl.render(&ctx)
+        tmpl.render(context)
             .map_err(|e| modo::Error::internal(format!("Layout render error: {e}")))
     }
 
@@ -102,7 +98,7 @@ impl LayoutEngine {
         let mut env = minijinja::Environment::new();
         env.set_auto_escape_callback(|_| minijinja::AutoEscape::None);
         env.add_template_owned(
-            "__builtin__/default.html".to_string(),
+            "layouts/default.html".to_string(),
             DEFAULT_LAYOUT.to_string(),
         )
         .expect("built-in layout is valid");
@@ -118,9 +114,10 @@ mod tests {
     #[test]
     fn render_with_builtin_layout() {
         let engine = LayoutEngine::builtin_only();
-        let mut ctx = HashMap::new();
-        ctx.insert("content".to_string(), serde_json::json!("<p>Hello</p>"));
-        ctx.insert("subject".to_string(), serde_json::json!("Test"));
+        let ctx = minijinja::context! {
+            content => "<p>Hello</p>",
+            subject => "Test",
+        };
 
         let html = engine.render("default", &ctx).unwrap();
         assert!(html.contains("<p>Hello</p>"));
@@ -140,8 +137,9 @@ mod tests {
         .unwrap();
 
         let engine = LayoutEngine::new(dir.path().to_str().unwrap());
-        let mut ctx = HashMap::new();
-        ctx.insert("content".to_string(), serde_json::json!("<p>Hi</p>"));
+        let ctx = minijinja::context! {
+            content => "<p>Hi</p>",
+        };
 
         let html = engine.render("default", &ctx).unwrap();
         assert!(html.contains("CUSTOM: <p>Hi</p>"));
@@ -150,8 +148,44 @@ mod tests {
     #[test]
     fn missing_layout_errors() {
         let engine = LayoutEngine::builtin_only();
-        let ctx = HashMap::new();
+        let ctx = minijinja::context! {};
         let result = engine.render("nonexistent", &ctx);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_layout_name() {
+        let engine = LayoutEngine::builtin_only();
+        let ctx = minijinja::context! {};
+        let result = engine.render("", &ctx);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_optional_context_vars() {
+        let engine = LayoutEngine::builtin_only();
+        let ctx = minijinja::context! {
+            content => "<p>Hello</p>",
+            subject => "Test",
+        };
+        // No logo_url or footer_text — should render without error
+        let html = engine.render("default", &ctx).unwrap();
+        assert!(html.contains("<p>Hello</p>"));
+        assert!(html.contains("Test"));
+        // logo_url block should be skipped ({% if logo_url %} is falsy)
+        assert!(!html.contains("<img"));
+    }
+
+    #[test]
+    fn context_with_html_in_content() {
+        let engine = LayoutEngine::builtin_only();
+        let ctx = minijinja::context! {
+            content => "<h1>Title</h1><p>Body &amp; more</p>",
+            subject => "Test",
+        };
+        let html = engine.render("default", &ctx).unwrap();
+        // Auto-escape is disabled, so HTML should be rendered verbatim
+        assert!(html.contains("<h1>Title</h1>"));
+        assert!(html.contains("<p>Body &amp; more</p>"));
     }
 }

--- a/modo-email/src/template/markdown.rs
+++ b/modo-email/src/template/markdown.rs
@@ -1,19 +1,17 @@
 use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
 
 const BUTTON_PREFIX: &str = "button|";
-const DEFAULT_BUTTON_COLOR: &str = "#4F46E5";
+pub const DEFAULT_BUTTON_COLOR: &str = "#4F46E5";
 
-/// Render Markdown to HTML, converting `[button|Label](url)` into email-safe button tables.
-pub fn render_markdown(markdown: &str) -> String {
-    render_markdown_with_color(markdown, DEFAULT_BUTTON_COLOR)
-}
-
-/// Render Markdown to HTML with a custom button background color.
-pub fn render_markdown_with_color(markdown: &str, button_color: &str) -> String {
-    let opts = Options::empty();
-    let parser = Parser::new_ext(markdown, opts);
+/// Render Markdown to both HTML and plain text in a single pass.
+///
+/// `[button|Label](url)` links become email-safe button tables in HTML
+/// and `Label (url)` in plain text.
+pub fn render(markdown: &str, button_color: &str) -> (String, String) {
+    let parser = Parser::new_ext(markdown, Options::empty());
 
     let mut html = String::new();
+    let mut text = String::new();
     let mut in_link = false;
     let mut link_url = String::new();
     let mut link_text = String::new();
@@ -25,72 +23,58 @@ pub fn render_markdown_with_color(markdown: &str, button_color: &str) -> String 
                 link_url = dest_url.to_string();
                 link_text.clear();
             }
-            Event::Text(text) if in_link => {
-                link_text.push_str(&text);
+            Event::Text(ref t) if in_link => {
+                link_text.push_str(t);
             }
             Event::End(TagEnd::Link) if in_link => {
                 in_link = false;
                 if let Some(label) = link_text.strip_prefix(BUTTON_PREFIX) {
                     html.push_str(&render_button(label, &link_url, button_color));
+                    text.push_str(&format!("{label} ({link_url})"));
                 } else {
                     html.push_str(&format!(
                         "<a href=\"{}\" style=\"color:{button_color}\">{}</a>",
                         link_url, link_text,
                     ));
+                    text.push_str(&format!("{link_text} ({link_url})"));
                 }
             }
             _ if in_link => {}
             _ => {
+                match &event {
+                    Event::Text(t) => text.push_str(t),
+                    Event::SoftBreak | Event::HardBreak => text.push('\n'),
+                    Event::End(TagEnd::Paragraph) => text.push_str("\n\n"),
+                    Event::End(TagEnd::Heading(_)) => text.push_str("\n\n"),
+                    _ => {}
+                }
                 pulldown_cmark::html::push_html(&mut html, std::iter::once(event));
             }
         }
     }
 
-    html
+    (html, text.trim().to_string())
+}
+
+/// Render Markdown to HTML, converting `[button|Label](url)` into email-safe button tables.
+pub fn render_markdown(markdown: &str) -> String {
+    render(markdown, DEFAULT_BUTTON_COLOR).0
+}
+
+/// Render Markdown to HTML with a custom button background color.
+pub fn render_markdown_with_color(markdown: &str, button_color: &str) -> String {
+    render(markdown, button_color).0
+}
+
+/// Convert Markdown to plain text, stripping formatting and converting links to `Text (URL)` form.
+pub fn render_plain_text(markdown: &str) -> String {
+    render(markdown, DEFAULT_BUTTON_COLOR).1
 }
 
 fn render_button(label: &str, url: &str, color: &str) -> String {
     format!(
         r#"<table role="presentation" cellpadding="0" cellspacing="0" style="margin:16px auto"><tr><td style="background-color:{color};border-radius:6px;padding:12px 24px;text-align:center"><a href="{url}" style="color:#ffffff;text-decoration:none;font-weight:bold;font-size:16px;display:inline-block">{label}</a></td></tr></table>"#,
     )
-}
-
-/// Convert Markdown to plain text, stripping formatting and converting links to `Text (URL)` form.
-pub fn render_plain_text(markdown: &str) -> String {
-    let opts = Options::empty();
-    let parser = Parser::new_ext(markdown, opts);
-
-    let mut text = String::new();
-    let mut in_link = false;
-    let mut link_text = String::new();
-    let mut link_url = String::new();
-
-    for event in parser {
-        match event {
-            Event::Start(Tag::Link { dest_url, .. }) => {
-                in_link = true;
-                link_url = dest_url.to_string();
-                link_text.clear();
-            }
-            Event::Text(t) if in_link => {
-                link_text.push_str(&t);
-            }
-            Event::End(TagEnd::Link) if in_link => {
-                in_link = false;
-                let display = link_text.strip_prefix(BUTTON_PREFIX).unwrap_or(&link_text);
-                text.push_str(&format!("{display} ({link_url})"));
-            }
-            Event::Text(t) => text.push_str(&t),
-            Event::SoftBreak | Event::HardBreak => text.push('\n'),
-            Event::Start(Tag::Paragraph) => {}
-            Event::End(TagEnd::Paragraph) => text.push_str("\n\n"),
-            Event::Start(Tag::Heading { .. }) => {}
-            Event::End(TagEnd::Heading(_)) => text.push_str("\n\n"),
-            _ => {}
-        }
-    }
-
-    text.trim().to_string()
 }
 
 #[cfg(test)]
@@ -137,5 +121,83 @@ mod tests {
         assert!(text.contains("Click (https://url.com)"));
         assert!(text.contains("Link (https://other.com)"));
         assert!(!text.contains("button|"));
+    }
+
+    #[test]
+    fn combined_render_produces_both() {
+        let (html, text) = render("Hi **world**\n\n[button|Click](https://url.com)", "#ff0000");
+        assert!(html.contains("<strong>world</strong>"));
+        assert!(html.contains("role=\"presentation\""));
+        assert!(html.contains("#ff0000"));
+        assert!(text.contains("Hello world") || text.contains("Hi world"));
+        assert!(text.contains("Click (https://url.com)"));
+    }
+
+    #[test]
+    fn empty_markdown() {
+        let (html, text) = render("", DEFAULT_BUTTON_COLOR);
+        assert!(html.is_empty());
+        assert!(text.is_empty());
+    }
+
+    #[test]
+    fn plain_text_no_formatting() {
+        let (html, text) = render("Just text", DEFAULT_BUTTON_COLOR);
+        assert!(html.contains("<p>Just text</p>"));
+        assert_eq!(text, "Just text");
+    }
+
+    #[test]
+    fn multiple_buttons() {
+        let md = "[button|First](https://a.com)\n\n[button|Second](https://b.com)";
+        let (html, text) = render(md, DEFAULT_BUTTON_COLOR);
+        // Two button tables in HTML
+        assert_eq!(html.matches("role=\"presentation\"").count(), 2);
+        assert!(html.contains("First"));
+        assert!(html.contains("Second"));
+        // Two labeled links in text
+        assert!(text.contains("First (https://a.com)"));
+        assert!(text.contains("Second (https://b.com)"));
+    }
+
+    #[test]
+    fn empty_button_label() {
+        let md = "[button|](https://example.com)";
+        let (html, text) = render(md, DEFAULT_BUTTON_COLOR);
+        assert!(html.contains("role=\"presentation\""));
+        assert!(html.contains("https://example.com"));
+        assert!(text.contains("(https://example.com)"));
+    }
+
+    #[test]
+    fn heading_rendering() {
+        let (html, text) = render("# Title", DEFAULT_BUTTON_COLOR);
+        assert!(html.contains("<h1>"));
+        assert!(html.contains("Title"));
+        assert!(text.contains("Title"));
+    }
+
+    #[test]
+    fn list_rendering() {
+        let md = "- item1\n- item2";
+        let html = render_markdown(md);
+        assert!(html.contains("<ul>"));
+        assert!(html.contains("<li>item1</li>"));
+        assert!(html.contains("<li>item2</li>"));
+    }
+
+    #[test]
+    fn code_block_preserved() {
+        let md = "```\nfn main() {}\n```";
+        let html = render_markdown(md);
+        assert!(html.contains("<pre><code>"));
+        assert!(html.contains("fn main() {}"));
+    }
+
+    #[test]
+    fn html_entities_escaped_in_text() {
+        let md = "Use &amp; and <tag>";
+        let text = render_plain_text(md);
+        assert!(text.contains("&") || text.contains("&amp;"));
     }
 }

--- a/modo-email/src/template/mod.rs
+++ b/modo-email/src/template/mod.rs
@@ -89,4 +89,58 @@ mod tests {
         let result = EmailTemplate::parse(raw);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn parse_empty_input() {
+        let result = EmailTemplate::parse("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_only_opening_delimiter() {
+        let result = EmailTemplate::parse("---");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_body_contains_triple_dash() {
+        let raw = "---\nsubject: \"Hi\"\n---\nBody\n---\nMore body";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Hi");
+        assert!(tpl.body.contains("Body"));
+        assert!(tpl.body.contains("---"));
+        assert!(tpl.body.contains("More body"));
+    }
+
+    #[test]
+    fn parse_empty_body() {
+        let raw = "---\nsubject: \"Hi\"\n---";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Hi");
+        assert!(tpl.body.trim().is_empty());
+    }
+
+    #[test]
+    fn parse_unicode_subject_and_body() {
+        let raw = "---\nsubject: \"Willkommen 🎉\"\n---\n你好世界";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Willkommen 🎉");
+        assert!(tpl.body.contains("你好世界"));
+    }
+
+    #[test]
+    fn parse_extra_whitespace_around_frontmatter() {
+        let raw = "  \n---\nsubject: \"Hi\"\n---\nBody  \n  ";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Hi");
+        assert!(tpl.body.contains("Body"));
+    }
+
+    #[test]
+    fn parse_extra_fields_ignored() {
+        let raw = "---\nsubject: \"Hi\"\npriority: high\ncustom_key: value\n---\nBody";
+        let tpl = EmailTemplate::parse(raw).unwrap();
+        assert_eq!(tpl.subject, "Hi");
+        assert!(tpl.body.contains("Body"));
+    }
 }

--- a/modo-email/src/template/vars.rs
+++ b/modo-email/src/template/vars.rs
@@ -5,10 +5,7 @@ use std::collections::HashMap;
 /// - Whitespace inside braces is trimmed: `{{ name }}` matches key `"name"`.
 /// - String values are inserted directly; other JSON types use their `to_string()` representation.
 /// - Unresolved placeholders are left as-is.
-pub fn substitute(
-    input: &str,
-    context: &HashMap<String, serde_json::Value>,
-) -> Result<String, modo::Error> {
+pub fn substitute(input: &str, context: &HashMap<String, serde_json::Value>) -> String {
     let mut result = String::with_capacity(input.len());
     let mut chars = input.chars().peekable();
 
@@ -48,7 +45,7 @@ pub fn substitute(
         }
     }
 
-    Ok(result)
+    result
 }
 
 #[cfg(test)]
@@ -62,14 +59,14 @@ mod tests {
         ctx.insert("name".to_string(), json!("Alice"));
         ctx.insert("code".to_string(), json!("1234"));
 
-        let result = substitute("Hello {{name}}, code: {{code}}", &ctx).unwrap();
+        let result = substitute("Hello {{name}}, code: {{code}}", &ctx);
         assert_eq!(result, "Hello Alice, code: 1234");
     }
 
     #[test]
     fn unresolved_vars_left_as_is() {
         let ctx = HashMap::new();
-        let result = substitute("Hello {{name}}", &ctx).unwrap();
+        let result = substitute("Hello {{name}}", &ctx);
         assert_eq!(result, "Hello {{name}}");
     }
 
@@ -77,7 +74,7 @@ mod tests {
     fn whitespace_in_braces() {
         let mut ctx = HashMap::new();
         ctx.insert("name".to_string(), json!("Bob"));
-        let result = substitute("Hello {{ name }}", &ctx).unwrap();
+        let result = substitute("Hello {{ name }}", &ctx);
         assert_eq!(result, "Hello Bob");
     }
 
@@ -86,34 +83,34 @@ mod tests {
         let mut ctx = HashMap::new();
         ctx.insert("count".to_string(), json!(42));
         ctx.insert("active".to_string(), json!(true));
-        let result = substitute("Count: {{count}}, active: {{active}}", &ctx).unwrap();
+        let result = substitute("Count: {{count}}, active: {{active}}", &ctx);
         assert_eq!(result, "Count: 42, active: true");
     }
 
     #[test]
     fn empty_input() {
         let ctx = HashMap::new();
-        assert_eq!(substitute("", &ctx).unwrap(), "");
+        assert_eq!(substitute("", &ctx), "");
     }
 
     #[test]
     fn no_placeholders_passthrough() {
         let ctx = HashMap::new();
-        let result = substitute("Plain text with no braces at all.", &ctx).unwrap();
+        let result = substitute("Plain text with no braces at all.", &ctx);
         assert_eq!(result, "Plain text with no braces at all.");
     }
 
     #[test]
     fn unclosed_placeholder_at_eof() {
         let ctx = HashMap::new();
-        let result = substitute("Hello {{name", &ctx).unwrap();
+        let result = substitute("Hello {{name", &ctx);
         assert_eq!(result, "Hello {{name");
     }
 
     #[test]
     fn unclosed_placeholder_mid_text() {
         let ctx = HashMap::new();
-        let result = substitute("Hello {{name and more", &ctx).unwrap();
+        let result = substitute("Hello {{name and more", &ctx);
         assert_eq!(result, "Hello {{name and more");
     }
 
@@ -122,14 +119,14 @@ mod tests {
         let mut ctx = HashMap::new();
         ctx.insert("a".to_string(), json!("X"));
         ctx.insert("b".to_string(), json!("Y"));
-        let result = substitute("{{a}}{{b}}", &ctx).unwrap();
+        let result = substitute("{{a}}{{b}}", &ctx);
         assert_eq!(result, "XY");
     }
 
     #[test]
     fn nested_braces() {
         let ctx = HashMap::new();
-        let result = substitute("{{{{name}}}}", &ctx).unwrap();
+        let result = substitute("{{{{name}}}}", &ctx);
         // First {{ matches first }} → key "{{name", not found → "{{{{name}}"
         // Remaining }} are literal
         assert_eq!(result, "{{{{name}}}}");
@@ -138,7 +135,7 @@ mod tests {
     #[test]
     fn whitespace_only_key() {
         let ctx = HashMap::new();
-        let result = substitute("{{ }}", &ctx).unwrap();
+        let result = substitute("{{ }}", &ctx);
         // Key trims to "", lookup fails → left as {{}}
         assert_eq!(result, "{{}}");
     }
@@ -147,7 +144,7 @@ mod tests {
     fn null_json_value() {
         let mut ctx = HashMap::new();
         ctx.insert("val".to_string(), json!(null));
-        let result = substitute("Got: {{val}}", &ctx).unwrap();
+        let result = substitute("Got: {{val}}", &ctx);
         assert_eq!(result, "Got: null");
     }
 
@@ -155,7 +152,7 @@ mod tests {
     fn object_json_value() {
         let mut ctx = HashMap::new();
         ctx.insert("obj".to_string(), json!({"key": "value"}));
-        let result = substitute("{{obj}}", &ctx).unwrap();
+        let result = substitute("{{obj}}", &ctx);
         assert_eq!(result, r#"{"key":"value"}"#);
     }
 
@@ -163,7 +160,7 @@ mod tests {
     fn array_json_value() {
         let mut ctx = HashMap::new();
         ctx.insert("arr".to_string(), json!([1, 2, 3]));
-        let result = substitute("{{arr}}", &ctx).unwrap();
+        let result = substitute("{{arr}}", &ctx);
         assert_eq!(result, "[1,2,3]");
     }
 
@@ -171,7 +168,7 @@ mod tests {
     fn unicode_in_keys_and_values() {
         let mut ctx = HashMap::new();
         ctx.insert("名前".to_string(), json!("太郎"));
-        let result = substitute("Hello {{名前}}", &ctx).unwrap();
+        let result = substitute("Hello {{名前}}", &ctx);
         assert_eq!(result, "Hello 太郎");
     }
 }

--- a/modo-email/src/template/vars.rs
+++ b/modo-email/src/template/vars.rs
@@ -5,7 +5,10 @@ use std::collections::HashMap;
 /// - Whitespace inside braces is trimmed: `{{ name }}` matches key `"name"`.
 /// - String values are inserted directly; other JSON types use their `to_string()` representation.
 /// - Unresolved placeholders are left as-is.
-pub fn substitute(input: &str, context: &HashMap<String, serde_json::Value>) -> String {
+pub fn substitute(
+    input: &str,
+    context: &HashMap<String, serde_json::Value>,
+) -> Result<String, modo::Error> {
     let mut result = String::with_capacity(input.len());
     let mut chars = input.chars().peekable();
 
@@ -45,7 +48,7 @@ pub fn substitute(input: &str, context: &HashMap<String, serde_json::Value>) -> 
         }
     }
 
-    result
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -59,14 +62,14 @@ mod tests {
         ctx.insert("name".to_string(), json!("Alice"));
         ctx.insert("code".to_string(), json!("1234"));
 
-        let result = substitute("Hello {{name}}, code: {{code}}", &ctx);
+        let result = substitute("Hello {{name}}, code: {{code}}", &ctx).unwrap();
         assert_eq!(result, "Hello Alice, code: 1234");
     }
 
     #[test]
     fn unresolved_vars_left_as_is() {
         let ctx = HashMap::new();
-        let result = substitute("Hello {{name}}", &ctx);
+        let result = substitute("Hello {{name}}", &ctx).unwrap();
         assert_eq!(result, "Hello {{name}}");
     }
 
@@ -74,7 +77,7 @@ mod tests {
     fn whitespace_in_braces() {
         let mut ctx = HashMap::new();
         ctx.insert("name".to_string(), json!("Bob"));
-        let result = substitute("Hello {{ name }}", &ctx);
+        let result = substitute("Hello {{ name }}", &ctx).unwrap();
         assert_eq!(result, "Hello Bob");
     }
 
@@ -83,13 +86,92 @@ mod tests {
         let mut ctx = HashMap::new();
         ctx.insert("count".to_string(), json!(42));
         ctx.insert("active".to_string(), json!(true));
-        let result = substitute("Count: {{count}}, active: {{active}}", &ctx);
+        let result = substitute("Count: {{count}}, active: {{active}}", &ctx).unwrap();
         assert_eq!(result, "Count: 42, active: true");
     }
 
     #[test]
     fn empty_input() {
         let ctx = HashMap::new();
-        assert_eq!(substitute("", &ctx), "");
+        assert_eq!(substitute("", &ctx).unwrap(), "");
+    }
+
+    #[test]
+    fn no_placeholders_passthrough() {
+        let ctx = HashMap::new();
+        let result = substitute("Plain text with no braces at all.", &ctx).unwrap();
+        assert_eq!(result, "Plain text with no braces at all.");
+    }
+
+    #[test]
+    fn unclosed_placeholder_at_eof() {
+        let ctx = HashMap::new();
+        let result = substitute("Hello {{name", &ctx).unwrap();
+        assert_eq!(result, "Hello {{name");
+    }
+
+    #[test]
+    fn unclosed_placeholder_mid_text() {
+        let ctx = HashMap::new();
+        let result = substitute("Hello {{name and more", &ctx).unwrap();
+        assert_eq!(result, "Hello {{name and more");
+    }
+
+    #[test]
+    fn adjacent_placeholders() {
+        let mut ctx = HashMap::new();
+        ctx.insert("a".to_string(), json!("X"));
+        ctx.insert("b".to_string(), json!("Y"));
+        let result = substitute("{{a}}{{b}}", &ctx).unwrap();
+        assert_eq!(result, "XY");
+    }
+
+    #[test]
+    fn nested_braces() {
+        let ctx = HashMap::new();
+        let result = substitute("{{{{name}}}}", &ctx).unwrap();
+        // First {{ matches first }} → key "{{name", not found → "{{{{name}}"
+        // Remaining }} are literal
+        assert_eq!(result, "{{{{name}}}}");
+    }
+
+    #[test]
+    fn whitespace_only_key() {
+        let ctx = HashMap::new();
+        let result = substitute("{{ }}", &ctx).unwrap();
+        // Key trims to "", lookup fails → left as {{}}
+        assert_eq!(result, "{{}}");
+    }
+
+    #[test]
+    fn null_json_value() {
+        let mut ctx = HashMap::new();
+        ctx.insert("val".to_string(), json!(null));
+        let result = substitute("Got: {{val}}", &ctx).unwrap();
+        assert_eq!(result, "Got: null");
+    }
+
+    #[test]
+    fn object_json_value() {
+        let mut ctx = HashMap::new();
+        ctx.insert("obj".to_string(), json!({"key": "value"}));
+        let result = substitute("{{obj}}", &ctx).unwrap();
+        assert_eq!(result, r#"{"key":"value"}"#);
+    }
+
+    #[test]
+    fn array_json_value() {
+        let mut ctx = HashMap::new();
+        ctx.insert("arr".to_string(), json!([1, 2, 3]));
+        let result = substitute("{{arr}}", &ctx).unwrap();
+        assert_eq!(result, "[1,2,3]");
+    }
+
+    #[test]
+    fn unicode_in_keys_and_values() {
+        let mut ctx = HashMap::new();
+        ctx.insert("名前".to_string(), json!("太郎"));
+        let result = substitute("Hello {{名前}}", &ctx).unwrap();
+        assert_eq!(result, "Hello 太郎");
     }
 }

--- a/modo-jobs-macros/src/job.rs
+++ b/modo-jobs-macros/src/job.rs
@@ -7,9 +7,9 @@ use syn::{FnArg, Ident, ItemFn, Lit, LitStr, Pat, Result, Token, Type, parse2};
 // ---------------------------------------------------------------------------
 
 struct JobArgs {
-    queue: String,
-    priority: i32,
-    max_attempts: u32,
+    queue: Option<String>,
+    priority: Option<i32>,
+    max_attempts: Option<u32>,
     timeout: String,
     cron: Option<String>,
 }
@@ -17,9 +17,9 @@ struct JobArgs {
 impl Default for JobArgs {
     fn default() -> Self {
         Self {
-            queue: "default".to_string(),
-            priority: 0,
-            max_attempts: 3,
+            queue: None,
+            priority: None,
+            max_attempts: None,
             timeout: "5m".to_string(),
             cron: None,
         }
@@ -29,50 +29,37 @@ impl Default for JobArgs {
 impl syn::parse::Parse for JobArgs {
     fn parse(input: syn::parse::ParseStream) -> Result<Self> {
         let mut args = JobArgs::default();
-        let mut has_queue = false;
-        let mut has_priority = false;
-        let mut has_max_attempts = false;
 
         while !input.is_empty() {
             let ident: Ident = input.parse()?;
             input.parse::<Token![=]>()?;
 
-            match ident.to_string().as_str() {
-                "queue" => {
-                    let val: LitStr = input.parse()?;
-                    args.queue = val.value();
-                    has_queue = true;
-                }
-                "priority" => {
-                    let val: Lit = input.parse()?;
-                    args.priority = match val {
-                        Lit::Int(i) => i.base10_parse()?,
-                        _ => return Err(syn::Error::new_spanned(val, "expected integer")),
-                    };
-                    has_priority = true;
-                }
-                "max_attempts" => {
-                    let val: Lit = input.parse()?;
-                    args.max_attempts = match val {
-                        Lit::Int(i) => i.base10_parse()?,
-                        _ => return Err(syn::Error::new_spanned(val, "expected integer")),
-                    };
-                    has_max_attempts = true;
-                }
-                "timeout" => {
-                    let val: LitStr = input.parse()?;
-                    args.timeout = val.value();
-                }
-                "cron" => {
-                    let val: LitStr = input.parse()?;
-                    args.cron = Some(val.value());
-                }
-                other => {
-                    return Err(syn::Error::new_spanned(
-                        ident,
-                        format!("unknown job attribute: {other}"),
-                    ));
-                }
+            if ident == "queue" {
+                let val: LitStr = input.parse()?;
+                args.queue = Some(val.value());
+            } else if ident == "priority" {
+                let val: Lit = input.parse()?;
+                args.priority = Some(match val {
+                    Lit::Int(i) => i.base10_parse()?,
+                    _ => return Err(syn::Error::new_spanned(val, "expected integer")),
+                });
+            } else if ident == "max_attempts" {
+                let val: Lit = input.parse()?;
+                args.max_attempts = Some(match val {
+                    Lit::Int(i) => i.base10_parse()?,
+                    _ => return Err(syn::Error::new_spanned(val, "expected integer")),
+                });
+            } else if ident == "timeout" {
+                let val: LitStr = input.parse()?;
+                args.timeout = val.value();
+            } else if ident == "cron" {
+                let val: LitStr = input.parse()?;
+                args.cron = Some(val.value());
+            } else {
+                return Err(syn::Error::new_spanned(
+                    &ident,
+                    format!("unknown job attribute: {ident}"),
+                ));
             }
 
             if input.peek(Token![,]) {
@@ -81,7 +68,9 @@ impl syn::parse::Parse for JobArgs {
         }
 
         // Mutual exclusion: cron + queue/priority/max_attempts
-        if args.cron.is_some() && (has_queue || has_priority || has_max_attempts) {
+        if args.cron.is_some()
+            && (args.queue.is_some() || args.priority.is_some() || args.max_attempts.is_some())
+        {
             return Err(syn::Error::new(
                 proc_macro2::Span::call_site(),
                 "cron jobs cannot have queue, priority, or max_attempts attributes",
@@ -111,33 +100,24 @@ fn to_pascal_case(s: &str) -> String {
 
 fn parse_duration_secs(s: &str) -> Result<u64> {
     let s = s.trim();
-    if let Some(num) = s.strip_suffix('s') {
-        num.parse::<u64>().map_err(|_| {
-            syn::Error::new(
-                proc_macro2::Span::call_site(),
-                format!("invalid timeout: {s}"),
-            )
-        })
-    } else if let Some(num) = s.strip_suffix('m') {
-        num.parse::<u64>().map(|n| n * 60).map_err(|_| {
-            syn::Error::new(
-                proc_macro2::Span::call_site(),
-                format!("invalid timeout: {s}"),
-            )
-        })
-    } else if let Some(num) = s.strip_suffix('h') {
-        num.parse::<u64>().map(|n| n * 3600).map_err(|_| {
-            syn::Error::new(
-                proc_macro2::Span::call_site(),
-                format!("invalid timeout: {s}"),
-            )
-        })
+    let (num_str, mult) = if let Some(n) = s.strip_suffix('h') {
+        (n, 3600u64)
+    } else if let Some(n) = s.strip_suffix('m') {
+        (n, 60)
+    } else if let Some(n) = s.strip_suffix('s') {
+        (n, 1)
     } else {
-        Err(syn::Error::new(
+        return Err(syn::Error::new(
             proc_macro2::Span::call_site(),
             format!("invalid timeout format: {s}. Use e.g. '30s', '5m', '1h'"),
-        ))
-    }
+        ));
+    };
+    num_str.parse::<u64>().map(|n| n * mult).map_err(|_| {
+        syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("invalid timeout: {s}"),
+        )
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -199,16 +179,15 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
         ));
     }
 
-    let func_name = func.sig.ident.clone();
+    let func_name = &func.sig.ident;
     let func_name_str = func_name.to_string();
     let impl_name = format_ident!("__job_{}_impl", func_name);
     let struct_name = format_ident!("{}Job", to_pascal_case(&func_name_str));
 
     let timeout_secs = parse_duration_secs(&args.timeout)?;
-    let queue = &args.queue;
-    let priority = args.priority;
-    let max_attempts = args.max_attempts;
-    let is_cron = args.cron.is_some();
+    let queue = args.queue.as_deref().unwrap_or("default");
+    let priority = args.priority.unwrap_or(0);
+    let max_attempts = args.max_attempts.unwrap_or(3);
 
     let cron_expr = match &args.cron {
         Some(expr) => quote! { Some(#expr) },
@@ -266,9 +245,13 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     impl_func.sig.ident = impl_name.clone();
     impl_func.vis = syn::Visibility::Inherited;
 
-    // Generate handler impl
+    // Generate handler impl with JOB_NAME const
     let handler_impl = quote! {
         pub struct #struct_name;
+
+        impl #struct_name {
+            pub const JOB_NAME: &str = #func_name_str;
+        }
 
         impl modo_jobs::JobHandler for #struct_name {
             async fn run(&self, ctx: modo_jobs::JobContext) -> Result<(), modo_jobs::modo::error::Error> {
@@ -279,42 +262,26 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     };
 
     // Generate enqueue methods (only for non-cron jobs)
-    let enqueue_methods = if !is_cron {
-        if let Some(ref payload_ty) = payload_type {
-            quote! {
-                impl #struct_name {
-                    pub async fn enqueue(
-                        queue: &modo_jobs::JobQueue,
-                        payload: &#payload_ty,
-                    ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
-                        queue.enqueue(#func_name_str, payload).await
-                    }
-
-                    pub async fn enqueue_at(
-                        queue: &modo_jobs::JobQueue,
-                        payload: &#payload_ty,
-                        run_at: modo_jobs::chrono::DateTime<modo_jobs::chrono::Utc>,
-                    ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
-                        queue.enqueue_at(#func_name_str, payload, run_at).await
-                    }
+    let enqueue_methods = if args.cron.is_none() {
+        let (payload_param, payload_arg) = match &payload_type {
+            Some(ty) => (quote! { payload: &#ty, }, quote! { payload }),
+            None => (quote! {}, quote! { &() }),
+        };
+        quote! {
+            impl #struct_name {
+                pub async fn enqueue(
+                    queue: &modo_jobs::JobQueue,
+                    #payload_param
+                ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
+                    queue.enqueue(Self::JOB_NAME, #payload_arg).await
                 }
-            }
-        } else {
-            // No-payload job
-            quote! {
-                impl #struct_name {
-                    pub async fn enqueue(
-                        queue: &modo_jobs::JobQueue,
-                    ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
-                        queue.enqueue(#func_name_str, &()).await
-                    }
 
-                    pub async fn enqueue_at(
-                        queue: &modo_jobs::JobQueue,
-                        run_at: modo_jobs::chrono::DateTime<modo_jobs::chrono::Utc>,
-                    ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
-                        queue.enqueue_at(#func_name_str, &(), run_at).await
-                    }
+                pub async fn enqueue_at(
+                    queue: &modo_jobs::JobQueue,
+                    #payload_param
+                    run_at: modo_jobs::chrono::DateTime<modo_jobs::chrono::Utc>,
+                ) -> Result<modo_jobs::JobId, modo_jobs::modo::error::Error> {
+                    queue.enqueue_at(Self::JOB_NAME, #payload_arg, run_at).await
                 }
             }
         }
@@ -326,7 +293,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     let registration = quote! {
         modo_jobs::inventory::submit! {
             modo_jobs::JobRegistration {
-                name: #func_name_str,
+                name: #struct_name::JOB_NAME,
                 queue: #queue,
                 priority: #priority,
                 max_attempts: #max_attempts,

--- a/modo-jobs/src/config.rs
+++ b/modo-jobs/src/config.rs
@@ -1,4 +1,5 @@
 use crate::types::JobState;
+use modo::Error;
 use serde::Deserialize;
 
 /// Top-level jobs configuration, deserialized from YAML.
@@ -20,23 +21,26 @@ pub struct JobsConfig {
 }
 
 impl JobsConfig {
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self) -> Result<(), Error> {
         if self.poll_interval_secs == 0 {
-            return Err("poll_interval_secs must be > 0".into());
+            return Err(Error::internal("poll_interval_secs must be > 0"));
         }
         if self.stale_threshold_secs == 0 {
-            return Err("stale_threshold_secs must be > 0".into());
+            return Err(Error::internal("stale_threshold_secs must be > 0"));
         }
         if self.queues.is_empty() {
-            return Err("at least one queue must be configured".into());
+            return Err(Error::internal("at least one queue must be configured"));
         }
         for q in &self.queues {
             if q.concurrency == 0 {
-                return Err(format!("queue '{}': concurrency must be > 0", q.name));
+                return Err(Error::internal(format!(
+                    "queue '{}': concurrency must be > 0",
+                    q.name
+                )));
             }
         }
         if self.cleanup.interval_secs == 0 {
-            return Err("cleanup.interval_secs must be > 0".into());
+            return Err(Error::internal("cleanup.interval_secs must be > 0"));
         }
         Ok(())
     }

--- a/modo-jobs/src/cron.rs
+++ b/modo-jobs/src/cron.rs
@@ -1,8 +1,6 @@
 use crate::handler::{JobContext, JobRegistration};
 use crate::types::JobId;
 use modo::app::ServiceRegistry;
-use modo_db::pool::DbPool;
-use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -55,7 +53,6 @@ async fn run_cron_loop(
     handler_factory: fn() -> Box<dyn crate::handler::JobHandlerDyn>,
     schedule: cron::Schedule,
 ) {
-    let db_pool: Option<Arc<DbPool>> = services.get::<DbPool>();
     let mut consecutive_failures: u32 = 0;
 
     loop {
@@ -84,7 +81,6 @@ async fn run_cron_loop(
                     queue: "cron".to_string(),
                     attempt: 1,
                     services: services.clone(),
-                    db: db_pool.as_ref().map(|p| (**p).clone()),
                     payload_json: "null".to_string(),
                 };
 
@@ -99,20 +95,14 @@ async fn run_cron_loop(
                         consecutive_failures = 0;
                         info!(job = name, "Cron job completed");
                     }
-                    Ok(Err(e)) => {
+                    outcome => {
+                        let err_msg = match &outcome {
+                            Ok(Err(e)) => format!("{e}"),
+                            Err(_) => format!("timed out after {timeout_secs}s"),
+                            _ => unreachable!(),
+                        };
                         consecutive_failures += 1;
-                        error!(job = name, error = %e, "Cron job failed");
-                        if consecutive_failures >= 5 {
-                            warn!(
-                                job = name,
-                                consecutive_failures,
-                                "Cron job has failed {consecutive_failures} consecutive times, investigate"
-                            );
-                        }
-                    }
-                    Err(_) => {
-                        consecutive_failures += 1;
-                        error!(job = name, "Cron job timed out");
+                        error!(job = name, error = %err_msg, "Cron job failed");
                         if consecutive_failures >= 5 {
                             warn!(
                                 job = name,

--- a/modo-jobs/src/handler.rs
+++ b/modo-jobs/src/handler.rs
@@ -12,7 +12,6 @@ pub struct JobContext {
     pub queue: String,
     pub attempt: i32,
     pub(crate) services: ServiceRegistry,
-    pub(crate) db: Option<DbPool>,
     pub(crate) payload_json: String,
 }
 
@@ -34,9 +33,9 @@ impl JobContext {
     }
 
     /// Get the database connection pool.
-    pub fn db(&self) -> Result<&DbPool, modo::Error> {
-        self.db
-            .as_ref()
+    pub fn db(&self) -> Result<Arc<DbPool>, modo::Error> {
+        self.services
+            .get::<DbPool>()
             .ok_or_else(|| modo::Error::internal("Database not available in job context"))
     }
 }

--- a/modo-jobs/src/queue.rs
+++ b/modo-jobs/src/queue.rs
@@ -3,21 +3,20 @@ use crate::handler::JobRegistration;
 use crate::types::{JobId, JobState};
 use chrono::{DateTime, Utc};
 use modo_db::sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter};
-use std::sync::Arc;
 
 /// Handle for enqueuing and cancelling jobs.
 ///
 /// Implements `FromRequestParts` for use as an axum extractor.
 #[derive(Clone)]
 pub struct JobQueue {
-    pub(crate) db: Arc<modo_db::sea_orm::DatabaseConnection>,
+    pub(crate) db: modo_db::sea_orm::DatabaseConnection,
     pub(crate) max_payload_bytes: Option<usize>,
 }
 
 impl JobQueue {
     pub fn new(db: &modo_db::pool::DbPool, max_payload_bytes: Option<usize>) -> Self {
         Self {
-            db: Arc::new(db.connection().clone()),
+            db: db.connection().clone(),
             max_payload_bytes,
         }
     }
@@ -72,7 +71,7 @@ impl JobQueue {
                     job::Column::UpdatedAt,
                     modo_db::sea_orm::sea_query::Expr::value(Utc::now()),
                 ),
-            self.db.as_ref(),
+            &self.db,
         )
         .await
         .map_err(|e| modo::Error::internal(format!("Failed to cancel job: {e}")))?;
@@ -114,7 +113,7 @@ impl JobQueue {
         };
 
         model
-            .insert(self.db.as_ref())
+            .insert(&self.db)
             .await
             .map_err(|e| modo::Error::internal(format!("Failed to insert job: {e}")))?;
 

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -3,11 +3,11 @@ use crate::entity::job;
 use crate::handler::{JobContext, JobHandlerDyn, JobRegistration};
 use crate::queue::JobQueue;
 use crate::types::{JobId, JobState};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use modo::app::ServiceRegistry;
-use modo_db::pool::DbPool;
 use modo_db::sea_orm::{
     ColumnTrait, DatabaseBackend, EntityTrait, ExprTrait, FromQueryResult, QueryFilter, Statement,
+    UpdateMany,
 };
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -87,13 +87,11 @@ struct PollContext {
 ///
 /// Returns a `JobsHandle` that should be registered as a service.
 pub async fn start(
-    db: &DbPool,
+    db: &modo_db::pool::DbPool,
     config: &JobsConfig,
     services: ServiceRegistry,
 ) -> Result<JobsHandle, modo::Error> {
-    config
-        .validate()
-        .map_err(|e| modo::Error::internal(format!("Invalid jobs config: {e}")))?;
+    config.validate()?;
 
     // Validate queue config against registered jobs
     let queue_names: HashMap<&str, usize> = config
@@ -107,12 +105,12 @@ pub async fn start(
             continue; // cron jobs don't use queues
         }
         if !queue_names.contains_key(reg.queue) {
-            panic!(
+            return Err(modo::Error::internal(format!(
                 "Job '{}' references queue '{}' which is not configured. Available queues: {:?}",
                 reg.name,
                 reg.queue,
                 queue_names.keys().collect::<Vec<_>>()
-            );
+            )));
         }
     }
 
@@ -249,8 +247,8 @@ pub async fn claim_next(
     // Raw SQL is required here because SeaORM doesn't support the atomic
     // UPDATE...WHERE id = (SELECT...) RETURNING * pattern. This single-statement
     // approach claims a job atomically without race conditions between workers.
-    let (sql, values) = match backend {
-        DatabaseBackend::Sqlite => (
+    let sql = match backend {
+        DatabaseBackend::Sqlite => {
             "UPDATE modo_jobs \
              SET state = 'running', locked_by = $1, \
                  locked_at = $2, attempts = attempts + 1, \
@@ -261,16 +259,9 @@ pub async fn claim_next(
                  ORDER BY priority DESC, run_at ASC \
                  LIMIT 1 \
              ) \
-             RETURNING *",
-            vec![
-                worker_id.into(),
-                now.into(),
-                now.into(),
-                queue.into(),
-                now.into(),
-            ],
-        ),
-        DatabaseBackend::Postgres => (
+             RETURNING *"
+        }
+        DatabaseBackend::Postgres => {
             "UPDATE modo_jobs \
              SET state = 'running', locked_by = $1, \
                  locked_at = $2, attempts = attempts + 1, \
@@ -282,19 +273,17 @@ pub async fn claim_next(
                  LIMIT 1 \
                  FOR UPDATE SKIP LOCKED \
              ) \
-             RETURNING *",
-            vec![
-                worker_id.into(),
-                now.into(),
-                now.into(),
-                queue.into(),
-                now.into(),
-            ],
-        ),
-        _ => {
-            return Err(modo::Error::internal("Unsupported database backend"));
+             RETURNING *"
         }
+        _ => return Err(modo::Error::internal("Unsupported database backend")),
     };
+    let values = vec![
+        worker_id.into(),
+        now.into(),
+        now.into(),
+        queue.into(),
+        now.into(),
+    ];
 
     let stmt = Statement::from_sql_and_values(backend, sql, values);
     let result = job::Model::find_by_statement(stmt)
@@ -310,37 +299,28 @@ async fn execute_job(
     job: job::Model,
     services: ServiceRegistry,
 ) {
-    let job_id = JobId::from_raw(&job.id);
-    let job_name = job.name.clone();
-    let queue = job.queue.clone();
-    let attempt = job.attempts;
-    let max_attempts = job.max_attempts;
+    let job_name = &job.name;
+    let queue = &job.queue;
     let timeout_secs = Ord::max(job.timeout_secs, 1) as u64;
 
     // Find handler
     let handler: Option<Box<dyn JobHandlerDyn>> = inventory::iter::<JobRegistration>
         .into_iter()
-        .find(|r| r.name == job_name)
+        .find(|r| r.name == *job_name)
         .map(|r| (r.handler_factory)());
 
     let Some(handler) = handler else {
-        error!(
-            job_id = %job_id,
-            job_name = %job_name,
-            "No handler registered for job"
-        );
+        error!(job_id = %job.id, job_name = %job_name, "No handler registered for job");
         mark_dead(db, &job.id, Some("No handler registered for job")).await;
         return;
     };
 
-    let db_pool = services.get::<DbPool>();
     let ctx = JobContext {
-        job_id: job_id.clone(),
-        name: job_name.clone(),
-        queue: queue.clone(),
-        attempt,
+        job_id: JobId::from(job.id.clone()),
+        name: job.name.clone(),
+        queue: job.queue.clone(),
+        attempt: job.attempts,
         services,
-        db: db_pool.map(|p| (*p).clone()),
         payload_json: job.payload.clone(),
     };
 
@@ -352,29 +332,20 @@ async fn execute_job(
             mark_completed(db, &job.id).await;
         }
         Ok(Err(e)) => {
-            let error_msg = e.to_string();
             error!(
-                job_id = %job_id,
-                job_name = %job_name,
-                queue = %queue,
-                attempt = attempt,
-                max_attempts = max_attempts,
-                error = %e,
-                "Job failed"
+                job_id = %job.id, job_name = %job_name, queue = %queue,
+                attempt = job.attempts, max_attempts = job.max_attempts,
+                error = %e, "Job failed"
             );
-            handle_failure(db, &job, Some(&error_msg)).await;
+            handle_failure(db, &job, Some(&e.to_string())).await;
         }
         Err(_) => {
-            let error_msg = format!("Job timed out after {timeout_secs}s");
             error!(
-                job_id = %job_id,
-                job_name = %job_name,
-                queue = %queue,
-                attempt = attempt,
-                max_attempts = max_attempts,
+                job_id = %job.id, job_name = %job_name, queue = %queue,
+                attempt = job.attempts, max_attempts = job.max_attempts,
                 "Job timed out"
             );
-            handle_failure(db, &job, Some(&error_msg)).await;
+            handle_failure(db, &job, Some(&format!("Job timed out after {timeout_secs}s"))).await;
         }
     }
 }
@@ -392,30 +363,33 @@ pub async fn handle_failure(
     }
 }
 
-#[doc(hidden)]
-pub async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
-    let now = Utc::now();
-    if let Err(e) = job::Entity::update_many()
-        .filter(job::Column::Id.eq(id))
-        .col_expr(
-            job::Column::State,
-            modo_db::sea_orm::sea_query::Expr::value(JobState::Completed.as_str()),
-        )
+/// Apply the common "release lock + set updated_at" columns to an update query.
+fn release_lock(update: UpdateMany<job::Entity>, now: DateTime<Utc>) -> UpdateMany<job::Entity> {
+    update
         .col_expr(
             job::Column::LockedBy,
             modo_db::sea_orm::sea_query::Expr::value(Option::<String>::None),
         )
         .col_expr(
             job::Column::LockedAt,
-            modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
+            modo_db::sea_orm::sea_query::Expr::value(Option::<DateTime<Utc>>::None),
         )
         .col_expr(
             job::Column::UpdatedAt,
             modo_db::sea_orm::sea_query::Expr::value(now),
         )
-        .exec(db)
-        .await
-    {
+}
+
+#[doc(hidden)]
+pub async fn mark_completed(db: &modo_db::sea_orm::DatabaseConnection, id: &str) {
+    let now = Utc::now();
+    let update = job::Entity::update_many()
+        .filter(job::Column::Id.eq(id))
+        .col_expr(
+            job::Column::State,
+            modo_db::sea_orm::sea_query::Expr::value(JobState::Completed.as_str()),
+        );
+    if let Err(e) = release_lock(update, now).exec(db).await {
         error!(job_id = id, error = %e, "Failed to mark job completed");
     }
 }
@@ -435,7 +409,7 @@ pub async fn schedule_retry(
     );
     let next_run = now + chrono::Duration::seconds(backoff_secs as i64);
 
-    if let Err(e) = job::Entity::update_many()
+    let update = job::Entity::update_many()
         .filter(job::Column::Id.eq(&job.id))
         .col_expr(
             job::Column::State,
@@ -446,24 +420,10 @@ pub async fn schedule_retry(
             modo_db::sea_orm::sea_query::Expr::value(next_run),
         )
         .col_expr(
-            job::Column::LockedBy,
-            modo_db::sea_orm::sea_query::Expr::value(Option::<String>::None),
-        )
-        .col_expr(
-            job::Column::LockedAt,
-            modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
-        )
-        .col_expr(
             job::Column::LastError,
             modo_db::sea_orm::sea_query::Expr::value(error_msg.map(|s| s.to_string())),
-        )
-        .col_expr(
-            job::Column::UpdatedAt,
-            modo_db::sea_orm::sea_query::Expr::value(now),
-        )
-        .exec(db)
-        .await
-    {
+        );
+    if let Err(e) = release_lock(update, now).exec(db).await {
         error!(job_id = &job.id, error = %e, "Failed to schedule job retry");
     }
 }
@@ -475,31 +435,17 @@ pub async fn mark_dead(
     error_msg: Option<&str>,
 ) {
     let now = Utc::now();
-    if let Err(e) = job::Entity::update_many()
+    let update = job::Entity::update_many()
         .filter(job::Column::Id.eq(id))
         .col_expr(
             job::Column::State,
             modo_db::sea_orm::sea_query::Expr::value(JobState::Dead.as_str()),
         )
         .col_expr(
-            job::Column::LockedBy,
-            modo_db::sea_orm::sea_query::Expr::value(Option::<String>::None),
-        )
-        .col_expr(
-            job::Column::LockedAt,
-            modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
-        )
-        .col_expr(
             job::Column::LastError,
             modo_db::sea_orm::sea_query::Expr::value(error_msg.map(|s| s.to_string())),
-        )
-        .col_expr(
-            job::Column::UpdatedAt,
-            modo_db::sea_orm::sea_query::Expr::value(now),
-        )
-        .exec(db)
-        .await
-    {
+        );
+    if let Err(e) = release_lock(update, now).exec(db).await {
         error!(job_id = id, error = %e, "Failed to mark job dead");
     }
 }
@@ -519,8 +465,9 @@ async fn reap_stale_loop(
                 break;
             }
             _ = interval.tick() => {
-                let cutoff = Utc::now() - chrono::Duration::seconds(threshold_secs as i64);
-                match job::Entity::update_many()
+                let now = Utc::now();
+                let cutoff = now - chrono::Duration::seconds(threshold_secs as i64);
+                let update = job::Entity::update_many()
                     .filter(job::Column::State.eq(JobState::Running.as_str()))
                     .filter(job::Column::LockedAt.lt(cutoff))
                     .col_expr(
@@ -528,23 +475,10 @@ async fn reap_stale_loop(
                         modo_db::sea_orm::sea_query::Expr::value(JobState::Pending.as_str()),
                     )
                     .col_expr(
-                        job::Column::LockedBy,
-                        modo_db::sea_orm::sea_query::Expr::value(Option::<String>::None),
-                    )
-                    .col_expr(
-                        job::Column::LockedAt,
-                        modo_db::sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
-                    )
-                    .col_expr(
                         job::Column::Attempts,
                         modo_db::sea_orm::sea_query::Expr::col(job::Column::Attempts).sub(1),
-                    )
-                    .col_expr(
-                        job::Column::UpdatedAt,
-                        modo_db::sea_orm::sea_query::Expr::value(Utc::now()),
-                    )
-                    .exec(db)
-                    .await
+                    );
+                match release_lock(update, now).exec(db).await
                 {
                     Ok(result) if result.rows_affected > 0 => {
                         warn!(count = result.rows_affected, "Reaped stale jobs");

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -345,7 +345,12 @@ async fn execute_job(
                 attempt = job.attempts, max_attempts = job.max_attempts,
                 "Job timed out"
             );
-            handle_failure(db, &job, Some(&format!("Job timed out after {timeout_secs}s"))).await;
+            handle_failure(
+                db,
+                &job,
+                Some(&format!("Job timed out after {timeout_secs}s")),
+            )
+            .await;
         }
     }
 }

--- a/modo-jobs/src/types.rs
+++ b/modo-jobs/src/types.rs
@@ -17,9 +17,27 @@ impl JobId {
         &self.0
     }
 
-    /// Create a `JobId` from an existing raw string (e.g. from DB).
-    pub fn from_raw(s: impl Into<String>) -> Self {
-        Self(s.into())
+    /// Consume the ID, returning the inner `String`.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl From<String> for JobId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for JobId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl AsRef<str> for JobId {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 

--- a/modo-jobs/tests/config.rs
+++ b/modo-jobs/tests/config.rs
@@ -80,12 +80,8 @@ fn test_validate_rejects_zero_poll_interval() {
         poll_interval_secs: 0,
         ..Default::default()
     };
-    assert!(
-        config
-            .validate()
-            .unwrap_err()
-            .contains("poll_interval_secs")
-    );
+    let err = config.validate().unwrap_err().to_string();
+    assert!(err.contains("poll_interval_secs"));
 }
 
 #[test]
@@ -94,12 +90,8 @@ fn test_validate_rejects_zero_stale_threshold() {
         stale_threshold_secs: 0,
         ..Default::default()
     };
-    assert!(
-        config
-            .validate()
-            .unwrap_err()
-            .contains("stale_threshold_secs")
-    );
+    let err = config.validate().unwrap_err().to_string();
+    assert!(err.contains("stale_threshold_secs"));
 }
 
 #[test]
@@ -108,7 +100,8 @@ fn test_validate_rejects_empty_queues() {
         queues: vec![],
         ..Default::default()
     };
-    assert!(config.validate().unwrap_err().contains("queue"));
+    let err = config.validate().unwrap_err().to_string();
+    assert!(err.contains("queue"));
 }
 
 #[test]
@@ -120,7 +113,8 @@ fn test_validate_rejects_zero_concurrency() {
         }],
         ..Default::default()
     };
-    assert!(config.validate().unwrap_err().contains("concurrency"));
+    let err = config.validate().unwrap_err().to_string();
+    assert!(err.contains("concurrency"));
 }
 
 #[test]
@@ -132,12 +126,8 @@ fn test_validate_rejects_zero_cleanup_interval() {
         },
         ..Default::default()
     };
-    assert!(
-        config
-            .validate()
-            .unwrap_err()
-            .contains("cleanup.interval_secs")
-    );
+    let err = config.validate().unwrap_err().to_string();
+    assert!(err.contains("cleanup.interval_secs"));
 }
 
 #[test]

--- a/modo-macros/src/handler.rs
+++ b/modo-macros/src/handler.rs
@@ -1,4 +1,4 @@
-use crate::middleware::{MiddlewareList, gen_handler_middleware_wrapper};
+use crate::middleware::{MiddlewareList, build_middleware_vec, gen_handler_middleware_wrapper};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{FnArg, Ident, ItemFn, LitStr, Pat, Result, Token, Type, parse2};
@@ -111,20 +111,17 @@ fn transform_path_params(
         }
     };
 
-    // Remove matched params from function signature (in reverse order to preserve indices)
-    let mut indices: Vec<usize> = matched.iter().map(|m| m.sig_index).collect();
-    indices.sort_unstable();
-    indices.reverse();
-    for idx in indices {
-        func.sig.inputs = func
-            .sig
-            .inputs
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| *i != idx)
-            .map(|(_, arg)| arg.clone())
-            .collect();
-    }
+    // Remove matched params from function signature in a single pass
+    let remove_indices: std::collections::HashSet<usize> =
+        matched.iter().map(|m| m.sig_index).collect();
+    func.sig.inputs = func
+        .sig
+        .inputs
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !remove_indices.contains(i))
+        .map(|(_, arg)| arg.clone())
+        .collect();
 
     // Build destructuring pattern with only declared fields + `..`
     let field_idents: Vec<&Ident> = matched.iter().map(|m| &m.ident).collect();
@@ -158,31 +155,41 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     }
 
     let method_str = method_ident.to_string().to_uppercase();
-    let modo_method = match method_str.as_str() {
-        "GET" => quote! { modo::router::Method::GET },
-        "POST" => quote! { modo::router::Method::POST },
-        "PUT" => quote! { modo::router::Method::PUT },
-        "PATCH" => quote! { modo::router::Method::PATCH },
-        "DELETE" => quote! { modo::router::Method::DELETE },
-        "HEAD" => quote! { modo::router::Method::HEAD },
-        "OPTIONS" => quote! { modo::router::Method::OPTIONS },
+    let (modo_method, axum_method) = match method_str.as_str() {
+        "GET" => (
+            quote! { modo::router::Method::GET },
+            quote! { modo::axum::routing::get },
+        ),
+        "POST" => (
+            quote! { modo::router::Method::POST },
+            quote! { modo::axum::routing::post },
+        ),
+        "PUT" => (
+            quote! { modo::router::Method::PUT },
+            quote! { modo::axum::routing::put },
+        ),
+        "PATCH" => (
+            quote! { modo::router::Method::PATCH },
+            quote! { modo::axum::routing::patch },
+        ),
+        "DELETE" => (
+            quote! { modo::router::Method::DELETE },
+            quote! { modo::axum::routing::delete },
+        ),
+        "HEAD" => (
+            quote! { modo::router::Method::HEAD },
+            quote! { modo::axum::routing::head },
+        ),
+        "OPTIONS" => (
+            quote! { modo::router::Method::OPTIONS },
+            quote! { modo::axum::routing::options },
+        ),
         _ => {
             return Err(syn::Error::new_spanned(
                 method_ident,
                 format!("unsupported HTTP method: {method_str}"),
             ));
         }
-    };
-
-    let axum_method = match method_str.as_str() {
-        "GET" => quote! { modo::axum::routing::get },
-        "POST" => quote! { modo::axum::routing::post },
-        "PUT" => quote! { modo::axum::routing::put },
-        "PATCH" => quote! { modo::axum::routing::patch },
-        "DELETE" => quote! { modo::axum::routing::delete },
-        "HEAD" => quote! { modo::axum::routing::head },
-        "OPTIONS" => quote! { modo::axum::routing::options },
-        _ => unreachable!(),
     };
 
     // Extract and remove #[middleware(...)] attributes from the function
@@ -210,11 +217,8 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
         wrapper_defs.push(def);
     }
 
-    let middleware_vec = if wrapper_names.is_empty() {
-        quote! { vec![] }
-    } else {
-        quote! { vec![#(#wrapper_names as modo::router::MiddlewareFn),*] }
-    };
+    let middleware_vec =
+        build_middleware_vec(&wrapper_names, quote! { modo::router::MiddlewareFn });
 
     let module_expr = match &args.module {
         Some(m) => quote! { Some(#m) },

--- a/modo-macros/src/lib.rs
+++ b/modo-macros/src/lib.rs
@@ -9,6 +9,7 @@ mod sanitize;
 mod t_macro;
 mod template_filter;
 mod template_function;
+mod utils;
 mod validate;
 mod view;
 

--- a/modo-macros/src/middleware.rs
+++ b/modo-macros/src/middleware.rs
@@ -38,6 +38,15 @@ impl Parse for MiddlewareList {
     }
 }
 
+/// Build the layer expression for a middleware attribute.
+fn build_layer_expr(attr: &MiddlewareAttr) -> TokenStream {
+    let path = &attr.path;
+    match &attr.args {
+        None => quote! { modo::axum::middleware::from_fn(#path) },
+        Some(args) => quote! { #path(#(#args),*) },
+    }
+}
+
 /// Generate a middleware wrapper function for a handler-level middleware.
 /// Returns (wrapper_fn_ident, wrapper_fn_definition).
 pub fn gen_handler_middleware_wrapper(
@@ -47,18 +56,7 @@ pub fn gen_handler_middleware_wrapper(
 ) -> (syn::Ident, TokenStream) {
     let wrapper_name =
         syn::Ident::new(&format!("__mw_{handler_name}_{index}"), handler_name.span());
-    let path = &attr.path;
-
-    let layer_expr = match &attr.args {
-        None => {
-            // Bare function -> wrap with from_fn()
-            quote! { modo::axum::middleware::from_fn(#path) }
-        }
-        Some(args) => {
-            // Factory function with args -> call directly, returns a Layer
-            quote! { #path(#(#args),*) }
-        }
-    };
+    let layer_expr = build_layer_expr(attr);
 
     let def = quote! {
         fn #wrapper_name(
@@ -82,16 +80,7 @@ pub fn gen_router_middleware_wrapper(
         &format!("__mw_mod_{module_name}_{index}"),
         module_name.span(),
     );
-    let path = &attr.path;
-
-    let layer_expr = match &attr.args {
-        None => {
-            quote! { modo::axum::middleware::from_fn(#path) }
-        }
-        Some(args) => {
-            quote! { #path(#(#args),*) }
-        }
-    };
+    let layer_expr = build_layer_expr(attr);
 
     let def = quote! {
         fn #wrapper_name(
@@ -102,4 +91,14 @@ pub fn gen_router_middleware_wrapper(
     };
 
     (wrapper_name, def)
+}
+
+/// Build a `vec![...]` expression casting wrapper function names to the given type.
+/// Returns `vec![]` when `wrapper_names` is empty.
+pub fn build_middleware_vec(wrapper_names: &[syn::Ident], cast_path: TokenStream) -> TokenStream {
+    if wrapper_names.is_empty() {
+        quote! { vec![] }
+    } else {
+        quote! { vec![#(#wrapper_names as #cast_path),*] }
+    }
 }

--- a/modo-macros/src/module.rs
+++ b/modo-macros/src/module.rs
@@ -1,4 +1,6 @@
-use crate::middleware::{MiddlewareAttr, MiddlewareList, gen_router_middleware_wrapper};
+use crate::middleware::{
+    MiddlewareAttr, MiddlewareList, build_middleware_vec, gen_router_middleware_wrapper,
+};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
@@ -72,11 +74,8 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
         wrapper_defs.push(def);
     }
 
-    let middleware_vec = if wrapper_names.is_empty() {
-        quote! { vec![] }
-    } else {
-        quote! { vec![#(#wrapper_names as modo::router::RouterMiddlewareFn),*] }
-    };
+    let middleware_vec =
+        build_middleware_vec(&wrapper_names, quote! { modo::router::RouterMiddlewareFn });
 
     Ok(quote! {
         #module

--- a/modo-macros/src/sanitize.rs
+++ b/modo-macros/src/sanitize.rs
@@ -68,18 +68,6 @@ impl Parse for SanitizeAttr {
     }
 }
 
-/// Returns true if the type is `Option<...>`.
-fn is_option_type(ty: &Type) -> bool {
-    if let Type::Path(tp) = ty {
-        tp.path
-            .segments
-            .last()
-            .is_some_and(|seg| seg.ident == "Option")
-    } else {
-        false
-    }
-}
-
 pub fn expand(input: TokenStream) -> Result<TokenStream> {
     let input: DeriveInput = parse2(input)?;
     let struct_name = &input.ident;
@@ -157,7 +145,7 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
 
 fn gen_field_sanitization(sf: &SanitizeField) -> TokenStream {
     let field_name = &sf.field_name;
-    let is_option = is_option_type(&sf.field_type);
+    let is_option = crate::utils::is_type_named(&sf.field_type, "Option");
 
     let rule_calls: Vec<TokenStream> = sf
         .rules

--- a/modo-macros/src/t_macro.rs
+++ b/modo-macros/src/t_macro.rs
@@ -39,8 +39,6 @@ pub fn expand(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::Token
     let i18n = &input.i18n_expr;
     let key = &input.key;
 
-    let has_count = input.vars.iter().any(|(name, _)| name == "count");
-
     let var_pairs: Vec<proc_macro2::TokenStream> = input
         .vars
         .iter()
@@ -50,14 +48,7 @@ pub fn expand(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::Token
         })
         .collect();
 
-    if has_count {
-        let count_expr = input
-            .vars
-            .iter()
-            .find(|(name, _)| name == "count")
-            .map(|(_, expr)| expr)
-            .unwrap();
-
+    if let Some((_, count_expr)) = input.vars.iter().find(|(name, _)| name == "count") {
         Ok(quote! {
             #i18n.t_plural(#key, u64::try_from(#count_expr).unwrap_or(u64::MAX), &[#(#var_pairs),*])
         })

--- a/modo-macros/src/template_filter.rs
+++ b/modo-macros/src/template_filter.rs
@@ -6,31 +6,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     let func: ItemFn = parse2(item)?;
     let func_name = &func.sig.ident;
 
-    // Parse optional name = "custom_name" attribute
-    let filter_name = if attr.is_empty() {
-        func_name.to_string()
-    } else {
-        let name_value: syn::MetaNameValue = parse2(attr)?;
-        if name_value.path.is_ident("name") {
-            if let syn::Expr::Lit(syn::ExprLit {
-                lit: syn::Lit::Str(s),
-                ..
-            }) = &name_value.value
-            {
-                s.value()
-            } else {
-                return Err(syn::Error::new_spanned(
-                    &name_value.value,
-                    "expected string literal for `name`",
-                ));
-            }
-        } else {
-            return Err(syn::Error::new_spanned(
-                &name_value.path,
-                "unknown attribute, expected `name`",
-            ));
-        }
-    };
+    let filter_name = crate::utils::parse_name_attr(attr, func_name.to_string())?;
 
     Ok(quote! {
         #[allow(dead_code)] // fn is referenced via inventory::submit! below

--- a/modo-macros/src/template_function.rs
+++ b/modo-macros/src/template_function.rs
@@ -6,31 +6,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
     let func: ItemFn = parse2(item)?;
     let func_name = &func.sig.ident;
 
-    // Parse optional name = "custom_name" attribute
-    let template_name = if attr.is_empty() {
-        func_name.to_string()
-    } else {
-        let name_value: syn::MetaNameValue = parse2(attr)?;
-        if name_value.path.is_ident("name") {
-            if let syn::Expr::Lit(syn::ExprLit {
-                lit: syn::Lit::Str(s),
-                ..
-            }) = &name_value.value
-            {
-                s.value()
-            } else {
-                return Err(syn::Error::new_spanned(
-                    &name_value.value,
-                    "expected string literal for `name`",
-                ));
-            }
-        } else {
-            return Err(syn::Error::new_spanned(
-                &name_value.path,
-                "unknown attribute, expected `name`",
-            ));
-        }
-    };
+    let template_name = crate::utils::parse_name_attr(attr, func_name.to_string())?;
 
     Ok(quote! {
         #[allow(dead_code)] // fn is referenced via inventory::submit! below

--- a/modo-macros/src/utils.rs
+++ b/modo-macros/src/utils.rs
@@ -1,0 +1,39 @@
+use proc_macro2::TokenStream;
+use syn::Result;
+
+/// Returns true if the last path segment of `ty` matches `name`.
+/// Replaces per-file `is_option_type()` and `is_string_type()` helpers.
+pub(crate) fn is_type_named(ty: &syn::Type, name: &str) -> bool {
+    if let syn::Type::Path(tp) = ty {
+        tp.path.segments.last().is_some_and(|seg| seg.ident == name)
+    } else {
+        false
+    }
+}
+
+/// Parse an optional `name = "..."` attribute, returning `default` when the attr is empty.
+/// Shared by `#[template_filter]` and `#[template_function]`.
+pub(crate) fn parse_name_attr(attr: TokenStream, default: String) -> Result<String> {
+    if attr.is_empty() {
+        return Ok(default);
+    }
+    let name_value: syn::MetaNameValue = syn::parse2(attr)?;
+    if !name_value.path.is_ident("name") {
+        return Err(syn::Error::new_spanned(
+            &name_value.path,
+            "unknown attribute, expected `name`",
+        ));
+    }
+    if let syn::Expr::Lit(syn::ExprLit {
+        lit: syn::Lit::Str(s),
+        ..
+    }) = &name_value.value
+    {
+        Ok(s.value())
+    } else {
+        Err(syn::Error::new_spanned(
+            &name_value.value,
+            "expected string literal for `name`",
+        ))
+    }
+}

--- a/modo-macros/src/validate.rs
+++ b/modo-macros/src/validate.rs
@@ -138,30 +138,6 @@ fn parse_rule_message(input: ParseStream) -> Result<Option<String>> {
     }
 }
 
-/// Returns true if the type is `Option<...>`.
-fn is_option_type(ty: &Type) -> bool {
-    if let Type::Path(tp) = ty {
-        tp.path
-            .segments
-            .last()
-            .is_some_and(|seg| seg.ident == "Option")
-    } else {
-        false
-    }
-}
-
-/// Returns true if the type is `String` (simple heuristic).
-fn is_string_type(ty: &Type) -> bool {
-    if let Type::Path(tp) = ty {
-        tp.path
-            .segments
-            .last()
-            .is_some_and(|seg| seg.ident == "String")
-    } else {
-        false
-    }
-}
-
 pub fn expand(input: TokenStream) -> Result<TokenStream> {
     let input: DeriveInput = parse2(input)?;
     let struct_name = &input.ident;
@@ -215,44 +191,72 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
     // Generate validation code for each field
     let field_checks: Vec<TokenStream> = validate_fields.iter().map(gen_field_validation).collect();
 
-    let field_collect: Vec<TokenStream> = validate_fields
-        .iter()
-        .map(|vf| {
-            let name_str = vf.field_name.to_string();
-            let errors_ident = quote::format_ident!("__errors_{}", vf.field_name);
-            quote! { (#name_str, #errors_ident) }
-        })
-        .collect();
-
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    // Defer Vec allocation to error path
+    let body = if validate_fields.is_empty() {
+        quote! { Ok(()) }
+    } else {
+        let error_idents: Vec<proc_macro2::Ident> = validate_fields
+            .iter()
+            .map(|vf| quote::format_ident!("__errors_{}", vf.field_name))
+            .collect();
+        let empty_checks: Vec<TokenStream> = error_idents
+            .iter()
+            .map(|id| quote! { #id.is_empty() })
+            .collect();
+        let field_collect: Vec<TokenStream> = validate_fields
+            .iter()
+            .zip(error_idents.iter())
+            .map(|(vf, id)| {
+                let name_str = vf.field_name.to_string();
+                quote! { (#name_str, #id) }
+            })
+            .collect();
+        quote! {
+            if #(#empty_checks)&&* {
+                Ok(())
+            } else {
+                Err(modo::validate::validation_error(vec![#(#field_collect),*]))
+            }
+        }
+    };
 
     Ok(quote! {
         impl #impl_generics modo::validate::Validate for #struct_name #ty_generics #where_clause {
             fn validate(&self) -> Result<(), modo::Error> {
                 #(#field_checks)*
-
-                let __field_errors: Vec<(&str, Vec<String>)> = vec![#(#field_collect),*];
-                let __has_errors = __field_errors.iter().any(|(_, msgs)| !msgs.is_empty());
-                if __has_errors {
-                    Err(modo::validate::validation_error(__field_errors))
-                } else {
-                    Ok(())
-                }
+                #body
             }
         }
     })
 }
 
+struct FieldContext<'a> {
+    field_name: &'a Ident,
+    is_option: bool,
+    is_string: bool,
+    has_required: bool,
+    has_field_msg: bool,
+    field_message: &'a Option<String>,
+}
+
 fn gen_field_validation(vf: &ValidateField) -> TokenStream {
     let field_name = &vf.field_name;
     let errors_ident = quote::format_ident!("__errors_{}", field_name);
-    let is_option = is_option_type(&vf.field_type);
-    let is_string = is_string_type(&vf.field_type);
     let has_field_msg = vf.field_message.is_some();
-    let has_required = vf
-        .rules
-        .iter()
-        .any(|r| matches!(r, ValidationRule::Required { .. }));
+
+    let ctx = FieldContext {
+        field_name,
+        is_option: crate::utils::is_type_named(&vf.field_type, "Option"),
+        is_string: crate::utils::is_type_named(&vf.field_type, "String"),
+        has_required: vf
+            .rules
+            .iter()
+            .any(|r| matches!(r, ValidationRule::Required { .. })),
+        has_field_msg,
+        field_message: &vf.field_message,
+    };
 
     let field_msg_added_decl = if has_field_msg {
         quote! { let mut __field_msg_added = false; }
@@ -263,17 +267,7 @@ fn gen_field_validation(vf: &ValidateField) -> TokenStream {
     let rule_checks: Vec<TokenStream> = vf
         .rules
         .iter()
-        .map(|rule| {
-            gen_rule_check(
-                rule,
-                field_name,
-                is_option,
-                is_string,
-                has_required,
-                has_field_msg,
-                &vf.field_message,
-            )
-        })
+        .map(|rule| gen_rule_check(rule, &ctx))
         .collect();
 
     quote! {
@@ -283,15 +277,13 @@ fn gen_field_validation(vf: &ValidateField) -> TokenStream {
     }
 }
 
-fn gen_rule_check(
-    rule: &ValidationRule,
-    field_name: &Ident,
-    is_option: bool,
-    is_string: bool,
-    has_required: bool,
-    has_field_msg: bool,
-    field_message: &Option<String>,
-) -> TokenStream {
+fn gen_rule_check(rule: &ValidationRule, ctx: &FieldContext) -> TokenStream {
+    let field_name = ctx.field_name;
+    let is_option = ctx.is_option;
+    let is_string = ctx.is_string;
+    let has_required = ctx.has_required;
+    let has_field_msg = ctx.has_field_msg;
+    let field_message = ctx.field_message;
     let errors_ident = quote::format_ident!("__errors_{}", field_name);
 
     match rule {

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use futures_util::future::BoxFuture;
 use http::{Request, Response};
 use modo::axum::extract::connect_info::ConnectInfo;
+use modo::cookies::{CookieOptions, build_cookie};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -161,19 +162,20 @@ where
             };
 
             let ttl_secs = config.session_ttl_secs;
-            let is_secure = cfg!(not(debug_assertions));
+            let cookie_config = store.cookie_config();
+            let set_opts = CookieOptions::from_config(cookie_config).max_age(ttl_secs);
+            let remove_opts = CookieOptions::from_config(cookie_config).max_age(0);
 
             match action {
                 SessionAction::Set(token) => {
-                    let cookie_val =
-                        build_set_cookie(cookie_name, &token.as_hex(), ttl_secs, is_secure);
-                    if let Ok(val) = cookie_val.parse() {
+                    let cookie = build_cookie(cookie_name, &token.as_hex(), &set_opts);
+                    if let Ok(val) = cookie.to_string().parse() {
                         response.headers_mut().append(http::header::SET_COOKIE, val);
                     }
                 }
                 SessionAction::Remove => {
-                    let cookie_val = build_remove_cookie(cookie_name);
-                    if let Ok(val) = cookie_val.parse() {
+                    let cookie = build_cookie(cookie_name, "", &remove_opts);
+                    if let Ok(val) = cookie.to_string().parse() {
                         response.headers_mut().append(http::header::SET_COOKIE, val);
                     }
                 }
@@ -186,9 +188,8 @@ where
                                 "Failed to touch session: {e}"
                             );
                         } else if let Some(ref token) = session_token {
-                            let cookie_val =
-                                build_set_cookie(cookie_name, &token.as_hex(), ttl_secs, is_secure);
-                            if let Ok(val) = cookie_val.parse() {
+                            let cookie = build_cookie(cookie_name, &token.as_hex(), &set_opts);
+                            if let Ok(val) = cookie.to_string().parse() {
                                 response.headers_mut().append(http::header::SET_COOKIE, val);
                             }
                         }
@@ -196,8 +197,8 @@ where
 
                     // Remove stale cookie (session not found, but cookie existed)
                     if had_cookie && current_session.is_none() && !read_failed {
-                        let cookie_val = build_remove_cookie(cookie_name);
-                        if let Ok(val) = cookie_val.parse() {
+                        let cookie = build_cookie(cookie_name, "", &remove_opts);
+                        if let Ok(val) = cookie.to_string().parse() {
                             response.headers_mut().append(http::header::SET_COOKIE, val);
                         }
                     }
@@ -244,17 +245,4 @@ fn read_session_cookie(headers: &http::HeaderMap, cookie_name: &str) -> Option<S
             }
             None
         })
-}
-
-fn build_set_cookie(name: &str, value: &str, max_age_secs: u64, secure: bool) -> String {
-    let mut cookie =
-        format!("{name}={value}; HttpOnly; SameSite=Lax; Path=/; Max-Age={max_age_secs}");
-    if secure {
-        cookie.push_str("; Secure");
-    }
-    cookie
-}
-
-fn build_remove_cookie(name: &str) -> String {
-    format!("{name}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0")
 }

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -87,7 +87,7 @@ where
         let mut inner = self.inner.clone();
 
         Box::pin(async move {
-            let config = store.config().clone();
+            let config = store.config();
             let cookie_name = &config.cookie_name;
 
             // Extract meta from request headers
@@ -162,22 +162,23 @@ where
             };
 
             let ttl_secs = config.session_ttl_secs;
-            let cookie_config = store.cookie_config();
-            let set_opts = CookieOptions::from_config(cookie_config).max_age(ttl_secs);
-            let remove_opts = CookieOptions::from_config(cookie_config).max_age(0);
 
             match action {
                 SessionAction::Set(token) => {
-                    let cookie = build_cookie(cookie_name, &token.as_hex(), &set_opts);
-                    if let Ok(val) = cookie.to_string().parse() {
-                        response.headers_mut().append(http::header::SET_COOKIE, val);
-                    }
+                    let opts = CookieOptions::from_config(store.cookie_config())
+                        .max_age(ttl_secs);
+                    append_cookie_header(
+                        &mut response,
+                        cookie_name,
+                        &token.as_hex(),
+                        &opts,
+                    );
                 }
                 SessionAction::Remove => {
-                    let cookie = build_cookie(cookie_name, "", &remove_opts);
-                    if let Ok(val) = cookie.to_string().parse() {
-                        response.headers_mut().append(http::header::SET_COOKIE, val);
-                    }
+                    // Max-Age=0 instructs the browser to delete the cookie
+                    let opts =
+                        CookieOptions::from_config(store.cookie_config()).max_age(0);
+                    append_cookie_header(&mut response, cookie_name, "", &opts);
                 }
                 SessionAction::None => {
                     if should_touch && let Some(ref session) = current_session {
@@ -188,19 +189,23 @@ where
                                 "Failed to touch session: {e}"
                             );
                         } else if let Some(ref token) = session_token {
-                            let cookie = build_cookie(cookie_name, &token.as_hex(), &set_opts);
-                            if let Ok(val) = cookie.to_string().parse() {
-                                response.headers_mut().append(http::header::SET_COOKIE, val);
-                            }
+                            let opts = CookieOptions::from_config(store.cookie_config())
+                                .max_age(ttl_secs);
+                            append_cookie_header(
+                                &mut response,
+                                cookie_name,
+                                &token.as_hex(),
+                                &opts,
+                            );
                         }
                     }
 
                     // Remove stale cookie (session not found, but cookie existed)
                     if had_cookie && current_session.is_none() && !read_failed {
-                        let cookie = build_cookie(cookie_name, "", &remove_opts);
-                        if let Ok(val) = cookie.to_string().parse() {
-                            response.headers_mut().append(http::header::SET_COOKIE, val);
-                        }
+                        // Max-Age=0 instructs the browser to delete the cookie
+                        let opts =
+                            CookieOptions::from_config(store.cookie_config()).max_age(0);
+                        append_cookie_header(&mut response, cookie_name, "", &opts);
                     }
                 }
             }
@@ -245,4 +250,21 @@ fn read_session_cookie(headers: &http::HeaderMap, cookie_name: &str) -> Option<S
             }
             None
         })
+}
+
+fn append_cookie_header<B>(
+    response: &mut Response<B>,
+    name: &str,
+    value: &str,
+    opts: &CookieOptions,
+) {
+    let cookie = build_cookie(name, value, opts);
+    match http::HeaderValue::try_from(cookie.to_string()) {
+        Ok(val) => {
+            response.headers_mut().append(http::header::SET_COOKIE, val);
+        }
+        Err(e) => {
+            tracing::warn!(cookie_name = name, "Failed to serialize session cookie: {e}");
+        }
+    }
 }

--- a/modo-session/src/middleware.rs
+++ b/modo-session/src/middleware.rs
@@ -165,19 +165,12 @@ where
 
             match action {
                 SessionAction::Set(token) => {
-                    let opts = CookieOptions::from_config(store.cookie_config())
-                        .max_age(ttl_secs);
-                    append_cookie_header(
-                        &mut response,
-                        cookie_name,
-                        &token.as_hex(),
-                        &opts,
-                    );
+                    let opts = CookieOptions::from_config(store.cookie_config()).max_age(ttl_secs);
+                    append_cookie_header(&mut response, cookie_name, &token.as_hex(), &opts);
                 }
                 SessionAction::Remove => {
                     // Max-Age=0 instructs the browser to delete the cookie
-                    let opts =
-                        CookieOptions::from_config(store.cookie_config()).max_age(0);
+                    let opts = CookieOptions::from_config(store.cookie_config()).max_age(0);
                     append_cookie_header(&mut response, cookie_name, "", &opts);
                 }
                 SessionAction::None => {
@@ -189,8 +182,8 @@ where
                                 "Failed to touch session: {e}"
                             );
                         } else if let Some(ref token) = session_token {
-                            let opts = CookieOptions::from_config(store.cookie_config())
-                                .max_age(ttl_secs);
+                            let opts =
+                                CookieOptions::from_config(store.cookie_config()).max_age(ttl_secs);
                             append_cookie_header(
                                 &mut response,
                                 cookie_name,
@@ -203,8 +196,7 @@ where
                     // Remove stale cookie (session not found, but cookie existed)
                     if had_cookie && current_session.is_none() && !read_failed {
                         // Max-Age=0 instructs the browser to delete the cookie
-                        let opts =
-                            CookieOptions::from_config(store.cookie_config()).max_age(0);
+                        let opts = CookieOptions::from_config(store.cookie_config()).max_age(0);
                         append_cookie_header(&mut response, cookie_name, "", &opts);
                     }
                 }
@@ -264,7 +256,10 @@ fn append_cookie_header<B>(
             response.headers_mut().append(http::header::SET_COOKIE, val);
         }
         Err(e) => {
-            tracing::warn!(cookie_name = name, "Failed to serialize session cookie: {e}");
+            tracing::warn!(
+                cookie_name = name,
+                "Failed to serialize session cookie: {e}"
+            );
         }
     }
 }

--- a/modo-session/src/store.rs
+++ b/modo-session/src/store.rs
@@ -4,6 +4,7 @@ use crate::meta::SessionMeta;
 use crate::types::{SessionData, SessionId, SessionToken};
 use chrono::{DateTime, Utc};
 use modo::Error;
+use modo::cookies::CookieConfig;
 use modo_db::DbPool;
 use modo_db::sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder,
@@ -14,18 +15,24 @@ use modo_db::sea_orm::{
 pub struct SessionStore {
     db: DbPool,
     config: SessionConfig,
+    cookie_config: CookieConfig,
 }
 
 impl SessionStore {
-    pub fn new(db: &DbPool, config: SessionConfig) -> Self {
+    pub fn new(db: &DbPool, config: SessionConfig, cookie_config: CookieConfig) -> Self {
         Self {
             db: db.clone(),
             config,
+            cookie_config,
         }
     }
 
     pub fn config(&self) -> &SessionConfig {
         &self.config
+    }
+
+    pub fn cookie_config(&self) -> &CookieConfig {
+        &self.cookie_config
     }
 
     pub async fn create(

--- a/modo-session/tests/integration.rs
+++ b/modo-session/tests/integration.rs
@@ -45,7 +45,7 @@ fn test_config() -> SessionConfig {
 #[tokio::test]
 async fn create_and_read_by_token() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, test_config());
+    let store = SessionStore::new(&db, test_config(), Default::default());
     let meta = test_meta();
 
     let (session, token) = store.create(&meta, "user1", None).await.unwrap();
@@ -60,7 +60,7 @@ async fn create_and_read_by_token() {
 #[tokio::test]
 async fn destroy_removes_session() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, test_config());
+    let store = SessionStore::new(&db, test_config(), Default::default());
     let meta = test_meta();
 
     let (session, token) = store.create(&meta, "user1", None).await.unwrap();
@@ -73,7 +73,7 @@ async fn destroy_removes_session() {
 #[tokio::test]
 async fn rotate_token_changes_hash() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, test_config());
+    let store = SessionStore::new(&db, test_config(), Default::default());
     let meta = test_meta();
 
     let (session, old_token) = store.create(&meta, "user1", None).await.unwrap();
@@ -90,7 +90,7 @@ async fn max_sessions_evicts_oldest() {
     let db = setup_db().await;
     let mut config = test_config();
     config.max_sessions_per_user = 2;
-    let store = SessionStore::new(&db, config);
+    let store = SessionStore::new(&db, config, Default::default());
     let meta = test_meta();
 
     let (s1, t1) = store.create(&meta, "user1", None).await.unwrap();
@@ -108,7 +108,7 @@ async fn max_sessions_evicts_oldest() {
 #[tokio::test]
 async fn list_for_user_returns_all_active() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, test_config());
+    let store = SessionStore::new(&db, test_config(), Default::default());
     let meta = test_meta();
 
     store.create(&meta, "user1", None).await.unwrap();
@@ -125,7 +125,7 @@ async fn list_for_user_returns_all_active() {
 #[tokio::test]
 async fn destroy_all_except_keeps_one() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, test_config());
+    let store = SessionStore::new(&db, test_config(), Default::default());
     let meta = test_meta();
 
     let (s1, _) = store.create(&meta, "user1", None).await.unwrap();
@@ -142,7 +142,7 @@ async fn destroy_all_except_keeps_one() {
 #[tokio::test]
 async fn update_data_roundtrip() {
     let db = setup_db().await;
-    let store = SessionStore::new(&db, test_config());
+    let store = SessionStore::new(&db, test_config(), Default::default());
     let meta = test_meta();
 
     let (session, _) = store.create(&meta, "user1", None).await.unwrap();
@@ -159,7 +159,7 @@ async fn cleanup_expired_removes_old() {
     let db = setup_db().await;
     let mut config = test_config();
     config.session_ttl_secs = 0;
-    let store = SessionStore::new(&db, config);
+    let store = SessionStore::new(&db, config, Default::default());
     let meta = test_meta();
 
     store.create(&meta, "user1", None).await.unwrap();

--- a/modo-tenant/src/context_layer.rs
+++ b/modo-tenant/src/context_layer.rs
@@ -1,22 +1,14 @@
-#[cfg(feature = "templates")]
 use crate::HasTenantId;
-#[cfg(feature = "templates")]
 use crate::resolver::TenantResolverService;
 
-#[cfg(feature = "templates")]
 use futures_util::future::BoxFuture;
-#[cfg(feature = "templates")]
 use modo::axum::http::Request;
-#[cfg(feature = "templates")]
 use modo::templates::TemplateContext;
-#[cfg(feature = "templates")]
 use std::task::{Context, Poll};
-#[cfg(feature = "templates")]
 use tower::{Layer, Service};
 
 /// Layer that injects the resolved tenant into TemplateContext.
 /// Graceful: skips if no tenant is resolved.
-#[cfg(feature = "templates")]
 pub struct TenantContextLayer<T>
 where
     T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
@@ -24,7 +16,6 @@ where
     tenant_svc: TenantResolverService<T>,
 }
 
-#[cfg(feature = "templates")]
 impl<T> Clone for TenantContextLayer<T>
 where
     T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
@@ -36,7 +27,6 @@ where
     }
 }
 
-#[cfg(feature = "templates")]
 impl<T> TenantContextLayer<T>
 where
     T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
@@ -46,7 +36,6 @@ where
     }
 }
 
-#[cfg(feature = "templates")]
 impl<S, T> Layer<S> for TenantContextLayer<T>
 where
     T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
@@ -61,7 +50,6 @@ where
     }
 }
 
-#[cfg(feature = "templates")]
 #[derive(Clone)]
 pub struct TenantContextMiddleware<S, T>
 where
@@ -71,7 +59,6 @@ where
     tenant_svc: TenantResolverService<T>,
 }
 
-#[cfg(feature = "templates")]
 impl<S, ReqBody, ResBody, T> Service<Request<ReqBody>> for TenantContextMiddleware<S, T>
 where
     S: Service<Request<ReqBody>, Response = modo::axum::http::Response<ResBody>>
@@ -99,7 +86,7 @@ where
             let (mut parts, body) = request.into_parts();
 
             // Resolve tenant (cached or fresh)
-            let tenant: Option<T> =
+            let tenant =
                 match crate::extractor::resolve_and_cache(&mut parts, &tenant_svc).await {
                     Ok(t) => t,
                     Err(e) => {
@@ -112,7 +99,7 @@ where
             if let Some(ref t) = tenant
                 && let Some(ctx) = parts.extensions.get_mut::<TemplateContext>()
             {
-                ctx.insert("tenant", modo::minijinja::Value::from_serialize(t));
+                ctx.insert("tenant", modo::minijinja::Value::from_serialize(&**t));
             }
 
             let request = Request::from_parts(parts, body);
@@ -121,7 +108,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "templates"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::resolver::TenantResolverService;

--- a/modo-tenant/src/context_layer.rs
+++ b/modo-tenant/src/context_layer.rs
@@ -220,6 +220,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn injected_tenant_has_correct_fields() {
+        let svc = TenantResolverService::new(OkResolver);
+        let layer = TenantContextLayer::new(svc);
+
+        let app = modo::axum::Router::new()
+            .route(
+                "/",
+                get(|Extension(ctx): Extension<TemplateContext>| async move {
+                    let tenant = ctx.get("tenant").expect("tenant should be injected");
+                    let id = tenant.get_attr("id").expect("id attr missing");
+                    id.to_string()
+                }),
+            )
+            .layer(layer);
+
+        let mut req = Request::builder()
+            .header("host", "acme.test.com")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(TemplateContext::new());
+
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = modo::axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"t-1");
+    }
+
+    #[tokio::test]
     async fn no_crash_without_template_context() {
         let svc = TenantResolverService::new(OkResolver);
         let layer = TenantContextLayer::new(svc);

--- a/modo-tenant/src/context_layer.rs
+++ b/modo-tenant/src/context_layer.rs
@@ -86,14 +86,13 @@ where
             let (mut parts, body) = request.into_parts();
 
             // Resolve tenant (cached or fresh)
-            let tenant =
-                match crate::extractor::resolve_and_cache(&mut parts, &tenant_svc).await {
-                    Ok(t) => t,
-                    Err(e) => {
-                        tracing::warn!("TenantContextLayer: tenant resolution failed: {e}");
-                        None
-                    }
-                };
+            let tenant = match crate::extractor::resolve_and_cache(&mut parts, &tenant_svc).await {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!("TenantContextLayer: tenant resolution failed: {e}");
+                    None
+                }
+            };
 
             // Inject tenant into template context
             if let Some(ref t) = tenant

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -21,32 +21,37 @@ impl<T: Clone + Send + Sync + 'static> Deref for Tenant<T> {
 
 /// Resolve tenant from cache or via resolver service, caching the result.
 ///
-/// Shared by both the `FromRequestParts` extractors and `TenantContextMiddleware`.
+/// Returns `Arc<T>` so callers that only need a reference (e.g. template injection)
+/// avoid cloning the inner value. Extractors clone at the boundary.
 pub(crate) async fn resolve_and_cache<T>(
     parts: &mut Parts,
     resolver: &TenantResolverService<T>,
-) -> Result<Option<T>, Error>
+) -> Result<Option<Arc<T>>, Error>
 where
     T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
 {
     if let Some(cached) = parts.extensions.get::<ResolvedTenant<T>>() {
-        return Ok(Some((*cached.0).clone()));
+        return Ok(Some(Arc::clone(&cached.0)));
     }
 
     let tenant = resolver.resolve(parts).await?;
 
-    if let Some(ref t) = tenant {
-        parts.extensions.insert(ResolvedTenant(Arc::new(t.clone())));
+    if let Some(t) = tenant {
+        let arc = Arc::new(t);
+        parts
+            .extensions
+            .insert(ResolvedTenant(Arc::clone(&arc)));
+        return Ok(Some(arc));
     }
 
-    Ok(tenant)
+    Ok(None)
 }
 
 /// Resolve tenant using the `TenantResolverService` from `AppState`.
 pub(crate) async fn resolve_tenant<T>(
     parts: &mut Parts,
     state: &AppState,
-) -> Result<Option<T>, Error>
+) -> Result<Option<Arc<T>>, Error>
 where
     T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static,
 {
@@ -73,10 +78,10 @@ where
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let tenant = resolve_tenant::<T>(parts, state)
+        let arc = resolve_tenant::<T>(parts, state)
             .await?
             .ok_or_else(|| Error::from(HttpError::NotFound))?;
-        Ok(Tenant(tenant))
+        Ok(Tenant((*arc).clone()))
     }
 }
 
@@ -106,8 +111,8 @@ where
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let tenant = resolve_tenant::<T>(parts, state).await?;
-        Ok(OptionalTenant(tenant))
+        let arc = resolve_tenant::<T>(parts, state).await?;
+        Ok(OptionalTenant(arc.map(|a| (*a).clone())))
     }
 }
 

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -38,9 +38,7 @@ where
 
     if let Some(t) = tenant {
         let arc = Arc::new(t);
-        parts
-            .extensions
-            .insert(ResolvedTenant(Arc::clone(&arc)));
+        parts.extensions.insert(ResolvedTenant(Arc::clone(&arc)));
         return Ok(Some(arc));
     }
 
@@ -331,10 +329,7 @@ mod tests {
     async fn optional_tenant_returns_500_on_resolver_error() {
         let state = app_state_with_error_resolver();
         let app = Router::new()
-            .route(
-                "/",
-                get(|_t: OptionalTenant<TestTenant>| async { "ok" }),
-            )
+            .route("/", get(|_t: OptionalTenant<TestTenant>| async { "ok" }))
             .with_state(state);
 
         let resp = app
@@ -374,10 +369,7 @@ mod tests {
     async fn optional_tenant_returns_500_when_service_not_registered() {
         let state = app_state_empty();
         let app = Router::new()
-            .route(
-                "/",
-                get(|_t: OptionalTenant<TestTenant>| async { "ok" }),
-            )
+            .route("/", get(|_t: OptionalTenant<TestTenant>| async { "ok" }))
             .with_state(state);
 
         let resp = app

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -277,6 +277,122 @@ mod tests {
         assert_eq!(call_count.load(Ordering::SeqCst), 1);
     }
 
+    struct ErrorResolver;
+
+    impl crate::TenantResolver for ErrorResolver {
+        type Tenant = TestTenant;
+
+        async fn resolve(
+            &self,
+            _parts: &modo::axum::http::request::Parts,
+        ) -> Result<Option<Self::Tenant>, modo::Error> {
+            Err(modo::Error::internal("db error"))
+        }
+    }
+
+    fn app_state_with_error_resolver() -> AppState {
+        let services = ServiceRegistry::new().with(TenantResolverService::new(ErrorResolver));
+        AppState {
+            services,
+            server_config: Default::default(),
+            cookie_key: axum_extra::extract::cookie::Key::generate(),
+        }
+    }
+
+    fn app_state_empty() -> AppState {
+        AppState {
+            services: ServiceRegistry::new(),
+            server_config: Default::default(),
+            cookie_key: axum_extra::extract::cookie::Key::generate(),
+        }
+    }
+
+    #[tokio::test]
+    async fn tenant_extractor_returns_500_on_resolver_error() {
+        let state = app_state_with_error_resolver();
+        let app = Router::new()
+            .route("/", get(|_t: Tenant<TestTenant>| async { "ok" }))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "acme.test.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn optional_tenant_returns_500_on_resolver_error() {
+        let state = app_state_with_error_resolver();
+        let app = Router::new()
+            .route(
+                "/",
+                get(|_t: OptionalTenant<TestTenant>| async { "ok" }),
+            )
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "acme.test.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn tenant_extractor_returns_500_when_service_not_registered() {
+        let state = app_state_empty();
+        let app = Router::new()
+            .route("/", get(|_t: Tenant<TestTenant>| async { "ok" }))
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "acme.test.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn optional_tenant_returns_500_when_service_not_registered() {
+        let state = app_state_empty();
+        let app = Router::new()
+            .route(
+                "/",
+                get(|_t: OptionalTenant<TestTenant>| async { "ok" }),
+            )
+            .with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .header("host", "acme.test.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
     #[tokio::test]
     async fn optional_tenant_returns_none_when_missing() {
         let state = app_state_with_resolver();

--- a/modo-tenant/src/resolvers/header.rs
+++ b/modo-tenant/src/resolvers/header.rs
@@ -37,8 +37,9 @@ where
             .headers
             .get(&self.header_name)
             .and_then(|v| v.to_str().ok())
+            .map(str::trim)
         {
-            Some(v) if !v.trim().is_empty() => v.trim().to_string(),
+            Some(v) if !v.is_empty() => v.to_string(),
             _ => return Ok(None),
         };
         (self.lookup)(value).await

--- a/modo-tenant/src/resolvers/path_prefix.rs
+++ b/modo-tenant/src/resolvers/path_prefix.rs
@@ -110,4 +110,82 @@ mod tests {
             .unwrap();
         assert_eq!(result, None);
     }
+
+    #[tokio::test]
+    async fn extracts_first_segment_from_multi_segment_path() {
+        let resolver =
+            PathPrefixResolver::new(|slug| async move { Ok(Some(TestTenant { id: slug })) });
+        let parts = Request::builder()
+            .uri("/org1/users/123/edit")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = crate::TenantResolver::resolve(&resolver, &parts)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            Some(TestTenant {
+                id: "org1".to_string()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn extracts_segment_with_trailing_slash() {
+        let resolver =
+            PathPrefixResolver::new(|slug| async move { Ok(Some(TestTenant { id: slug })) });
+        let parts = Request::builder()
+            .uri("/acme/")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = crate::TenantResolver::resolve(&resolver, &parts)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            Some(TestTenant {
+                id: "acme".to_string()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn extracts_single_segment_without_trailing_slash() {
+        let resolver =
+            PathPrefixResolver::new(|slug| async move { Ok(Some(TestTenant { id: slug })) });
+        let parts = Request::builder()
+            .uri("/acme")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = crate::TenantResolver::resolve(&resolver, &parts)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            Some(TestTenant {
+                id: "acme".to_string()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn propagates_lookup_error() {
+        let resolver = PathPrefixResolver::new(|_slug| async move {
+            Err::<Option<TestTenant>, _>(modo::Error::internal("db connection lost"))
+        });
+        let parts = Request::builder()
+            .uri("/acme/dashboard")
+            .body(())
+            .unwrap()
+            .into_parts()
+            .0;
+        let result = crate::TenantResolver::resolve(&resolver, &parts).await;
+        assert!(result.is_err());
+    }
 }

--- a/modo-tenant/src/resolvers/subdomain.rs
+++ b/modo-tenant/src/resolvers/subdomain.rs
@@ -129,4 +129,39 @@ mod tests {
         let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
         assert_eq!(result, None);
     }
+
+    #[tokio::test]
+    async fn extracts_multi_level_subdomain() {
+        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
+            Ok(Some(TestTenant { id: slug }))
+        });
+        let p = parts("a.b.myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
+        assert_eq!(
+            result,
+            Some(TestTenant {
+                id: "a.b".to_string()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_none_for_different_base_domain() {
+        let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
+            Ok(Some(TestTenant { id: slug }))
+        });
+        let p = parts("acme.otherdomain.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn propagates_lookup_error() {
+        let resolver = SubdomainResolver::new("myapp.com", |_slug| async move {
+            Err::<Option<TestTenant>, _>(modo::Error::internal("db error"))
+        });
+        let p = parts("acme.myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p).await;
+        assert!(result.is_err());
+    }
 }

--- a/modo/src/cookies/config.rs
+++ b/modo/src/cookies/config.rs
@@ -9,6 +9,16 @@ pub enum SameSite {
     None,
 }
 
+impl From<SameSite> for cookie::SameSite {
+    fn from(val: SameSite) -> Self {
+        match val {
+            SameSite::Strict => cookie::SameSite::Strict,
+            SameSite::Lax => cookie::SameSite::Lax,
+            SameSite::None => cookie::SameSite::None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct CookieConfig {
@@ -64,11 +74,6 @@ impl CookieOptions {
 
     pub fn domain(mut self, domain: impl Into<String>) -> Self {
         self.domain = Some(domain.into());
-        self
-    }
-
-    pub fn no_domain(mut self) -> Self {
-        self.domain = None;
         self
     }
 

--- a/modo/src/cookies/config.rs
+++ b/modo/src/cookies/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SameSite {
     Strict,
@@ -62,7 +62,7 @@ impl CookieOptions {
             domain: config.domain.clone(),
             secure: config.secure,
             http_only: config.http_only,
-            same_site: config.same_site.clone(),
+            same_site: config.same_site,
             max_age: config.max_age,
         }
     }

--- a/modo/src/cookies/manager.rs
+++ b/modo/src/cookies/manager.rs
@@ -1,4 +1,4 @@
-use super::config::{CookieConfig, CookieOptions, SameSite};
+use super::config::{CookieConfig, CookieOptions};
 use axum::extract::FromRef;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
@@ -123,13 +123,7 @@ impl CookieManager {
     // --- JSON convenience ---
 
     pub fn get_json<T: serde::de::DeserializeOwned>(&self, name: &str) -> Option<T> {
-        self.get(name).and_then(|v| match serde_json::from_str(&v) {
-            Ok(val) => Some(val),
-            Err(e) => {
-                tracing::debug!(cookie = name, error = %e, "failed to deserialize cookie JSON");
-                None
-            }
-        })
+        deserialize_cookie_json(self.get(name), name)
     }
 
     pub fn set_json<T: serde::Serialize>(
@@ -142,16 +136,8 @@ impl CookieManager {
         Ok(())
     }
 
-    // --- Signed JSON convenience ---
-
     pub fn get_signed_json<T: serde::de::DeserializeOwned>(&self, name: &str) -> Option<T> {
-        self.get_signed(name).and_then(|v| match serde_json::from_str(&v) {
-            Ok(val) => Some(val),
-            Err(e) => {
-                tracing::debug!(cookie = name, error = %e, "failed to deserialize signed cookie JSON");
-                None
-            }
-        })
+        deserialize_cookie_json(self.get_signed(name), name)
     }
 
     pub fn set_signed_json<T: serde::Serialize>(
@@ -164,16 +150,8 @@ impl CookieManager {
         Ok(())
     }
 
-    // --- Encrypted JSON convenience ---
-
     pub fn get_encrypted_json<T: serde::de::DeserializeOwned>(&self, name: &str) -> Option<T> {
-        self.get_encrypted(name).and_then(|v| match serde_json::from_str(&v) {
-            Ok(val) => Some(val),
-            Err(e) => {
-                tracing::debug!(cookie = name, error = %e, "failed to deserialize encrypted cookie JSON");
-                None
-            }
-        })
+        deserialize_cookie_json(self.get_encrypted(name), name)
     }
 
     pub fn set_encrypted_json<T: serde::Serialize>(
@@ -208,17 +186,26 @@ impl IntoResponse for CookieManager {
     }
 }
 
-pub(crate) fn build_cookie<'a>(name: &str, value: &str, opts: &CookieOptions) -> Cookie<'a> {
+fn deserialize_cookie_json<T: serde::de::DeserializeOwned>(
+    raw: Option<String>,
+    name: &str,
+) -> Option<T> {
+    raw.and_then(|v| match serde_json::from_str(&v) {
+        Ok(val) => Some(val),
+        Err(e) => {
+            tracing::debug!(cookie = name, error = %e, "failed to deserialize cookie JSON");
+            None
+        }
+    })
+}
+
+pub fn build_cookie<'a>(name: &str, value: &str, opts: &CookieOptions) -> Cookie<'a> {
     let mut cookie = Cookie::new(name.to_string(), value.to_string());
     cookie.set_path(opts.path.clone());
     cookie.set_http_only(opts.http_only);
     cookie.set_secure(opts.secure);
 
-    match opts.same_site {
-        SameSite::Strict => cookie.set_same_site(cookie::SameSite::Strict),
-        SameSite::Lax => cookie.set_same_site(cookie::SameSite::Lax),
-        SameSite::None => cookie.set_same_site(cookie::SameSite::None),
-    }
+    cookie.set_same_site(cookie::SameSite::from(opts.same_site.clone()));
 
     if let Some(domain) = &opts.domain {
         cookie.set_domain(domain.clone());

--- a/modo/src/cookies/manager.rs
+++ b/modo/src/cookies/manager.rs
@@ -205,7 +205,7 @@ pub fn build_cookie<'a>(name: &str, value: &str, opts: &CookieOptions) -> Cookie
     cookie.set_http_only(opts.http_only);
     cookie.set_secure(opts.secure);
 
-    cookie.set_same_site(cookie::SameSite::from(opts.same_site.clone()));
+    cookie.set_same_site(cookie::SameSite::from(opts.same_site));
 
     if let Some(domain) = &opts.domain {
         cookie.set_domain(domain.clone());

--- a/modo/src/cookies/mod.rs
+++ b/modo/src/cookies/mod.rs
@@ -3,4 +3,4 @@ pub mod manager;
 
 pub use config::{CookieConfig, CookieOptions, SameSite};
 pub use manager::CookieManager;
-pub(crate) use manager::build_cookie;
+pub use manager::build_cookie;

--- a/modo/src/csrf/middleware.rs
+++ b/modo/src/csrf/middleware.rs
@@ -43,15 +43,11 @@ pub async fn csrf_protection(
         config.validate()
     );
 
-    let arc_cookie_config = state.services.get::<CookieConfig>();
-    let default_cookie_config;
-    let cookie_config: &CookieConfig = match &arc_cookie_config {
-        Some(c) => c,
-        None => {
-            default_cookie_config = CookieConfig::default();
-            &default_cookie_config
-        }
-    };
+    let arc_cookie_config = state
+        .services
+        .get::<CookieConfig>()
+        .expect("CookieConfig must be registered (auto-registered by AppBuilder)");
+    let cookie_config: &CookieConfig = &arc_cookie_config;
 
     let key = state.server_config.secret_key.as_bytes();
     let method = request.method().clone();

--- a/modo/tests/error_handler_macro.rs
+++ b/modo/tests/error_handler_macro.rs
@@ -1,0 +1,29 @@
+use modo::error::{Error, ErrorContext, ErrorHandlerRegistration, HttpError};
+
+#[modo::error_handler]
+fn custom_error_handler(err: Error, _ctx: &ErrorContext) -> axum::response::Response {
+    err.default_response()
+}
+
+#[test]
+fn test_error_handler_registered() {
+    let count = inventory::iter::<ErrorHandlerRegistration>().count();
+    assert!(count > 0, "no error handler registered");
+}
+
+#[test]
+fn test_error_handler_callable() {
+    let reg = inventory::iter::<ErrorHandlerRegistration>()
+        .next()
+        .expect("no error handler registered");
+
+    let error = Error::from(HttpError::NotFound);
+    let ctx = ErrorContext {
+        method: http::Method::GET,
+        uri: "/test".parse().unwrap(),
+        headers: http::HeaderMap::new(),
+    };
+
+    let response = (reg.handler)(error, &ctx);
+    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+}

--- a/modo/tests/handler_macro.rs
+++ b/modo/tests/handler_macro.rs
@@ -1,4 +1,6 @@
-use modo::router::RouteRegistration;
+use modo::router::{Method, RouteRegistration};
+
+// -- Basic HTTP method handlers --
 
 #[modo::handler(GET, "/hello")]
 async fn hello() -> &'static str {
@@ -10,20 +12,156 @@ async fn echo(body: String) -> String {
     body
 }
 
+#[modo::handler(PUT, "/items")]
+async fn put_item() -> &'static str {
+    "put"
+}
+
+#[modo::handler(PATCH, "/items/patch")]
+async fn patch_item() -> &'static str {
+    "patch"
+}
+
+#[modo::handler(DELETE, "/items/del")]
+async fn delete_item() -> &'static str {
+    "deleted"
+}
+
+#[modo::handler(HEAD, "/ping")]
+async fn head_ping() -> &'static str {
+    ""
+}
+
+#[modo::handler(OPTIONS, "/opts")]
+async fn options_handler() -> &'static str {
+    ""
+}
+
+// -- Case-insensitive method (lowercase) --
+
+#[modo::handler(get, "/lower")]
+async fn lowercase_get() -> &'static str {
+    "lower"
+}
+
+// -- Path parameters --
+
+#[modo::handler(GET, "/users/{id}")]
+async fn get_user(id: String) -> String {
+    id
+}
+
+#[modo::handler(GET, "/users/{user_id}/posts/{post_id}")]
+async fn get_user_post(user_id: String, post_id: String) -> String {
+    format!("{user_id}/{post_id}")
+}
+
+// -- Typed path param --
+
+#[modo::handler(GET, "/typed/{id}")]
+async fn typed_param(id: u64) -> String {
+    id.to_string()
+}
+
+// -- Partial extraction (only extract some params) --
+
+#[modo::handler(GET, "/partial/{org}/{repo}/{branch}")]
+async fn partial_extract(repo: String) -> String {
+    repo
+}
+
+// -- Handler with module attribute --
+
+#[modo::handler(GET, "/modular", module = "api")]
+async fn modular_handler() -> &'static str {
+    "modular"
+}
+
+// ======================== Tests ========================
+
+fn find_route(path: &str) -> &'static RouteRegistration {
+    inventory::iter::<RouteRegistration>()
+        .find(|r| r.path == path)
+        .unwrap_or_else(|| panic!("route {path} not registered"))
+}
+
 #[test]
-fn test_handler_macro_registers_routes() {
-    let routes: Vec<&RouteRegistration> = inventory::iter::<RouteRegistration>().collect();
-    let paths: Vec<&str> = routes.iter().map(|r| r.path).collect();
+fn test_get_and_post_registered() {
+    let paths: Vec<&str> = inventory::iter::<RouteRegistration>()
+        .map(|r| r.path)
+        .collect();
     assert!(paths.contains(&"/hello"), "GET /hello not registered");
     assert!(paths.contains(&"/echo"), "POST /echo not registered");
 }
 
 #[test]
-fn test_handler_macro_correct_methods() {
-    let routes: Vec<&RouteRegistration> = inventory::iter::<RouteRegistration>().collect();
-    let hello = routes.iter().find(|r| r.path == "/hello").unwrap();
-    assert_eq!(hello.method, modo::router::Method::GET);
+fn test_get_post_methods() {
+    assert_eq!(find_route("/hello").method, Method::GET);
+    assert_eq!(find_route("/echo").method, Method::POST);
+}
 
-    let echo = routes.iter().find(|r| r.path == "/echo").unwrap();
-    assert_eq!(echo.method, modo::router::Method::POST);
+#[test]
+fn test_put_method() {
+    assert_eq!(find_route("/items").method, Method::PUT);
+}
+
+#[test]
+fn test_patch_method() {
+    assert_eq!(find_route("/items/patch").method, Method::PATCH);
+}
+
+#[test]
+fn test_delete_method() {
+    assert_eq!(find_route("/items/del").method, Method::DELETE);
+}
+
+#[test]
+fn test_head_method() {
+    assert_eq!(find_route("/ping").method, Method::HEAD);
+}
+
+#[test]
+fn test_options_method() {
+    assert_eq!(find_route("/opts").method, Method::OPTIONS);
+}
+
+#[test]
+fn test_lowercase_method_uppercased() {
+    assert_eq!(find_route("/lower").method, Method::GET);
+}
+
+#[test]
+fn test_single_path_param_registered() {
+    let route = find_route("/users/{id}");
+    assert_eq!(route.method, Method::GET);
+}
+
+#[test]
+fn test_multiple_path_params_registered() {
+    let route = find_route("/users/{user_id}/posts/{post_id}");
+    assert_eq!(route.method, Method::GET);
+}
+
+#[test]
+fn test_typed_path_param_registered() {
+    let route = find_route("/typed/{id}");
+    assert_eq!(route.method, Method::GET);
+}
+
+#[test]
+fn test_partial_extraction_registered() {
+    let route = find_route("/partial/{org}/{repo}/{branch}");
+    assert_eq!(route.method, Method::GET);
+}
+
+#[test]
+fn test_handler_with_module_attribute() {
+    let route = find_route("/modular");
+    assert_eq!(route.module, Some("api"));
+}
+
+#[test]
+fn test_handler_without_module_is_none() {
+    let route = find_route("/hello");
+    assert_eq!(route.module, None);
 }

--- a/modo/tests/module_macro.rs
+++ b/modo/tests/module_macro.rs
@@ -1,0 +1,45 @@
+use modo::router::{ModuleRegistration, RouteRegistration};
+
+#[modo::module(prefix = "/api")]
+mod api {
+    use modo::handler;
+
+    #[modo::handler(GET, "/status")]
+    pub async fn status() -> &'static str {
+        "ok"
+    }
+}
+
+fn find_module(name: &str) -> &'static ModuleRegistration {
+    inventory::iter::<ModuleRegistration>()
+        .find(|m| m.name == name)
+        .unwrap_or_else(|| panic!("module '{name}' not registered"))
+}
+
+#[test]
+fn test_module_registered() {
+    let names: Vec<&str> = inventory::iter::<ModuleRegistration>()
+        .map(|m| m.name)
+        .collect();
+    assert!(names.contains(&"api"), "module 'api' not registered");
+}
+
+#[test]
+fn test_module_prefix() {
+    let module = find_module("api");
+    assert_eq!(module.prefix, "/api");
+}
+
+#[test]
+fn test_module_name() {
+    let module = find_module("api");
+    assert_eq!(module.name, "api");
+}
+
+#[test]
+fn test_inner_handler_gets_module() {
+    let route = inventory::iter::<RouteRegistration>()
+        .find(|r| r.path == "/status")
+        .expect("handler /status not registered");
+    assert_eq!(route.module, Some("api"));
+}


### PR DESCRIPTION
## Summary

Wide-ranging simplification pass across every workspace crate — removes duplicated code, tightens API contracts, closes correctness bugs, and adds test coverage so the changes are verifiable.

### Changes

- **cookies**: expose `build_cookie` publicly, add `SameSite` `From` impl, deduplicate JSON helpers; CSRF middleware now panics early on missing `CookieConfig` instead of silently using defaults
- **session**: `SessionStore::new` accepts an explicit `CookieConfig` and uses `build_cookie` internally; `append_cookie_header` extracted to remove shared mutable cookie refs
- **auth**: extract `ResolvedUser<U>` into its own `cache` module shared between extractors and `UserContextLayer`; fix argon2 verify to pass configured cost params; add `Debug` for `UserProviderService`; drop `templates` feature guards that were incorrectly gating non-template code
- **tenant**: `resolve_and_cache` returns `Arc<T>`; `templates` feature guards removed from resolver and extractor paths that do not depend on the template engine
- **modo-macros**: extract shared utilities into `utils.rs` to remove duplication across `handler`, `module`, `middleware`, `sanitize`, `validate`, and `t_macro` codegen; add comprehensive tests for handler, error-handler, and module macros
- **modo-jobs**: remove `Arc<DbPool>` from job context — DB pool is now looked up from the service registry at runtime; extract `release_lock` helper; make `queue`, `priority`, and `max_attempts` optional in the `#[job]` macro, add `JOB_NAME` const to generated code
- **modo-email**: single-pass markdown render, minijinja-based template context, `Result`-returning `substitute`; add edge-case tests for filesystem templates and frontmatter parsing
- **modo-db**: remove `ulid` direct dependency, simplify extractor `Clone`, single-pass sync partition; fix SQLite detection via backend enum (was string-matching); fix URL redaction offset bug
- **modo-db-macros**: simplify relation target resolution, annotate nullable relations

### Breaking Changes

- `SessionStore::new` now requires a `CookieConfig` argument — callers must pass `CookieConfig::default()` or a configured instance
- `modo_auth::context_layer::ResolvedUser` is no longer public; cache is internal to the crate
- `modo-jobs` job context no longer holds an `Arc<DbPool>` — use the service registry extractor (`Db`) instead
- CSRF middleware panics at startup if `CookieConfig` is not registered as a service (previously used a silent default)

## Test plan

- [ ] `just check` passes (fmt + clippy + all workspace tests)
- [ ] Example app (`hello`) builds and runs with the updated `SessionStore::new` signature
- [ ] CSRF middleware correctly panics when `CookieConfig` is missing from services
- [ ] Jobs enqueue and execute without direct DB pool access on the context
- [ ] Tenant resolution returns `Arc<T>` and caches correctly