### PR TITLE
feat(templates): add ViewRenderer and HTMX view rendering

### DIFF
--- a/examples/jobs/src/main.rs
+++ b/examples/jobs/src/main.rs
@@ -3,7 +3,7 @@ use modo::{HandlerResult, JsonResult};
 use modo_db::DatabaseConfig;
 use modo_jobs::JobQueue;
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 // --- Config ---
 
@@ -51,21 +51,13 @@ async fn heartbeat() -> HandlerResult<()> {
 // --- Handlers ---
 
 #[modo::handler(POST, "/jobs/greet")]
-async fn enqueue_greet(
-    queue: JobQueue,
-    input: modo::Json<GreetingPayload>,
-) -> JsonResult<Value> {
+async fn enqueue_greet(queue: JobQueue, input: modo::Json<GreetingPayload>) -> JsonResult<Value> {
     let job_id = SayHelloJob::enqueue(&queue, &input).await?;
-    Ok(modo::Json(
-        json!({ "job_id": job_id.to_string() }),
-    ))
+    Ok(modo::Json(json!({ "job_id": job_id.to_string() })))
 }
 
 #[modo::handler(POST, "/jobs/remind")]
-async fn enqueue_remind(
-    queue: JobQueue,
-    input: modo::Json<ReminderPayload>,
-) -> JsonResult<Value> {
+async fn enqueue_remind(queue: JobQueue, input: modo::Json<ReminderPayload>) -> JsonResult<Value> {
     let run_at = chrono::Utc::now() + chrono::Duration::seconds(10);
     let job_id = RemindJob::enqueue_at(&queue, &input, run_at).await?;
     Ok(modo::Json(

--- a/examples/todo-api/src/main.rs
+++ b/examples/todo-api/src/main.rs
@@ -2,7 +2,7 @@ use modo::HttpError;
 use modo::JsonResult;
 use modo_db::{DatabaseConfig, Db};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 // --- Config ---
 
@@ -84,10 +84,7 @@ async fn create_todo(
 }
 
 #[modo::handler(DELETE, "/todos/{id}")]
-async fn delete_todo(
-    Db(db): Db,
-    id: String,
-) -> JsonResult<Value> {
+async fn delete_todo(Db(db): Db, id: String) -> JsonResult<Value> {
     use modo_db::sea_orm::{EntityTrait, ModelTrait};
     let todo = todo::Entity::find_by_id(&id)
         .one(&*db)

--- a/modo-macros/src/view.rs
+++ b/modo-macros/src/view.rs
@@ -56,6 +56,13 @@ pub fn expand(
         },
     };
 
+    let htmx_template_expr = match &attr.htmx_template {
+        Some(htmx_lit) => quote! { #htmx_lit },
+        None => quote! { #template_path },
+    };
+
+    let has_dual = attr.htmx_template.is_some();
+
     Ok(quote! {
         #[derive(::modo::serde::Serialize)]
         #[serde(crate = "::modo::serde")]
@@ -66,6 +73,28 @@ pub fn expand(
                 let user_context = ::modo::minijinja::Value::from_serialize(&self);
                 let view = #view_construction;
                 view.into_response()
+            }
+        }
+
+        impl ::modo::templates::ViewRender for #struct_name {
+            fn has_dual_template(&self) -> bool {
+                #has_dual
+            }
+
+            fn render_with(
+                &self,
+                engine: &::modo::templates::TemplateEngine,
+                context: &::modo::templates::TemplateContext,
+                is_htmx: bool,
+            ) -> Result<String, ::modo::templates::TemplateError> {
+                let user_context = ::modo::minijinja::Value::from_serialize(&self);
+                let template = if is_htmx {
+                    #htmx_template_expr
+                } else {
+                    #template_path
+                };
+                let merged = context.merge_with(user_context);
+                engine.render(template, merged)
             }
         }
     })

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -73,3 +73,4 @@ tower = { version = "0.5", features = ["util"] }
 http = "1"
 minijinja = "2"
 serde = { version = "1", features = ["derive"] }
+tempfile = "3"

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -508,6 +508,7 @@ impl AppBuilder {
         #[cfg(feature = "templates")]
         if let Some(ref engine) = template_engine {
             router = router.layer(crate::templates::RenderLayer::new(engine.clone()));
+            router = router.layer(axum::extract::Extension(engine.clone()));
         }
 
         // --- User global layers (innermost of framework layers) ---

--- a/modo/src/error.rs
+++ b/modo/src/error.rs
@@ -281,6 +281,13 @@ impl From<HttpError> for Error {
     }
 }
 
+#[cfg(feature = "templates")]
+impl From<crate::templates::TemplateError> for Error {
+    fn from(e: crate::templates::TemplateError) -> Self {
+        Error::internal(format!("Template render failed: {e}"))
+    }
+}
+
 impl From<anyhow::Error> for Error {
     fn from(err: anyhow::Error) -> Self {
         let message = err.to_string();
@@ -325,6 +332,11 @@ pub type JsonResult<T, E = Error> = Result<axum::Json<T>, E>;
 /// Convenience alias for generic handler results.
 /// Defaults to `Result<T, Error>`, but the error type can be overridden.
 pub type HandlerResult<T, E = Error> = Result<T, E>;
+
+/// Result type for handlers that use `ViewRenderer`.
+/// Supports rendering views, composing multiple views, and smart redirects.
+#[cfg(feature = "templates")]
+pub type ViewResult<E = Error> = Result<crate::templates::ViewResponse, E>;
 
 /// Signature for custom error handler functions.
 pub type ErrorHandlerFn = fn(Error, &ErrorContext) -> Response;

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -48,7 +48,7 @@ pub use middleware::{ClientIp, RateLimitInfo};
 pub use request_id::RequestId;
 pub use shutdown::{GracefulShutdown, ShutdownPhase};
 #[cfg(feature = "templates")]
-pub use templates::{ViewRenderer, ViewResponse};
+pub use templates::{ViewRender, ViewRenderer, ViewResponse};
 
 // Re-exports for macro-generated code
 pub use axum;

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -45,6 +45,8 @@ pub use error::{
 #[cfg(feature = "templates")]
 pub use error::ViewResult;
 pub use middleware::{ClientIp, RateLimitInfo};
+#[cfg(feature = "templates")]
+pub use templates::{ViewRenderer, ViewResponse};
 pub use request_id::RequestId;
 pub use shutdown::{GracefulShutdown, ShutdownPhase};
 

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -38,17 +38,17 @@ pub use axum::Json;
 pub use config::{AppConfig, HttpConfig, RateLimitConfig, SecurityHeadersConfig, TrailingSlash};
 pub use cookies::{CookieConfig, CookieManager, CookieOptions, SameSite};
 pub use cors::CorsConfig;
+#[cfg(feature = "templates")]
+pub use error::ViewResult;
 pub use error::{
     Error, ErrorContext, ErrorHandlerFn, ErrorHandlerRegistration, HandlerResult, HttpError,
     JsonResult,
 };
-#[cfg(feature = "templates")]
-pub use error::ViewResult;
 pub use middleware::{ClientIp, RateLimitInfo};
-#[cfg(feature = "templates")]
-pub use templates::{ViewRenderer, ViewResponse};
 pub use request_id::RequestId;
 pub use shutdown::{GracefulShutdown, ShutdownPhase};
+#[cfg(feature = "templates")]
+pub use templates::{ViewRenderer, ViewResponse};
 
 // Re-exports for macro-generated code
 pub use axum;

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -42,6 +42,8 @@ pub use error::{
     Error, ErrorContext, ErrorHandlerFn, ErrorHandlerRegistration, HandlerResult, HttpError,
     JsonResult,
 };
+#[cfg(feature = "templates")]
+pub use error::ViewResult;
 pub use middleware::{ClientIp, RateLimitInfo};
 pub use request_id::RequestId;
 pub use shutdown::{GracefulShutdown, ShutdownPhase};

--- a/modo/src/templates/context.rs
+++ b/modo/src/templates/context.rs
@@ -26,6 +26,22 @@ impl TemplateContext {
     pub fn into_values(self) -> BTreeMap<String, Value> {
         self.values
     }
+
+    /// Merge this context with user-provided context values.
+    /// User context values take precedence on key collision.
+    /// Returns a `minijinja::Value` ready for template rendering.
+    pub fn merge_with(&self, user_context: Value) -> Value {
+        let mut map = self.clone().into_values();
+        if let Ok(keys) = user_context.try_iter() {
+            for key in keys {
+                let k_str = key.to_string();
+                if let Ok(val) = user_context.get_attr(&k_str) {
+                    map.insert(k_str, val);
+                }
+            }
+        }
+        Value::from_serialize(&map)
+    }
 }
 
 #[cfg(test)]

--- a/modo/src/templates/mod.rs
+++ b/modo/src/templates/mod.rs
@@ -6,6 +6,7 @@ pub mod middleware;
 pub mod render;
 pub mod view;
 pub mod view_render;
+pub mod view_renderer;
 pub mod view_response;
 
 pub use config::TemplateConfig;
@@ -16,6 +17,7 @@ pub use middleware::ContextLayer;
 pub use render::RenderLayer;
 pub use view::View;
 pub use view_render::ViewRender;
+pub use view_renderer::ViewRenderer;
 pub use view_response::ViewResponse;
 
 /// Registration entry for auto-discovered template functions.

--- a/modo/src/templates/mod.rs
+++ b/modo/src/templates/mod.rs
@@ -5,6 +5,8 @@ pub mod error;
 pub mod middleware;
 pub mod render;
 pub mod view;
+pub mod view_render;
+pub mod view_response;
 
 pub use config::TemplateConfig;
 pub use context::TemplateContext;
@@ -13,6 +15,8 @@ pub use error::TemplateError;
 pub use middleware::ContextLayer;
 pub use render::RenderLayer;
 pub use view::View;
+pub use view_render::ViewRender;
+pub use view_response::ViewResponse;
 
 /// Registration entry for auto-discovered template functions.
 pub struct TemplateFunctionEntry {

--- a/modo/src/templates/render.rs
+++ b/modo/src/templates/render.rs
@@ -93,7 +93,7 @@ where
             };
 
             // Merge request context with user context
-            let merged = merge_contexts(template_ctx, view.user_context);
+            let merged = template_ctx.merge_with(view.user_context);
 
             match engine.render(template_name, merged) {
                 Ok(html) => {
@@ -121,22 +121,4 @@ where
             }
         })
     }
-}
-
-/// Merge request-scoped context (locale, csrf, etc.) with user context (struct fields).
-/// User context values take precedence over request context on key collision.
-fn merge_contexts(request_ctx: TemplateContext, user_ctx: minijinja::Value) -> minijinja::Value {
-    let mut map = request_ctx.into_values();
-
-    // user_ctx is a struct serialized to Value — iterate its keys
-    if let Ok(keys) = user_ctx.try_iter() {
-        for key in keys {
-            let k_str: String = key.to_string();
-            if let Ok(val) = user_ctx.get_attr(&k_str) {
-                map.insert(k_str, val);
-            }
-        }
-    }
-
-    minijinja::Value::from_serialize(&map)
 }

--- a/modo/src/templates/view_render.rs
+++ b/modo/src/templates/view_render.rs
@@ -41,7 +41,6 @@ macro_rules! impl_view_render_tuple {
     };
 }
 
-impl_view_render_tuple!(0: A);
 impl_view_render_tuple!(0: A, 1: B);
 impl_view_render_tuple!(0: A, 1: B, 2: C);
 impl_view_render_tuple!(0: A, 1: B, 2: C, 3: D);

--- a/modo/src/templates/view_render.rs
+++ b/modo/src/templates/view_render.rs
@@ -1,0 +1,48 @@
+use crate::templates::{TemplateContext, TemplateEngine, TemplateError};
+
+/// Trait for types that can be rendered by `ViewRenderer`.
+///
+/// Implemented by `#[modo::view]` structs (via macro) and tuples of views.
+/// Tuples render each element and concatenate the HTML.
+pub trait ViewRender {
+    /// Whether this view has a dual template (htmx = "...").
+    /// Used by ViewRenderer to add `Vary: HX-Request` header.
+    fn has_dual_template(&self) -> bool {
+        false
+    }
+
+    /// Render this view to an HTML string.
+    fn render_with(
+        &self,
+        engine: &TemplateEngine,
+        context: &TemplateContext,
+        is_htmx: bool,
+    ) -> Result<String, TemplateError>;
+}
+
+macro_rules! impl_view_render_tuple {
+    ($($idx:tt : $T:ident),+) => {
+        impl<$($T: ViewRender),+> ViewRender for ($($T,)+) {
+            fn has_dual_template(&self) -> bool {
+                $(self.$idx.has_dual_template() ||)+ false
+            }
+
+            fn render_with(
+                &self,
+                engine: &TemplateEngine,
+                context: &TemplateContext,
+                is_htmx: bool,
+            ) -> Result<String, TemplateError> {
+                let mut html = String::new();
+                $(html.push_str(&self.$idx.render_with(engine, context, is_htmx)?);)+
+                Ok(html)
+            }
+        }
+    };
+}
+
+impl_view_render_tuple!(0: A);
+impl_view_render_tuple!(0: A, 1: B);
+impl_view_render_tuple!(0: A, 1: B, 2: C);
+impl_view_render_tuple!(0: A, 1: B, 2: C, 3: D);
+impl_view_render_tuple!(0: A, 1: B, 2: C, 3: D, 4: E);

--- a/modo/src/templates/view_renderer.rs
+++ b/modo/src/templates/view_renderer.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use http::request::Parts;
+
+use crate::error::Error;
+use crate::templates::view_response::ViewResponse;
+use crate::templates::{TemplateContext, TemplateEngine, ViewRender};
+
+/// Request-scoped extractor for explicit template rendering.
+///
+/// Combines the `TemplateEngine`, `TemplateContext`, and HTMX detection.
+/// Use this when you need to compose multiple views, return different view
+/// types from different branches, or perform smart redirects.
+pub struct ViewRenderer {
+    engine: Arc<TemplateEngine>,
+    context: TemplateContext,
+    is_htmx: bool,
+}
+
+impl ViewRenderer {
+    /// Render one or more views into an HTTP response.
+    ///
+    /// Accepts a single `#[view]` struct or a tuple of views.
+    /// Multiple views are rendered independently and concatenated.
+    /// Adds `Vary: HX-Request` header when any view has a dual template.
+    pub fn render(&self, views: impl ViewRender) -> Result<ViewResponse, Error> {
+        let has_dual = views.has_dual_template();
+        let html = views.render_with(&self.engine, &self.context, self.is_htmx)?;
+        if has_dual {
+            Ok(ViewResponse::html_with_vary(html))
+        } else {
+            Ok(ViewResponse::html(html))
+        }
+    }
+
+    /// Smart redirect — returns 302 for normal requests,
+    /// `HX-Redirect` header + 200 for HTMX requests.
+    pub fn redirect(&self, url: &str) -> Result<ViewResponse, Error> {
+        if self.is_htmx {
+            Ok(ViewResponse::hx_redirect(url))
+        } else {
+            Ok(ViewResponse::redirect(url))
+        }
+    }
+
+    /// Render a view to a plain `String`.
+    ///
+    /// Useful for non-HTTP contexts: SSE events, WebSocket messages, emails.
+    /// Always uses the main template (not the HTMX partial).
+    pub fn render_to_string(&self, view: impl ViewRender) -> Result<String, Error> {
+        view.render_with(&self.engine, &self.context, false)
+            .map_err(Into::into)
+    }
+
+    /// Whether this is an HTMX request (`HX-Request` header present).
+    pub fn is_htmx(&self) -> bool {
+        self.is_htmx
+    }
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for ViewRenderer {
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let engine = parts
+            .extensions
+            .get::<Arc<TemplateEngine>>()
+            .cloned()
+            .ok_or_else(|| {
+                Error::internal(
+                    "ViewRenderer requires TemplateEngine. \
+                     Register it as a service or add Extension(Arc::new(engine)).",
+                )
+            })?;
+
+        let context = parts
+            .extensions
+            .get::<TemplateContext>()
+            .cloned()
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    "TemplateContext not found in request extensions. \
+                     Ensure ContextLayer is applied."
+                );
+                TemplateContext::default()
+            });
+
+        let is_htmx = parts.headers.get("hx-request").is_some();
+
+        Ok(Self {
+            engine,
+            context,
+            is_htmx,
+        })
+    }
+}

--- a/modo/src/templates/view_renderer.rs
+++ b/modo/src/templates/view_renderer.rs
@@ -36,6 +36,9 @@ impl ViewRenderer {
 
     /// Smart redirect — returns 302 for normal requests,
     /// `HX-Redirect` header + 200 for HTMX requests.
+    ///
+    /// Returns `Result` for ergonomic consistency with `render()` so handlers
+    /// can use `?` uniformly across all branches without wrapping in `Ok(...)`.
     pub fn redirect(&self, url: &str) -> Result<ViewResponse, Error> {
         if self.is_htmx {
             Ok(ViewResponse::hx_redirect(url))

--- a/modo/src/templates/view_response.rs
+++ b/modo/src/templates/view_response.rs
@@ -57,17 +57,17 @@ impl IntoResponse for ViewResponse {
             ViewResponseKind::Redirect { url } => {
                 let mut resp = Response::new(axum::body::Body::empty());
                 *resp.status_mut() = StatusCode::FOUND;
-                if let Ok(val) = HeaderValue::from_str(&url) {
-                    resp.headers_mut().insert("location", val);
-                }
+                let val =
+                    HeaderValue::try_from(&url).expect("redirect URL must be a valid header value");
+                resp.headers_mut().insert("location", val);
                 resp
             }
             ViewResponseKind::HxRedirect { url } => {
                 let mut resp = Response::new(axum::body::Body::empty());
                 *resp.status_mut() = StatusCode::OK;
-                if let Ok(val) = HeaderValue::from_str(&url) {
-                    resp.headers_mut().insert("hx-redirect", val);
-                }
+                let val = HeaderValue::try_from(&url)
+                    .expect("HX-Redirect URL must be a valid header value");
+                resp.headers_mut().insert("hx-redirect", val);
                 resp
             }
         }

--- a/modo/src/templates/view_response.rs
+++ b/modo/src/templates/view_response.rs
@@ -1,0 +1,82 @@
+use axum::response::{Html, IntoResponse, Response};
+use http::{HeaderValue, StatusCode};
+
+/// Opaque response type returned by `ViewRenderer` methods.
+/// Can hold rendered HTML or a redirect.
+pub struct ViewResponse {
+    kind: ViewResponseKind,
+}
+
+enum ViewResponseKind {
+    Html {
+        body: String,
+        vary: bool,
+    },
+    Redirect {
+        url: String,
+    },
+    HxRedirect {
+        url: String,
+    },
+}
+
+impl ViewResponse {
+    /// Create an HTML response with 200 status.
+    pub fn html(body: String) -> Self {
+        Self {
+            kind: ViewResponseKind::Html { body, vary: false },
+        }
+    }
+
+    /// Create an HTML response with `Vary: HX-Request` header.
+    pub fn html_with_vary(body: String) -> Self {
+        Self {
+            kind: ViewResponseKind::Html { body, vary: true },
+        }
+    }
+
+    /// Create a standard 302 redirect.
+    pub fn redirect(url: impl Into<String>) -> Self {
+        Self {
+            kind: ViewResponseKind::Redirect { url: url.into() },
+        }
+    }
+
+    /// Create an HTMX-aware redirect (200 + HX-Redirect header).
+    pub fn hx_redirect(url: impl Into<String>) -> Self {
+        Self {
+            kind: ViewResponseKind::HxRedirect { url: url.into() },
+        }
+    }
+}
+
+impl IntoResponse for ViewResponse {
+    fn into_response(self) -> Response {
+        match self.kind {
+            ViewResponseKind::Html { body, vary } => {
+                let mut resp = Html(body).into_response();
+                if vary {
+                    resp.headers_mut()
+                        .insert("vary", HeaderValue::from_static("HX-Request"));
+                }
+                resp
+            }
+            ViewResponseKind::Redirect { url } => {
+                let mut resp = Response::new(axum::body::Body::empty());
+                *resp.status_mut() = StatusCode::FOUND;
+                if let Ok(val) = HeaderValue::from_str(&url) {
+                    resp.headers_mut().insert("location", val);
+                }
+                resp
+            }
+            ViewResponseKind::HxRedirect { url } => {
+                let mut resp = Response::new(axum::body::Body::empty());
+                *resp.status_mut() = StatusCode::OK;
+                if let Ok(val) = HeaderValue::from_str(&url) {
+                    resp.headers_mut().insert("hx-redirect", val);
+                }
+                resp
+            }
+        }
+    }
+}

--- a/modo/src/templates/view_response.rs
+++ b/modo/src/templates/view_response.rs
@@ -8,16 +8,9 @@ pub struct ViewResponse {
 }
 
 enum ViewResponseKind {
-    Html {
-        body: String,
-        vary: bool,
-    },
-    Redirect {
-        url: String,
-    },
-    HxRedirect {
-        url: String,
-    },
+    Html { body: String, vary: bool },
+    Redirect { url: String },
+    HxRedirect { url: String },
 }
 
 impl ViewResponse {

--- a/modo/tests/common/mod.rs
+++ b/modo/tests/common/mod.rs
@@ -1,0 +1,25 @@
+use modo::templates::{TemplateConfig, TemplateEngine, engine};
+use std::io::Write;
+use tempfile::TempDir;
+
+/// Create a temporary template directory and engine for testing.
+///
+/// Each `(name, content)` pair creates a template file under the temp dir.
+/// Returns the `TempDir` guard (must be kept alive) and the engine.
+pub fn setup_engine(templates: &[(&str, &str)]) -> (TempDir, TemplateEngine) {
+    let dir = TempDir::new().unwrap();
+    for (name, content) in templates {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+    let config = TemplateConfig {
+        path: dir.path().to_string_lossy().to_string(),
+        ..Default::default()
+    };
+    let eng = engine(&config).unwrap();
+    (dir, eng)
+}

--- a/modo/tests/templates_context_merge.rs
+++ b/modo/tests/templates_context_merge.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "templates")]
+
+use minijinja::Value;
+use modo::templates::TemplateContext;
+
+#[test]
+fn merge_with_combines_request_and_user_context() {
+    let mut ctx = TemplateContext::new();
+    ctx.insert("request_key", Value::from("request_value"));
+    ctx.insert("shared_key", Value::from("from_request"));
+
+    let user_ctx = Value::from_serialize(&serde_json::json!({
+        "user_key": "user_value",
+        "shared_key": "from_user"
+    }));
+
+    let merged = ctx.merge_with(user_ctx);
+
+    // Request-only key preserved
+    assert_eq!(
+        merged.get_attr("request_key").unwrap().to_string(),
+        "request_value"
+    );
+    // User-only key present
+    assert_eq!(
+        merged.get_attr("user_key").unwrap().to_string(),
+        "user_value"
+    );
+    // User context wins on collision
+    assert_eq!(
+        merged.get_attr("shared_key").unwrap().to_string(),
+        "from_user"
+    );
+}
+
+#[test]
+fn merge_with_empty_user_context() {
+    let mut ctx = TemplateContext::new();
+    ctx.insert("key", Value::from("value"));
+
+    let merged = ctx.merge_with(Value::UNDEFINED);
+
+    assert_eq!(merged.get_attr("key").unwrap().to_string(), "value");
+}

--- a/modo/tests/templates_context_merge.rs
+++ b/modo/tests/templates_context_merge.rs
@@ -9,7 +9,7 @@ fn merge_with_combines_request_and_user_context() {
     ctx.insert("request_key", Value::from("request_value"));
     ctx.insert("shared_key", Value::from("from_request"));
 
-    let user_ctx = Value::from_serialize(&serde_json::json!({
+    let user_ctx = Value::from_serialize(serde_json::json!({
         "user_key": "user_value",
         "shared_key": "from_user"
     }));

--- a/modo/tests/templates_view_render_macro.rs
+++ b/modo/tests/templates_view_render_macro.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "templates")]
+
+use minijinja::Value;
+use modo::templates::{engine, TemplateConfig, TemplateContext, TemplateEngine, ViewRender};
+use std::io::Write;
+use tempfile::TempDir;
+
+fn setup_engine(templates: &[(&str, &str)]) -> (TempDir, TemplateEngine) {
+    let dir = TempDir::new().unwrap();
+    for (name, content) in templates {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+    let config = TemplateConfig {
+        path: dir.path().to_string_lossy().to_string(),
+        ..Default::default()
+    };
+    let eng = engine(&config).unwrap();
+    (dir, eng)
+}
+
+#[modo::view("test.html")]
+struct SimpleView {
+    name: String,
+}
+
+#[modo::view("page.html", htmx = "partial.html")]
+struct DualView {
+    title: String,
+}
+
+#[test]
+fn simple_view_implements_view_render() {
+    let (_dir, eng) = setup_engine(&[("test.html", "Hello {{ name }}!")]);
+    let ctx = TemplateContext::new();
+    let view = SimpleView { name: "World".into() };
+
+    let html = view.render_with(&eng, &ctx, false).unwrap();
+    assert_eq!(html, "Hello World!");
+}
+
+#[test]
+fn simple_view_has_no_dual_template() {
+    let view = SimpleView { name: "test".into() };
+    assert!(!view.has_dual_template());
+}
+
+#[test]
+fn dual_view_selects_htmx_template() {
+    let (_dir, eng) = setup_engine(&[
+        ("page.html", "Full: {{ title }}"),
+        ("partial.html", "Partial: {{ title }}"),
+    ]);
+    let ctx = TemplateContext::new();
+    let view = DualView { title: "Test".into() };
+
+    let full = view.render_with(&eng, &ctx, false).unwrap();
+    assert_eq!(full, "Full: Test");
+
+    let partial = view.render_with(&eng, &ctx, true).unwrap();
+    assert_eq!(partial, "Partial: Test");
+}
+
+#[test]
+fn dual_view_has_dual_template() {
+    let view = DualView { title: "test".into() };
+    assert!(view.has_dual_template());
+}
+
+#[test]
+fn view_render_merges_request_context() {
+    let (_dir, eng) = setup_engine(&[("test.html", "{{ name }} ({{ csrf_token }})")]);
+    let mut ctx = TemplateContext::new();
+    ctx.insert("csrf_token", Value::from("abc123"));
+    let view = SimpleView { name: "World".into() };
+
+    let html = view.render_with(&eng, &ctx, false).unwrap();
+    assert_eq!(html, "World (abc123)");
+}

--- a/modo/tests/templates_view_render_macro.rs
+++ b/modo/tests/templates_view_render_macro.rs
@@ -1,27 +1,9 @@
 #![cfg(feature = "templates")]
 
-use minijinja::Value;
-use modo::templates::{TemplateConfig, TemplateContext, TemplateEngine, ViewRender, engine};
-use std::io::Write;
-use tempfile::TempDir;
+mod common;
 
-fn setup_engine(templates: &[(&str, &str)]) -> (TempDir, TemplateEngine) {
-    let dir = TempDir::new().unwrap();
-    for (name, content) in templates {
-        let path = dir.path().join(name);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-        let mut f = std::fs::File::create(path).unwrap();
-        f.write_all(content.as_bytes()).unwrap();
-    }
-    let config = TemplateConfig {
-        path: dir.path().to_string_lossy().to_string(),
-        ..Default::default()
-    };
-    let eng = engine(&config).unwrap();
-    (dir, eng)
-}
+use minijinja::Value;
+use modo::templates::{TemplateContext, ViewRender};
 
 #[modo::view("test.html")]
 struct SimpleView {
@@ -35,7 +17,7 @@ struct DualView {
 
 #[test]
 fn simple_view_implements_view_render() {
-    let (_dir, eng) = setup_engine(&[("test.html", "Hello {{ name }}!")]);
+    let (_dir, eng) = common::setup_engine(&[("test.html", "Hello {{ name }}!")]);
     let ctx = TemplateContext::new();
     let view = SimpleView {
         name: "World".into(),
@@ -55,7 +37,7 @@ fn simple_view_has_no_dual_template() {
 
 #[test]
 fn dual_view_selects_htmx_template() {
-    let (_dir, eng) = setup_engine(&[
+    let (_dir, eng) = common::setup_engine(&[
         ("page.html", "Full: {{ title }}"),
         ("partial.html", "Partial: {{ title }}"),
     ]);
@@ -81,7 +63,7 @@ fn dual_view_has_dual_template() {
 
 #[test]
 fn view_render_merges_request_context() {
-    let (_dir, eng) = setup_engine(&[("test.html", "{{ name }} ({{ csrf_token }})")]);
+    let (_dir, eng) = common::setup_engine(&[("test.html", "{{ name }} ({{ csrf_token }})")]);
     let mut ctx = TemplateContext::new();
     ctx.insert("csrf_token", Value::from("abc123"));
     let view = SimpleView {

--- a/modo/tests/templates_view_render_macro.rs
+++ b/modo/tests/templates_view_render_macro.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "templates")]
 
 use minijinja::Value;
-use modo::templates::{engine, TemplateConfig, TemplateContext, TemplateEngine, ViewRender};
+use modo::templates::{TemplateConfig, TemplateContext, TemplateEngine, ViewRender, engine};
 use std::io::Write;
 use tempfile::TempDir;
 
@@ -37,7 +37,9 @@ struct DualView {
 fn simple_view_implements_view_render() {
     let (_dir, eng) = setup_engine(&[("test.html", "Hello {{ name }}!")]);
     let ctx = TemplateContext::new();
-    let view = SimpleView { name: "World".into() };
+    let view = SimpleView {
+        name: "World".into(),
+    };
 
     let html = view.render_with(&eng, &ctx, false).unwrap();
     assert_eq!(html, "Hello World!");
@@ -45,7 +47,9 @@ fn simple_view_implements_view_render() {
 
 #[test]
 fn simple_view_has_no_dual_template() {
-    let view = SimpleView { name: "test".into() };
+    let view = SimpleView {
+        name: "test".into(),
+    };
     assert!(!view.has_dual_template());
 }
 
@@ -56,7 +60,9 @@ fn dual_view_selects_htmx_template() {
         ("partial.html", "Partial: {{ title }}"),
     ]);
     let ctx = TemplateContext::new();
-    let view = DualView { title: "Test".into() };
+    let view = DualView {
+        title: "Test".into(),
+    };
 
     let full = view.render_with(&eng, &ctx, false).unwrap();
     assert_eq!(full, "Full: Test");
@@ -67,7 +73,9 @@ fn dual_view_selects_htmx_template() {
 
 #[test]
 fn dual_view_has_dual_template() {
-    let view = DualView { title: "test".into() };
+    let view = DualView {
+        title: "test".into(),
+    };
     assert!(view.has_dual_template());
 }
 
@@ -76,7 +84,9 @@ fn view_render_merges_request_context() {
     let (_dir, eng) = setup_engine(&[("test.html", "{{ name }} ({{ csrf_token }})")]);
     let mut ctx = TemplateContext::new();
     ctx.insert("csrf_token", Value::from("abc123"));
-    let view = SimpleView { name: "World".into() };
+    let view = SimpleView {
+        name: "World".into(),
+    };
 
     let html = view.render_with(&eng, &ctx, false).unwrap();
     assert_eq!(html, "World (abc123)");

--- a/modo/tests/templates_view_render_trait.rs
+++ b/modo/tests/templates_view_render_trait.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "templates")]
 
-use modo::templates::{
-    engine, TemplateConfig, TemplateContext, TemplateEngine, ViewRender,
-};
+use modo::templates::{TemplateConfig, TemplateContext, TemplateEngine, ViewRender, engine};
 use std::io::Write;
 use tempfile::TempDir;
 
@@ -37,7 +35,7 @@ impl ViewRender for TestView {
         context: &TemplateContext,
         _is_htmx: bool,
     ) -> Result<String, modo::templates::TemplateError> {
-        let user_ctx = minijinja::Value::from_serialize(&serde_json::json!({
+        let user_ctx = minijinja::Value::from_serialize(serde_json::json!({
             "name": self.name,
         }));
         let merged = context.merge_with(user_ctx);
@@ -53,7 +51,9 @@ impl ViewRender for TestView {
 fn single_view_renders() {
     let (_dir, eng) = setup_engine(&[("test.html", "Hello {{ name }}!")]);
     let ctx = TemplateContext::new();
-    let view = TestView { name: "World".into() };
+    let view = TestView {
+        name: "World".into(),
+    };
 
     let html = view.render_with(&eng, &ctx, false).unwrap();
     assert_eq!(html, "Hello World!");
@@ -65,7 +65,9 @@ fn tuple_renders_concatenated() {
     let ctx = TemplateContext::new();
 
     let views = (
-        TestView { name: "Alice".into() },
+        TestView {
+            name: "Alice".into(),
+        },
         TestView { name: "Bob".into() },
     );
     let html = views.render_with(&eng, &ctx, false).unwrap();
@@ -77,7 +79,9 @@ fn single_view_merges_request_context() {
     let (_dir, eng) = setup_engine(&[("test.html", "{{ name }} at {{ current_url|safe }}")]);
     let mut ctx = TemplateContext::new();
     ctx.insert("current_url", minijinja::Value::from("/home"));
-    let view = TestView { name: "World".into() };
+    let view = TestView {
+        name: "World".into(),
+    };
 
     let html = view.render_with(&eng, &ctx, false).unwrap();
     assert_eq!(html, "World at /home");

--- a/modo/tests/templates_view_render_trait.rs
+++ b/modo/tests/templates_view_render_trait.rs
@@ -1,26 +1,8 @@
 #![cfg(feature = "templates")]
 
-use modo::templates::{TemplateConfig, TemplateContext, TemplateEngine, ViewRender, engine};
-use std::io::Write;
-use tempfile::TempDir;
+mod common;
 
-fn setup_engine(templates: &[(&str, &str)]) -> (TempDir, TemplateEngine) {
-    let dir = TempDir::new().unwrap();
-    for (name, content) in templates {
-        let path = dir.path().join(name);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-        let mut f = std::fs::File::create(path).unwrap();
-        f.write_all(content.as_bytes()).unwrap();
-    }
-    let config = TemplateConfig {
-        path: dir.path().to_string_lossy().to_string(),
-        ..Default::default()
-    };
-    let eng = engine(&config).unwrap();
-    (dir, eng)
-}
+use modo::templates::{TemplateContext, TemplateEngine, ViewRender};
 
 // A manual ViewRender implementation for testing
 // (macro-generated impls tested separately)
@@ -49,7 +31,7 @@ impl ViewRender for TestView {
 
 #[test]
 fn single_view_renders() {
-    let (_dir, eng) = setup_engine(&[("test.html", "Hello {{ name }}!")]);
+    let (_dir, eng) = common::setup_engine(&[("test.html", "Hello {{ name }}!")]);
     let ctx = TemplateContext::new();
     let view = TestView {
         name: "World".into(),
@@ -61,7 +43,7 @@ fn single_view_renders() {
 
 #[test]
 fn tuple_renders_concatenated() {
-    let (_dir, eng) = setup_engine(&[("test.html", "Hello {{ name }}!")]);
+    let (_dir, eng) = common::setup_engine(&[("test.html", "Hello {{ name }}!")]);
     let ctx = TemplateContext::new();
 
     let views = (
@@ -76,7 +58,8 @@ fn tuple_renders_concatenated() {
 
 #[test]
 fn single_view_merges_request_context() {
-    let (_dir, eng) = setup_engine(&[("test.html", "{{ name }} at {{ current_url|safe }}")]);
+    let (_dir, eng) =
+        common::setup_engine(&[("test.html", "{{ name }} at {{ current_url|safe }}")]);
     let mut ctx = TemplateContext::new();
     ctx.insert("current_url", minijinja::Value::from("/home"));
     let view = TestView {

--- a/modo/tests/templates_view_render_trait.rs
+++ b/modo/tests/templates_view_render_trait.rs
@@ -1,0 +1,84 @@
+#![cfg(feature = "templates")]
+
+use modo::templates::{
+    engine, TemplateConfig, TemplateContext, TemplateEngine, ViewRender,
+};
+use std::io::Write;
+use tempfile::TempDir;
+
+fn setup_engine(templates: &[(&str, &str)]) -> (TempDir, TemplateEngine) {
+    let dir = TempDir::new().unwrap();
+    for (name, content) in templates {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+    let config = TemplateConfig {
+        path: dir.path().to_string_lossy().to_string(),
+        ..Default::default()
+    };
+    let eng = engine(&config).unwrap();
+    (dir, eng)
+}
+
+// A manual ViewRender implementation for testing
+// (macro-generated impls tested separately)
+struct TestView {
+    name: String,
+}
+
+impl ViewRender for TestView {
+    fn render_with(
+        &self,
+        engine: &TemplateEngine,
+        context: &TemplateContext,
+        _is_htmx: bool,
+    ) -> Result<String, modo::templates::TemplateError> {
+        let user_ctx = minijinja::Value::from_serialize(&serde_json::json!({
+            "name": self.name,
+        }));
+        let merged = context.merge_with(user_ctx);
+        engine.render("test.html", merged)
+    }
+
+    fn has_dual_template(&self) -> bool {
+        false
+    }
+}
+
+#[test]
+fn single_view_renders() {
+    let (_dir, eng) = setup_engine(&[("test.html", "Hello {{ name }}!")]);
+    let ctx = TemplateContext::new();
+    let view = TestView { name: "World".into() };
+
+    let html = view.render_with(&eng, &ctx, false).unwrap();
+    assert_eq!(html, "Hello World!");
+}
+
+#[test]
+fn tuple_renders_concatenated() {
+    let (_dir, eng) = setup_engine(&[("test.html", "Hello {{ name }}!")]);
+    let ctx = TemplateContext::new();
+
+    let views = (
+        TestView { name: "Alice".into() },
+        TestView { name: "Bob".into() },
+    );
+    let html = views.render_with(&eng, &ctx, false).unwrap();
+    assert_eq!(html, "Hello Alice!Hello Bob!");
+}
+
+#[test]
+fn single_view_merges_request_context() {
+    let (_dir, eng) = setup_engine(&[("test.html", "{{ name }} at {{ current_url|safe }}")]);
+    let mut ctx = TemplateContext::new();
+    ctx.insert("current_url", minijinja::Value::from("/home"));
+    let view = TestView { name: "World".into() };
+
+    let html = view.render_with(&eng, &ctx, false).unwrap();
+    assert_eq!(html, "World at /home");
+}

--- a/modo/tests/templates_view_renderer.rs
+++ b/modo/tests/templates_view_renderer.rs
@@ -1,0 +1,248 @@
+#![cfg(feature = "templates")]
+
+use axum::{
+    body::Body,
+    extract::Extension,
+    routing::{get, post},
+    Router,
+};
+use http::{Request, StatusCode};
+use modo::templates::{engine, ContextLayer, TemplateConfig, TemplateEngine, ViewRenderer};
+use modo::ViewResult;
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn setup(templates: &[(&str, &str)]) -> (TempDir, Arc<TemplateEngine>) {
+    let dir = TempDir::new().unwrap();
+    for (name, content) in templates {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+    let config = TemplateConfig {
+        path: dir.path().to_string_lossy().to_string(),
+        ..Default::default()
+    };
+    let eng = engine(&config).unwrap();
+    (dir, Arc::new(eng))
+}
+
+#[modo::view("hello.html")]
+struct HelloView {
+    name: String,
+}
+
+#[modo::view("toast.html")]
+struct ToastView {
+    message: String,
+}
+
+#[modo::view("page.html", htmx = "partial.html")]
+struct DualView {
+    title: String,
+}
+
+// Test handler: single view
+async fn single_view(view: ViewRenderer) -> ViewResult {
+    view.render(HelloView { name: "World".into() })
+}
+
+// Test handler: tuple of views
+async fn multi_view(view: ViewRenderer) -> ViewResult {
+    view.render((
+        HelloView { name: "Alice".into() },
+        ToastView {
+            message: "Done!".into(),
+        },
+    ))
+}
+
+// Test handler: smart redirect
+async fn redirect_handler(view: ViewRenderer) -> ViewResult {
+    view.redirect("/dashboard")
+}
+
+// Test handler: is_htmx check
+async fn check_htmx(view: ViewRenderer) -> String {
+    format!("{}", view.is_htmx())
+}
+
+// Test handler: dual template
+async fn dual_template(view: ViewRenderer) -> ViewResult {
+    view.render(DualView {
+        title: "Test".into(),
+    })
+}
+
+// Test handler: render_to_string
+async fn render_string(view: ViewRenderer) -> String {
+    view.render_to_string(HelloView {
+        name: "String".into(),
+    })
+    .unwrap()
+}
+
+fn app(engine: Arc<TemplateEngine>) -> Router {
+    Router::new()
+        .route("/hello", get(single_view))
+        .route("/multi", get(multi_view))
+        .route("/redirect", post(redirect_handler))
+        .route("/check-htmx", get(check_htmx))
+        .route("/dual", get(dual_template))
+        .route("/render-string", get(render_string))
+        .layer(ContextLayer::new())
+        .layer(Extension(engine))
+}
+
+async fn body_string(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn render_single_view() {
+    let (_dir, eng) = setup(&[("hello.html", "Hello {{ name }}!")]);
+    let resp = app(eng)
+        .oneshot(Request::get("/hello").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_string(resp).await, "Hello World!");
+}
+
+#[tokio::test]
+async fn render_tuple_of_views() {
+    let (_dir, eng) = setup(&[
+        ("hello.html", "Hello {{ name }}!"),
+        ("toast.html", "<div>{{ message }}</div>"),
+    ]);
+    let resp = app(eng)
+        .oneshot(Request::get("/multi").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_string(resp).await, "Hello Alice!<div>Done!</div>");
+}
+
+#[tokio::test]
+async fn redirect_normal_request() {
+    let (_dir, eng) = setup(&[]);
+    let resp = app(eng)
+        .oneshot(
+            Request::post("/redirect")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::FOUND);
+    assert_eq!(resp.headers().get("location").unwrap(), "/dashboard");
+}
+
+#[tokio::test]
+async fn redirect_htmx_request() {
+    let (_dir, eng) = setup(&[]);
+    let resp = app(eng)
+        .oneshot(
+            Request::post("/redirect")
+                .header("hx-request", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("hx-redirect").unwrap(), "/dashboard");
+}
+
+#[tokio::test]
+async fn is_htmx_detection() {
+    let (_dir, eng) = setup(&[]);
+
+    // Normal request
+    let resp = app(Arc::clone(&eng))
+        .oneshot(Request::get("/check-htmx").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(body_string(resp).await, "false");
+
+    // HTMX request
+    let resp = app(Arc::clone(&eng))
+        .oneshot(
+            Request::get("/check-htmx")
+                .header("hx-request", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(body_string(resp).await, "true");
+}
+
+#[tokio::test]
+async fn dual_template_selects_htmx_partial() {
+    let (_dir, eng) = setup(&[
+        ("page.html", "Full: {{ title }}"),
+        ("partial.html", "Partial: {{ title }}"),
+    ]);
+
+    // Normal request — full page
+    let resp = app(Arc::clone(&eng))
+        .oneshot(Request::get("/dual").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(body_string(resp).await, "Full: Test");
+
+    // HTMX request — partial
+    let resp = app(eng)
+        .oneshot(
+            Request::get("/dual")
+                .header("hx-request", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(body_string(resp).await, "Partial: Test");
+}
+
+#[tokio::test]
+async fn dual_template_adds_vary_header() {
+    let (_dir, eng) = setup(&[
+        ("page.html", "Full: {{ title }}"),
+        ("partial.html", "Partial: {{ title }}"),
+    ]);
+    let resp = app(eng)
+        .oneshot(Request::get("/dual").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.headers().get("vary").unwrap(), "HX-Request");
+}
+
+#[tokio::test]
+async fn render_to_string_works() {
+    let (_dir, eng) = setup(&[("hello.html", "Hello {{ name }}!")]);
+    let resp = app(eng)
+        .oneshot(
+            Request::get("/render-string")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_string(resp).await, "Hello String!");
+}

--- a/modo/tests/templates_view_renderer.rs
+++ b/modo/tests/templates_view_renderer.rs
@@ -1,14 +1,14 @@
 #![cfg(feature = "templates")]
 
 use axum::{
+    Router,
     body::Body,
     extract::Extension,
     routing::{get, post},
-    Router,
 };
 use http::{Request, StatusCode};
-use modo::templates::{engine, ContextLayer, TemplateConfig, TemplateEngine, ViewRenderer};
 use modo::ViewResult;
+use modo::templates::{ContextLayer, TemplateConfig, TemplateEngine, ViewRenderer, engine};
 use std::io::Write;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -49,13 +49,17 @@ struct DualView {
 
 // Test handler: single view
 async fn single_view(view: ViewRenderer) -> ViewResult {
-    view.render(HelloView { name: "World".into() })
+    view.render(HelloView {
+        name: "World".into(),
+    })
 }
 
 // Test handler: tuple of views
 async fn multi_view(view: ViewRenderer) -> ViewResult {
     view.render((
-        HelloView { name: "Alice".into() },
+        HelloView {
+            name: "Alice".into(),
+        },
         ToastView {
             message: "Done!".into(),
         },
@@ -137,11 +141,7 @@ async fn render_tuple_of_views() {
 async fn redirect_normal_request() {
     let (_dir, eng) = setup(&[]);
     let resp = app(eng)
-        .oneshot(
-            Request::post("/redirect")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::post("/redirect").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
@@ -235,11 +235,7 @@ async fn dual_template_adds_vary_header() {
 async fn render_to_string_works() {
     let (_dir, eng) = setup(&[("hello.html", "Hello {{ name }}!")]);
     let resp = app(eng)
-        .oneshot(
-            Request::get("/render-string")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::get("/render-string").body(Body::empty()).unwrap())
         .await
         .unwrap();
 

--- a/modo/tests/templates_view_renderer.rs
+++ b/modo/tests/templates_view_renderer.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "templates")]
 
+mod common;
+
 use axum::{
     Router,
     body::Body,
@@ -8,27 +10,12 @@ use axum::{
 };
 use http::{Request, StatusCode};
 use modo::ViewResult;
-use modo::templates::{ContextLayer, TemplateConfig, TemplateEngine, ViewRenderer, engine};
-use std::io::Write;
+use modo::templates::{ContextLayer, TemplateEngine, ViewRenderer};
 use std::sync::Arc;
-use tempfile::TempDir;
 use tower::ServiceExt;
 
-fn setup(templates: &[(&str, &str)]) -> (TempDir, Arc<TemplateEngine>) {
-    let dir = TempDir::new().unwrap();
-    for (name, content) in templates {
-        let path = dir.path().join(name);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-        let mut f = std::fs::File::create(path).unwrap();
-        f.write_all(content.as_bytes()).unwrap();
-    }
-    let config = TemplateConfig {
-        path: dir.path().to_string_lossy().to_string(),
-        ..Default::default()
-    };
-    let eng = engine(&config).unwrap();
+fn setup_arc(templates: &[(&str, &str)]) -> (tempfile::TempDir, Arc<TemplateEngine>) {
+    let (dir, eng) = common::setup_engine(templates);
     (dir, Arc::new(eng))
 }
 
@@ -112,7 +99,7 @@ async fn body_string(resp: axum::response::Response) -> String {
 
 #[tokio::test]
 async fn render_single_view() {
-    let (_dir, eng) = setup(&[("hello.html", "Hello {{ name }}!")]);
+    let (_dir, eng) = setup_arc(&[("hello.html", "Hello {{ name }}!")]);
     let resp = app(eng)
         .oneshot(Request::get("/hello").body(Body::empty()).unwrap())
         .await
@@ -124,7 +111,7 @@ async fn render_single_view() {
 
 #[tokio::test]
 async fn render_tuple_of_views() {
-    let (_dir, eng) = setup(&[
+    let (_dir, eng) = setup_arc(&[
         ("hello.html", "Hello {{ name }}!"),
         ("toast.html", "<div>{{ message }}</div>"),
     ]);
@@ -139,7 +126,7 @@ async fn render_tuple_of_views() {
 
 #[tokio::test]
 async fn redirect_normal_request() {
-    let (_dir, eng) = setup(&[]);
+    let (_dir, eng) = setup_arc(&[]);
     let resp = app(eng)
         .oneshot(Request::post("/redirect").body(Body::empty()).unwrap())
         .await
@@ -151,7 +138,7 @@ async fn redirect_normal_request() {
 
 #[tokio::test]
 async fn redirect_htmx_request() {
-    let (_dir, eng) = setup(&[]);
+    let (_dir, eng) = setup_arc(&[]);
     let resp = app(eng)
         .oneshot(
             Request::post("/redirect")
@@ -168,7 +155,7 @@ async fn redirect_htmx_request() {
 
 #[tokio::test]
 async fn is_htmx_detection() {
-    let (_dir, eng) = setup(&[]);
+    let (_dir, eng) = setup_arc(&[]);
 
     // Normal request
     let resp = app(Arc::clone(&eng))
@@ -192,7 +179,7 @@ async fn is_htmx_detection() {
 
 #[tokio::test]
 async fn dual_template_selects_htmx_partial() {
-    let (_dir, eng) = setup(&[
+    let (_dir, eng) = setup_arc(&[
         ("page.html", "Full: {{ title }}"),
         ("partial.html", "Partial: {{ title }}"),
     ]);
@@ -219,7 +206,7 @@ async fn dual_template_selects_htmx_partial() {
 
 #[tokio::test]
 async fn dual_template_adds_vary_header() {
-    let (_dir, eng) = setup(&[
+    let (_dir, eng) = setup_arc(&[
         ("page.html", "Full: {{ title }}"),
         ("partial.html", "Partial: {{ title }}"),
     ]);
@@ -233,7 +220,7 @@ async fn dual_template_adds_vary_header() {
 
 #[tokio::test]
 async fn render_to_string_works() {
-    let (_dir, eng) = setup(&[("hello.html", "Hello {{ name }}!")]);
+    let (_dir, eng) = setup_arc(&[("hello.html", "Hello {{ name }}!")]);
     let resp = app(eng)
         .oneshot(Request::get("/render-string").body(Body::empty()).unwrap())
         .await
@@ -241,4 +228,24 @@ async fn render_to_string_works() {
 
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(body_string(resp).await, "Hello String!");
+}
+
+#[tokio::test]
+async fn extraction_fails_without_template_engine() {
+    // Router without Extension(engine) — ViewRenderer extraction should fail
+    let app = Router::new()
+        .route("/hello", get(single_view))
+        .layer(ContextLayer::new());
+
+    let resp = app
+        .oneshot(Request::get("/hello").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = body_string(resp).await;
+    assert!(
+        body.contains("internal_server_error"),
+        "expected internal_server_error code, got: {body}"
+    );
 }

--- a/modo/tests/templates_view_response.rs
+++ b/modo/tests/templates_view_response.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "templates")]
+
+use axum::response::IntoResponse;
+use http::StatusCode;
+use modo::templates::ViewResponse;
+
+#[test]
+fn html_response_has_correct_content_type() {
+    let resp = ViewResponse::html("Hello".to_string()).into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "text/html; charset=utf-8"
+    );
+}
+
+#[test]
+fn redirect_response_is_302() {
+    let resp = ViewResponse::redirect("/dashboard").into_response();
+    assert_eq!(resp.status(), StatusCode::FOUND);
+    assert_eq!(resp.headers().get("location").unwrap(), "/dashboard");
+}
+
+#[test]
+fn hx_redirect_response_is_200_with_header() {
+    let resp = ViewResponse::hx_redirect("/dashboard").into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("hx-redirect").unwrap(), "/dashboard");
+}
+
+#[test]
+fn html_response_includes_vary_header() {
+    let resp = ViewResponse::html_with_vary("Hello".to_string()).into_response();
+    assert_eq!(resp.headers().get("vary").unwrap(), "HX-Request");
+}


### PR DESCRIPTION
## Summary

Introduces a structured HTMX-aware rendering layer to the templates feature, providing a `ViewRenderer` extractor, `ViewRender` trait, and `ViewResponse` type that together enable handlers to render views (including HTMX partial/full dual templates) without manually wiring template engines or checking request headers.

### Changes

- Add `TemplateContext::merge_with` to compose contexts from middleware and handlers
- Add `ViewRender` trait (implemented by `#[view]` structs via macro and by tuples up to 5 elements) for generic rendering
- Update `#[modo::view]` macro to auto-generate `ViewRender` impl for annotated structs, including HTMX dual-template support
- Add `ViewResponse` type with `.html()`, `.html_with_vary()`, `.redirect()`, and `.hx_redirect()` constructors
- Add `ViewResult` type alias for `Result<ViewResponse, Error>`
- Add `ViewRenderer` axum extractor that reads `TemplateEngine`, `TemplateContext`, and `HX-Request` from request parts and exposes `.render()`, `.redirect()`, and `.render_to_string()` methods
- Register `Arc<TemplateEngine>` as a request extension so `ViewRenderer` can extract it without a state type parameter
- Add integration tests covering all new types (22 new tests, 0 regressions)

### Breaking Changes

None. All additions are additive under the existing `templates` feature flag.