### PR TITLE
feat(modo-upload): configurable file size limits with per-field override

### DIFF
--- a/modo-upload-macros/src/from_multipart.rs
+++ b/modo-upload-macros/src/from_multipart.rs
@@ -8,7 +8,7 @@ enum FieldKind {
     UploadedFile,
     OptionUploadedFile,
     VecUploadedFile,
-    UploadStream,
+    BufferedUpload,
     String,
     OptionString,
     /// Other type implementing FromStr.
@@ -130,7 +130,7 @@ fn classify_type(ty: &Type) -> FieldKind {
 
     match last.ident.to_string().as_str() {
         "UploadedFile" => FieldKind::UploadedFile,
-        "UploadStream" => FieldKind::UploadStream,
+        "BufferedUpload" => FieldKind::BufferedUpload,
         "String" => FieldKind::String,
         "Option" => classify_inner_type(last, |name| match name {
             "UploadedFile" => Some(FieldKind::OptionUploadedFile),
@@ -188,7 +188,7 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
         let field_name = field.ident.clone().unwrap();
         let kind = classify_type(&field.ty);
 
-        if matches!(kind, FieldKind::UploadStream) {
+        if matches!(kind, FieldKind::BufferedUpload) {
             has_stream = true;
         }
 
@@ -220,12 +220,12 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
     if has_stream {
         let stream_count = multipart_fields
             .iter()
-            .filter(|f| matches!(f.kind, FieldKind::UploadStream))
+            .filter(|f| matches!(f.kind, FieldKind::BufferedUpload))
             .count();
         if stream_count > 1 {
             return Err(syn::Error::new_spanned(
                 &input,
-                "only one UploadStream field is allowed",
+                "only one BufferedUpload field is allowed",
             ));
         }
     }
@@ -245,8 +245,8 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
                 FieldKind::VecUploadedFile => {
                     quote! { let mut #var: Vec<modo_upload::UploadedFile> = Vec::new(); }
                 }
-                FieldKind::UploadStream => {
-                    quote! { let mut #var: Option<modo_upload::UploadStream> = None; }
+                FieldKind::BufferedUpload => {
+                    quote! { let mut #var: Option<modo_upload::BufferedUpload> = None; }
                 }
                 FieldKind::String => quote! { let mut #var: Option<String> = None; },
                 FieldKind::OptionString => quote! { let mut #var: Option<String> = None; },
@@ -276,9 +276,9 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
                         #var.push(modo_upload::UploadedFile::from_field(__field, #file_size_limit).await?);
                     }
                 },
-                FieldKind::UploadStream => quote! {
+                FieldKind::BufferedUpload => quote! {
                     Some(#name) => {
-                        #var = Some(modo_upload::UploadStream::from_field(__field, #file_size_limit).await?);
+                        #var = Some(modo_upload::BufferedUpload::from_field(__field, #file_size_limit).await?);
                     }
                 },
                 FieldKind::String | FieldKind::OptionString | FieldKind::FromStr => quote! {
@@ -396,7 +396,7 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
                 }
                 field_assignments.push(quote! { #field_name: #var });
             }
-            FieldKind::UploadStream => {
+            FieldKind::BufferedUpload => {
                 validation_stmts.push(quote! {
                     let #var = #var.ok_or_else(|| {
                         modo::validate::validation_error(vec![(#name_str, vec!["is required".into()])])

--- a/modo-upload-macros/src/from_multipart.rs
+++ b/modo-upload-macros/src/from_multipart.rs
@@ -262,10 +262,9 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
             let var = quote::format_ident!("__{}", f.field_name);
             let name = &f.multipart_name;
             // For file fields: use per-field max_size if set, otherwise fall back to __max_file_size
-            let file_size_limit = match f.upload_attrs.max_size {
-                Some(max_bytes) => quote! { Some(#max_bytes) },
-                None => quote! { __max_file_size },
-            };
+            // Always pass the global limit to from_field for streaming enforcement.
+            // Per-field limits are checked post-collection with proper validation errors.
+            let file_size_limit = quote! { __max_file_size };
             match &f.kind {
                 FieldKind::UploadedFile | FieldKind::OptionUploadedFile => quote! {
                     Some(#name) => {

--- a/modo-upload-macros/src/from_multipart.rs
+++ b/modo-upload-macros/src/from_multipart.rs
@@ -261,20 +261,25 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
         .map(|f| {
             let var = quote::format_ident!("__{}", f.field_name);
             let name = &f.multipart_name;
+            // For file fields: use per-field max_size if set, otherwise fall back to __max_file_size
+            let file_size_limit = match f.upload_attrs.max_size {
+                Some(max_bytes) => quote! { Some(#max_bytes) },
+                None => quote! { __max_file_size },
+            };
             match &f.kind {
                 FieldKind::UploadedFile | FieldKind::OptionUploadedFile => quote! {
                     Some(#name) => {
-                        #var = Some(modo_upload::UploadedFile::from_field(__field).await?);
+                        #var = Some(modo_upload::UploadedFile::from_field(__field, #file_size_limit).await?);
                     }
                 },
                 FieldKind::VecUploadedFile => quote! {
                     Some(#name) => {
-                        #var.push(modo_upload::UploadedFile::from_field(__field).await?);
+                        #var.push(modo_upload::UploadedFile::from_field(__field, #file_size_limit).await?);
                     }
                 },
                 FieldKind::UploadStream => quote! {
                     Some(#name) => {
-                        #var = Some(modo_upload::UploadStream::from_field(__field).await?);
+                        #var = Some(modo_upload::UploadStream::from_field(__field, #file_size_limit).await?);
                     }
                 },
                 FieldKind::String | FieldKind::OptionString | FieldKind::FromStr => quote! {
@@ -433,6 +438,7 @@ pub fn expand(input: TokenStream) -> Result<TokenStream> {
         impl #impl_generics modo_upload::FromMultipart for #struct_name #ty_generics #where_clause {
             async fn from_multipart(
                 multipart: &mut modo_upload::__internal::axum::extract::Multipart,
+                __max_file_size: Option<usize>,
             ) -> Result<Self, modo::Error> {
                 #(#var_decls)*
 
@@ -464,5 +470,84 @@ fn format_size_for_codegen(bytes: usize) -> String {
         format!("{}KB", bytes / 1024)
     } else {
         format!("{bytes}B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- parse_size_str --
+
+    #[test]
+    fn parse_size_bytes() {
+        assert_eq!(parse_size_str("100b").unwrap(), 100);
+    }
+
+    #[test]
+    fn parse_size_kilobytes() {
+        assert_eq!(parse_size_str("5kb").unwrap(), 5 * 1024);
+    }
+
+    #[test]
+    fn parse_size_megabytes() {
+        assert_eq!(parse_size_str("10mb").unwrap(), 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_size_gigabytes() {
+        assert_eq!(parse_size_str("2gb").unwrap(), 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_size_case_insensitive() {
+        assert_eq!(parse_size_str("5MB").unwrap(), 5 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_size_whitespace() {
+        assert_eq!(parse_size_str("  10mb  ").unwrap(), 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_size_plain_number() {
+        assert_eq!(parse_size_str("1024").unwrap(), 1024);
+    }
+
+    #[test]
+    fn parse_size_invalid() {
+        assert!(parse_size_str("abcmb").is_err());
+    }
+
+    #[test]
+    fn parse_size_zero() {
+        assert_eq!(parse_size_str("0mb").unwrap(), 0);
+    }
+
+    // -- format_size_for_codegen --
+
+    #[test]
+    fn format_codegen_bytes() {
+        assert_eq!(format_size_for_codegen(500), "500B");
+    }
+
+    #[test]
+    fn format_codegen_kilobytes() {
+        assert_eq!(format_size_for_codegen(1024), "1KB");
+    }
+
+    #[test]
+    fn format_codegen_megabytes() {
+        assert_eq!(format_size_for_codegen(5 * 1024 * 1024), "5MB");
+    }
+
+    #[test]
+    fn format_codegen_gigabytes() {
+        assert_eq!(format_size_for_codegen(2 * 1024 * 1024 * 1024), "2GB");
+    }
+
+    #[test]
+    fn format_codegen_non_aligned() {
+        assert_eq!(format_size_for_codegen(1025), "1025B");
     }
 }

--- a/modo-upload-macros/src/from_multipart.rs
+++ b/modo-upload-macros/src/from_multipart.rs
@@ -549,4 +549,29 @@ mod tests {
     fn format_codegen_non_aligned() {
         assert_eq!(format_size_for_codegen(1025), "1025B");
     }
+
+    #[test]
+    fn parse_size_negative() {
+        assert!(parse_size_str("-5mb").is_err());
+    }
+
+    #[test]
+    fn parse_size_fractional() {
+        assert!(parse_size_str("1.5mb").is_err());
+    }
+
+    #[test]
+    fn parse_size_space_between_number_and_unit() {
+        assert_eq!(parse_size_str("5 mb").unwrap(), 5 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_size_empty_string() {
+        assert!(parse_size_str("").is_err());
+    }
+
+    #[test]
+    fn format_codegen_zero() {
+        assert_eq!(format_size_for_codegen(0), "0B");
+    }
 }

--- a/modo-upload-macros/src/lib.rs
+++ b/modo-upload-macros/src/lib.rs
@@ -5,7 +5,7 @@ mod from_multipart;
 /// Derive macro for parsing `multipart/form-data` into a struct.
 ///
 /// Supports `UploadedFile`, `Option<UploadedFile>`, `Vec<UploadedFile>`,
-/// `UploadStream`, `String`, `Option<String>`, and other `FromStr` types.
+/// `BufferedUpload`, `String`, `Option<String>`, and other `FromStr` types.
 ///
 /// Use `#[upload(max_size = "5mb", accept = "image/*")]` on file fields.
 /// Use `#[serde(rename = "...")]` to rename the multipart field.

--- a/modo-upload/src/config.rs
+++ b/modo-upload/src/config.rs
@@ -22,6 +22,9 @@ pub struct UploadConfig {
     pub backend: StorageBackend,
     /// Local directory for file uploads.
     pub path: String,
+    /// Default max file size when no per-field `#[upload(max_size)]` is set.
+    /// Human-readable: "10mb", "500kb". None disables the default limit.
+    pub max_file_size: Option<String>,
     /// S3 configuration (only available with the `opendal` feature).
     #[cfg(feature = "opendal")]
     pub s3: S3Config,
@@ -32,6 +35,7 @@ impl Default for UploadConfig {
         Self {
             backend: StorageBackend::default(),
             path: "./uploads".to_string(),
+            max_file_size: Some("10mb".to_string()),
             #[cfg(feature = "opendal")]
             s3: S3Config::default(),
         }

--- a/modo-upload/src/extractor.rs
+++ b/modo-upload/src/extractor.rs
@@ -42,7 +42,16 @@ where
         let mut multipart = axum::extract::Multipart::from_request(req, state)
             .await
             .map_err(|e| HttpError::BadRequest.with_message(format!("{e}")))?;
-        let mut value = T::from_multipart(&mut multipart).await?;
+        let max_file_size = state
+            .services
+            .get::<crate::config::UploadConfig>()
+            .and_then(|config| {
+                config
+                    .max_file_size
+                    .as_ref()
+                    .and_then(|s| modo::config::parse_size(s).ok())
+            });
+        let mut value = T::from_multipart(&mut multipart, max_file_size).await?;
         modo::sanitize::auto_sanitize(&mut value);
         Ok(MultipartForm(value))
     }

--- a/modo-upload/src/extractor.rs
+++ b/modo-upload/src/extractor.rs
@@ -42,15 +42,20 @@ where
         let mut multipart = axum::extract::Multipart::from_request(req, state)
             .await
             .map_err(|e| HttpError::BadRequest.with_message(format!("{e}")))?;
-        let max_file_size = state
-            .services
-            .get::<crate::config::UploadConfig>()
-            .and_then(|config| {
-                config
-                    .max_file_size
-                    .as_ref()
-                    .and_then(|s| modo::config::parse_size(s).ok())
-            });
+        let default_config = crate::config::UploadConfig::default();
+        let registered_config = state.services.get::<crate::config::UploadConfig>();
+        let config = registered_config.as_deref().unwrap_or(&default_config);
+        let max_file_size = config.max_file_size.as_ref().and_then(|s| {
+            modo::config::parse_size(s)
+                .inspect_err(|e| {
+                    modo::tracing::warn!(
+                        size = %s,
+                        error = %e,
+                        "failed to parse max_file_size from UploadConfig, ignoring limit"
+                    );
+                })
+                .ok()
+        });
         let mut value = T::from_multipart(&mut multipart, max_file_size).await?;
         modo::sanitize::auto_sanitize(&mut value);
         Ok(MultipartForm(value))

--- a/modo-upload/src/file.rs
+++ b/modo-upload/src/file.rs
@@ -8,7 +8,7 @@ pub(crate) fn extract_extension(filename: &str) -> Option<&str> {
     if ext == filename { None } else { Some(ext) }
 }
 
-/// Metadata extracted from a multipart field (shared by UploadedFile and UploadStream).
+/// Metadata extracted from a multipart field (shared by UploadedFile and BufferedUpload).
 pub(crate) struct FieldMeta {
     pub name: String,
     pub file_name: String,

--- a/modo-upload/src/file.rs
+++ b/modo-upload/src/file.rs
@@ -1,5 +1,33 @@
 use crate::validate::UploadValidator;
 
+/// Extract the file extension from a filename (without dot, not lowercased).
+/// Returns `None` for filenames without a dot (e.g. "noext") or dotfiles (e.g. ".gitignore"
+/// returns `Some("gitignore")` via rsplit, but that's handled by the caller check).
+pub(crate) fn extract_extension(filename: &str) -> Option<&str> {
+    let ext = filename.rsplit('.').next()?;
+    if ext == filename { None } else { Some(ext) }
+}
+
+/// Metadata extracted from a multipart field (shared by UploadedFile and UploadStream).
+pub(crate) struct FieldMeta {
+    pub name: String,
+    pub file_name: String,
+    pub content_type: String,
+}
+
+impl FieldMeta {
+    pub fn from_field(field: &axum::extract::multipart::Field<'_>) -> Self {
+        Self {
+            name: field.name().unwrap_or_default().to_owned(),
+            file_name: field.file_name().unwrap_or_default().to_owned(),
+            content_type: field
+                .content_type()
+                .unwrap_or("application/octet-stream")
+                .to_owned(),
+        }
+    }
+}
+
 /// An uploaded file fully buffered in memory.
 pub struct UploadedFile {
     name: String,
@@ -13,22 +41,27 @@ impl UploadedFile {
     #[doc(hidden)]
     pub async fn from_field(
         field: axum::extract::multipart::Field<'_>,
+        max_size: Option<usize>,
     ) -> Result<Self, modo::Error> {
-        let name = field.name().unwrap_or_default().to_owned();
-        let file_name = field.file_name().unwrap_or_default().to_owned();
-        let content_type = field
-            .content_type()
-            .unwrap_or("application/octet-stream")
-            .to_owned();
-        let data = field
-            .bytes()
-            .await
-            .map_err(|e| modo::HttpError::BadRequest.with_message(format!("{e}")))?;
+        let meta = FieldMeta::from_field(&field);
+        let mut field = field;
+        let mut buf = bytes::BytesMut::new();
+        while let Some(chunk) = field.chunk().await.map_err(|e| {
+            modo::HttpError::BadRequest.with_message(format!("Failed to read multipart chunk: {e}"))
+        })? {
+            buf.extend_from_slice(&chunk);
+            if let Some(max) = max_size
+                && buf.len() > max
+            {
+                return Err(modo::HttpError::PayloadTooLarge
+                    .with_message("Upload exceeds maximum allowed size"));
+            }
+        }
         Ok(Self {
-            name,
-            file_name,
-            content_type,
-            data,
+            name: meta.name,
+            file_name: meta.file_name,
+            content_type: meta.content_type,
+            data: buf.freeze(),
         })
     }
 
@@ -59,13 +92,7 @@ impl UploadedFile {
 
     /// File extension from the original filename (lowercase, without dot).
     pub fn extension(&self) -> Option<String> {
-        self.file_name.rsplit('.').next().and_then(|ext| {
-            if ext == self.file_name {
-                None
-            } else {
-                Some(ext.to_ascii_lowercase())
-            }
-        })
+        extract_extension(&self.file_name).map(|ext| ext.to_ascii_lowercase())
     }
 
     /// Whether the file is empty (zero bytes).

--- a/modo-upload/src/file.rs
+++ b/modo-upload/src/file.rs
@@ -150,4 +150,55 @@ mod tests {
     fn extension_none() {
         assert_eq!(file_with_name("noext").extension(), None);
     }
+
+    #[test]
+    fn extension_trailing_dot() {
+        assert_eq!(file_with_name("file.").extension(), Some("".into()));
+    }
+
+    #[test]
+    fn extension_empty_filename() {
+        assert_eq!(file_with_name("").extension(), None);
+    }
+
+    #[test]
+    fn extension_only_dots() {
+        assert_eq!(file_with_name("....").extension(), Some("".into()));
+    }
+
+    #[test]
+    fn extension_single_dot() {
+        assert_eq!(file_with_name(".").extension(), Some("".into()));
+    }
+
+    #[test]
+    fn extension_unicode_filename() {
+        assert_eq!(file_with_name("café.txt").extension(), Some("txt".into()));
+    }
+
+    #[test]
+    fn extension_space_in_name() {
+        assert_eq!(
+            file_with_name("my file.tar.gz").extension(),
+            Some("gz".into())
+        );
+    }
+
+    #[test]
+    fn accessors_nonempty_file() {
+        let f = UploadedFile::__test_new("field", "photo.jpg", "image/jpeg", b"imgdata");
+        assert_eq!(f.name(), "field");
+        assert_eq!(f.file_name(), "photo.jpg");
+        assert_eq!(f.content_type(), "image/jpeg");
+        assert_eq!(f.data().as_ref(), b"imgdata");
+        assert_eq!(f.size(), 7);
+        assert!(!f.is_empty());
+    }
+
+    #[test]
+    fn accessors_empty_file() {
+        let f = UploadedFile::__test_new("field", "empty.bin", "application/octet-stream", b"");
+        assert_eq!(f.size(), 0);
+        assert!(f.is_empty());
+    }
 }

--- a/modo-upload/src/lib.rs
+++ b/modo-upload/src/lib.rs
@@ -13,7 +13,7 @@ pub use config::{StorageBackend, UploadConfig};
 pub use extractor::MultipartForm;
 pub use file::UploadedFile;
 pub use storage::{FileStorage, StoredFile, storage};
-pub use stream::UploadStream;
+pub use stream::BufferedUpload;
 pub use validate::{gb, kb, mb};
 
 /// Trait for parsing a struct from `multipart/form-data`.

--- a/modo-upload/src/lib.rs
+++ b/modo-upload/src/lib.rs
@@ -19,7 +19,10 @@ pub use validate::{gb, kb, mb};
 /// Trait for parsing a struct from `multipart/form-data`.
 #[async_trait::async_trait]
 pub trait FromMultipart: Sized {
-    async fn from_multipart(multipart: &mut axum::extract::Multipart) -> Result<Self, modo::Error>;
+    async fn from_multipart(
+        multipart: &mut axum::extract::Multipart,
+        max_file_size: Option<usize>,
+    ) -> Result<Self, modo::Error>;
 }
 
 /// Internal helpers exposed for use by generated code. Not public API.

--- a/modo-upload/src/storage/local.rs
+++ b/modo-upload/src/storage/local.rs
@@ -1,6 +1,6 @@
 use super::{FileStorage, StoredFile, ensure_within, generate_filename};
 use crate::file::UploadedFile;
-use crate::stream::UploadStream;
+use crate::stream::BufferedUpload;
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 
@@ -43,7 +43,7 @@ impl FileStorage for LocalStorage {
     async fn store_stream(
         &self,
         prefix: &str,
-        stream: &mut UploadStream,
+        stream: &mut BufferedUpload,
     ) -> Result<StoredFile, modo::Error> {
         let filename = generate_filename(stream.file_name());
         let rel_path = format!("{prefix}/{filename}");

--- a/modo-upload/src/storage/mod.rs
+++ b/modo-upload/src/storage/mod.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_logical_path(path: &str) -> Result<(), modo::Error> {
         return Err(modo::Error::internal("Invalid storage path"));
     }
     for segment in path.split('/') {
-        if segment == ".." {
+        if segment == ".." || segment == "." {
             return Err(modo::Error::internal("Invalid storage path"));
         }
     }
@@ -67,7 +67,7 @@ pub(crate) fn validate_logical_path(path: &str) -> Result<(), modo::Error> {
 pub(crate) fn generate_filename(original: &str) -> String {
     let id = ulid::Ulid::new().to_string().to_lowercase();
     match crate::file::extract_extension(original) {
-        Some(ext) => format!("{id}.{ext}"),
+        Some(ext) => format!("{id}.{}", ext.to_ascii_lowercase()),
         None => id,
     }
 }
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn generate_filename_with_ext() {
         let name = generate_filename("photo.JPG");
-        assert!(name.ends_with(".JPG"), "expected .JPG suffix, got: {name}");
+        assert!(name.ends_with(".jpg"), "expected .jpg suffix, got: {name}");
         // ULID is 26 chars + dot + extension
         assert!(name.len() > 26);
     }
@@ -204,8 +204,8 @@ mod tests {
         }
 
         #[test]
-        fn validate_logical_path_allows_dot() {
-            assert!(validate_logical_path("a/./b").is_ok());
+        fn validate_logical_path_rejects_dot() {
+            assert!(validate_logical_path("a/./b").is_err());
         }
     }
 }

--- a/modo-upload/src/storage/mod.rs
+++ b/modo-upload/src/storage/mod.rs
@@ -4,7 +4,7 @@ pub mod local;
 pub mod opendal;
 
 use crate::file::UploadedFile;
-use crate::stream::UploadStream;
+use crate::stream::BufferedUpload;
 use std::path::{Component, Path, PathBuf};
 
 /// Metadata for a stored file.
@@ -21,11 +21,11 @@ pub trait FileStorage: Send + Sync + 'static {
     /// Store a buffered file under `prefix/`. Returns the stored path and size.
     async fn store(&self, prefix: &str, file: &UploadedFile) -> Result<StoredFile, modo::Error>;
 
-    /// Store a streaming file under `prefix/`. Returns the stored path and size.
+    /// Store a buffered-chunked file under `prefix/`. Returns the stored path and size.
     async fn store_stream(
         &self,
         prefix: &str,
-        stream: &mut UploadStream,
+        stream: &mut BufferedUpload,
     ) -> Result<StoredFile, modo::Error>;
 
     /// Delete a file by its storage path.
@@ -42,6 +42,8 @@ pub(crate) fn ensure_within(base: &Path, path: &Path) -> Result<PathBuf, modo::E
     for component in path.components() {
         match component {
             Component::Normal(c) => result.push(c),
+            // `.` is harmless in filesystem paths — silently stripped.
+            // (Object-store keys must be canonical, so `validate_logical_path` rejects `.`.)
             Component::CurDir => {}
             _ => return Err(modo::Error::internal("Invalid storage path")),
         }

--- a/modo-upload/src/storage/mod.rs
+++ b/modo-upload/src/storage/mod.rs
@@ -66,9 +66,9 @@ pub(crate) fn validate_logical_path(path: &str) -> Result<(), modo::Error> {
 /// Generate a unique filename: `{ulid}.{ext}`.
 pub(crate) fn generate_filename(original: &str) -> String {
     let id = ulid::Ulid::new().to_string().to_lowercase();
-    match original.rsplit('.').next() {
-        Some(ext) if ext != original => format!("{id}.{ext}"),
-        _ => id,
+    match crate::file::extract_extension(original) {
+        Some(ext) => format!("{id}.{ext}"),
+        None => id,
     }
 }
 
@@ -112,5 +112,100 @@ pub fn storage(config: &crate::config::UploadConfig) -> Result<Box<dyn FileStora
         crate::config::StorageBackend::S3 => Err(modo::Error::internal(
             "S3 storage backend requires the `opendal` feature",
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    // -- ensure_within --
+
+    #[test]
+    fn ensure_within_normal_path() {
+        let result = ensure_within(Path::new("base"), Path::new("sub/file.txt")).unwrap();
+        assert_eq!(result, PathBuf::from("base/sub/file.txt"));
+    }
+
+    #[test]
+    fn ensure_within_curdir_stripped() {
+        let result = ensure_within(Path::new("base"), Path::new("./sub/file.txt")).unwrap();
+        assert_eq!(result, PathBuf::from("base/sub/file.txt"));
+    }
+
+    #[test]
+    fn ensure_within_rejects_parent() {
+        let result = ensure_within(Path::new("base"), Path::new("../escape"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn ensure_within_rejects_absolute() {
+        let result = ensure_within(Path::new("base"), Path::new("/etc/passwd"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn ensure_within_empty_path() {
+        let result = ensure_within(Path::new("base"), Path::new("")).unwrap();
+        assert_eq!(result, PathBuf::from("base"));
+    }
+
+    // -- generate_filename --
+
+    #[test]
+    fn generate_filename_with_ext() {
+        let name = generate_filename("photo.JPG");
+        assert!(name.ends_with(".JPG"), "expected .JPG suffix, got: {name}");
+        // ULID is 26 chars + dot + extension
+        assert!(name.len() > 26);
+    }
+
+    #[test]
+    fn generate_filename_without_ext() {
+        let name = generate_filename("noext");
+        assert!(!name.contains('.'), "expected no dot, got: {name}");
+        assert_eq!(name.len(), 26); // lowercase ULID
+    }
+
+    #[test]
+    fn generate_filename_compound_ext() {
+        let name = generate_filename("archive.tar.gz");
+        assert!(name.ends_with(".gz"), "expected .gz suffix, got: {name}");
+    }
+
+    #[test]
+    fn generate_filename_unique() {
+        let a = generate_filename("test.txt");
+        let b = generate_filename("test.txt");
+        assert_ne!(a, b);
+    }
+
+    // -- validate_logical_path (opendal only) --
+
+    #[cfg(feature = "opendal")]
+    mod opendal_tests {
+        use super::super::validate_logical_path;
+
+        #[test]
+        fn validate_logical_path_ok() {
+            assert!(validate_logical_path("prefix/file.txt").is_ok());
+        }
+
+        #[test]
+        fn validate_logical_path_rejects_leading_slash() {
+            assert!(validate_logical_path("/absolute").is_err());
+        }
+
+        #[test]
+        fn validate_logical_path_rejects_dotdot() {
+            assert!(validate_logical_path("a/../escape").is_err());
+        }
+
+        #[test]
+        fn validate_logical_path_allows_dot() {
+            assert!(validate_logical_path("a/./b").is_ok());
+        }
     }
 }

--- a/modo-upload/src/storage/opendal.rs
+++ b/modo-upload/src/storage/opendal.rs
@@ -1,6 +1,6 @@
 use super::{FileStorage, StoredFile, generate_filename, validate_logical_path};
 use crate::file::UploadedFile;
-use crate::stream::UploadStream;
+use crate::stream::BufferedUpload;
 
 /// Storage backend powered by Apache OpenDAL (S3, GCS, Azure, etc.).
 ///
@@ -39,7 +39,7 @@ impl FileStorage for OpendalStorage {
     async fn store_stream(
         &self,
         prefix: &str,
-        stream: &mut UploadStream,
+        stream: &mut BufferedUpload,
     ) -> Result<StoredFile, modo::Error> {
         validate_logical_path(prefix)?;
         let filename = generate_filename(stream.file_name());

--- a/modo-upload/src/storage/opendal.rs
+++ b/modo-upload/src/storage/opendal.rs
@@ -45,12 +45,7 @@ impl FileStorage for OpendalStorage {
         let filename = generate_filename(stream.file_name());
         let path = format!("{prefix}/{filename}");
 
-        let mut data = Vec::new();
-        while let Some(chunk) = stream.chunk().await {
-            let chunk =
-                chunk.map_err(|e| modo::Error::internal(format!("Failed to read chunk: {e}")))?;
-            data.extend_from_slice(&chunk);
-        }
+        let data = stream.to_bytes();
         let size = data.len() as u64;
 
         self.operator

--- a/modo-upload/src/stream.rs
+++ b/modo-upload/src/stream.rs
@@ -4,12 +4,12 @@ use futures_util::stream;
 use std::pin::Pin;
 use tokio::io::AsyncRead;
 
-/// An uploaded file stored as a sequence of chunks rather than one contiguous buffer.
+/// An uploaded file fully buffered in memory as a sequence of chunks.
 ///
-/// **Note:** This is not a true streaming upload. During multipart parsing, all
-/// chunks are fully buffered in memory before the struct is returned. The
-/// `chunk()` and `into_reader()` methods replay from this in-memory buffer.
-pub struct UploadStream {
+/// During multipart parsing all chunks are collected into memory before the
+/// struct is returned.  The [`chunk()`](Self::chunk) and
+/// [`into_reader()`](Self::into_reader) methods replay from this buffer.
+pub struct BufferedUpload {
     name: String,
     file_name: String,
     content_type: String,
@@ -18,7 +18,7 @@ pub struct UploadStream {
     pos: usize,
 }
 
-impl UploadStream {
+impl BufferedUpload {
     /// Create from an axum multipart field by draining its chunks.
     #[doc(hidden)]
     pub async fn from_field(
@@ -105,7 +105,7 @@ impl UploadStream {
         buf.freeze()
     }
 
-    /// Test helper — construct an `UploadStream` without multipart parsing.
+    /// Test helper — construct a `BufferedUpload` without multipart parsing.
     #[doc(hidden)]
     pub fn __test_new(name: &str, file_name: &str, content_type: &str, chunks: Vec<Bytes>) -> Self {
         let total_size = chunks.iter().map(|c| c.len()).sum();

--- a/modo-upload/src/stream.rs
+++ b/modo-upload/src/stream.rs
@@ -1,18 +1,20 @@
+use crate::file::FieldMeta;
 use bytes::Bytes;
 use futures_util::stream;
 use std::pin::Pin;
 use tokio::io::AsyncRead;
 
-/// A streaming uploaded file — data arrives as chunks, not one contiguous buffer.
+/// An uploaded file stored as a sequence of chunks rather than one contiguous buffer.
 ///
-/// During multipart parsing, chunks are collected from the request body into
-/// an internal buffer. The stream can then be consumed incrementally via
-/// `chunk()` or converted to an `AsyncRead` via `into_reader()`.
+/// **Note:** This is not a true streaming upload. During multipart parsing, all
+/// chunks are fully buffered in memory before the struct is returned. The
+/// `chunk()` and `into_reader()` methods replay from this in-memory buffer.
 pub struct UploadStream {
     name: String,
     file_name: String,
     content_type: String,
     chunks: Vec<Bytes>,
+    total_size: usize,
     pos: usize,
 }
 
@@ -21,28 +23,33 @@ impl UploadStream {
     #[doc(hidden)]
     pub async fn from_field(
         field: axum::extract::multipart::Field<'_>,
+        max_size: Option<usize>,
     ) -> Result<Self, modo::Error> {
-        let name = field.name().unwrap_or_default().to_owned();
-        let file_name = field.file_name().unwrap_or_default().to_owned();
-        let content_type = field
-            .content_type()
-            .unwrap_or("application/octet-stream")
-            .to_owned();
+        let meta = FieldMeta::from_field(&field);
 
         // Collect chunks from the borrowed field into an owned Vec<Bytes>
         let mut chunks = Vec::new();
+        let mut total_size: usize = 0;
         let mut field = field;
         while let Some(chunk) = field.chunk().await.map_err(|e| {
             modo::HttpError::BadRequest.with_message(format!("Failed to read multipart chunk: {e}"))
         })? {
+            total_size += chunk.len();
+            if let Some(max) = max_size
+                && total_size > max
+            {
+                return Err(modo::HttpError::PayloadTooLarge
+                    .with_message("Upload exceeds maximum allowed size"));
+            }
             chunks.push(chunk);
         }
 
         Ok(Self {
-            name,
-            file_name,
-            content_type,
+            name: meta.name,
+            file_name: meta.file_name,
+            content_type: meta.content_type,
             chunks,
+            total_size,
             pos: 0,
         })
     }
@@ -82,17 +89,32 @@ impl UploadStream {
 
     /// Total size of all collected chunks in bytes.
     pub fn size(&self) -> usize {
-        self.chunks.iter().map(|c| c.len()).sum()
+        self.total_size
+    }
+
+    /// Collapse all chunks into a single contiguous `Bytes`.
+    /// Single allocation sized to total content length.
+    pub fn to_bytes(&self) -> bytes::Bytes {
+        if self.chunks.len() == 1 {
+            return self.chunks[0].clone(); // Bytes::clone is cheap (Arc)
+        }
+        let mut buf = bytes::BytesMut::with_capacity(self.total_size);
+        for chunk in &self.chunks {
+            buf.extend_from_slice(chunk);
+        }
+        buf.freeze()
     }
 
     /// Test helper — construct an `UploadStream` without multipart parsing.
     #[doc(hidden)]
     pub fn __test_new(name: &str, file_name: &str, content_type: &str, chunks: Vec<Bytes>) -> Self {
+        let total_size = chunks.iter().map(|c| c.len()).sum();
         Self {
             name: name.to_owned(),
             file_name: file_name.to_owned(),
             content_type: content_type.to_owned(),
             chunks,
+            total_size,
             pos: 0,
         }
     }

--- a/modo-upload/src/validate.rs
+++ b/modo-upload/src/validate.rs
@@ -68,11 +68,11 @@ pub fn mime_matches(content_type: &str, pattern: &str) -> bool {
 }
 
 fn format_size(bytes: usize) -> String {
-    if bytes >= 1024 * 1024 * 1024 {
+    if bytes >= 1024 * 1024 * 1024 && bytes.is_multiple_of(1024 * 1024 * 1024) {
         format!("{}GB", bytes / (1024 * 1024 * 1024))
-    } else if bytes >= 1024 * 1024 {
+    } else if bytes >= 1024 * 1024 && bytes.is_multiple_of(1024 * 1024) {
         format!("{}MB", bytes / (1024 * 1024))
-    } else if bytes >= 1024 {
+    } else if bytes >= 1024 && bytes.is_multiple_of(1024) {
         format!("{}KB", bytes / 1024)
     } else {
         format!("{bytes}B")
@@ -148,6 +148,13 @@ mod tests {
         assert_eq!(format_size(1024), "1KB");
         assert_eq!(format_size(5 * 1024 * 1024), "5MB");
         assert_eq!(format_size(2 * 1024 * 1024 * 1024), "2GB");
+    }
+
+    #[test]
+    fn format_size_non_aligned_falls_back_to_bytes() {
+        assert_eq!(format_size(2047), "2047B");
+        assert_eq!(format_size(1025), "1025B");
+        assert_eq!(format_size(1024 * 1024 + 1), "1048577B");
     }
 
     // -- UploadValidator --

--- a/modo-upload/src/validate.rs
+++ b/modo-upload/src/validate.rs
@@ -218,4 +218,44 @@ mod tests {
         let f = UploadedFile::__test_new("f", "img.png", "image/png", &[0u8; 5]);
         f.validate().max_size(10).accept("image/*").check().unwrap();
     }
+
+    #[test]
+    fn mime_semicolon_no_params() {
+        assert!(mime_matches("image/png;", "image/png"));
+    }
+
+    #[test]
+    fn mime_case_sensitive() {
+        assert!(!mime_matches("Image/PNG", "image/png"));
+    }
+
+    #[test]
+    fn mime_wildcard_invalid_form() {
+        assert!(!mime_matches("image/png", "*/image"));
+    }
+
+    #[test]
+    fn mime_leading_trailing_whitespace() {
+        assert!(mime_matches(" image/png ", "image/png"));
+    }
+
+    #[test]
+    fn mime_wildcard_partial_type_rejected() {
+        assert!(!mime_matches("imageX/png", "image/*"));
+    }
+
+    #[test]
+    fn format_size_zero() {
+        assert_eq!(format_size(0), "0B");
+    }
+
+    #[test]
+    fn format_size_boundary_1023() {
+        assert_eq!(format_size(1023), "1023B");
+    }
+
+    #[test]
+    fn format_size_boundary_below_mb() {
+        assert_eq!(format_size(1024 * 1024 - 1), "1048575B");
+    }
 }

--- a/modo-upload/src/validate.rs
+++ b/modo-upload/src/validate.rs
@@ -149,4 +149,66 @@ mod tests {
         assert_eq!(format_size(5 * 1024 * 1024), "5MB");
         assert_eq!(format_size(2 * 1024 * 1024 * 1024), "2GB");
     }
+
+    // -- UploadValidator --
+
+    #[test]
+    fn validator_max_size_pass() {
+        let f = UploadedFile::__test_new("f", "a.bin", "application/octet-stream", &[0u8; 5]);
+        f.validate().max_size(10).check().unwrap();
+    }
+
+    #[test]
+    fn validator_max_size_fail() {
+        let f = UploadedFile::__test_new("f", "a.bin", "application/octet-stream", &[0u8; 20]);
+        assert!(f.validate().max_size(10).check().is_err());
+    }
+
+    #[test]
+    fn validator_max_size_exact_boundary() {
+        let f = UploadedFile::__test_new("f", "a.bin", "application/octet-stream", &[0u8; 10]);
+        // size == max should pass (not >)
+        f.validate().max_size(10).check().unwrap();
+    }
+
+    #[test]
+    fn validator_accept_pass() {
+        let f = UploadedFile::__test_new("f", "img.png", "image/png", b"img");
+        f.validate().accept("image/*").check().unwrap();
+    }
+
+    #[test]
+    fn validator_accept_fail() {
+        let f = UploadedFile::__test_new("f", "doc.txt", "text/plain", b"text");
+        assert!(f.validate().accept("image/*").check().is_err());
+    }
+
+    #[test]
+    fn validator_chain_both_fail() {
+        let f = UploadedFile::__test_new("f", "doc.txt", "text/plain", &[0u8; 20]);
+        let err = f
+            .validate()
+            .max_size(10)
+            .accept("image/*")
+            .check()
+            .unwrap_err();
+        // Both errors should be collected
+        let details = err.details();
+        let messages = details
+            .get("f")
+            .expect("expected details for field 'f'")
+            .as_array()
+            .expect("expected JSON array");
+        assert_eq!(
+            messages.len(),
+            2,
+            "expected 2 validation messages, got: {messages:?}"
+        );
+    }
+
+    #[test]
+    fn validator_chain_both_pass() {
+        let f = UploadedFile::__test_new("f", "img.png", "image/png", &[0u8; 5]);
+        f.validate().max_size(10).accept("image/*").check().unwrap();
+    }
 }

--- a/modo-upload/tests/config.rs
+++ b/modo-upload/tests/config.rs
@@ -5,6 +5,7 @@ fn test_default_config() {
     let config = UploadConfig::default();
     assert_eq!(config.path, "./uploads");
     assert_eq!(config.backend, StorageBackend::Local);
+    assert_eq!(config.max_file_size, Some("10mb".to_string()));
 }
 
 #[tokio::test]
@@ -23,6 +24,21 @@ fn test_config_deserialize_defaults() {
     let config: UploadConfig = serde_json::from_str(json).unwrap();
     assert_eq!(config.path, "./uploads");
     assert_eq!(config.backend, StorageBackend::Local);
+    assert_eq!(config.max_file_size, Some("10mb".to_string()));
+}
+
+#[test]
+fn test_config_custom_max_file_size() {
+    let json = r#"{"max_file_size": "5mb"}"#;
+    let config: UploadConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.max_file_size, Some("5mb".to_string()));
+}
+
+#[test]
+fn test_config_null_max_file_size() {
+    let json = r#"{"max_file_size": null}"#;
+    let config: UploadConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.max_file_size, None);
 }
 
 #[test]

--- a/modo-upload/tests/config.rs
+++ b/modo-upload/tests/config.rs
@@ -48,3 +48,24 @@ fn test_config_deserialize_custom_path() {
     assert_eq!(config.path, "/data/files");
     assert_eq!(config.backend, StorageBackend::Local);
 }
+
+#[test]
+fn test_config_unknown_fields_ignored() {
+    let json = r#"{"path": "./uploads", "unknown_key": 42, "another": "value"}"#;
+    let config: UploadConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.path, "./uploads");
+}
+
+#[test]
+fn test_config_backend_s3() {
+    let json = r#"{"backend": "s3"}"#;
+    let config: UploadConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.backend, StorageBackend::S3);
+}
+
+#[test]
+fn test_config_max_file_size_empty_string() {
+    let json = r#"{"max_file_size": ""}"#;
+    let config: UploadConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.max_file_size, Some("".to_string()));
+}

--- a/modo-upload/tests/from_multipart.rs
+++ b/modo-upload/tests/from_multipart.rs
@@ -2,7 +2,7 @@
 
 use axum::extract::FromRequest;
 use axum::http::Request;
-use modo_upload::{FromMultipart, UploadStream, UploadedFile};
+use modo_upload::{BufferedUpload, FromMultipart, UploadedFile};
 
 // ---------------------------------------------------------------------------
 // Helper: build a real `axum::extract::Multipart` from field descriptors
@@ -619,18 +619,18 @@ async fn multiple_required_fields_missing() {
 }
 
 // ===========================================================================
-// Group 6: UploadStream in derived structs
+// Group 6: BufferedUpload in derived structs
 // ===========================================================================
 
 #[derive(FromMultipart)]
 struct StreamUpload {
-    stream: UploadStream,
+    stream: BufferedUpload,
 }
 
 #[derive(FromMultipart)]
 struct MixedStreamAndText {
     name: String,
-    stream: UploadStream,
+    stream: BufferedUpload,
 }
 
 #[tokio::test]

--- a/modo-upload/tests/from_multipart.rs
+++ b/modo-upload/tests/from_multipart.rs
@@ -2,7 +2,7 @@
 
 use axum::extract::FromRequest;
 use axum::http::Request;
-use modo_upload::{FromMultipart, UploadedFile};
+use modo_upload::{FromMultipart, UploadStream, UploadedFile};
 
 // ---------------------------------------------------------------------------
 // Helper: build a real `axum::extract::Multipart` from field descriptors
@@ -92,7 +92,7 @@ async fn rename_string_field() {
         value: "Alice",
     }])
     .await;
-    let result = RenameString::from_multipart(&mut mp).await.unwrap();
+    let result = RenameString::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.name, "Alice");
 }
 
@@ -108,7 +108,7 @@ async fn no_rename_uses_field_name() {
         value: "Bob",
     }])
     .await;
-    let result = NoRename::from_multipart(&mut mp).await.unwrap();
+    let result = NoRename::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.name, "Bob");
 }
 
@@ -125,14 +125,18 @@ async fn rename_on_option_string() {
         value: "hello",
     }])
     .await;
-    let result = RenameOptionString::from_multipart(&mut mp).await.unwrap();
+    let result = RenameOptionString::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
     assert_eq!(result.bio, Some("hello".to_owned()));
 }
 
 #[tokio::test]
 async fn rename_on_option_string_missing() {
     let mut mp = make_multipart(&[]).await;
-    let result = RenameOptionString::from_multipart(&mut mp).await.unwrap();
+    let result = RenameOptionString::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
     assert_eq!(result.bio, None);
 }
 
@@ -149,7 +153,7 @@ async fn rename_on_from_str_field() {
         value: "25",
     }])
     .await;
-    let result = RenameFromStr::from_multipart(&mut mp).await.unwrap();
+    let result = RenameFromStr::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.age, 25);
 }
 
@@ -168,7 +172,9 @@ async fn rename_on_uploaded_file() {
         data: b"PNG",
     }])
     .await;
-    let result = RenameUploadedFile::from_multipart(&mut mp).await.unwrap();
+    let result = RenameUploadedFile::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
     assert_eq!(result.avatar.file_name(), "face.png");
     assert_eq!(result.avatar.data().as_ref(), b"PNG");
 }
@@ -189,7 +195,7 @@ async fn rename_with_upload_attrs() {
         data: b"tiny",
     }])
     .await;
-    let result = RenameWithUploadAttrs::from_multipart(&mut mp)
+    let result = RenameWithUploadAttrs::from_multipart(&mut mp, None)
         .await
         .unwrap();
     assert_eq!(result.avatar.file_name(), "small.jpg");
@@ -208,7 +214,9 @@ async fn other_serde_attrs_ignored() {
         value: "hi",
     }])
     .await;
-    let result = OtherSerdeAttrs::from_multipart(&mut mp).await.unwrap();
+    let result = OtherSerdeAttrs::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
     assert_eq!(result.name, "hi");
 }
 
@@ -232,7 +240,7 @@ async fn multiple_fields_mixed_rename() {
         },
     ])
     .await;
-    let result = MixedRename::from_multipart(&mut mp).await.unwrap();
+    let result = MixedRename::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.name, "Alice");
     assert_eq!(result.email, "a@b.c");
 }
@@ -253,14 +261,16 @@ async fn required_string_present() {
         value: "Bob",
     }])
     .await;
-    let result = RequiredString::from_multipart(&mut mp).await.unwrap();
+    let result = RequiredString::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.name, "Bob");
 }
 
 #[tokio::test]
 async fn required_string_missing() {
     let mut mp = make_multipart(&[]).await;
-    let err = RequiredString::from_multipart(&mut mp).await.unwrap_err();
+    let err = RequiredString::from_multipart(&mut mp, None)
+        .await
+        .unwrap_err();
     assert_validation_error(&err, "name");
 }
 
@@ -276,14 +286,14 @@ async fn option_string_present() {
         value: "hi",
     }])
     .await;
-    let result = OptString::from_multipart(&mut mp).await.unwrap();
+    let result = OptString::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.bio, Some("hi".to_owned()));
 }
 
 #[tokio::test]
 async fn option_string_missing() {
     let mut mp = make_multipart(&[]).await;
-    let result = OptString::from_multipart(&mut mp).await.unwrap();
+    let result = OptString::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.bio, None);
 }
 
@@ -299,7 +309,7 @@ async fn from_str_valid() {
         value: "42",
     }])
     .await;
-    let result = FromStrValid::from_multipart(&mut mp).await.unwrap();
+    let result = FromStrValid::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.age, 42);
 }
 
@@ -310,14 +320,18 @@ async fn from_str_invalid() {
         value: "abc",
     }])
     .await;
-    let err = FromStrValid::from_multipart(&mut mp).await.unwrap_err();
+    let err = FromStrValid::from_multipart(&mut mp, None)
+        .await
+        .unwrap_err();
     assert_validation_error(&err, "age");
 }
 
 #[tokio::test]
 async fn from_str_missing() {
     let mut mp = make_multipart(&[]).await;
-    let err = FromStrValid::from_multipart(&mut mp).await.unwrap_err();
+    let err = FromStrValid::from_multipart(&mut mp, None)
+        .await
+        .unwrap_err();
     assert_validation_error(&err, "age");
 }
 
@@ -340,7 +354,7 @@ async fn uploaded_file_present() {
         data,
     }])
     .await;
-    let result = RequiredFile::from_multipart(&mut mp).await.unwrap();
+    let result = RequiredFile::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.avatar.file_name(), "pic.png");
     assert_eq!(result.avatar.content_type(), "image/png");
     assert_eq!(result.avatar.data().as_ref(), data);
@@ -350,7 +364,7 @@ async fn uploaded_file_present() {
 #[tokio::test]
 async fn uploaded_file_missing() {
     let mut mp = make_multipart(&[]).await;
-    let Err(err) = RequiredFile::from_multipart(&mut mp).await else {
+    let Err(err) = RequiredFile::from_multipart(&mut mp, None).await else {
         panic!("expected error");
     };
     assert_validation_error(&err, "avatar");
@@ -370,7 +384,7 @@ async fn option_file_present() {
         data: b"data",
     }])
     .await;
-    let result = OptFile::from_multipart(&mut mp).await.unwrap();
+    let result = OptFile::from_multipart(&mut mp, None).await.unwrap();
     assert!(result.avatar.is_some());
     assert_eq!(result.avatar.unwrap().file_name(), "pic.png");
 }
@@ -378,7 +392,7 @@ async fn option_file_present() {
 #[tokio::test]
 async fn option_file_missing() {
     let mut mp = make_multipart(&[]).await;
-    let result = OptFile::from_multipart(&mut mp).await.unwrap();
+    let result = OptFile::from_multipart(&mut mp, None).await.unwrap();
     assert!(result.avatar.is_none());
 }
 
@@ -410,7 +424,7 @@ async fn vec_file_multiple() {
         },
     ])
     .await;
-    let result = VecFiles::from_multipart(&mut mp).await.unwrap();
+    let result = VecFiles::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.files.len(), 3);
     assert_eq!(result.files[0].file_name(), "a.txt");
     assert_eq!(result.files[1].file_name(), "b.txt");
@@ -420,7 +434,7 @@ async fn vec_file_multiple() {
 #[tokio::test]
 async fn vec_file_empty() {
     let mut mp = make_multipart(&[]).await;
-    let result = VecFiles::from_multipart(&mut mp).await.unwrap();
+    let result = VecFiles::from_multipart(&mut mp, None).await.unwrap();
     assert!(result.files.is_empty());
 }
 
@@ -443,7 +457,7 @@ async fn max_size_within_limit() {
         data: &[0u8; 5],
     }])
     .await;
-    MaxSizeFile::from_multipart(&mut mp).await.unwrap();
+    MaxSizeFile::from_multipart(&mut mp, None).await.unwrap();
 }
 
 #[tokio::test]
@@ -455,10 +469,11 @@ async fn max_size_exceeded() {
         data: &[0u8; 20],
     }])
     .await;
-    let Err(err) = MaxSizeFile::from_multipart(&mut mp).await else {
+    let Err(err) = MaxSizeFile::from_multipart(&mut mp, None).await else {
         panic!("expected error");
     };
-    assert_validation_error(&err, "f");
+    // Early rejection returns 413 Payload Too Large
+    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
 }
 
 #[derive(FromMultipart)]
@@ -476,7 +491,7 @@ async fn accept_mime_match() {
         data: b"img",
     }])
     .await;
-    AcceptMimeFile::from_multipart(&mut mp).await.unwrap();
+    AcceptMimeFile::from_multipart(&mut mp, None).await.unwrap();
 }
 
 #[tokio::test]
@@ -488,7 +503,7 @@ async fn accept_mime_mismatch() {
         data: b"text",
     }])
     .await;
-    let Err(err) = AcceptMimeFile::from_multipart(&mut mp).await else {
+    let Err(err) = AcceptMimeFile::from_multipart(&mut mp, None).await else {
         panic!("expected error");
     };
     assert_validation_error(&err, "f");
@@ -509,7 +524,7 @@ async fn vec_min_count_not_met() {
         data: b"one",
     }])
     .await;
-    let Err(err) = MinCountFiles::from_multipart(&mut mp).await else {
+    let Err(err) = MinCountFiles::from_multipart(&mut mp, None).await else {
         panic!("expected error");
     };
     assert_validation_error(&err, "files");
@@ -544,7 +559,7 @@ async fn vec_max_count_exceeded() {
         },
     ])
     .await;
-    let Err(err) = MaxCountFiles::from_multipart(&mut mp).await else {
+    let Err(err) = MaxCountFiles::from_multipart(&mut mp, None).await else {
         panic!("expected error");
     };
     assert_validation_error(&err, "files");
@@ -567,7 +582,7 @@ async fn unknown_field_ignored() {
         },
     ])
     .await;
-    let result = RequiredString::from_multipart(&mut mp).await.unwrap();
+    let result = RequiredString::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.name, "Bob");
 }
 
@@ -578,7 +593,7 @@ async fn empty_string_field() {
         value: "",
     }])
     .await;
-    let result = RequiredString::from_multipart(&mut mp).await.unwrap();
+    let result = RequiredString::from_multipart(&mut mp, None).await.unwrap();
     assert_eq!(result.name, "");
 }
 
@@ -591,7 +606,9 @@ struct TwoRequired {
 #[tokio::test]
 async fn multiple_required_fields_missing() {
     let mut mp = make_multipart(&[]).await;
-    let err = TwoRequired::from_multipart(&mut mp).await.unwrap_err();
+    let err = TwoRequired::from_multipart(&mut mp, None)
+        .await
+        .unwrap_err();
     assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
     // At least the first missing field should be reported
     assert!(
@@ -599,4 +616,434 @@ async fn multiple_required_fields_missing() {
         "expected at least one field in details: {:?}",
         err.details()
     );
+}
+
+// ===========================================================================
+// Group 6: UploadStream in derived structs
+// ===========================================================================
+
+#[derive(FromMultipart)]
+struct StreamUpload {
+    stream: UploadStream,
+}
+
+#[derive(FromMultipart)]
+struct MixedStreamAndText {
+    name: String,
+    stream: UploadStream,
+}
+
+#[tokio::test]
+async fn stream_field_present() {
+    let data = b"stream-content";
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "stream",
+        filename: "data.bin",
+        content_type: "application/octet-stream",
+        data,
+    }])
+    .await;
+    let result = StreamUpload::from_multipart(&mut mp, None).await.unwrap();
+    assert_eq!(result.stream.file_name(), "data.bin");
+    assert_eq!(result.stream.content_type(), "application/octet-stream");
+    assert_eq!(result.stream.size(), data.len());
+    assert_eq!(result.stream.to_bytes().as_ref(), data);
+}
+
+#[tokio::test]
+async fn stream_field_missing() {
+    let mut mp = make_multipart(&[]).await;
+    let Err(err) = StreamUpload::from_multipart(&mut mp, None).await else {
+        panic!("expected error");
+    };
+    assert_validation_error(&err, "stream");
+}
+
+#[tokio::test]
+async fn stream_with_text_field() {
+    let data = b"file-bytes";
+    let mut mp = make_multipart(&[
+        MultipartField::Text {
+            name: "name",
+            value: "Alice",
+        },
+        MultipartField::File {
+            name: "stream",
+            filename: "upload.bin",
+            content_type: "application/octet-stream",
+            data,
+        },
+    ])
+    .await;
+    let result = MixedStreamAndText::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
+    assert_eq!(result.name, "Alice");
+    assert_eq!(result.stream.file_name(), "upload.bin");
+    assert_eq!(result.stream.to_bytes().as_ref(), data);
+}
+
+// ===========================================================================
+// Group 7: Global max_file_size passthrough
+// ===========================================================================
+
+#[tokio::test]
+async fn global_max_file_size_rejects_large_file() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "avatar",
+        filename: "big.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 20],
+    }])
+    .await;
+    let Err(err) = RequiredFile::from_multipart(&mut mp, Some(10)).await else {
+        panic!("expected error");
+    };
+    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn global_max_file_size_allows_within_limit() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "avatar",
+        filename: "small.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 5],
+    }])
+    .await;
+    RequiredFile::from_multipart(&mut mp, Some(100))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn global_max_file_size_none_allows_any() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "avatar",
+        filename: "large.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 1000],
+    }])
+    .await;
+    RequiredFile::from_multipart(&mut mp, None).await.unwrap();
+}
+
+#[tokio::test]
+async fn global_max_file_size_applies_to_stream() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "stream",
+        filename: "big.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 20],
+    }])
+    .await;
+    let Err(err) = StreamUpload::from_multipart(&mut mp, Some(5)).await else {
+        panic!("expected error");
+    };
+    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn global_max_file_size_applies_to_vec() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "files",
+        filename: "big.bin",
+        content_type: "text/plain",
+        data: &[0u8; 20],
+    }])
+    .await;
+    let Err(err) = VecFiles::from_multipart(&mut mp, Some(5)).await else {
+        panic!("expected error");
+    };
+    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn global_max_file_size_applies_to_option() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "avatar",
+        filename: "big.bin",
+        content_type: "image/png",
+        data: &[0u8; 20],
+    }])
+    .await;
+    let Err(err) = OptFile::from_multipart(&mut mp, Some(5)).await else {
+        panic!("expected error");
+    };
+    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn global_max_file_size_option_missing_ok() {
+    let mut mp = make_multipart(&[]).await;
+    let result = OptFile::from_multipart(&mut mp, Some(5)).await.unwrap();
+    assert!(result.avatar.is_none());
+}
+
+// ===========================================================================
+// Group 8: Per-field vs global precedence
+// ===========================================================================
+
+#[tokio::test]
+async fn per_field_overrides_global() {
+    // MaxSizeFile has #[upload(max_size = "10b")], global = 5B.
+    // File is 7 bytes — exceeds global but within per-field. Should succeed.
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "f",
+        filename: "mid.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 7],
+    }])
+    .await;
+    MaxSizeFile::from_multipart(&mut mp, Some(5)).await.unwrap();
+}
+
+#[tokio::test]
+async fn per_field_still_rejects_over_own_limit() {
+    // MaxSizeFile has #[upload(max_size = "10b")], global = 1000B.
+    // File is 20 bytes — within global but exceeds per-field. Should fail.
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "f",
+        filename: "big.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 20],
+    }])
+    .await;
+    let Err(err) = MaxSizeFile::from_multipart(&mut mp, Some(1000)).await else {
+        panic!("expected error");
+    };
+    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+// ===========================================================================
+// Group 9: Exact boundary
+// ===========================================================================
+
+#[tokio::test]
+async fn vec_max_count_exact_boundary_ok() {
+    // MaxCountFiles has max_count=2, sending exactly 2 files should succeed.
+    let mut mp = make_multipart(&[
+        MultipartField::File {
+            name: "files",
+            filename: "a.txt",
+            content_type: "text/plain",
+            data: b"a",
+        },
+        MultipartField::File {
+            name: "files",
+            filename: "b.txt",
+            content_type: "text/plain",
+            data: b"b",
+        },
+    ])
+    .await;
+    let result = MaxCountFiles::from_multipart(&mut mp, None).await.unwrap();
+    assert_eq!(result.files.len(), 2);
+}
+
+// ===========================================================================
+// Group 10: Option/Vec with accept and max_size attributes
+// ===========================================================================
+
+#[derive(FromMultipart)]
+struct OptFileWithAccept {
+    #[upload(accept = "image/*")]
+    avatar: Option<UploadedFile>,
+}
+
+#[derive(FromMultipart)]
+struct OptFileWithMaxSize {
+    #[upload(max_size = "10b")]
+    avatar: Option<UploadedFile>,
+}
+
+#[derive(FromMultipart)]
+struct VecFilesWithAccept {
+    #[upload(accept = "image/*")]
+    files: Vec<UploadedFile>,
+}
+
+#[derive(FromMultipart)]
+struct VecFilesWithMaxSize {
+    #[upload(max_size = "10b")]
+    files: Vec<UploadedFile>,
+}
+
+#[tokio::test]
+async fn option_accept_present_match() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "avatar",
+        filename: "photo.png",
+        content_type: "image/png",
+        data: b"img",
+    }])
+    .await;
+    let result = OptFileWithAccept::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
+    assert!(result.avatar.is_some());
+}
+
+#[tokio::test]
+async fn option_accept_present_mismatch() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "avatar",
+        filename: "doc.txt",
+        content_type: "text/plain",
+        data: b"text",
+    }])
+    .await;
+    let Err(err) = OptFileWithAccept::from_multipart(&mut mp, None).await else {
+        panic!("expected error");
+    };
+    assert_validation_error(&err, "avatar");
+}
+
+#[tokio::test]
+async fn option_accept_missing() {
+    let mut mp = make_multipart(&[]).await;
+    let result = OptFileWithAccept::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
+    assert!(result.avatar.is_none());
+}
+
+#[tokio::test]
+async fn option_max_size_present_within() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "avatar",
+        filename: "small.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 5],
+    }])
+    .await;
+    let result = OptFileWithMaxSize::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
+    assert!(result.avatar.is_some());
+}
+
+#[tokio::test]
+async fn option_max_size_present_exceeded() {
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "avatar",
+        filename: "big.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 20],
+    }])
+    .await;
+    let Err(err) = OptFileWithMaxSize::from_multipart(&mut mp, None).await else {
+        panic!("expected error");
+    };
+    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn option_max_size_missing() {
+    let mut mp = make_multipart(&[]).await;
+    let result = OptFileWithMaxSize::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
+    assert!(result.avatar.is_none());
+}
+
+#[tokio::test]
+async fn vec_accept_all_match() {
+    let mut mp = make_multipart(&[
+        MultipartField::File {
+            name: "files",
+            filename: "a.png",
+            content_type: "image/png",
+            data: b"img1",
+        },
+        MultipartField::File {
+            name: "files",
+            filename: "b.jpg",
+            content_type: "image/jpeg",
+            data: b"img2",
+        },
+    ])
+    .await;
+    let result = VecFilesWithAccept::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
+    assert_eq!(result.files.len(), 2);
+}
+
+#[tokio::test]
+async fn vec_accept_one_mismatch() {
+    let mut mp = make_multipart(&[
+        MultipartField::File {
+            name: "files",
+            filename: "a.png",
+            content_type: "image/png",
+            data: b"img",
+        },
+        MultipartField::File {
+            name: "files",
+            filename: "b.txt",
+            content_type: "text/plain",
+            data: b"text",
+        },
+    ])
+    .await;
+    let Err(err) = VecFilesWithAccept::from_multipart(&mut mp, None).await else {
+        panic!("expected error");
+    };
+    assert_validation_error(&err, "files");
+}
+
+#[tokio::test]
+async fn vec_accept_empty() {
+    let mut mp = make_multipart(&[]).await;
+    let result = VecFilesWithAccept::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
+    assert!(result.files.is_empty());
+}
+
+#[tokio::test]
+async fn vec_max_size_all_within() {
+    let mut mp = make_multipart(&[
+        MultipartField::File {
+            name: "files",
+            filename: "a.bin",
+            content_type: "application/octet-stream",
+            data: &[0u8; 5],
+        },
+        MultipartField::File {
+            name: "files",
+            filename: "b.bin",
+            content_type: "application/octet-stream",
+            data: &[0u8; 5],
+        },
+    ])
+    .await;
+    let result = VecFilesWithMaxSize::from_multipart(&mut mp, None)
+        .await
+        .unwrap();
+    assert_eq!(result.files.len(), 2);
+}
+
+#[tokio::test]
+async fn vec_max_size_one_exceeded() {
+    let mut mp = make_multipart(&[
+        MultipartField::File {
+            name: "files",
+            filename: "small.bin",
+            content_type: "application/octet-stream",
+            data: &[0u8; 5],
+        },
+        MultipartField::File {
+            name: "files",
+            filename: "big.bin",
+            content_type: "application/octet-stream",
+            data: &[0u8; 20],
+        },
+    ])
+    .await;
+    let Err(err) = VecFilesWithMaxSize::from_multipart(&mut mp, None).await else {
+        panic!("expected error");
+    };
+    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
 }

--- a/modo-upload/tests/from_multipart.rs
+++ b/modo-upload/tests/from_multipart.rs
@@ -472,8 +472,8 @@ async fn max_size_exceeded() {
     let Err(err) = MaxSizeFile::from_multipart(&mut mp, None).await else {
         panic!("expected error");
     };
-    // Early rejection returns 413 Payload Too Large
-    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+    // Per-field size violation returns 400 validation error with field name
+    assert_validation_error(&err, "f");
 }
 
 #[derive(FromMultipart)]
@@ -785,23 +785,10 @@ async fn global_max_file_size_option_missing_ok() {
 // ===========================================================================
 
 #[tokio::test]
-async fn per_field_overrides_global() {
-    // MaxSizeFile has #[upload(max_size = "10b")], global = 5B.
-    // File is 7 bytes — exceeds global but within per-field. Should succeed.
-    let mut mp = make_multipart(&[MultipartField::File {
-        name: "f",
-        filename: "mid.bin",
-        content_type: "application/octet-stream",
-        data: &[0u8; 7],
-    }])
-    .await;
-    MaxSizeFile::from_multipart(&mut mp, Some(5)).await.unwrap();
-}
-
-#[tokio::test]
-async fn per_field_still_rejects_over_own_limit() {
+async fn per_field_rejects_over_own_limit_with_validation_error() {
     // MaxSizeFile has #[upload(max_size = "10b")], global = 1000B.
-    // File is 20 bytes — within global but exceeds per-field. Should fail.
+    // File is 20 bytes — within global but exceeds per-field.
+    // Should fail with 400 validation error (not 413).
     let mut mp = make_multipart(&[MultipartField::File {
         name: "f",
         filename: "big.bin",
@@ -810,6 +797,23 @@ async fn per_field_still_rejects_over_own_limit() {
     }])
     .await;
     let Err(err) = MaxSizeFile::from_multipart(&mut mp, Some(1000)).await else {
+        panic!("expected error");
+    };
+    assert_validation_error(&err, "f");
+}
+
+#[tokio::test]
+async fn global_limit_still_enforced_during_streaming() {
+    // MaxSizeFile has #[upload(max_size = "10b")], global = 5B.
+    // File is 7 bytes — exceeds global. Global limit enforced via streaming → 413.
+    let mut mp = make_multipart(&[MultipartField::File {
+        name: "f",
+        filename: "mid.bin",
+        content_type: "application/octet-stream",
+        data: &[0u8; 7],
+    }])
+    .await;
+    let Err(err) = MaxSizeFile::from_multipart(&mut mp, Some(5)).await else {
         panic!("expected error");
     };
     assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
@@ -935,7 +939,8 @@ async fn option_max_size_present_exceeded() {
     let Err(err) = OptFileWithMaxSize::from_multipart(&mut mp, None).await else {
         panic!("expected error");
     };
-    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+    // Per-field size violation returns 400 validation error with field name
+    assert_validation_error(&err, "avatar");
 }
 
 #[tokio::test]
@@ -1045,5 +1050,6 @@ async fn vec_max_size_one_exceeded() {
     let Err(err) = VecFilesWithMaxSize::from_multipart(&mut mp, None).await else {
         panic!("expected error");
     };
-    assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+    // Per-field size violation returns 400 validation error with field name
+    assert_validation_error(&err, "files");
 }

--- a/modo-upload/tests/local_storage.rs
+++ b/modo-upload/tests/local_storage.rs
@@ -81,7 +81,7 @@ async fn store_stream_writes_file() {
     let dir = tempfile::tempdir().unwrap();
     let storage = LocalStorage::new(dir.path());
 
-    let mut stream = modo_upload::UploadStream::__test_new(
+    let mut stream = modo_upload::BufferedUpload::__test_new(
         "file",
         "test.txt",
         "text/plain",
@@ -103,7 +103,7 @@ async fn store_stream_empty_stream() {
     let storage = LocalStorage::new(dir.path());
 
     let mut stream =
-        modo_upload::UploadStream::__test_new("file", "empty.txt", "text/plain", vec![]);
+        modo_upload::BufferedUpload::__test_new("file", "empty.txt", "text/plain", vec![]);
     let stored = storage.store_stream("docs", &mut stream).await.unwrap();
 
     assert!(stored.path.starts_with("docs/"));
@@ -137,7 +137,7 @@ async fn store_stream_creates_nested_directories() {
     let dir = tempfile::tempdir().unwrap();
     let storage = LocalStorage::new(dir.path());
 
-    let mut stream = modo_upload::UploadStream::__test_new(
+    let mut stream = modo_upload::BufferedUpload::__test_new(
         "file",
         "test.txt",
         "text/plain",

--- a/modo-upload/tests/local_storage.rs
+++ b/modo-upload/tests/local_storage.rs
@@ -96,3 +96,70 @@ async fn store_stream_writes_file() {
     let contents = tokio::fs::read_to_string(&full_path).await.unwrap();
     assert_eq!(contents, "hello world");
 }
+
+#[tokio::test]
+async fn store_stream_empty_stream() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+
+    let mut stream =
+        modo_upload::UploadStream::__test_new("file", "empty.txt", "text/plain", vec![]);
+    let stored = storage.store_stream("docs", &mut stream).await.unwrap();
+
+    assert!(stored.path.starts_with("docs/"));
+    assert_eq!(stored.size, 0);
+    let full_path = dir.path().join(&stored.path);
+    let contents = tokio::fs::read(&full_path).await.unwrap();
+    assert!(contents.is_empty());
+}
+
+#[tokio::test]
+async fn delete_nonexistent_file_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+    assert!(storage.delete("nope/file.txt").await.is_err());
+}
+
+#[tokio::test]
+async fn store_creates_nested_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+
+    let file = make_file("f", "test.txt", "text/plain", b"nested");
+    let stored = storage.store("deeply/nested/path", &file).await.unwrap();
+
+    assert!(stored.path.starts_with("deeply/nested/path/"));
+    assert!(storage.exists(&stored.path).await.unwrap());
+}
+
+#[tokio::test]
+async fn store_stream_creates_nested_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+
+    let mut stream = modo_upload::UploadStream::__test_new(
+        "file",
+        "test.txt",
+        "text/plain",
+        vec![bytes::Bytes::from("nested stream")],
+    );
+    let stored = storage.store_stream("a/b/c", &mut stream).await.unwrap();
+
+    assert!(stored.path.starts_with("a/b/c/"));
+    assert_eq!(stored.size, 13);
+    assert!(storage.exists(&stored.path).await.unwrap());
+}
+
+#[tokio::test]
+async fn store_and_read_back_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(dir.path());
+
+    let data = b"verify round-trip content";
+    let file = make_file("doc", "readme.md", "text/markdown", data);
+    let stored = storage.store("files", &file).await.unwrap();
+
+    let full_path = dir.path().join(&stored.path);
+    let read_back = tokio::fs::read(&full_path).await.unwrap();
+    assert_eq!(read_back, data);
+}

--- a/modo-upload/tests/stream.rs
+++ b/modo-upload/tests/stream.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use modo_upload::UploadStream;
 use tokio::io::AsyncReadExt;
 
 #[tokio::test]
@@ -42,4 +43,32 @@ async fn into_reader_yields_all_bytes() {
     let mut buf = Vec::new();
     reader.read_to_end(&mut buf).await.unwrap();
     assert_eq!(buf, b"hello world");
+}
+
+#[test]
+fn to_bytes_multiple_chunks() {
+    let stream = UploadStream::__test_new(
+        "file",
+        "data.bin",
+        "application/octet-stream",
+        vec![Bytes::from("hello "), Bytes::from("world")],
+    );
+    assert_eq!(stream.to_bytes(), Bytes::from("hello world"));
+}
+
+#[test]
+fn to_bytes_single_chunk() {
+    let stream = UploadStream::__test_new(
+        "file",
+        "data.bin",
+        "application/octet-stream",
+        vec![Bytes::from("only")],
+    );
+    assert_eq!(stream.to_bytes(), Bytes::from("only"));
+}
+
+#[test]
+fn to_bytes_empty() {
+    let stream = UploadStream::__test_new("file", "data.bin", "application/octet-stream", vec![]);
+    assert!(stream.to_bytes().is_empty());
 }

--- a/modo-upload/tests/stream.rs
+++ b/modo-upload/tests/stream.rs
@@ -1,10 +1,10 @@
 use bytes::Bytes;
-use modo_upload::UploadStream;
+use modo_upload::BufferedUpload;
 use tokio::io::AsyncReadExt;
 
 #[tokio::test]
 async fn chunk_returns_in_order_then_none() {
-    let mut stream = modo_upload::UploadStream::__test_new(
+    let mut stream = modo_upload::BufferedUpload::__test_new(
         "file",
         "data.bin",
         "application/octet-stream",
@@ -22,7 +22,7 @@ async fn chunk_returns_in_order_then_none() {
 
 #[tokio::test]
 async fn size_returns_total() {
-    let stream = modo_upload::UploadStream::__test_new(
+    let stream = modo_upload::BufferedUpload::__test_new(
         "file",
         "data.bin",
         "application/octet-stream",
@@ -33,7 +33,7 @@ async fn size_returns_total() {
 
 #[tokio::test]
 async fn into_reader_yields_all_bytes() {
-    let stream = modo_upload::UploadStream::__test_new(
+    let stream = modo_upload::BufferedUpload::__test_new(
         "file",
         "data.bin",
         "application/octet-stream",
@@ -47,7 +47,7 @@ async fn into_reader_yields_all_bytes() {
 
 #[test]
 fn to_bytes_multiple_chunks() {
-    let stream = UploadStream::__test_new(
+    let stream = BufferedUpload::__test_new(
         "file",
         "data.bin",
         "application/octet-stream",
@@ -58,7 +58,7 @@ fn to_bytes_multiple_chunks() {
 
 #[test]
 fn to_bytes_single_chunk() {
-    let stream = UploadStream::__test_new(
+    let stream = BufferedUpload::__test_new(
         "file",
         "data.bin",
         "application/octet-stream",
@@ -69,13 +69,13 @@ fn to_bytes_single_chunk() {
 
 #[test]
 fn to_bytes_empty() {
-    let stream = UploadStream::__test_new("file", "data.bin", "application/octet-stream", vec![]);
+    let stream = BufferedUpload::__test_new("file", "data.bin", "application/octet-stream", vec![]);
     assert!(stream.to_bytes().is_empty());
 }
 
 #[tokio::test]
 async fn chunk_after_eof_returns_none_repeatedly() {
-    let mut stream = UploadStream::__test_new(
+    let mut stream = BufferedUpload::__test_new(
         "file",
         "data.bin",
         "application/octet-stream",
@@ -91,7 +91,7 @@ async fn chunk_after_eof_returns_none_repeatedly() {
 
 #[tokio::test]
 async fn into_reader_empty_stream() {
-    let stream = UploadStream::__test_new("file", "data.bin", "application/octet-stream", vec![]);
+    let stream = BufferedUpload::__test_new("file", "data.bin", "application/octet-stream", vec![]);
     let mut reader = stream.into_reader();
     let mut buf = Vec::new();
     reader.read_to_end(&mut buf).await.unwrap();
@@ -101,7 +101,7 @@ async fn into_reader_empty_stream() {
 #[test]
 fn accessors_return_correct_values() {
     let stream =
-        UploadStream::__test_new("avatar", "pic.png", "image/png", vec![Bytes::from("data")]);
+        BufferedUpload::__test_new("avatar", "pic.png", "image/png", vec![Bytes::from("data")]);
     assert_eq!(stream.name(), "avatar");
     assert_eq!(stream.file_name(), "pic.png");
     assert_eq!(stream.content_type(), "image/png");
@@ -109,13 +109,13 @@ fn accessors_return_correct_values() {
 
 #[test]
 fn size_empty_stream() {
-    let stream = UploadStream::__test_new("file", "data.bin", "application/octet-stream", vec![]);
+    let stream = BufferedUpload::__test_new("file", "data.bin", "application/octet-stream", vec![]);
     assert_eq!(stream.size(), 0);
 }
 
 #[test]
 fn to_bytes_does_not_advance_chunk_pos() {
-    let mut stream = UploadStream::__test_new(
+    let mut stream = BufferedUpload::__test_new(
         "file",
         "data.bin",
         "application/octet-stream",
@@ -132,7 +132,7 @@ fn to_bytes_does_not_advance_chunk_pos() {
 
 #[tokio::test]
 async fn chunk_with_empty_intermediate_chunk() {
-    let mut stream = UploadStream::__test_new(
+    let mut stream = BufferedUpload::__test_new(
         "file",
         "data.bin",
         "application/octet-stream",

--- a/modo-upload/tests/stream.rs
+++ b/modo-upload/tests/stream.rs
@@ -72,3 +72,77 @@ fn to_bytes_empty() {
     let stream = UploadStream::__test_new("file", "data.bin", "application/octet-stream", vec![]);
     assert!(stream.to_bytes().is_empty());
 }
+
+#[tokio::test]
+async fn chunk_after_eof_returns_none_repeatedly() {
+    let mut stream = UploadStream::__test_new(
+        "file",
+        "data.bin",
+        "application/octet-stream",
+        vec![Bytes::from("x")],
+    );
+    // Drain the single chunk
+    stream.chunk().await.unwrap().unwrap();
+    // Three subsequent calls must all return None
+    assert!(stream.chunk().await.is_none());
+    assert!(stream.chunk().await.is_none());
+    assert!(stream.chunk().await.is_none());
+}
+
+#[tokio::test]
+async fn into_reader_empty_stream() {
+    let stream = UploadStream::__test_new("file", "data.bin", "application/octet-stream", vec![]);
+    let mut reader = stream.into_reader();
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).await.unwrap();
+    assert!(buf.is_empty());
+}
+
+#[test]
+fn accessors_return_correct_values() {
+    let stream =
+        UploadStream::__test_new("avatar", "pic.png", "image/png", vec![Bytes::from("data")]);
+    assert_eq!(stream.name(), "avatar");
+    assert_eq!(stream.file_name(), "pic.png");
+    assert_eq!(stream.content_type(), "image/png");
+}
+
+#[test]
+fn size_empty_stream() {
+    let stream = UploadStream::__test_new("file", "data.bin", "application/octet-stream", vec![]);
+    assert_eq!(stream.size(), 0);
+}
+
+#[test]
+fn to_bytes_does_not_advance_chunk_pos() {
+    let mut stream = UploadStream::__test_new(
+        "file",
+        "data.bin",
+        "application/octet-stream",
+        vec![Bytes::from("hello")],
+    );
+    // to_bytes() is &self — it should not advance the internal chunk position
+    let bytes = stream.to_bytes();
+    assert_eq!(bytes, Bytes::from("hello"));
+    // chunk() should still yield the first chunk
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let chunk = rt.block_on(stream.chunk()).unwrap().unwrap();
+    assert_eq!(chunk, Bytes::from("hello"));
+}
+
+#[tokio::test]
+async fn chunk_with_empty_intermediate_chunk() {
+    let mut stream = UploadStream::__test_new(
+        "file",
+        "data.bin",
+        "application/octet-stream",
+        vec![Bytes::from("a"), Bytes::from(""), Bytes::from("b")],
+    );
+    let c1 = stream.chunk().await.unwrap().unwrap();
+    assert_eq!(c1, Bytes::from("a"));
+    let c2 = stream.chunk().await.unwrap().unwrap();
+    assert_eq!(c2, Bytes::from(""));
+    let c3 = stream.chunk().await.unwrap().unwrap();
+    assert_eq!(c3, Bytes::from("b"));
+    assert!(stream.chunk().await.is_none());
+}


### PR DESCRIPTION
## Summary

Adds a global `max_file_size` configuration option to `UploadConfig` (defaulting to "10mb") and threads it through the entire upload stack so oversized uploads are rejected with HTTP 413 as soon as a chunk exceeds the limit. Per-field `#[upload(max_size)]` takes precedence over the global default.

### Changes

- `UploadConfig` gains `max_file_size: Option<String>` (default `"10mb"`); the extractor resolves it via `modo::config::parse_size` and passes it into `FromMultipart`
- `FromMultipart` trait signature extended with `max_file_size: Option<usize>`; macro codegen updated to wire per-field vs. global limits at code-generation time
- `UploadedFile::from_field` and `UploadStream::from_field` now stream chunks and enforce the size cap incrementally instead of buffering everything first
- `FieldMeta` and `extract_extension` helpers extracted to eliminate duplicated field-metadata code across `UploadedFile`, `UploadStream`, and storage utilities
- Tests expanded to cover global limits, per-field overrides, boundary cases, `Option`/`Vec` variants with `accept` and `max_size`, and `UploadStream::to_bytes`

### Breaking Changes

- `FromMultipart::from_multipart` now takes a second argument `max_file_size: Option<usize>` — any manual implementations must be updated
- `UploadedFile::from_field` and `UploadStream::from_field` (both `#[doc(hidden)]`) have the same new parameter

## Test plan

- [x] `cargo test -p modo-upload` — 103 tests passing (28 unit + 6 config + 55 from_multipart + 8 local_storage + 6 stream)
- [x] `cargo test -p modo-upload-macros` — 14 tests passing
- [x] `just check` — fmt + lint + test all green