### PR TITLE
refactor(modo): dedup helpers and optimize hot-path allocations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - Template layers: auto-registered when `TemplateEngine` is a service — no manual `.layer()` needed
 - HTMX views: htmx template rendered on HX-Request, always HTTP 200, non-200 skips render
 - i18n in templates: `{{ t("key", name=val) }}` — register via `modo::i18n::register_template_functions`
-- i18n layer: `modo::i18n::layer(store, cookie_config)` / `modo::i18n::layer_with_source(store, cookie_config, source_fn)`
+- i18n layer: `modo::i18n::layer(store, Arc::new(cookie_config))` / `modo::i18n::layer_with_source(store, Arc::new(cookie_config), source_fn)`
 - Middleware: plain async functions, attached via `#[middleware(fn_name(params))]`
 - Middleware stacking order: Global (outermost) → Module → Handler (innermost)
 - Services: manually constructed, registered via `.service(instance)`

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -366,6 +366,14 @@ impl AppBuilder {
             Arc::new(app_config.csrf.clone()),
         );
 
+        // --- Pre-parse trusted proxies (avoids per-request CIDR parsing) ---
+        self.services.insert(
+            TypeId::of::<middleware::TrustedProxies>(),
+            Arc::new(middleware::TrustedProxies(
+                middleware::parse_trusted_proxies(&server_config.trusted_proxies),
+            )),
+        );
+
         let state = AppState {
             services: ServiceRegistry {
                 services: Arc::new(self.services),
@@ -537,7 +545,10 @@ impl AppBuilder {
         // --- i18n layer (auto-wired) ---
         #[cfg(feature = "i18n")]
         if let Some(store) = state.services.get::<crate::i18n::TranslationStore>() {
-            router = router.layer(crate::i18n::layer(store, app_config.cookies.clone()));
+            router = router.layer(crate::i18n::layer(
+                store,
+                Arc::new(app_config.cookies.clone()),
+            ));
         }
 
         // --- Rate limiter (global) ---

--- a/modo/src/cookie_util.rs
+++ b/modo/src/cookie_util.rs
@@ -1,3 +1,13 @@
+/// Convert an ASCII hex byte to its numeric value (0–15).
+pub(crate) fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
 /// Read a cookie value by name from HTTP headers.
 ///
 /// Handles multiple `Cookie` headers and semicolon-separated pairs.

--- a/modo/src/csrf/middleware.rs
+++ b/modo/src/csrf/middleware.rs
@@ -59,6 +59,14 @@ pub async fn csrf_protection(
     }
 }
 
+#[cfg(feature = "templates")]
+fn inject_csrf_context(extensions: &mut http::Extensions, token: &str, field_name: &str) {
+    if let Some(ctx) = extensions.get_mut::<crate::templates::TemplateContext>() {
+        ctx.insert("csrf_token", token.to_owned());
+        ctx.insert("csrf_field_name", field_name.to_owned());
+    }
+}
+
 fn is_safe_method(method: &Method) -> bool {
     matches!(
         *method,
@@ -87,15 +95,8 @@ async fn handle_safe_request(
     // Insert token into extensions for handlers
     parts.extensions.insert(CsrfToken(raw_token.clone()));
 
-    // Insert into TemplateContext if available
     #[cfg(feature = "templates")]
-    if let Some(ctx) = parts
-        .extensions
-        .get_mut::<crate::templates::TemplateContext>()
-    {
-        ctx.insert("csrf_token", raw_token.clone());
-        ctx.insert("csrf_field_name", config.field_name.clone());
-    }
+    inject_csrf_context(&mut parts.extensions, &raw_token, &config.field_name);
 
     let request = Request::from_parts(parts, body);
     let mut response = next.run(request).await;
@@ -172,13 +173,7 @@ async fn handle_mutating_request(
     parts.extensions.insert(CsrfToken(cookie_token.clone()));
 
     #[cfg(feature = "templates")]
-    if let Some(ctx) = parts
-        .extensions
-        .get_mut::<crate::templates::TemplateContext>()
-    {
-        ctx.insert("csrf_token", cookie_token.clone());
-        ctx.insert("csrf_field_name", config.field_name.clone());
-    }
+    inject_csrf_context(&mut parts.extensions, &cookie_token, &config.field_name);
 
     let request = Request::from_parts(parts, body);
     next.run(request).await

--- a/modo/src/csrf/template.rs
+++ b/modo/src/csrf/template.rs
@@ -1,6 +1,20 @@
 use crate::templates::html_escape;
 use minijinja::{Environment, Error, ErrorKind, State};
 
+fn require_csrf_token(state: &State) -> Result<String, Error> {
+    let token = state
+        .lookup("csrf_token")
+        .map(|v: minijinja::Value| v.to_string())
+        .unwrap_or_default();
+    if token.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidOperation,
+            "csrf_token not found in template context — is the CSRF middleware active?",
+        ));
+    }
+    Ok(token)
+}
+
 /// Register CSRF template functions on the MiniJinja environment.
 ///
 /// Registers:
@@ -11,17 +25,7 @@ use minijinja::{Environment, Error, ErrorKind, State};
 /// the CSRF middleware via `TemplateContext`.
 pub fn register_template_functions(env: &mut Environment<'static>) {
     env.add_function("csrf_field", |state: &State| -> Result<String, Error> {
-        let token = state
-            .lookup("csrf_token")
-            .map(|v: minijinja::Value| v.to_string())
-            .unwrap_or_default();
-
-        if token.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidOperation,
-                "csrf_token not found in template context — is the CSRF middleware active?",
-            ));
-        }
+        let token = require_csrf_token(state)?;
 
         let field_name = state
             .lookup("csrf_field_name")
@@ -40,18 +44,6 @@ pub fn register_template_functions(env: &mut Environment<'static>) {
     });
 
     env.add_function("csrf_token", |state: &State| -> Result<String, Error> {
-        let token = state
-            .lookup("csrf_token")
-            .map(|v: minijinja::Value| v.to_string())
-            .unwrap_or_default();
-
-        if token.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidOperation,
-                "csrf_token not found in template context — is the CSRF middleware active?",
-            ));
-        }
-
-        Ok(token)
+        require_csrf_token(state)
     });
 }

--- a/modo/src/csrf/token.rs
+++ b/modo/src/csrf/token.rs
@@ -1,3 +1,4 @@
+use crate::cookie_util::hex_digit;
 use hmac::{Hmac, Mac};
 use rand::RngCore;
 use sha2::Sha256;
@@ -84,15 +85,6 @@ fn hex_decode(s: &str) -> Option<Vec<u8>> {
         bytes.push((hi << 4) | lo);
     }
     Some(bytes)
-}
-
-fn hex_digit(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/modo/src/i18n/middleware.rs
+++ b/modo/src/i18n/middleware.rs
@@ -1,7 +1,7 @@
 use super::extractor::ResolvedLang;
 use super::locale::{normalize_lang, resolve_from_accept_language};
 use super::store::TranslationStore;
-use crate::cookie_util::read_cookie;
+use crate::cookie_util::{hex_digit, read_cookie};
 use crate::cookies::{CookieConfig, CookieOptions, build_cookie};
 use futures_util::future::BoxFuture;
 use http::{Request, Response};
@@ -21,7 +21,7 @@ type CustomSourceFn = dyn Fn(&http::request::Parts) -> Option<String> + Send + S
 #[derive(Clone)]
 pub struct I18nLayer {
     store: Arc<TranslationStore>,
-    cookie_config: CookieConfig,
+    cookie_config: Arc<CookieConfig>,
     custom_source: Option<Arc<CustomSourceFn>>,
 }
 
@@ -31,7 +31,7 @@ pub struct I18nLayer {
 ///
 /// The resolved locale is inserted into request extensions as [`ResolvedLang`]
 /// for downstream extractors (e.g., [`I18n`](crate::extractor::I18n)).
-pub fn layer(store: Arc<TranslationStore>, cookie_config: CookieConfig) -> I18nLayer {
+pub fn layer(store: Arc<TranslationStore>, cookie_config: Arc<CookieConfig>) -> I18nLayer {
     I18nLayer {
         store,
         cookie_config,
@@ -49,7 +49,7 @@ pub fn layer(store: Arc<TranslationStore>, cookie_config: CookieConfig) -> I18nL
 /// is normalized and checked against available locales before being accepted.
 pub fn layer_with_source(
     store: Arc<TranslationStore>,
-    cookie_config: CookieConfig,
+    cookie_config: Arc<CookieConfig>,
     source: impl Fn(&http::request::Parts) -> Option<String> + Send + Sync + 'static,
 ) -> I18nLayer {
     I18nLayer {
@@ -79,7 +79,7 @@ impl<S> Layer<S> for I18nLayer {
 pub struct I18nMiddleware<S> {
     inner: S,
     store: Arc<TranslationStore>,
-    cookie_config: CookieConfig,
+    cookie_config: Arc<CookieConfig>,
     custom_source: Option<Arc<CustomSourceFn>>,
 }
 
@@ -212,15 +212,6 @@ fn percent_decode(input: &str) -> String {
         i += 1;
     }
     String::from_utf8(out).unwrap_or_else(|_| input.to_string())
-}
-
-fn hex_digit(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/modo/src/middleware/client_ip.rs
+++ b/modo/src/middleware/client_ip.rs
@@ -8,6 +8,9 @@ use axum::middleware::Next;
 use axum::response::Response;
 use std::net::{IpAddr, SocketAddr};
 
+/// Pre-parsed trusted proxy CIDR ranges, registered as a service at startup.
+pub(crate) struct TrustedProxies(pub Vec<CidrRange>);
+
 /// The resolved client IP address, inserted into request extensions.
 #[derive(Debug, Clone, Copy)]
 pub struct ClientIp(pub IpAddr);
@@ -33,12 +36,13 @@ pub async fn client_ip_middleware(
     request: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    let trusted = parse_trusted_proxies(&state.server_config.trusted_proxies);
+    let trusted_arc = state.services.get::<TrustedProxies>();
+    let trusted: &[CidrRange] = trusted_arc.as_ref().map(|t| t.0.as_slice()).unwrap_or(&[]);
     let socket_ip = connect_info.0.ip();
 
     let (mut parts, body) = request.into_parts();
 
-    let ip = resolve_client_ip(&parts.headers, socket_ip, &trusted);
+    let ip = resolve_client_ip(&parts.headers, socket_ip, trusted);
     parts.extensions.insert(ClientIp(ip));
 
     let request = Request::from_parts(parts, body);
@@ -99,7 +103,7 @@ fn is_trusted(ip: IpAddr, trusted: &[CidrRange]) -> bool {
     trusted.iter().any(|cidr| cidr.contains(ip))
 }
 
-fn parse_trusted_proxies(proxies: &[String]) -> Vec<CidrRange> {
+pub(crate) fn parse_trusted_proxies(proxies: &[String]) -> Vec<CidrRange> {
     proxies.iter().filter_map(|s| CidrRange::parse(s)).collect()
 }
 
@@ -107,8 +111,8 @@ fn parse_trusted_proxies(proxies: &[String]) -> Vec<CidrRange> {
 // CIDR matching
 // ---------------------------------------------------------------------------
 
-#[derive(Debug)]
-struct CidrRange {
+#[derive(Debug, Clone)]
+pub(crate) struct CidrRange {
     network: IpAddr,
     prefix_len: u8,
 }

--- a/modo/src/middleware/client_ip.rs
+++ b/modo/src/middleware/client_ip.rs
@@ -9,6 +9,7 @@ use axum::response::Response;
 use std::net::{IpAddr, SocketAddr};
 
 /// Pre-parsed trusted proxy CIDR ranges, registered as a service at startup.
+#[derive(Debug)]
 pub(crate) struct TrustedProxies(pub Vec<CidrRange>);
 
 /// The resolved client IP address, inserted into request extensions.
@@ -111,7 +112,7 @@ pub(crate) fn parse_trusted_proxies(proxies: &[String]) -> Vec<CidrRange> {
 // CIDR matching
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct CidrRange {
     network: IpAddr,
     prefix_len: u8,

--- a/modo/src/middleware/mod.rs
+++ b/modo/src/middleware/mod.rs
@@ -9,6 +9,7 @@ mod trailing_slash;
 pub use crate::csrf::csrf_protection;
 pub use catch_panic::PanicHandler;
 pub use client_ip::{ClientIp, client_ip_middleware};
+pub(crate) use client_ip::{TrustedProxies, parse_trusted_proxies};
 pub use maintenance::maintenance_middleware;
 pub use rate_limit::{
     RateLimitInfo, RateLimiterState, by_header, by_ip, by_path, rate_limit_middleware,

--- a/modo/tests/i18n_integration.rs
+++ b/modo/tests/i18n_integration.rs
@@ -126,7 +126,7 @@ async fn lang_handler(Extension(lang): Extension<ResolvedLang>) -> String {
 fn middleware_app(store: Arc<modo::i18n::TranslationStore>) -> Router {
     Router::new()
         .route("/", get(lang_handler))
-        .layer(modo::i18n::layer(store, CookieConfig::default()))
+        .layer(modo::i18n::layer(store, Arc::new(CookieConfig::default())))
 }
 
 fn middleware_app_with_source(
@@ -137,7 +137,7 @@ fn middleware_app_with_source(
         .route("/", get(lang_handler))
         .layer(modo::i18n::layer_with_source(
             store,
-            CookieConfig::default(),
+            Arc::new(CookieConfig::default()),
             source,
         ))
 }


### PR DESCRIPTION
## Summary

Consolidates duplicated utility code and eliminates per-request allocations in the modo core crate to reduce overhead and improve maintainability.

### Changes

- Move `hex_digit` into `cookie_util` and import it from `csrf/token` and `i18n/middleware`, removing two duplicate definitions
- Change `i18n::layer()` and `layer_with_source()` to accept `Arc<CookieConfig>` instead of a cloned value, avoiding an extra clone per middleware wrap
- Pre-parse trusted proxy CIDRs once at app startup and register as a `TrustedProxies` service; `client_ip_middleware` now reads from the service registry instead of re-parsing on every request
- Extract `inject_csrf_context` helper (CSRF middleware) and `require_csrf_token` helper (CSRF template functions) to eliminate repeated inline blocks

## Test plan

- [x] `just check` passes (fmt-check + clippy `-D warnings` + all workspace tests)
- [x] No dead code warnings from removed private functions
- [x] `#[cfg(feature = "templates")]` gating preserved on new CSRF helper
- [x] All i18n integration tests pass with new `Arc` signatures