### PR TITLE
feat(sse): add Server-Sent Events support

### DIFF
--- a/docs/superpowers/plans/2026-03-11-sse-implementation.md
+++ b/docs/superpowers/plans/2026-03-11-sse-implementation.md
@@ -1,0 +1,2618 @@
+# SSE Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Server-Sent Events support to the `modo` core crate with broadcasting, channel, and stream ergonomics, plus two example applications.
+
+**Architecture:** Feature-flagged `sse` module in `modo/` core. `SseEvent` builder wraps data for SSE protocol. `SseResponse` wraps axum's `Sse<S>` with auto keep-alive. `SseBroadcastManager<K,T>` provides keyed multi-subscriber channels via `tokio::sync::broadcast` (with `std::sync::RwLock` for the channel registry — safe in async context for brief HashMap ops). Two entry points: `from_stream()` for any stream, `channel()` for imperative producers. `SseConfig` is registered as a service for handlers to read, but `from_stream` uses a hardcoded default (15s) — handlers override via `.with_keep_alive()`.
+
+**Tech Stack:** axum 0.8 (built-in SSE), tokio broadcast/mpsc channels, futures-util streams, serde for JSON serialization.
+
+**Spec:** `docs/superpowers/specs/2026-03-11-sse-design.md`
+
+---
+
+## File Structure
+
+### New files (modo/src/sse/)
+
+| File | Responsibility |
+|------|---------------|
+| `modo/src/sse/mod.rs` | Module docs, re-exports, `from_stream()` and `channel()` entry points |
+| `modo/src/sse/config.rs` | `SseConfig` — YAML-deserializable keep-alive config |
+| `modo/src/sse/event.rs` | `SseEvent` — builder for SSE events (data/json/html/event/id/retry) |
+| `modo/src/sse/response.rs` | `SseResponse` — handler return type wrapping axum's `Sse<S>` |
+| `modo/src/sse/sender.rs` | `SseSender` — mpsc-backed sender for `channel()` |
+| `modo/src/sse/broadcast.rs` | `SseBroadcastManager<K,T>` and `SseStream<T>` |
+| `modo/src/sse/last_event_id.rs` | `LastEventId` extractor |
+| `modo/src/sse/stream_ext.rs` | `SseStreamExt` trait for ergonomic stream mapping |
+
+### Modified files (modo core integration)
+
+| File | Change |
+|------|--------|
+| `modo/Cargo.toml` | Add `sse` feature flag |
+| `modo/src/config.rs` | Add `SseConfig` field to `AppConfig` |
+| `modo/src/app.rs` | Auto-register `SseConfig` as service |
+| `modo/src/lib.rs` | Add `#[cfg(feature = "sse")] pub mod sse;` and re-exports |
+
+### Test files
+
+| File | Tests |
+|------|-------|
+| `modo/tests/sse_event.rs` | SseEvent builder, mutually exclusive data, conversion |
+| `modo/tests/sse_response.rs` | SseResponse headers, keep-alive override |
+| `modo/tests/sse_last_event_id.rs` | LastEventId extractor with/without header |
+| `modo/tests/sse_channel.rs` | channel() send/receive, disconnect cleanup |
+| `modo/tests/sse_broadcast.rs` | SseBroadcastManager subscribe/send/cleanup |
+| `modo/tests/sse_stream_ext.rs` | SseStreamExt sse_json, sse_map |
+
+### Example 1: SSE Dashboard
+
+| File | Purpose |
+|------|---------|
+| `examples/sse-dashboard/Cargo.toml` | Dependencies |
+| `examples/sse-dashboard/src/main.rs` | Fake server monitoring with HTMX SSE |
+| `examples/sse-dashboard/config/development.yaml` | Server config |
+| `examples/sse-dashboard/templates/layouts/base.html` | Base layout with HTMX |
+| `examples/sse-dashboard/templates/pages/dashboard.html` | Dashboard page |
+| `examples/sse-dashboard/templates/partials/status_card.html` | Status card partial |
+
+### Example 2: SSE Chat
+
+| File | Purpose |
+|------|---------|
+| `examples/sse-chat/Cargo.toml` | Dependencies (modo, modo-db, modo-session) |
+| `examples/sse-chat/src/main.rs` | Chat app with rooms, DB messages, session auth |
+| `examples/sse-chat/config/development.yaml` | Server + DB config |
+| `examples/sse-chat/templates/layouts/base.html` | Base layout with HTMX |
+| `examples/sse-chat/templates/pages/login.html` | Username entry page |
+| `examples/sse-chat/templates/pages/rooms.html` | Room list page |
+| `examples/sse-chat/templates/pages/chat.html` | Chat room page (last 50 messages + SSE) |
+| `examples/sse-chat/templates/partials/message.html` | Single message bubble partial |
+
+---
+
+## Chunk 1: Core Types
+
+### Task 1: SseConfig
+
+**Files:**
+- Create: `modo/src/sse/config.rs`
+- Test: `modo/tests/sse_config.rs`
+
+- [ ] **Step 1: Write failing test for SseConfig deserialization**
+
+```rust
+// modo/tests/sse_config.rs
+#![cfg(feature = "sse")]
+
+#[test]
+fn sse_config_default_values() {
+    let config: modo::sse::SseConfig = serde_yaml_ng::from_str("{}").unwrap();
+    assert_eq!(config.keep_alive_interval_secs, 15);
+}
+
+#[test]
+fn sse_config_custom_values() {
+    let config: modo::sse::SseConfig =
+        serde_yaml_ng::from_str("keep_alive_interval_secs: 30").unwrap();
+    assert_eq!(config.keep_alive_interval_secs, 30);
+}
+
+#[test]
+fn sse_config_keep_alive_interval_method() {
+    let config = modo::sse::SseConfig::default();
+    assert_eq!(
+        config.keep_alive_interval(),
+        std::time::Duration::from_secs(15)
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p modo --features sse --test sse_config -- --nocapture`
+Expected: FAIL — module `sse` not found
+
+- [ ] **Step 3: Create SseConfig with minimal module structure**
+
+```rust
+// modo/src/sse/config.rs
+use serde::Deserialize;
+use std::time::Duration;
+
+fn default_keep_alive_interval_secs() -> u64 {
+    15
+}
+
+/// Configuration for Server-Sent Events.
+///
+/// Controls keep-alive behavior for SSE connections. Loaded from the `sse`
+/// section of your application config YAML.
+///
+/// # Example
+///
+/// ```yaml
+/// sse:
+///     keep_alive_interval_secs: 30
+/// ```
+///
+/// # Defaults
+///
+/// | Field | Default |
+/// |-------|---------|
+/// | `keep_alive_interval_secs` | `15` |
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SseConfig {
+    /// Keep-alive interval in seconds. The server sends a comment line (`:`)
+    /// at this interval to prevent proxies and browsers from closing idle
+    /// connections.
+    ///
+    /// Converted to [`Duration`] via [`keep_alive_interval()`](Self::keep_alive_interval).
+    #[serde(default = "default_keep_alive_interval_secs")]
+    pub keep_alive_interval_secs: u64,
+}
+
+impl Default for SseConfig {
+    fn default() -> Self {
+        Self {
+            keep_alive_interval_secs: default_keep_alive_interval_secs(),
+        }
+    }
+}
+
+impl SseConfig {
+    /// Returns the keep-alive interval as a [`Duration`].
+    pub fn keep_alive_interval(&self) -> Duration {
+        Duration::from_secs(self.keep_alive_interval_secs)
+    }
+}
+```
+
+```rust
+// modo/src/sse/mod.rs
+pub mod config;
+
+pub use config::SseConfig;
+```
+
+Add to `modo/src/lib.rs` (after the `templates` module, keeping alphabetical order):
+```rust
+#[cfg(feature = "sse")]
+pub mod sse;
+```
+
+Add to `modo/Cargo.toml` features section:
+```toml
+sse = ["dep:futures-util"]
+```
+
+Note: `serde_yaml_ng` is already a non-optional dependency — no additional dev-dep needed for config tests.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p modo --features sse --test sse_config -- --nocapture`
+Expected: PASS — all 3 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modo/src/sse/config.rs modo/src/sse/mod.rs modo/src/lib.rs modo/Cargo.toml modo/tests/sse_config.rs
+git commit -m "feat(sse): add SseConfig with keep-alive interval"
+```
+
+---
+
+### Task 2: SseEvent builder
+
+**Files:**
+- Create: `modo/src/sse/event.rs`
+- Modify: `modo/src/sse/mod.rs`
+- Test: `modo/tests/sse_event.rs`
+
+- [ ] **Step 1: Write failing tests for SseEvent**
+
+```rust
+// modo/tests/sse_event.rs
+#![cfg(feature = "sse")]
+
+use modo::sse::SseEvent;
+use std::time::Duration;
+
+#[test]
+fn event_with_data() {
+    let event = SseEvent::new().data("hello");
+    let axum_event: axum::response::sse::Event = event.try_into().unwrap();
+    // Event has data set — we verify it doesn't panic during conversion
+}
+
+#[test]
+fn event_with_json() {
+    #[derive(serde::Serialize)]
+    struct Msg {
+        text: String,
+    }
+    let event = SseEvent::new()
+        .event("message")
+        .json(&Msg {
+            text: "hello".into(),
+        })
+        .unwrap();
+    let axum_event: axum::response::sse::Event = event.try_into().unwrap();
+}
+
+#[test]
+fn event_with_html() {
+    let event = SseEvent::new()
+        .event("update")
+        .html("<div>hello</div>");
+    let axum_event: axum::response::sse::Event = event.try_into().unwrap();
+}
+
+#[test]
+fn event_with_id_and_retry() {
+    let event = SseEvent::new()
+        .data("hello")
+        .id("evt-1")
+        .retry(Duration::from_secs(5));
+    let axum_event: axum::response::sse::Event = event.try_into().unwrap();
+}
+
+#[test]
+fn event_json_overrides_data() {
+    #[derive(serde::Serialize)]
+    struct Msg {
+        n: i32,
+    }
+    // json() after data() should override
+    let event = SseEvent::new().data("old").json(&Msg { n: 42 }).unwrap();
+    let _: axum::response::sse::Event = event.try_into().unwrap();
+}
+
+#[test]
+fn event_json_serialization_error() {
+    use std::collections::BTreeMap;
+    // f64::NAN is not valid JSON
+    let mut map = BTreeMap::new();
+    map.insert("bad", f64::NAN);
+    let result = SseEvent::new().json(&map);
+    assert!(result.is_err());
+}
+
+#[test]
+fn event_default_has_no_data() {
+    let event = SseEvent::new();
+    // Converting event without data should still work (axum allows it)
+    let axum_event: axum::response::sse::Event = event.try_into().unwrap();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p modo --features sse --test sse_event -- --nocapture`
+Expected: FAIL — `SseEvent` not found
+
+- [ ] **Step 3: Implement SseEvent**
+
+```rust
+// modo/src/sse/event.rs
+use crate::error::Error;
+use serde::Serialize;
+use std::time::Duration;
+
+/// A Server-Sent Event to be delivered to a connected client.
+///
+/// Uses a builder pattern to construct events with optional fields.
+/// At minimum, an event should have data (via [`data()`](Self::data),
+/// [`json()`](Self::json), or [`html()`](Self::html)).
+///
+/// # Examples
+///
+/// ```rust
+/// use modo::sse::SseEvent;
+///
+/// // Plain text event
+/// let event = SseEvent::new()
+///     .event("message")
+///     .data("Hello, world!");
+///
+/// // JSON event
+/// # use serde::Serialize;
+/// # #[derive(Serialize)]
+/// # struct Status { ok: bool }
+/// let event = SseEvent::new()
+///     .event("status")
+///     .json(&Status { ok: true })
+///     .unwrap();
+///
+/// // HTML partial (for HTMX)
+/// let event = SseEvent::new()
+///     .event("update")
+///     .html("<div class=\"card\">New content</div>");
+/// ```
+///
+/// # Data methods
+///
+/// [`data()`](Self::data), [`json()`](Self::json), and [`html()`](Self::html) are
+/// mutually exclusive — each sets the event's data payload, replacing any
+/// previous value. [`json()`](Self::json) is fallible because serialization can fail.
+///
+/// # SSE protocol fields
+///
+/// | Method | SSE field | Purpose |
+/// |--------|-----------|---------|
+/// | [`event()`](Self::event) | `event:` | Named event type for client-side listeners |
+/// | [`id()`](Self::id) | `id:` | Last-event-id for reconnection (see [`LastEventId`](super::LastEventId)) |
+/// | [`retry()`](Self::retry) | `retry:` | Client reconnect delay hint (serialized as milliseconds) |
+#[must_use]
+#[derive(Debug, Clone)]
+pub struct SseEvent {
+    pub(crate) event_name: Option<String>,
+    pub(crate) data: Option<String>,
+    pub(crate) id: Option<String>,
+    pub(crate) retry: Option<Duration>,
+}
+
+impl SseEvent {
+    /// Create a new empty SSE event.
+    pub fn new() -> Self {
+        Self {
+            event_name: None,
+            data: None,
+            id: None,
+            retry: None,
+        }
+    }
+
+    /// Set the event type name.
+    ///
+    /// Clients can listen for specific event types. In JavaScript:
+    /// `eventSource.addEventListener("message", handler)`.
+    /// In HTMX: `hx-trigger="sse:message"`.
+    pub fn event(mut self, name: impl Into<String>) -> Self {
+        self.event_name = Some(name.into());
+        self
+    }
+
+    /// Set the data payload as a plain string.
+    ///
+    /// Multi-line strings are handled automatically — each line gets its own
+    /// `data:` prefix per the SSE spec. The browser reassembles them with `\n`.
+    pub fn data(mut self, data: impl Into<String>) -> Self {
+        self.data = Some(data.into());
+        self
+    }
+
+    /// Set the data payload as JSON-serialized data.
+    ///
+    /// Mutually exclusive with [`data()`](Self::data) and [`html()`](Self::html)
+    /// — replaces any previously set data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `serde_json` serialization fails (e.g., the value
+    /// contains `f64::NAN`).
+    pub fn json<T: Serialize>(mut self, data: &T) -> Result<Self, Error> {
+        let json = serde_json::to_string(data)
+            .map_err(|e| Error::internal(format!("SSE JSON serialization failed: {e}")))?;
+        self.data = Some(json);
+        Ok(self)
+    }
+
+    /// Set the data payload as an HTML fragment.
+    ///
+    /// Semantically identical to [`data()`](Self::data) — the SSE protocol
+    /// treats all data as text. This method communicates intent and may gain
+    /// additional behavior (e.g., escaping) in the future.
+    ///
+    /// **Best practice:** Keep HTML partials small — send individual components
+    /// (a chat bubble, a table row, a notification card), not entire page sections.
+    /// SSE has no built-in chunking or compression.
+    pub fn html(self, html: impl Into<String>) -> Self {
+        self.data(html)
+    }
+
+    /// Set the event ID for client reconnection.
+    ///
+    /// When a client reconnects, the browser sends a `Last-Event-ID` header
+    /// with this value. Use [`LastEventId`](super::LastEventId) to read it
+    /// in the handler and replay missed events.
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Set the reconnection delay hint for the client.
+    ///
+    /// Tells the browser how long to wait before reconnecting after a
+    /// disconnect. Serialized as milliseconds in the SSE `retry:` field.
+    pub fn retry(mut self, duration: Duration) -> Self {
+        self.retry = Some(duration);
+        self
+    }
+}
+
+impl Default for SseEvent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<SseEvent> for axum::response::sse::Event {
+    type Error = Error;
+
+    fn try_from(sse: SseEvent) -> Result<Self, Self::Error> {
+        let mut event = axum::response::sse::Event::default();
+        if let Some(name) = sse.event_name {
+            event = event.event(name);
+        }
+        if let Some(data) = sse.data {
+            event = event.data(data);
+        }
+        if let Some(id) = sse.id {
+            event = event.id(id);
+        }
+        if let Some(retry) = sse.retry {
+            event = event.retry(retry);
+        }
+        Ok(event)
+    }
+}
+```
+
+Update `modo/src/sse/mod.rs`:
+```rust
+pub mod config;
+pub mod event;
+
+pub use config::SseConfig;
+pub use event::SseEvent;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p modo --features sse --test sse_event -- --nocapture`
+Expected: PASS — all 7 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modo/src/sse/event.rs modo/src/sse/mod.rs modo/tests/sse_event.rs
+git commit -m "feat(sse): add SseEvent builder with data/json/html/id/retry"
+```
+
+---
+
+### Task 3: SseResponse + from_stream
+
+**Files:**
+- Create: `modo/src/sse/response.rs`
+- Modify: `modo/src/sse/mod.rs`
+- Test: `modo/tests/sse_response.rs`
+
+- [ ] **Step 1: Write failing tests for SseResponse**
+
+```rust
+// modo/tests/sse_response.rs
+#![cfg(feature = "sse")]
+
+use axum::response::IntoResponse;
+use futures_util::stream;
+use modo::sse::{SseEvent, SseResponse};
+
+#[tokio::test]
+async fn sse_response_has_correct_content_type() {
+    let s = stream::empty::<Result<SseEvent, modo::Error>>();
+    let resp = modo::sse::from_stream(s).into_response();
+    let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+    assert!(ct.contains("text/event-stream"), "got: {ct}");
+}
+
+#[tokio::test]
+async fn sse_response_has_cache_control() {
+    let s = stream::empty::<Result<SseEvent, modo::Error>>();
+    let resp = modo::sse::from_stream(s).into_response();
+    let cc = resp.headers().get("cache-control").unwrap().to_str().unwrap();
+    assert_eq!(cc, "no-cache");
+}
+
+#[tokio::test]
+async fn sse_response_with_keep_alive_override() {
+    use std::time::Duration;
+    let s = stream::empty::<Result<SseEvent, modo::Error>>();
+    // Should not panic
+    let resp = modo::sse::from_stream(s)
+        .with_keep_alive(Duration::from_secs(60))
+        .into_response();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p modo --features sse --test sse_response -- --nocapture`
+Expected: FAIL — `SseResponse` and `from_stream` not found
+
+- [ ] **Step 3: Implement SseResponse and from_stream**
+
+```rust
+// modo/src/sse/response.rs
+use super::event::SseEvent;
+use crate::error::Error;
+use axum::response::{IntoResponse, Response};
+use futures_util::{Stream, StreamExt};
+use std::{pin::Pin, time::Duration};
+
+const DEFAULT_KEEP_ALIVE_SECS: u64 = 15;
+
+/// SSE response type for handlers.
+///
+/// Wraps an event stream with automatic keep-alive. Return this from any
+/// handler to start an SSE connection.
+///
+/// # Construction
+///
+/// Use [`from_stream()`](super::from_stream) or [`channel()`](super::channel)
+/// to create an `SseResponse`. Do not construct directly.
+///
+/// # Keep-alive
+///
+/// By default, sends a comment line (`:`) every 15 seconds to keep the
+/// connection alive through proxies. Override with
+/// [`with_keep_alive()`](Self::with_keep_alive).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use modo::sse::{SseEvent, SseResponse};
+///
+/// #[modo::handler(GET, "/events")]
+/// async fn events() -> SseResponse {
+///     let stream = futures_util::stream::repeat_with(|| {
+///         Ok(SseEvent::new().data("ping"))
+///     });
+///     modo::sse::from_stream(stream)
+/// }
+/// ```
+pub struct SseResponse {
+    stream: Pin<
+        Box<dyn Stream<Item = Result<axum::response::sse::Event, axum::Error>> + Send>,
+    >,
+    keep_alive_interval: Duration,
+}
+
+impl SseResponse {
+    pub(crate) fn new<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<axum::response::sse::Event, axum::Error>> + Send + 'static,
+    {
+        Self {
+            stream: Box::pin(stream),
+            keep_alive_interval: Duration::from_secs(DEFAULT_KEEP_ALIVE_SECS),
+        }
+    }
+
+    /// Override the keep-alive interval for this response.
+    ///
+    /// The default is 15 seconds. Set a shorter interval if your clients are
+    /// behind aggressive proxies, or longer to reduce overhead.
+    pub fn with_keep_alive(mut self, interval: Duration) -> Self {
+        self.keep_alive_interval = interval;
+        self
+    }
+}
+
+impl IntoResponse for SseResponse {
+    fn into_response(self) -> Response {
+        axum::response::sse::Sse::new(self.stream)
+            .keep_alive(
+                axum::response::sse::KeepAlive::new()
+                    .interval(self.keep_alive_interval),
+            )
+            .into_response()
+    }
+}
+
+/// Create an [`SseResponse`] from any stream of [`SseEvent`]s.
+///
+/// This is the main entry point for SSE handlers. The stream is wrapped with
+/// automatic keep-alive (configurable via [`SseResponse::with_keep_alive()`]).
+///
+/// # Type requirements
+///
+/// The stream must yield `Result<SseEvent, E>` where `E: Into<Error>`.
+/// Use [`SseStreamExt`](super::SseStreamExt) combinators or `.map()` to
+/// convert domain types to `SseEvent` before passing to this function.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use modo::sse::{SseEvent, SseResponse};
+///
+/// #[modo::handler(GET, "/events")]
+/// async fn events(Service(bc): Service<SseBroadcastManager<String, MyEvent>>) -> SseResponse {
+///     let stream = bc.subscribe(&"topic".into())
+///         .sse_map(|event| Ok(SseEvent::from(event)));
+///     modo::sse::from_stream(stream)
+/// }
+/// ```
+pub fn from_stream<S, E>(stream: S) -> SseResponse
+where
+    S: Stream<Item = Result<SseEvent, E>> + Send + 'static,
+    E: Into<Error> + Send + 'static,
+{
+    let mapped = stream.map(|result| {
+        result
+            .map_err(|e| {
+                let err: Error = e.into();
+                axum::Error::new(err)
+            })
+            .and_then(|event| {
+                axum::response::sse::Event::try_from(event)
+                    .map_err(|e| axum::Error::new(e))
+            })
+    });
+    SseResponse::new(mapped)
+}
+```
+
+Update `modo/src/sse/mod.rs`:
+```rust
+pub mod config;
+pub mod event;
+pub mod response;
+
+pub use config::SseConfig;
+pub use event::SseEvent;
+pub use response::{SseResponse, from_stream};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p modo --features sse --test sse_response -- --nocapture`
+Expected: PASS — all 3 tests pass
+
+- [ ] **Step 5: Run all SSE tests so far**
+
+Run: `cargo test -p modo --features sse -- sse --nocapture`
+Expected: PASS — all tests pass (config + event + response)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add modo/src/sse/response.rs modo/src/sse/mod.rs modo/tests/sse_response.rs
+git commit -m "feat(sse): add SseResponse wrapper and from_stream entry point"
+```
+
+---
+
+## Chunk 2: Channel & Extractor
+
+### Task 4: SseSender + channel()
+
+**Files:**
+- Create: `modo/src/sse/sender.rs`
+- Modify: `modo/src/sse/mod.rs`
+- Test: `modo/tests/sse_channel.rs`
+
+- [ ] **Step 1: Write failing tests for channel()**
+
+```rust
+// modo/tests/sse_channel.rs
+#![cfg(feature = "sse")]
+
+use axum::response::IntoResponse;
+use modo::sse::SseEvent;
+
+#[tokio::test]
+async fn channel_sends_events() {
+    let resp = modo::sse::channel(|tx| async move {
+        tx.send(SseEvent::new().event("msg").data("hello")).await?;
+        tx.send(SseEvent::new().event("msg").data("world")).await?;
+        Ok(())
+    })
+    .into_response();
+
+    assert_eq!(resp.status(), http::StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(text.contains("data: hello"), "body: {text}");
+    assert!(text.contains("data: world"), "body: {text}");
+}
+
+#[tokio::test]
+async fn channel_sender_error_on_drop() {
+    // When the response is dropped, the sender should get an error
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+    let resp = modo::sse::channel(|tx| async move {
+        // First send should succeed (response exists)
+        let _ = tx.send(SseEvent::new().data("first")).await;
+        // Wait a bit for the response to be dropped
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let send_result = tx.send(SseEvent::new().data("after-drop")).await;
+        let _ = result_tx.send(send_result.is_err());
+        Ok(())
+    });
+
+    // Drop the response immediately
+    drop(resp);
+
+    // The sender should eventually detect the drop
+    let was_err = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        result_rx,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(was_err, "send after response drop should fail");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p modo --features sse --test sse_channel -- --nocapture`
+Expected: FAIL — `channel` not found
+
+- [ ] **Step 3: Implement SseSender and channel()**
+
+```rust
+// modo/src/sse/sender.rs
+use super::event::SseEvent;
+use super::response::SseResponse;
+use crate::error::Error;
+use futures_util::{Stream, StreamExt, stream};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::mpsc;
+
+const CHANNEL_BUFFER: usize = 32;
+
+/// Sender for imperative SSE event production.
+///
+/// Used within [`channel()`](super::channel) closures to push events to the
+/// connected client. When the client disconnects, [`send()`](Self::send)
+/// returns an error.
+///
+/// # Cleanup
+///
+/// Cleanup is cooperative: the spawned task runs until the closure returns
+/// or a `send()` call fails. Handlers producing messages in a loop should
+/// check the `send()` result and break on error.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// modo::sse::channel(|tx| async move {
+///     for i in 0..10 {
+///         tx.send(SseEvent::new().data(format!("count: {i}"))).await?;
+///         tokio::time::sleep(Duration::from_secs(1)).await;
+///     }
+///     Ok(())
+/// })
+/// ```
+pub struct SseSender {
+    tx: mpsc::Sender<SseEvent>,
+}
+
+impl SseSender {
+    /// Send an event to the connected client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the client has disconnected (the response stream
+    /// was dropped). Use this as a signal to stop producing events.
+    pub async fn send(&self, event: SseEvent) -> Result<(), Error> {
+        self.tx
+            .send(event)
+            .await
+            .map_err(|_| Error::internal("SSE client disconnected"))
+    }
+}
+
+/// Receiver stream that wraps mpsc::Receiver<SseEvent> for use in SseResponse.
+struct ReceiverStream {
+    rx: mpsc::Receiver<SseEvent>,
+}
+
+impl Stream for ReceiverStream {
+    type Item = Result<SseEvent, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx).map(|opt| opt.map(Ok))
+    }
+}
+
+/// Create an [`SseResponse`] with an imperative sender.
+///
+/// Spawns the closure as a tokio task and returns an SSE response backed by
+/// the receiver end of an internal channel. The closure receives an
+/// [`SseSender`] for pushing events.
+///
+/// The task runs until:
+/// - The closure returns `Ok(())` — stream ends cleanly
+/// - The closure returns `Err(e)` — error is logged, stream ends
+/// - A `tx.send()` call fails — client disconnected
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[modo::handler(GET, "/jobs/{id}/progress")]
+/// async fn job_progress(id: String, Service(jobs): Service<JobService>) -> SseResponse {
+///     modo::sse::channel(|tx| async move {
+///         while let Some(status) = jobs.poll_status(&id).await {
+///             tx.send(SseEvent::new().event("progress").json(&status)?).await?;
+///             if status.is_done() { break; }
+///         }
+///         Ok(())
+///     })
+/// }
+/// ```
+pub fn channel<F, Fut>(f: F) -> SseResponse
+where
+    F: FnOnce(SseSender) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = Result<(), Error>> + Send,
+{
+    let (tx, rx) = mpsc::channel(CHANNEL_BUFFER);
+    let sender = SseSender { tx };
+
+    tokio::spawn(async move {
+        if let Err(e) = f(sender).await {
+            tracing::debug!(error = %e, "SSE channel closure ended with error");
+        }
+    });
+
+    let stream = ReceiverStream { rx };
+    super::response::from_stream(stream)
+}
+```
+
+Update `modo/src/sse/mod.rs`:
+```rust
+pub mod config;
+pub mod event;
+pub mod response;
+pub mod sender;
+
+pub use config::SseConfig;
+pub use event::SseEvent;
+pub use response::{SseResponse, from_stream};
+pub use sender::{SseSender, channel};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p modo --features sse --test sse_channel -- --nocapture`
+Expected: PASS — both tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modo/src/sse/sender.rs modo/src/sse/mod.rs modo/tests/sse_channel.rs
+git commit -m "feat(sse): add SseSender and channel() entry point"
+```
+
+---
+
+### Task 5: LastEventId extractor
+
+**Files:**
+- Create: `modo/src/sse/last_event_id.rs`
+- Modify: `modo/src/sse/mod.rs`
+- Test: `modo/tests/sse_last_event_id.rs`
+
+- [ ] **Step 1: Write failing tests for LastEventId**
+
+```rust
+// modo/tests/sse_last_event_id.rs
+#![cfg(feature = "sse")]
+
+use axum::{Router, routing::get, response::IntoResponse};
+use http::{Request, StatusCode};
+use tower::ServiceExt;
+use modo::sse::LastEventId;
+
+async fn handler(last_id: LastEventId) -> impl IntoResponse {
+    match last_id.0 {
+        Some(id) => format!("reconnect:{id}"),
+        None => "first-connect".to_string(),
+    }
+}
+
+fn app() -> Router {
+    Router::new().route("/events", get(handler))
+}
+
+#[tokio::test]
+async fn last_event_id_absent() {
+    let resp = app()
+        .oneshot(Request::get("/events").body(axum::body::Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&body[..], b"first-connect");
+}
+
+#[tokio::test]
+async fn last_event_id_present() {
+    let resp = app()
+        .oneshot(
+            Request::get("/events")
+                .header("Last-Event-ID", "evt-42")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(&body[..], b"reconnect:evt-42");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p modo --features sse --test sse_last_event_id -- --nocapture`
+Expected: FAIL — `LastEventId` not found
+
+- [ ] **Step 3: Implement LastEventId**
+
+```rust
+// modo/src/sse/last_event_id.rs
+use axum::extract::FromRequestParts;
+use http::request::Parts;
+
+/// Extracts the `Last-Event-ID` header from the request.
+///
+/// When a client reconnects after a disconnect, the browser's `EventSource`
+/// sends a `Last-Event-ID` header with the ID of the last event it received.
+/// Use this extractor to detect reconnections and replay missed events.
+///
+/// Contains `None` on first connection (header absent).
+///
+/// # Replay is application logic
+///
+/// The SSE module does NOT replay events automatically. Your handler is
+/// responsible for fetching missed events (e.g., from a database) and sending
+/// them before subscribing to the live stream.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[modo::handler(GET, "/events")]
+/// async fn events(
+///     last_event_id: LastEventId,
+///     Service(bc): Service<SseBroadcastManager<String, MyEvent>>,
+///     Db(db): Db,
+/// ) -> SseResponse {
+///     let stream = if let Some(last_id) = last_event_id.0 {
+///         // Replay missed events from DB, then subscribe to live
+///         let missed = load_events_after(&db, &last_id).await?;
+///         let live = bc.subscribe(&"topic".into());
+///         missed.chain(live)
+///     } else {
+///         bc.subscribe(&"topic".into())
+///     };
+///     modo::sse::from_stream(stream.sse_map(|e| Ok(SseEvent::from(e))))
+/// }
+/// ```
+pub struct LastEventId(pub Option<String>);
+
+impl<S> FromRequestParts<S> for LastEventId
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let value = parts
+            .headers
+            .get("last-event-id")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        Ok(LastEventId(value))
+    }
+}
+```
+
+Update `modo/src/sse/mod.rs`:
+```rust
+pub mod config;
+pub mod event;
+pub mod last_event_id;
+pub mod response;
+pub mod sender;
+
+pub use config::SseConfig;
+pub use event::SseEvent;
+pub use last_event_id::LastEventId;
+pub use response::{SseResponse, from_stream};
+pub use sender::{SseSender, channel};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p modo --features sse --test sse_last_event_id -- --nocapture`
+Expected: PASS — both tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modo/src/sse/last_event_id.rs modo/src/sse/mod.rs modo/tests/sse_last_event_id.rs
+git commit -m "feat(sse): add LastEventId extractor for reconnection"
+```
+
+---
+
+## Chunk 3: Broadcasting
+
+### Task 6: SseStream and SseBroadcastManager
+
+**Files:**
+- Create: `modo/src/sse/broadcast.rs`
+- Modify: `modo/src/sse/mod.rs`
+- Test: `modo/tests/sse_broadcast.rs`
+
+- [ ] **Step 1: Write failing tests for SseBroadcastManager**
+
+```rust
+// modo/tests/sse_broadcast.rs
+#![cfg(feature = "sse")]
+
+use futures_util::StreamExt;
+use modo::sse::{SseBroadcastManager, SseStream};
+
+#[tokio::test]
+async fn broadcast_subscribe_and_send() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let mut stream = mgr.subscribe(&"room1".into());
+
+    let count = mgr.send(&"room1".into(), "hello".into()).unwrap();
+    assert_eq!(count, 1);
+
+    let item = stream.next().await.unwrap().unwrap();
+    assert_eq!(item, "hello");
+}
+
+#[tokio::test]
+async fn broadcast_multiple_subscribers() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let mut s1 = mgr.subscribe(&"room".into());
+    let mut s2 = mgr.subscribe(&"room".into());
+
+    let count = mgr.send(&"room".into(), "msg".into()).unwrap();
+    assert_eq!(count, 2);
+
+    assert_eq!(s1.next().await.unwrap().unwrap(), "msg");
+    assert_eq!(s2.next().await.unwrap().unwrap(), "msg");
+}
+
+#[tokio::test]
+async fn broadcast_send_to_nonexistent_key_is_noop() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let count = mgr.send(&"nobody".into(), "hello".into()).unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn broadcast_subscriber_count() {
+    let mgr: SseBroadcastManager<String, i32> = SseBroadcastManager::new(16);
+    assert_eq!(mgr.subscriber_count(&"k".into()), 0);
+
+    let _s1 = mgr.subscribe(&"k".into());
+    assert_eq!(mgr.subscriber_count(&"k".into()), 1);
+
+    let _s2 = mgr.subscribe(&"k".into());
+    assert_eq!(mgr.subscriber_count(&"k".into()), 2);
+
+    drop(_s1);
+    // After drop, count may still be 2 until next operation triggers cleanup.
+    // Force cleanup by subscribing or sending.
+    let _ = mgr.send(&"k".into(), 0);
+    // tokio broadcast receiver_count decrements on drop
+    assert_eq!(mgr.subscriber_count(&"k".into()), 1);
+}
+
+#[tokio::test]
+async fn broadcast_auto_cleanup_on_last_unsubscribe() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let s = mgr.subscribe(&"temp".into());
+    assert_eq!(mgr.subscriber_count(&"temp".into()), 1);
+
+    drop(s);
+
+    // Trigger cleanup via send
+    let count = mgr.send(&"temp".into(), "test".into()).unwrap();
+    assert_eq!(count, 0);
+    // Channel should be pruned
+    assert_eq!(mgr.subscriber_count(&"temp".into()), 0);
+}
+
+#[tokio::test]
+async fn broadcast_remove() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let _s = mgr.subscribe(&"room".into());
+    assert_eq!(mgr.subscriber_count(&"room".into()), 1);
+
+    mgr.remove(&"room".into());
+    assert_eq!(mgr.subscriber_count(&"room".into()), 0);
+}
+
+#[tokio::test]
+async fn broadcast_stream_closed_when_sender_dropped() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let mut stream = mgr.subscribe(&"room".into());
+
+    mgr.remove(&"room".into());
+
+    // Stream should end (return None)
+    let next = stream.next().await;
+    assert!(next.is_none());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p modo --features sse --test sse_broadcast -- --nocapture`
+Expected: FAIL — `SseBroadcastManager` not found
+
+- [ ] **Step 3: Implement SseBroadcastManager and SseStream**
+
+```rust
+// modo/src/sse/broadcast.rs
+use crate::error::Error;
+use futures_util::Stream;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+use tokio::sync::broadcast;
+
+/// Registry of keyed broadcast channels for fan-out SSE delivery.
+///
+/// Each key maps to an independent broadcast channel. All subscribers of a key
+/// receive every message sent to that key. Use one manager per domain concept
+/// (e.g., chat messages, uptime checks, notifications).
+///
+/// # Construction
+///
+/// ```rust
+/// use modo::sse::SseBroadcastManager;
+///
+/// let chat: SseBroadcastManager<String, ChatMessage> = SseBroadcastManager::new(128);
+/// let notifications: SseBroadcastManager<UserId, Notification> = SseBroadcastManager::new(64);
+/// ```
+///
+/// Register as a service — the service registry handles `Arc` wrapping:
+/// ```rust,ignore
+/// app.service(chat);
+/// ```
+///
+/// # Channel lifecycle
+///
+/// - Channels are created lazily on first [`subscribe()`](Self::subscribe)
+/// - Channels are auto-cleaned when the last subscriber drops (detected on
+///   next [`send()`](Self::send) or [`subscribe()`](Self::subscribe) call)
+/// - [`remove()`](Self::remove) forces immediate cleanup
+///
+/// # Filtering
+///
+/// All subscribers receive all messages. Filter on the consumer side:
+/// ```rust,ignore
+/// let stream = mgr.subscribe(&room_id)
+///     .filter_map(|result| match result {
+///         Ok(msg) if msg.sender != my_id => Some(msg),
+///         _ => None,
+///     });
+/// ```
+pub struct SseBroadcastManager<K, T>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+{
+    channels: Arc<RwLock<HashMap<K, broadcast::Sender<T>>>>,
+    buffer: usize,
+}
+
+impl<K, T> SseBroadcastManager<K, T>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+{
+    /// Create a new manager with the given per-channel buffer size.
+    ///
+    /// The buffer size determines how many messages can be buffered before
+    /// slow subscribers start lagging (skipping missed messages with a warning).
+    /// Typical values: 64-256 for chat, 16-64 for dashboards.
+    pub fn new(buffer: usize) -> Self {
+        Self {
+            channels: Arc::new(RwLock::new(HashMap::new())),
+            buffer,
+        }
+    }
+
+    /// Subscribe to a keyed channel.
+    ///
+    /// Creates the channel lazily on first subscription. Returns a stream of
+    /// raw `T` values — convert to [`SseEvent`](super::SseEvent) downstream
+    /// using [`SseStreamExt`](super::SseStreamExt) or `.map()`.
+    pub fn subscribe(&self, key: &K) -> SseStream<T> {
+        // Use blocking_write since this is called from sync context in handlers
+        // (handler extractors and body are async, but this is a quick operation)
+        let mut channels = self.channels.write().unwrap();
+
+        // Prune dead channels while we have the lock
+        channels.retain(|_, sender| sender.receiver_count() > 0);
+
+        let sender = channels
+            .entry(key.clone())
+            .or_insert_with(|| broadcast::channel(self.buffer).0);
+        let rx = sender.subscribe();
+        SseStream::new(rx)
+    }
+
+    /// Send an event to all subscribers of a keyed channel.
+    ///
+    /// Returns the number of receivers that got the message. Returns `Ok(0)`
+    /// if no subscribers exist for the key.
+    ///
+    /// **Does NOT create a channel** — only [`subscribe()`](Self::subscribe)
+    /// creates channels lazily. Sending to a nonexistent key is a silent no-op.
+    pub fn send(&self, key: &K, event: T) -> Result<usize, Error> {
+        let mut channels = self.channels.write().unwrap();
+
+        // Prune dead channels
+        channels.retain(|_, sender| sender.receiver_count() > 0);
+
+        if let Some(sender) = channels.get(key) {
+            match sender.send(event) {
+                Ok(count) => Ok(count),
+                Err(_) => Ok(0), // All receivers dropped between retain and send
+            }
+        } else {
+            Ok(0)
+        }
+    }
+
+    /// Number of active subscribers for a key.
+    ///
+    /// Returns 0 if the key has no channel.
+    pub fn subscriber_count(&self, key: &K) -> usize {
+        let channels = self.channels.read().unwrap();
+        channels
+            .get(key)
+            .map(|s| s.receiver_count())
+            .unwrap_or(0)
+    }
+
+    /// Manually remove a channel and disconnect all its subscribers.
+    ///
+    /// Typically not needed — channels auto-clean when the last subscriber
+    /// drops. Use this for explicit teardown (e.g., deleting a chat room).
+    pub fn remove(&self, key: &K) {
+        let mut channels = self.channels.write().unwrap();
+        channels.remove(key);
+    }
+}
+
+// Clone so it can be shared via Arc in the service registry
+impl<K, T> Clone for SseBroadcastManager<K, T>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            channels: Arc::clone(&self.channels),
+            buffer: self.buffer,
+        }
+    }
+}
+
+/// A stream of events from a broadcast channel.
+///
+/// Yields raw `T` values (not [`SseEvent`](super::SseEvent)). Convert
+/// downstream using [`SseStreamExt`](super::SseStreamExt) combinators or
+/// standard stream methods (`.map()`, `.filter_map()`, etc.).
+///
+/// # Lagging
+///
+/// If a subscriber falls behind (buffer full), missed messages are skipped
+/// with a warning log. The stream continues with the next available message.
+///
+/// # End of stream
+///
+/// The stream ends (`None`) when the broadcast sender is dropped — either
+/// via [`SseBroadcastManager::remove()`] or when the manager itself is dropped.
+pub struct SseStream<T> {
+    inner: Pin<Box<dyn Stream<Item = Result<T, Error>> + Send>>,
+}
+
+impl<T: Clone + Send + 'static> SseStream<T> {
+    pub(crate) fn new(rx: broadcast::Receiver<T>) -> Self {
+        let stream = futures_util::stream::unfold(rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(item) => return Some((Ok(item), rx)),
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(
+                            skipped = n,
+                            "SSE subscriber lagged, skipping {n} messages"
+                        );
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        });
+        Self {
+            inner: Box::pin(stream),
+        }
+    }
+}
+
+impl<T> Stream for SseStream<T> {
+    type Item = Result<T, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+```
+
+Update `modo/src/sse/mod.rs`:
+```rust
+pub mod broadcast;
+pub mod config;
+pub mod event;
+pub mod last_event_id;
+pub mod response;
+pub mod sender;
+
+pub use broadcast::{SseBroadcastManager, SseStream};
+pub use config::SseConfig;
+pub use event::SseEvent;
+pub use last_event_id::LastEventId;
+pub use response::{SseResponse, from_stream};
+pub use sender::{SseSender, channel};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p modo --features sse --test sse_broadcast -- --nocapture`
+Expected: PASS — all 7 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modo/src/sse/broadcast.rs modo/src/sse/mod.rs modo/tests/sse_broadcast.rs
+git commit -m "feat(sse): add SseBroadcastManager and SseStream"
+```
+
+---
+
+## Chunk 4: Stream Ergonomics & Integration
+
+### Task 7: SseStreamExt trait
+
+**Files:**
+- Create: `modo/src/sse/stream_ext.rs`
+- Modify: `modo/src/sse/mod.rs`
+- Test: `modo/tests/sse_stream_ext.rs`
+
+- [ ] **Step 1: Write failing tests for SseStreamExt**
+
+```rust
+// modo/tests/sse_stream_ext.rs
+#![cfg(feature = "sse")]
+
+use futures_util::{StreamExt, stream};
+use modo::sse::{SseEvent, SseStreamExt};
+
+#[tokio::test]
+async fn sse_json_converts_serializable_items() {
+    #[derive(Clone, serde::Serialize)]
+    struct Msg { text: String }
+
+    let items = vec![
+        Ok::<_, modo::Error>(Msg { text: "hello".into() }),
+        Ok(Msg { text: "world".into() }),
+    ];
+    let s = stream::iter(items);
+    let events: Vec<_> = s.sse_json().collect().await;
+    assert_eq!(events.len(), 2);
+    assert!(events[0].is_ok());
+    assert!(events[1].is_ok());
+}
+
+#[tokio::test]
+async fn sse_map_transforms_items() {
+    let items = vec![Ok::<_, modo::Error>(42i32), Ok(99)];
+    let s = stream::iter(items);
+    let events: Vec<_> = s
+        .sse_map(|n| Ok(SseEvent::new().event("number").data(n.to_string())))
+        .collect()
+        .await;
+    assert_eq!(events.len(), 2);
+    assert!(events[0].is_ok());
+}
+
+#[tokio::test]
+async fn sse_map_propagates_stream_errors() {
+    let items = vec![
+        Ok::<_, modo::Error>(1i32),
+        Err(modo::Error::internal("fail")),
+        Ok(3),
+    ];
+    let s = stream::iter(items);
+    let events: Vec<_> = s
+        .sse_map(|n| Ok(SseEvent::new().data(n.to_string())))
+        .collect()
+        .await;
+    assert_eq!(events.len(), 3);
+    assert!(events[0].is_ok());
+    assert!(events[1].is_err());
+    assert!(events[2].is_ok());
+}
+
+#[tokio::test]
+async fn sse_event_sets_name_and_converts() {
+    let items = vec![
+        Ok::<_, modo::Error>(SseEvent::new().data("hello")),
+    ];
+    let s = stream::iter(items);
+    let events: Vec<_> = s.sse_event("ping").collect().await;
+    assert_eq!(events.len(), 1);
+    assert!(events[0].is_ok());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p modo --features sse --test sse_stream_ext -- --nocapture`
+Expected: FAIL — `SseStreamExt` not found
+
+- [ ] **Step 3: Implement SseStreamExt**
+
+```rust
+// modo/src/sse/stream_ext.rs
+use super::event::SseEvent;
+use crate::error::Error;
+use futures_util::{Stream, StreamExt};
+use serde::Serialize;
+
+/// Extension trait for converting streams into SSE event streams.
+///
+/// Operates on streams of `Result<T, E>` — errors pass through unchanged,
+/// and the conversion closure/trait only operates on `Ok` values.
+///
+/// # Usage
+///
+/// Import the trait and call methods on any compatible stream:
+///
+/// ```rust,ignore
+/// use modo::sse::SseStreamExt;
+///
+/// // JSON conversion
+/// let stream = bc.subscribe(&key).sse_json();
+///
+/// // Custom mapping
+/// let stream = bc.subscribe(&key).sse_map(|item| {
+///     Ok(SseEvent::new().event("update").json(&item)?)
+/// });
+/// ```
+pub trait SseStreamExt<T, E>: Stream<Item = Result<T, E>> + Sized
+where
+    E: Into<Error>,
+{
+    /// Set event name on each item and pass through.
+    ///
+    /// Items must already be [`SseEvent`]s (or convertible via `Into<SseEvent>`).
+    /// This is useful when you have a stream of pre-built events and want to
+    /// override or set the event name uniformly.
+    fn sse_event(
+        self,
+        name: &'static str,
+    ) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+    where
+        T: Into<SseEvent> + Send,
+        E: Send,
+        Self: Send,
+    {
+        self.map(move |result| {
+            result
+                .map_err(Into::into)
+                .map(|item| item.into().event(name))
+        })
+    }
+
+    /// Serialize each item as JSON data in an [`SseEvent`].
+    ///
+    /// Equivalent to `.sse_map(|item| SseEvent::new().json(&item))`.
+    ///
+    /// # Errors
+    ///
+    /// Yields an error if JSON serialization fails for any item.
+    fn sse_json(self) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+    where
+        T: Serialize + Send,
+        E: Send,
+        Self: Send,
+    {
+        self.map(|result| {
+            result
+                .map_err(Into::into)
+                .and_then(|item| SseEvent::new().json(&item))
+        })
+    }
+
+    /// Map each item to an [`SseEvent`] with a custom closure.
+    ///
+    /// The closure receives the unwrapped `Ok` value. Stream errors pass
+    /// through unchanged.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let stream = bc.subscribe(&room_id).sse_map(|msg| {
+    ///     let html = view.render_to_string(MessageView::from(&msg))?;
+    ///     Ok(SseEvent::new().event("message").html(html))
+    /// });
+    /// ```
+    fn sse_map<F>(self, mut f: F) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+    where
+        F: FnMut(T) -> Result<SseEvent, Error> + Send,
+        E: Send,
+        Self: Send,
+    {
+        self.map(move |result| result.map_err(Into::into).and_then(|item| f(item)))
+    }
+}
+
+// Blanket implementation for all compatible streams
+impl<S, T, E> SseStreamExt<T, E> for S
+where
+    S: Stream<Item = Result<T, E>> + Sized,
+    E: Into<Error>,
+{
+}
+```
+
+Update `modo/src/sse/mod.rs`:
+```rust
+pub mod broadcast;
+pub mod config;
+pub mod event;
+pub mod last_event_id;
+pub mod response;
+pub mod sender;
+pub mod stream_ext;
+
+pub use broadcast::{SseBroadcastManager, SseStream};
+pub use config::SseConfig;
+pub use event::SseEvent;
+pub use last_event_id::LastEventId;
+pub use response::{SseResponse, from_stream};
+pub use sender::{SseSender, channel};
+pub use stream_ext::SseStreamExt;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p modo --features sse --test sse_stream_ext -- --nocapture`
+Expected: PASS — all 4 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modo/src/sse/stream_ext.rs modo/src/sse/mod.rs modo/tests/sse_stream_ext.rs
+git commit -m "feat(sse): add SseStreamExt trait (sse_json, sse_map, sse_event)"
+```
+
+---
+
+### Task 8: Core integration
+
+**Files:**
+- Modify: `modo/Cargo.toml`
+- Modify: `modo/src/config.rs`
+- Modify: `modo/src/app.rs`
+- Modify: `modo/src/lib.rs`
+
+Note: Some of these files were partially modified in Task 1 (Cargo.toml feature flag, lib.rs module declaration). This task completes the integration.
+
+- [ ] **Step 1: Add SseConfig to AppConfig**
+
+In `modo/src/config.rs`, add the `sse` field to `AppConfig` struct (alongside existing cfg-gated fields like `templates`, `i18n`, `csrf`):
+
+```rust
+#[cfg(feature = "sse")]
+#[serde(default)]
+pub sse: crate::sse::SseConfig,
+```
+
+- [ ] **Step 2: Auto-register SseConfig in AppBuilder::run()**
+
+In `modo/src/app.rs`, add a block inside the `run()` method, after the existing feature-gated service registrations (after the csrf block):
+
+```rust
+#[cfg(feature = "sse")]
+self.services.insert(
+    TypeId::of::<crate::sse::SseConfig>(),
+    Arc::new(app_config.sse.clone()),
+);
+```
+
+- [ ] **Step 3: Verify feature flag and lib.rs re-exports**
+
+Verify `modo/Cargo.toml` has:
+```toml
+sse = ["dep:futures-util"]
+```
+
+Verify `modo/src/lib.rs` has (in alphabetical position among other modules):
+```rust
+#[cfg(feature = "sse")]
+pub mod sse;
+```
+
+No additional re-exports at the lib.rs level are needed — users access everything via `modo::sse::*`.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cargo test -p modo --features sse -- --nocapture`
+Expected: PASS — all SSE tests pass
+
+Run: `cargo test -p modo -- --nocapture`
+Expected: PASS — all tests pass without `sse` feature too (no compile errors)
+
+- [ ] **Step 5: Run clippy and fmt**
+
+Run: `just fmt && cargo clippy -p modo --features sse --all-targets -- -D warnings`
+Expected: No warnings or errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add modo/src/config.rs modo/src/app.rs modo/Cargo.toml modo/src/lib.rs
+git commit -m "feat(sse): integrate SseConfig into AppConfig and AppBuilder"
+```
+
+---
+
+### Task 9: Module documentation
+
+**Files:**
+- Modify: `modo/src/sse/mod.rs`
+
+- [ ] **Step 1: Add comprehensive module-level documentation**
+
+Replace the `mod.rs` content with full docs + re-exports:
+
+```rust
+// modo/src/sse/mod.rs
+
+//! Server-Sent Events (SSE) support for modo.
+//!
+//! This module provides a streaming primitive for real-time event delivery
+//! over HTTP. Events flow from server to client over a long-lived connection
+//! using the [SSE protocol](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).
+//!
+//! # Quick start
+//!
+//! Enable the `sse` feature in your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! modo = { path = "../../modo", features = ["sse"] }
+//! ```
+//!
+//! ## Stream from a broadcast channel
+//!
+//! ```rust,ignore
+//! use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+//!
+//! // Register a broadcast manager as a service in main()
+//! let notifications: SseBroadcastManager<UserId, Notification> =
+//!     SseBroadcastManager::new(64);
+//! app.service(notifications);
+//!
+//! // Subscribe in a handler
+//! #[modo::handler(GET, "/notifications/events")]
+//! async fn events(
+//!     auth: Auth<User>,
+//!     Service(bc): Service<SseBroadcastManager<UserId, Notification>>,
+//! ) -> SseResponse {
+//!     modo::sse::from_stream(bc.subscribe(&auth.user.id).sse_json())
+//! }
+//! ```
+//!
+//! ## Imperative channel
+//!
+//! ```rust,ignore
+//! #[modo::handler(GET, "/jobs/{id}/progress")]
+//! async fn progress(id: String, Service(jobs): Service<JobService>) -> SseResponse {
+//!     modo::sse::channel(|tx| async move {
+//!         while let Some(status) = jobs.poll_status(&id).await {
+//!             tx.send(SseEvent::new().event("progress").json(&status)?).await?;
+//!             if status.is_done() { break; }
+//!         }
+//!         Ok(())
+//!     })
+//! }
+//! ```
+//!
+//! ## HTML partials (HTMX)
+//!
+//! ```rust,ignore
+//! #[modo::handler(GET, "/chat/{id}/events")]
+//! async fn chat(
+//!     id: String,
+//!     view: ViewRenderer,
+//!     Service(bc): Service<SseBroadcastManager<String, ChatMessage>>,
+//! ) -> SseResponse {
+//!     let stream = bc.subscribe(&id).sse_map(move |msg| {
+//!         let html = view.render_to_string(MessageView::from(&msg))?;
+//!         Ok(SseEvent::new().event("message").html(html))
+//!     });
+//!     modo::sse::from_stream(stream)
+//! }
+//! ```
+//!
+//! # Architecture
+//!
+//! | Type | Purpose |
+//! |------|---------|
+//! | [`SseEvent`] | Builder for a single event (data/json/html + metadata) |
+//! | [`SseResponse`] | Handler return type — wraps a stream with keep-alive |
+//! | [`SseBroadcastManager`] | Keyed broadcast channels for fan-out delivery |
+//! | [`SseStream`] | Stream of raw `T` values from a broadcast channel |
+//! | [`SseSender`] | Imperative sender for [`channel()`] closures |
+//! | [`LastEventId`] | Extractor for the `Last-Event-ID` reconnection header |
+//! | [`SseStreamExt`] | Ergonomic stream-to-event conversion methods |
+//! | [`SseConfig`] | Keep-alive configuration |
+//!
+//! # Entry points
+//!
+//! | Function | Use case |
+//! |----------|----------|
+//! | [`from_stream()`] | Wrap any `Stream<Item = Result<SseEvent, E>>` as SSE |
+//! | [`channel()`] | Imperative event production via closure + sender |
+//!
+//! # Gotchas
+//!
+//! ## Request timeout
+//!
+//! The global `TimeoutLayer` will terminate SSE connections after the
+//! configured request timeout. SSE connections are long-lived, so you must
+//! either set a long timeout or disable it for SSE routes.
+//!
+//! ```yaml
+//! server:
+//!     http:
+//!         request_timeout: 3600  # 1 hour, suitable for SSE
+//! ```
+//!
+//! ## Reconnection and `Last-Event-ID`
+//!
+//! When a client reconnects, the browser sends a `Last-Event-ID` header.
+//! Use [`LastEventId`] to read it and replay missed events from your
+//! data store. The SSE module does NOT replay automatically.
+//!
+//! ## Multi-line HTML
+//!
+//! Multi-line data (including HTML partials) is handled automatically per
+//! the SSE spec. Keep partials small — send individual components, not
+//! entire page sections.
+
+pub mod broadcast;
+pub mod config;
+pub mod event;
+pub mod last_event_id;
+pub mod response;
+pub mod sender;
+pub mod stream_ext;
+
+pub use broadcast::{SseBroadcastManager, SseStream};
+pub use config::SseConfig;
+pub use event::SseEvent;
+pub use last_event_id::LastEventId;
+pub use response::{SseResponse, from_stream};
+pub use sender::{SseSender, channel};
+pub use stream_ext::SseStreamExt;
+```
+
+- [ ] **Step 2: Run full check**
+
+Run: `just fmt && cargo clippy -p modo --features sse --all-targets -- -D warnings && cargo test -p modo --features sse -- --nocapture`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add modo/src/sse/mod.rs
+git commit -m "docs(sse): add comprehensive module documentation"
+```
+
+---
+
+## Chunk 5: SSE Dashboard Example
+
+### Task 10: SSE Dashboard example (HTMX)
+
+Fake server monitoring dashboard. A background task generates random status events for multiple services. The HTMX frontend receives HTML partial updates via SSE.
+
+**Files:**
+- Create: `examples/sse-dashboard/Cargo.toml`
+- Create: `examples/sse-dashboard/src/main.rs`
+- Create: `examples/sse-dashboard/config/development.yaml`
+- Create: `examples/sse-dashboard/templates/layouts/base.html`
+- Create: `examples/sse-dashboard/templates/pages/dashboard.html`
+- Create: `examples/sse-dashboard/templates/partials/status_card.html`
+- Modify: `Cargo.toml` (workspace members)
+
+- [ ] **Step 1: Create Cargo.toml**
+
+```toml
+# examples/sse-dashboard/Cargo.toml
+[package]
+name = "sse-dashboard"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+modo = { path = "../../modo", features = ["templates", "sse"] }
+chrono = "0.4"
+rand = "0.9"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse"))'] }
+```
+
+- [ ] **Step 2: Add to workspace members**
+
+In root `Cargo.toml`, add `"examples/sse-dashboard"` to the `members` array.
+
+- [ ] **Step 3: Create config**
+
+```yaml
+# examples/sse-dashboard/config/development.yaml
+server:
+  port: 3002
+  secret_key: ${SECRET_KEY:-sse-dashboard-dev-secret-key-change-in-prod-please}
+  http:
+    request_timeout: 3600
+templates:
+  path: templates
+```
+
+- [ ] **Step 4: Create base layout template**
+
+```html
+{# examples/sse-dashboard/templates/layouts/base.html #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}SSE Dashboard{% endblock %}</title>
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+    <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; padding: 2rem; }
+        h1 { margin-bottom: 1.5rem; font-size: 1.5rem; }
+        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
+        .card { background: #1e293b; border-radius: 0.5rem; padding: 1.25rem; border-left: 4px solid #475569; }
+        .card.up { border-left-color: #22c55e; }
+        .card.down { border-left-color: #ef4444; }
+        .card.degraded { border-left-color: #f59e0b; }
+        .card h2 { font-size: 1rem; margin-bottom: 0.75rem; }
+        .card .status { font-size: 0.875rem; font-weight: 600; text-transform: uppercase; }
+        .card .status.up { color: #22c55e; }
+        .card .status.down { color: #ef4444; }
+        .card .status.degraded { color: #f59e0b; }
+        .card .metrics { display: flex; gap: 1rem; margin-top: 0.75rem; font-size: 0.8rem; color: #94a3b8; }
+        .card .metric span { font-weight: 600; color: #e2e8f0; }
+        .connected { color: #22c55e; font-size: 0.8rem; margin-bottom: 1rem; }
+    </style>
+</head>
+<body>
+    {% block content %}{% endblock %}
+</body>
+</html>
+```
+
+- [ ] **Step 5: Create dashboard page template**
+
+```html
+{# examples/sse-dashboard/templates/pages/dashboard.html #}
+{% extends "layouts/base.html" %}
+{% block content %}
+<h1>Server Status Dashboard</h1>
+<p class="connected">Live — updates via SSE</p>
+<div class="grid"
+     hx-ext="sse"
+     sse-connect="/events"
+     sse-swap="status_update"
+     hx-swap="innerHTML">
+    <p style="color: #94a3b8;">Waiting for data...</p>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 6: Create status card partial template**
+
+```html
+{# examples/sse-dashboard/templates/partials/status_card.html #}
+{% for server in servers %}
+<div class="card {{ server.status }}">
+    <h2>{{ server.name }}</h2>
+    <div class="status {{ server.status }}">{{ server.status }}</div>
+    <div class="metrics">
+        <div class="metric">CPU: <span>{{ server.cpu }}%</span></div>
+        <div class="metric">MEM: <span>{{ server.memory }}%</span></div>
+        <div class="metric">Latency: <span>{{ server.latency_ms }}ms</span></div>
+    </div>
+</div>
+{% endfor %}
+```
+
+- [ ] **Step 7: Create main.rs**
+
+```rust
+// examples/sse-dashboard/src/main.rs
+use modo::extractors::Service;
+use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+use modo::templates::ViewRenderer;
+use modo::AppConfig;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+// --- Config ---
+
+#[derive(Default, Deserialize)]
+struct Config {
+    #[serde(flatten)]
+    core: AppConfig,
+}
+
+// --- Domain types ---
+
+#[derive(Debug, Clone, Serialize)]
+struct ServerStatus {
+    name: String,
+    status: String, // "up", "down", "degraded"
+    cpu: u32,
+    memory: u32,
+    latency_ms: u32,
+}
+
+// --- Broadcaster type alias ---
+
+type StatusBroadcaster = SseBroadcastManager<(), Vec<ServerStatus>>;
+
+// --- Background task: generate fake server statuses ---
+
+async fn fake_monitor(bc: StatusBroadcaster) {
+    let servers = vec![
+        "api-gateway",
+        "auth-service",
+        "payment-service",
+        "notification-service",
+        "database-primary",
+        "cache-redis",
+    ];
+
+    loop {
+        let mut rng = rand::rng();
+        let statuses: Vec<ServerStatus> = servers
+            .iter()
+            .map(|name| {
+                let roll: f64 = rng.random();
+                let (status, cpu, memory, latency) = if roll < 0.05 {
+                    ("down", rng.random_range(0..10), rng.random_range(0..20), rng.random_range(5000..10000))
+                } else if roll < 0.15 {
+                    ("degraded", rng.random_range(70..95), rng.random_range(70..90), rng.random_range(500..2000))
+                } else {
+                    ("up", rng.random_range(10..60), rng.random_range(30..70), rng.random_range(5..100))
+                };
+                ServerStatus {
+                    name: name.to_string(),
+                    status: status.to_string(),
+                    cpu,
+                    memory,
+                    latency_ms: latency,
+                }
+            })
+            .collect();
+
+        let _ = bc.send(&(), statuses);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    }
+}
+
+// --- Handlers ---
+
+#[modo::view("pages/dashboard.html")]
+struct DashboardPage {}
+
+#[modo::handler(GET, "/")]
+async fn dashboard() -> DashboardPage {
+    DashboardPage {}
+}
+
+#[modo::handler(GET, "/events")]
+async fn events(
+    view: ViewRenderer,
+    Service(bc): Service<StatusBroadcaster>,
+) -> SseResponse {
+    let stream = bc.subscribe(&()).sse_map(move |servers| {
+        let html = view.render_to_string(StatusCards { servers })?;
+        Ok(SseEvent::new().event("status_update").html(html))
+    });
+    modo::sse::from_stream(stream)
+}
+
+#[modo::view("partials/status_card.html")]
+struct StatusCards {
+    servers: Vec<ServerStatus>,
+}
+
+// --- Entry point ---
+
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bc: StatusBroadcaster = SseBroadcastManager::new(16);
+
+    tokio::spawn(fake_monitor(bc.clone()));
+
+    app.config(config.core).service(bc).run().await
+}
+```
+
+- [ ] **Step 8: Verify it compiles**
+
+Run: `cargo check -p sse-dashboard`
+Expected: Compiles without errors
+
+- [ ] **Step 9: Run fmt and clippy**
+
+Run: `just fmt && cargo clippy -p sse-dashboard --all-targets -- -D warnings`
+Expected: No warnings
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add examples/sse-dashboard/ Cargo.toml
+git commit -m "feat: add SSE dashboard example with HTMX and fake server monitoring"
+```
+
+---
+
+## Chunk 6: SSE Chat Example
+
+### Task 11: SSE Chat example with rooms and DB
+
+Chat application with rooms, session-based username, SQLite message storage, and SSE delivery of HTML partials.
+
+**Files:**
+- Create: `examples/sse-chat/Cargo.toml`
+- Create: `examples/sse-chat/src/main.rs`
+- Create: `examples/sse-chat/config/development.yaml`
+- Create: `examples/sse-chat/templates/layouts/base.html`
+- Create: `examples/sse-chat/templates/pages/login.html`
+- Create: `examples/sse-chat/templates/pages/rooms.html`
+- Create: `examples/sse-chat/templates/pages/chat.html`
+- Create: `examples/sse-chat/templates/partials/message.html`
+- Modify: `Cargo.toml` (workspace members)
+
+- [ ] **Step 1: Create Cargo.toml**
+
+```toml
+# examples/sse-chat/Cargo.toml
+[package]
+name = "sse-chat"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+modo = { path = "../../modo", features = ["templates", "sse", "csrf"] }
+modo-db = { path = "../../modo-db", features = ["sqlite"] }
+modo-session = { path = "../../modo-session" }
+chrono = "0.4"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse", "csrf"))'] }
+```
+
+- [ ] **Step 2: Add to workspace members**
+
+In root `Cargo.toml`, add `"examples/sse-chat"` to the `members` array.
+
+- [ ] **Step 3: Create config**
+
+```yaml
+# examples/sse-chat/config/development.yaml
+server:
+  port: 3003
+  secret_key: ${SECRET_KEY:-sse-chat-dev-secret-key-change-in-production-please}
+  http:
+    request_timeout: 3600
+templates:
+  path: templates
+database:
+  url: ${DATABASE_URL:-sqlite://chat.db?mode=rwc}
+  max_connections: 5
+  min_connections: 1
+```
+
+- [ ] **Step 4: Create base layout template**
+
+```html
+{# examples/sse-chat/templates/layouts/base.html #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}SSE Chat{% endblock %}</title>
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+    <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; }
+        .container { max-width: 800px; margin: 0 auto; padding: 2rem; }
+        h1 { margin-bottom: 1rem; }
+        a { color: #2563eb; }
+        .form-group { margin-bottom: 1rem; }
+        label { display: block; margin-bottom: 0.25rem; font-weight: 600; font-size: 0.875rem; }
+        input[type="text"] { width: 100%; padding: 0.5rem; border: 1px solid #cbd5e1; border-radius: 0.375rem; font-size: 1rem; }
+        button { padding: 0.5rem 1rem; background: #2563eb; color: white; border: none; border-radius: 0.375rem; cursor: pointer; font-size: 0.875rem; }
+        button:hover { background: #1d4ed8; }
+        .rooms-list { list-style: none; }
+        .rooms-list li { margin-bottom: 0.5rem; }
+        .rooms-list a { display: block; padding: 0.75rem 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem; text-decoration: none; color: #1e293b; }
+        .rooms-list a:hover { background: #f1f5f9; }
+        .chat-container { display: flex; flex-direction: column; height: calc(100vh - 10rem); }
+        .messages { flex: 1; overflow-y: auto; padding: 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem 0.375rem 0 0; }
+        .message { margin-bottom: 0.75rem; }
+        .message .meta { font-size: 0.75rem; color: #64748b; margin-bottom: 0.125rem; }
+        .message .meta .username { font-weight: 600; color: #1e293b; }
+        .message .text { font-size: 0.9rem; }
+        .message-form { display: flex; gap: 0.5rem; padding: 0.75rem; background: white; border: 1px solid #e2e8f0; border-top: none; border-radius: 0 0 0.375rem 0.375rem; }
+        .message-form input { flex: 1; }
+        .nav { display: flex; gap: 1rem; align-items: center; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid #e2e8f0; }
+        .nav .user { margin-left: auto; font-size: 0.875rem; color: #64748b; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        {% block content %}{% endblock %}
+    </div>
+    {% block scripts %}{% endblock %}
+</body>
+</html>
+```
+
+- [ ] **Step 5: Create login page template**
+
+```html
+{# examples/sse-chat/templates/pages/login.html #}
+{% extends "layouts/base.html" %}
+{% block title %}Login — SSE Chat{% endblock %}
+{% block content %}
+<h1>Enter your username</h1>
+<form method="POST" action="/login">
+    <div class="form-group">
+        <label for="username">Username</label>
+        <input type="text" id="username" name="username" placeholder="Your name" required minlength="2" maxlength="30" autofocus>
+    </div>
+    <button type="submit">Join Chat</button>
+</form>
+{% endblock %}
+```
+
+- [ ] **Step 6: Create rooms page template**
+
+```html
+{# examples/sse-chat/templates/pages/rooms.html #}
+{% extends "layouts/base.html" %}
+{% block title %}Rooms — SSE Chat{% endblock %}
+{% block content %}
+<div class="nav">
+    <h1>Chat Rooms</h1>
+    <span class="user">Logged in as <strong>{{ username }}</strong> · <a href="/logout">Logout</a></span>
+</div>
+<ul class="rooms-list">
+    {% for room in rooms %}
+    <li><a href="/chat/{{ room }}">{{ room }}</a></li>
+    {% endfor %}
+</ul>
+{% endblock %}
+```
+
+- [ ] **Step 7: Create chat page template**
+
+```html
+{# examples/sse-chat/templates/pages/chat.html #}
+{% extends "layouts/base.html" %}
+{% block title %}{{ room }} — SSE Chat{% endblock %}
+{% block content %}
+<div class="nav">
+    <a href="/rooms">&larr; Rooms</a>
+    <h1>{{ room }}</h1>
+    <span class="user">{{ username }}</span>
+</div>
+<div class="chat-container">
+    <div class="messages" id="messages"
+         hx-ext="sse"
+         sse-connect="/chat/{{ room }}/events"
+         sse-swap="message"
+         hx-swap="beforeend">
+        {% for msg in messages %}
+        {{ msg }}
+        {% endfor %}
+    </div>
+    <form class="message-form" hx-post="/chat/{{ room }}/send" hx-swap="none" hx-on::after-request="this.reset()">
+        <input type="text" name="text" placeholder="Type a message..." required autocomplete="off" autofocus>
+        <button type="submit">Send</button>
+    </form>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+    // Auto-scroll to bottom on new messages
+    const messages = document.getElementById('messages');
+    const observer = new MutationObserver(() => {
+        messages.scrollTop = messages.scrollHeight;
+    });
+    observer.observe(messages, { childList: true });
+    // Scroll to bottom on load
+    messages.scrollTop = messages.scrollHeight;
+</script>
+{% endblock %}
+```
+
+- [ ] **Step 8: Create message partial template**
+
+```html
+{# examples/sse-chat/templates/partials/message.html #}
+<div class="message">
+    <div class="meta">
+        <span class="username">{{ username }}</span>
+        · {{ created_at }}
+    </div>
+    <div class="text">{{ text }}</div>
+</div>
+```
+
+- [ ] **Step 9: Create main.rs**
+
+```rust
+// examples/sse-chat/src/main.rs
+use modo::extractors::Service;
+use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+use modo::templates::ViewRenderer;
+use modo::{AppConfig, HandlerResult, HttpError};
+use modo_db::{DatabaseConfig, Db};
+use modo_session::SessionManager;
+use serde::{Deserialize, Serialize};
+
+// --- Config ---
+
+#[derive(Default, Deserialize)]
+struct Config {
+    #[serde(flatten)]
+    core: AppConfig,
+    database: DatabaseConfig,
+}
+
+// --- Entity ---
+
+#[modo_db::entity(table = "messages")]
+#[entity(timestamps)]
+pub struct Message {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub room: String,
+    pub username: String,
+    pub text: String,
+}
+
+// --- Broadcaster ---
+
+#[derive(Debug, Clone, Serialize)]
+struct ChatEvent {
+    username: String,
+    text: String,
+    created_at: String,
+}
+
+type ChatBroadcaster = SseBroadcastManager<String, ChatEvent>;
+
+// --- Helpers ---
+
+const ROOMS: &[&str] = &["general", "random", "support", "dev"];
+const MESSAGE_LIMIT: u64 = 50;
+
+async fn get_username(session: &SessionManager) -> Result<Option<String>, modo::Error> {
+    session.get::<String>("username").await
+}
+
+// --- Handlers ---
+
+// Login page
+#[modo::view("pages/login.html")]
+struct LoginPage {}
+
+#[modo::handler(GET, "/login")]
+async fn login_page() -> LoginPage {
+    LoginPage {}
+}
+
+#[derive(Deserialize)]
+struct LoginForm {
+    username: String,
+}
+
+#[modo::handler(POST, "/login")]
+async fn login_submit(
+    session: SessionManager,
+    form: modo::axum::extract::Form<LoginForm>,
+) -> HandlerResult<modo::templates::ViewResponse> {
+    let username = form.username.trim().to_string();
+    if username.is_empty() || username.len() > 30 {
+        return Err(HttpError::BadRequest.into());
+    }
+    // authenticate() creates the session, then set() stores the username
+    session.authenticate(&username).await?;
+    session.set("username", &username).await?;
+    Ok(modo::templates::ViewResponse::redirect("/rooms"))
+}
+
+#[modo::handler(GET, "/logout")]
+async fn logout(session: SessionManager) -> HandlerResult<modo::templates::ViewResponse> {
+    session.logout().await?;
+    Ok(modo::templates::ViewResponse::redirect("/login"))
+}
+
+// Rooms list
+#[modo::view("pages/rooms.html")]
+struct RoomsPage {
+    username: String,
+    rooms: Vec<String>,
+}
+
+#[modo::handler(GET, "/rooms")]
+async fn rooms_page(session: SessionManager, view: ViewRenderer) -> modo::ViewResult {
+    let username = match get_username(&session).await? {
+        Some(u) => u,
+        None => return Ok(modo::templates::ViewResponse::redirect("/login")),
+    };
+    view.render(RoomsPage {
+        username,
+        rooms: ROOMS.iter().map(|s| s.to_string()).collect(),
+    })
+}
+
+// Redirect root to rooms
+#[modo::handler(GET, "/")]
+async fn index(session: SessionManager) -> modo::ViewResult {
+    match get_username(&session).await? {
+        Some(_) => Ok(modo::templates::ViewResponse::redirect("/rooms")),
+        None => Ok(modo::templates::ViewResponse::redirect("/login")),
+    }
+}
+
+// Chat page — loads last 50 messages
+#[modo::view("pages/chat.html")]
+struct ChatPage {
+    room: String,
+    username: String,
+    messages: Vec<String>,
+}
+
+#[modo::view("partials/message.html")]
+struct MessagePartial {
+    username: String,
+    text: String,
+    created_at: String,
+}
+
+#[modo::handler(GET, "/chat/{room}")]
+async fn chat_page(
+    room: String,
+    session: SessionManager,
+    view: ViewRenderer,
+    Db(db): Db,
+) -> modo::ViewResult {
+    let username = match get_username(&session).await? {
+        Some(u) => u,
+        None => return Ok(modo::templates::ViewResponse::redirect("/login")),
+    };
+    if !ROOMS.contains(&room.as_str()) {
+        return Err(HttpError::NotFound.into());
+    }
+
+    use modo_db::sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+    let recent = message::Entity::find()
+        .filter(message::Column::Room.eq(&room))
+        .order_by_desc(message::Column::CreatedAt)
+        .limit(MESSAGE_LIMIT)
+        .all(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(e.to_string()))?
+        .into_iter()
+        .rev()
+        .map(|m| {
+            view.render_to_string(MessagePartial {
+                username: m.username,
+                text: m.text,
+                created_at: m.created_at.format("%H:%M").to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    view.render(ChatPage {
+        room,
+        username,
+        messages: recent,
+    })
+}
+
+// SSE event stream for a room
+#[modo::handler(GET, "/chat/{room}/events")]
+async fn chat_events(
+    room: String,
+    session: SessionManager,
+    view: ViewRenderer,
+    Service(bc): Service<ChatBroadcaster>,
+) -> HandlerResult<SseResponse> {
+    // For SSE, return 401 if not authenticated (no redirect for EventSource)
+    let _ = get_username(&session).await?.ok_or(HttpError::Unauthorized)?;
+    if !ROOMS.contains(&room.as_str()) {
+        return Err(HttpError::NotFound.into());
+    }
+
+    let stream = bc.subscribe(&room).sse_map(move |evt| {
+        let html = view.render_to_string(MessagePartial {
+            username: evt.username,
+            text: evt.text,
+            created_at: evt.created_at,
+        })?;
+        Ok(SseEvent::new().event("message").html(html))
+    });
+    Ok(modo::sse::from_stream(stream))
+}
+
+// Send a message
+#[derive(Deserialize)]
+struct SendForm {
+    text: String,
+}
+
+#[modo::handler(POST, "/chat/{room}/send")]
+async fn chat_send(
+    room: String,
+    session: SessionManager,
+    Db(db): Db,
+    Service(bc): Service<ChatBroadcaster>,
+    form: modo::axum::extract::Form<SendForm>,
+) -> HandlerResult<()> {
+    let username = get_username(&session).await?.ok_or(HttpError::Unauthorized)?;
+    if !ROOMS.contains(&room.as_str()) {
+        return Err(HttpError::NotFound.into());
+    }
+    let text = form.text.trim().to_string();
+    if text.is_empty() || text.len() > 2000 {
+        return Err(HttpError::BadRequest.into());
+    }
+
+    // Save to DB
+    use modo_db::sea_orm::{ActiveModelTrait, Set};
+    let now = chrono::Utc::now();
+    let model = message::ActiveModel {
+        room: Set(room.clone()),
+        username: Set(username.clone()),
+        text: Set(text.clone()),
+        ..Default::default()
+    };
+    model.insert(&*db).await.map_err(|e| modo::Error::internal(e.to_string()))?;
+
+    // Broadcast to SSE subscribers
+    let _ = bc.send(
+        &room,
+        ChatEvent {
+            username,
+            text,
+            created_at: now.format("%H:%M").to_string(),
+        },
+    );
+
+    Ok(())
+}
+
+// --- Entry point ---
+
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let db = modo_db::connect(&config.database).await?;
+    modo_db::sync_and_migrate(&db).await?;
+
+    let session_config = modo_session::SessionConfig::default();
+    let cookie_config = config.core.cookies.clone();
+    let session_store =
+        modo_session::SessionStore::new(&db, session_config, cookie_config);
+
+    let bc: ChatBroadcaster = SseBroadcastManager::new(128);
+
+    app.config(config.core)
+        .managed_service(db)
+        .layer(modo_session::layer(session_store))
+        .service(bc)
+        .run()
+        .await
+}
+```
+
+- [ ] **Step 10: Verify it compiles**
+
+Run: `cargo check -p sse-chat`
+Expected: Compiles without errors
+
+- [ ] **Step 11: Run fmt and clippy**
+
+Run: `just fmt && cargo clippy -p sse-chat --all-targets -- -D warnings`
+Expected: No warnings
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add examples/sse-chat/ Cargo.toml
+git commit -m "feat: add SSE chat example with rooms, DB messages, and session auth"
+```
+
+---
+
+## Final Verification
+
+### Task 12: Full workspace check
+
+- [ ] **Step 1: Run full workspace check**
+
+Run: `just check`
+Expected: All formatting, linting, and tests pass
+
+- [ ] **Step 2: Verify both examples build**
+
+Run: `cargo build -p sse-dashboard && cargo build -p sse-chat`
+Expected: Both compile successfully
+
+- [ ] **Step 3: Final commit if any fixups needed**
+
+```bash
+git add -A
+git commit -m "fix: address any final clippy/fmt issues"
+```

--- a/docs/superpowers/plans/2026-03-11-sse-implementation.md
+++ b/docs/superpowers/plans/2026-03-11-sse-implementation.md
@@ -16,60 +16,60 @@
 
 ### New files (modo/src/sse/)
 
-| File | Responsibility |
-|------|---------------|
-| `modo/src/sse/mod.rs` | Module docs, re-exports, `from_stream()` and `channel()` entry points |
-| `modo/src/sse/config.rs` | `SseConfig` — YAML-deserializable keep-alive config |
-| `modo/src/sse/event.rs` | `SseEvent` — builder for SSE events (data/json/html/event/id/retry) |
-| `modo/src/sse/response.rs` | `SseResponse` — handler return type wrapping axum's `Sse<S>` |
-| `modo/src/sse/sender.rs` | `SseSender` — mpsc-backed sender for `channel()` |
-| `modo/src/sse/broadcast.rs` | `SseBroadcastManager<K,T>` and `SseStream<T>` |
-| `modo/src/sse/last_event_id.rs` | `LastEventId` extractor |
-| `modo/src/sse/stream_ext.rs` | `SseStreamExt` trait for ergonomic stream mapping |
+| File                            | Responsibility                                                        |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `modo/src/sse/mod.rs`           | Module docs, re-exports, `from_stream()` and `channel()` entry points |
+| `modo/src/sse/config.rs`        | `SseConfig` — YAML-deserializable keep-alive config                   |
+| `modo/src/sse/event.rs`         | `SseEvent` — builder for SSE events (data/json/html/event/id/retry)   |
+| `modo/src/sse/response.rs`      | `SseResponse` — handler return type wrapping axum's `Sse<S>`          |
+| `modo/src/sse/sender.rs`        | `SseSender` — mpsc-backed sender for `channel()`                      |
+| `modo/src/sse/broadcast.rs`     | `SseBroadcastManager<K,T>` and `SseStream<T>`                         |
+| `modo/src/sse/last_event_id.rs` | `LastEventId` extractor                                               |
+| `modo/src/sse/stream_ext.rs`    | `SseStreamExt` trait for ergonomic stream mapping                     |
 
 ### Modified files (modo core integration)
 
-| File | Change |
-|------|--------|
-| `modo/Cargo.toml` | Add `sse` feature flag |
-| `modo/src/config.rs` | Add `SseConfig` field to `AppConfig` |
-| `modo/src/app.rs` | Auto-register `SseConfig` as service |
-| `modo/src/lib.rs` | Add `#[cfg(feature = "sse")] pub mod sse;` and re-exports |
+| File                 | Change                                                    |
+| -------------------- | --------------------------------------------------------- |
+| `modo/Cargo.toml`    | Add `sse` feature flag                                    |
+| `modo/src/config.rs` | Add `SseConfig` field to `AppConfig`                      |
+| `modo/src/app.rs`    | Auto-register `SseConfig` as service                      |
+| `modo/src/lib.rs`    | Add `#[cfg(feature = "sse")] pub mod sse;` and re-exports |
 
 ### Test files
 
-| File | Tests |
-|------|-------|
-| `modo/tests/sse_event.rs` | SseEvent builder, mutually exclusive data, conversion |
-| `modo/tests/sse_response.rs` | SseResponse headers, keep-alive override |
-| `modo/tests/sse_last_event_id.rs` | LastEventId extractor with/without header |
-| `modo/tests/sse_channel.rs` | channel() send/receive, disconnect cleanup |
-| `modo/tests/sse_broadcast.rs` | SseBroadcastManager subscribe/send/cleanup |
-| `modo/tests/sse_stream_ext.rs` | SseStreamExt sse_json, sse_map |
+| File                              | Tests                                                 |
+| --------------------------------- | ----------------------------------------------------- |
+| `modo/tests/sse_event.rs`         | SseEvent builder, mutually exclusive data, conversion |
+| `modo/tests/sse_response.rs`      | SseResponse headers, keep-alive override              |
+| `modo/tests/sse_last_event_id.rs` | LastEventId extractor with/without header             |
+| `modo/tests/sse_channel.rs`       | channel() send/receive, disconnect cleanup            |
+| `modo/tests/sse_broadcast.rs`     | SseBroadcastManager subscribe/send/cleanup            |
+| `modo/tests/sse_stream_ext.rs`    | SseStreamExt sse_json, sse_map                        |
 
 ### Example 1: SSE Dashboard
 
-| File | Purpose |
-|------|---------|
-| `examples/sse-dashboard/Cargo.toml` | Dependencies |
-| `examples/sse-dashboard/src/main.rs` | Fake server monitoring with HTMX SSE |
-| `examples/sse-dashboard/config/development.yaml` | Server config |
-| `examples/sse-dashboard/templates/layouts/base.html` | Base layout with HTMX |
-| `examples/sse-dashboard/templates/pages/dashboard.html` | Dashboard page |
-| `examples/sse-dashboard/templates/partials/status_card.html` | Status card partial |
+| File                                                         | Purpose                              |
+| ------------------------------------------------------------ | ------------------------------------ |
+| `examples/sse-dashboard/Cargo.toml`                          | Dependencies                         |
+| `examples/sse-dashboard/src/main.rs`                         | Fake server monitoring with HTMX SSE |
+| `examples/sse-dashboard/config/development.yaml`             | Server config                        |
+| `examples/sse-dashboard/templates/layouts/base.html`         | Base layout with HTMX                |
+| `examples/sse-dashboard/templates/pages/dashboard.html`      | Dashboard page                       |
+| `examples/sse-dashboard/templates/partials/status_card.html` | Status card partial                  |
 
 ### Example 2: SSE Chat
 
-| File | Purpose |
-|------|---------|
-| `examples/sse-chat/Cargo.toml` | Dependencies (modo, modo-db, modo-session) |
-| `examples/sse-chat/src/main.rs` | Chat app with rooms, DB messages, session auth |
-| `examples/sse-chat/config/development.yaml` | Server + DB config |
-| `examples/sse-chat/templates/layouts/base.html` | Base layout with HTMX |
-| `examples/sse-chat/templates/pages/login.html` | Username entry page |
-| `examples/sse-chat/templates/pages/rooms.html` | Room list page |
-| `examples/sse-chat/templates/pages/chat.html` | Chat room page (last 50 messages + SSE) |
-| `examples/sse-chat/templates/partials/message.html` | Single message bubble partial |
+| File                                                | Purpose                                        |
+| --------------------------------------------------- | ---------------------------------------------- |
+| `examples/sse-chat/Cargo.toml`                      | Dependencies (modo, modo-db, modo-session)     |
+| `examples/sse-chat/src/main.rs`                     | Chat app with rooms, DB messages, session auth |
+| `examples/sse-chat/config/development.yaml`         | Server + DB config                             |
+| `examples/sse-chat/templates/layouts/base.html`     | Base layout with HTMX                          |
+| `examples/sse-chat/templates/pages/login.html`      | Username entry page                            |
+| `examples/sse-chat/templates/pages/rooms.html`      | Room list page                                 |
+| `examples/sse-chat/templates/pages/chat.html`       | Chat room page (last 50 messages + SSE)        |
+| `examples/sse-chat/templates/partials/message.html` | Single message bubble partial                  |
 
 ---
 
@@ -78,6 +78,7 @@
 ### Task 1: SseConfig
 
 **Files:**
+
 - Create: `modo/src/sse/config.rs`
 - Test: `modo/tests/sse_config.rs`
 
@@ -117,7 +118,7 @@ Expected: FAIL — module `sse` not found
 
 - [ ] **Step 3: Create SseConfig with minimal module structure**
 
-```rust
+````rust
 // modo/src/sse/config.rs
 use serde::Deserialize;
 use std::time::Duration;
@@ -169,7 +170,7 @@ impl SseConfig {
         Duration::from_secs(self.keep_alive_interval_secs)
     }
 }
-```
+````
 
 ```rust
 // modo/src/sse/mod.rs
@@ -179,12 +180,14 @@ pub use config::SseConfig;
 ```
 
 Add to `modo/src/lib.rs` (after the `templates` module, keeping alphabetical order):
+
 ```rust
 #[cfg(feature = "sse")]
 pub mod sse;
 ```
 
 Add to `modo/Cargo.toml` features section:
+
 ```toml
 sse = ["dep:futures-util"]
 ```
@@ -208,6 +211,7 @@ git commit -m "feat(sse): add SseConfig with keep-alive interval"
 ### Task 2: SseEvent builder
 
 **Files:**
+
 - Create: `modo/src/sse/event.rs`
 - Modify: `modo/src/sse/mod.rs`
 - Test: `modo/tests/sse_event.rs`
@@ -296,7 +300,7 @@ Expected: FAIL — `SseEvent` not found
 
 - [ ] **Step 3: Implement SseEvent**
 
-```rust
+````rust
 // modo/src/sse/event.rs
 use crate::error::Error;
 use serde::Serialize;
@@ -460,9 +464,10 @@ impl TryFrom<SseEvent> for axum::response::sse::Event {
         Ok(event)
     }
 }
-```
+````
 
 Update `modo/src/sse/mod.rs`:
+
 ```rust
 pub mod config;
 pub mod event;
@@ -488,6 +493,7 @@ git commit -m "feat(sse): add SseEvent builder with data/json/html/id/retry"
 ### Task 3: SseResponse + from_stream
 
 **Files:**
+
 - Create: `modo/src/sse/response.rs`
 - Modify: `modo/src/sse/mod.rs`
 - Test: `modo/tests/sse_response.rs`
@@ -537,7 +543,7 @@ Expected: FAIL — `SseResponse` and `from_stream` not found
 
 - [ ] **Step 3: Implement SseResponse and from_stream**
 
-```rust
+````rust
 // modo/src/sse/response.rs
 use super::event::SseEvent;
 use crate::error::Error;
@@ -656,9 +662,10 @@ where
     });
     SseResponse::new(mapped)
 }
-```
+````
 
 Update `modo/src/sse/mod.rs`:
+
 ```rust
 pub mod config;
 pub mod event;
@@ -693,6 +700,7 @@ git commit -m "feat(sse): add SseResponse wrapper and from_stream entry point"
 ### Task 4: SseSender + channel()
 
 **Files:**
+
 - Create: `modo/src/sse/sender.rs`
 - Modify: `modo/src/sse/mod.rs`
 - Test: `modo/tests/sse_channel.rs`
@@ -760,7 +768,7 @@ Expected: FAIL — `channel` not found
 
 - [ ] **Step 3: Implement SseSender and channel()**
 
-```rust
+````rust
 // modo/src/sse/sender.rs
 use super::event::SseEvent;
 use super::response::SseResponse;
@@ -869,9 +877,10 @@ where
     let stream = ReceiverStream { rx };
     super::response::from_stream(stream)
 }
-```
+````
 
 Update `modo/src/sse/mod.rs`:
+
 ```rust
 pub mod config;
 pub mod event;
@@ -901,6 +910,7 @@ git commit -m "feat(sse): add SseSender and channel() entry point"
 ### Task 5: LastEventId extractor
 
 **Files:**
+
 - Create: `modo/src/sse/last_event_id.rs`
 - Modify: `modo/src/sse/mod.rs`
 - Test: `modo/tests/sse_last_event_id.rs`
@@ -962,7 +972,7 @@ Expected: FAIL — `LastEventId` not found
 
 - [ ] **Step 3: Implement LastEventId**
 
-```rust
+````rust
 // modo/src/sse/last_event_id.rs
 use axum::extract::FromRequestParts;
 use http::request::Parts;
@@ -1021,9 +1031,10 @@ where
         Ok(LastEventId(value))
     }
 }
-```
+````
 
 Update `modo/src/sse/mod.rs`:
+
 ```rust
 pub mod config;
 pub mod event;
@@ -1057,6 +1068,7 @@ git commit -m "feat(sse): add LastEventId extractor for reconnection"
 ### Task 6: SseStream and SseBroadcastManager
 
 **Files:**
+
 - Create: `modo/src/sse/broadcast.rs`
 - Modify: `modo/src/sse/mod.rs`
 - Test: `modo/tests/sse_broadcast.rs`
@@ -1166,7 +1178,7 @@ Expected: FAIL — `SseBroadcastManager` not found
 
 - [ ] **Step 3: Implement SseBroadcastManager and SseStream**
 
-```rust
+````rust
 // modo/src/sse/broadcast.rs
 use crate::error::Error;
 use futures_util::Stream;
@@ -1367,9 +1379,10 @@ impl<T> Stream for SseStream<T> {
         self.inner.as_mut().poll_next(cx)
     }
 }
-```
+````
 
 Update `modo/src/sse/mod.rs`:
+
 ```rust
 pub mod broadcast;
 pub mod config;
@@ -1405,6 +1418,7 @@ git commit -m "feat(sse): add SseBroadcastManager and SseStream"
 ### Task 7: SseStreamExt trait
 
 **Files:**
+
 - Create: `modo/src/sse/stream_ext.rs`
 - Modify: `modo/src/sse/mod.rs`
 - Test: `modo/tests/sse_stream_ext.rs`
@@ -1483,7 +1497,7 @@ Expected: FAIL — `SseStreamExt` not found
 
 - [ ] **Step 3: Implement SseStreamExt**
 
-```rust
+````rust
 // modo/src/sse/stream_ext.rs
 use super::event::SseEvent;
 use crate::error::Error;
@@ -1585,9 +1599,10 @@ where
     E: Into<Error>,
 {
 }
-```
+````
 
 Update `modo/src/sse/mod.rs`:
+
 ```rust
 pub mod broadcast;
 pub mod config;
@@ -1623,6 +1638,7 @@ git commit -m "feat(sse): add SseStreamExt trait (sse_json, sse_map, sse_event)"
 ### Task 8: Core integration
 
 **Files:**
+
 - Modify: `modo/Cargo.toml`
 - Modify: `modo/src/config.rs`
 - Modify: `modo/src/app.rs`
@@ -1655,11 +1671,13 @@ self.services.insert(
 - [ ] **Step 3: Verify feature flag and lib.rs re-exports**
 
 Verify `modo/Cargo.toml` has:
+
 ```toml
 sse = ["dep:futures-util"]
 ```
 
 Verify `modo/src/lib.rs` has (in alphabetical position among other modules):
+
 ```rust
 #[cfg(feature = "sse")]
 pub mod sse;
@@ -1692,13 +1710,14 @@ git commit -m "feat(sse): integrate SseConfig into AppConfig and AppBuilder"
 ### Task 9: Module documentation
 
 **Files:**
+
 - Modify: `modo/src/sse/mod.rs`
 
 - [ ] **Step 1: Add comprehensive module-level documentation**
 
 Replace the `mod.rs` content with full docs + re-exports:
 
-```rust
+````rust
 // modo/src/sse/mod.rs
 
 //! Server-Sent Events (SSE) support for modo.
@@ -1829,7 +1848,7 @@ pub use last_event_id::LastEventId;
 pub use response::{SseResponse, from_stream};
 pub use sender::{SseSender, channel};
 pub use stream_ext::SseStreamExt;
-```
+````
 
 - [ ] **Step 2: Run full check**
 
@@ -1852,6 +1871,7 @@ git commit -m "docs(sse): add comprehensive module documentation"
 Fake server monitoring dashboard. A background task generates random status events for multiple services. The HTMX frontend receives HTML partial updates via SSE.
 
 **Files:**
+
 - Create: `examples/sse-dashboard/Cargo.toml`
 - Create: `examples/sse-dashboard/src/main.rs`
 - Create: `examples/sse-dashboard/config/development.yaml`
@@ -1890,12 +1910,12 @@ In root `Cargo.toml`, add `"examples/sse-dashboard"` to the `members` array.
 ```yaml
 # examples/sse-dashboard/config/development.yaml
 server:
-  port: 3002
-  secret_key: ${SECRET_KEY:-sse-dashboard-dev-secret-key-change-in-prod-please}
-  http:
-    request_timeout: 3600
+    port: 3002
+    secret_key: ${SECRET_KEY:-sse-dashboard-dev-secret-key-change-in-prod-please}
+    http:
+        request_timeout: 3600
 templates:
-  path: templates
+    path: templates
 ```
 
 - [ ] **Step 4: Create base layout template**
@@ -1904,50 +1924,97 @@ templates:
 {# examples/sse-dashboard/templates/layouts/base.html #}
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}SSE Dashboard{% endblock %}</title>
-    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
-    <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; padding: 2rem; }
-        h1 { margin-bottom: 1.5rem; font-size: 1.5rem; }
-        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
-        .card { background: #1e293b; border-radius: 0.5rem; padding: 1.25rem; border-left: 4px solid #475569; }
-        .card.up { border-left-color: #22c55e; }
-        .card.down { border-left-color: #ef4444; }
-        .card.degraded { border-left-color: #f59e0b; }
-        .card h2 { font-size: 1rem; margin-bottom: 0.75rem; }
-        .card .status { font-size: 0.875rem; font-weight: 600; text-transform: uppercase; }
-        .card .status.up { color: #22c55e; }
-        .card .status.down { color: #ef4444; }
-        .card .status.degraded { color: #f59e0b; }
-        .card .metrics { display: flex; gap: 1rem; margin-top: 0.75rem; font-size: 0.8rem; color: #94a3b8; }
-        .card .metric span { font-weight: 600; color: #e2e8f0; }
-        .connected { color: #22c55e; font-size: 0.8rem; margin-bottom: 1rem; }
-    </style>
-</head>
-<body>
-    {% block content %}{% endblock %}
-</body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{% block title %}SSE Dashboard{% endblock %}</title>
+        <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+        <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
+        <style>
+            * {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+            body {
+                font-family: system-ui, sans-serif;
+                background: #0f172a;
+                color: #e2e8f0;
+                padding: 2rem;
+            }
+            h1 {
+                margin-bottom: 1.5rem;
+                font-size: 1.5rem;
+            }
+            .grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+                gap: 1rem;
+            }
+            .card {
+                background: #1e293b;
+                border-radius: 0.5rem;
+                padding: 1.25rem;
+                border-left: 4px solid #475569;
+            }
+            .card.up {
+                border-left-color: #22c55e;
+            }
+            .card.down {
+                border-left-color: #ef4444;
+            }
+            .card.degraded {
+                border-left-color: #f59e0b;
+            }
+            .card h2 {
+                font-size: 1rem;
+                margin-bottom: 0.75rem;
+            }
+            .card .status {
+                font-size: 0.875rem;
+                font-weight: 600;
+                text-transform: uppercase;
+            }
+            .card .status.up {
+                color: #22c55e;
+            }
+            .card .status.down {
+                color: #ef4444;
+            }
+            .card .status.degraded {
+                color: #f59e0b;
+            }
+            .card .metrics {
+                display: flex;
+                gap: 1rem;
+                margin-top: 0.75rem;
+                font-size: 0.8rem;
+                color: #94a3b8;
+            }
+            .card .metric span {
+                font-weight: 600;
+                color: #e2e8f0;
+            }
+            .connected {
+                color: #22c55e;
+                font-size: 0.8rem;
+                margin-bottom: 1rem;
+            }
+        </style>
+    </head>
+    <body>
+        {% block content %}{% endblock %}
+    </body>
 </html>
 ```
 
 - [ ] **Step 5: Create dashboard page template**
 
 ```html
-{# examples/sse-dashboard/templates/pages/dashboard.html #}
-{% extends "layouts/base.html" %}
-{% block content %}
+{# examples/sse-dashboard/templates/pages/dashboard.html #} {% extends "layouts/base.html" %} {% block content %}
 <h1>Server Status Dashboard</h1>
 <p class="connected">Live — updates via SSE</p>
-<div class="grid"
-     hx-ext="sse"
-     sse-connect="/events"
-     sse-swap="status_update"
-     hx-swap="innerHTML">
+<div class="grid" hx-ext="sse" sse-connect="/events" sse-swap="status_update" hx-swap="innerHTML">
     <p style="color: #94a3b8;">Waiting for data...</p>
 </div>
 {% endblock %}
@@ -1956,8 +2023,7 @@ templates:
 - [ ] **Step 6: Create status card partial template**
 
 ```html
-{# examples/sse-dashboard/templates/partials/status_card.html #}
-{% for server in servers %}
+{# examples/sse-dashboard/templates/partials/status_card.html #} {% for server in servers %}
 <div class="card {{ server.status }}">
     <h2>{{ server.name }}</h2>
     <div class="status {{ server.status }}">{{ server.status }}</div>
@@ -2112,6 +2178,7 @@ git commit -m "feat: add SSE dashboard example with HTMX and fake server monitor
 Chat application with rooms, session-based username, SQLite message storage, and SSE delivery of HTML partials.
 
 **Files:**
+
 - Create: `examples/sse-chat/Cargo.toml`
 - Create: `examples/sse-chat/src/main.rs`
 - Create: `examples/sse-chat/config/development.yaml`
@@ -2153,16 +2220,16 @@ In root `Cargo.toml`, add `"examples/sse-chat"` to the `members` array.
 ```yaml
 # examples/sse-chat/config/development.yaml
 server:
-  port: 3003
-  secret_key: ${SECRET_KEY:-sse-chat-dev-secret-key-change-in-production-please}
-  http:
-    request_timeout: 3600
+    port: 3003
+    secret_key: ${SECRET_KEY:-sse-chat-dev-secret-key-change-in-production-please}
+    http:
+        request_timeout: 3600
 templates:
-  path: templates
+    path: templates
 database:
-  url: ${DATABASE_URL:-sqlite://chat.db?mode=rwc}
-  max_connections: 5
-  min_connections: 1
+    url: ${DATABASE_URL:-sqlite://chat.db?mode=rwc}
+    max_connections: 5
+    min_connections: 1
 ```
 
 - [ ] **Step 4: Create base layout template**
@@ -2171,60 +2238,161 @@ database:
 {# examples/sse-chat/templates/layouts/base.html #}
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}SSE Chat{% endblock %}</title>
-    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
-    <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
-    <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; }
-        .container { max-width: 800px; margin: 0 auto; padding: 2rem; }
-        h1 { margin-bottom: 1rem; }
-        a { color: #2563eb; }
-        .form-group { margin-bottom: 1rem; }
-        label { display: block; margin-bottom: 0.25rem; font-weight: 600; font-size: 0.875rem; }
-        input[type="text"] { width: 100%; padding: 0.5rem; border: 1px solid #cbd5e1; border-radius: 0.375rem; font-size: 1rem; }
-        button { padding: 0.5rem 1rem; background: #2563eb; color: white; border: none; border-radius: 0.375rem; cursor: pointer; font-size: 0.875rem; }
-        button:hover { background: #1d4ed8; }
-        .rooms-list { list-style: none; }
-        .rooms-list li { margin-bottom: 0.5rem; }
-        .rooms-list a { display: block; padding: 0.75rem 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem; text-decoration: none; color: #1e293b; }
-        .rooms-list a:hover { background: #f1f5f9; }
-        .chat-container { display: flex; flex-direction: column; height: calc(100vh - 10rem); }
-        .messages { flex: 1; overflow-y: auto; padding: 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem 0.375rem 0 0; }
-        .message { margin-bottom: 0.75rem; }
-        .message .meta { font-size: 0.75rem; color: #64748b; margin-bottom: 0.125rem; }
-        .message .meta .username { font-weight: 600; color: #1e293b; }
-        .message .text { font-size: 0.9rem; }
-        .message-form { display: flex; gap: 0.5rem; padding: 0.75rem; background: white; border: 1px solid #e2e8f0; border-top: none; border-radius: 0 0 0.375rem 0.375rem; }
-        .message-form input { flex: 1; }
-        .nav { display: flex; gap: 1rem; align-items: center; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid #e2e8f0; }
-        .nav .user { margin-left: auto; font-size: 0.875rem; color: #64748b; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        {% block content %}{% endblock %}
-    </div>
-    {% block scripts %}{% endblock %}
-</body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{% block title %}SSE Chat{% endblock %}</title>
+        <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+        <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
+        <style>
+            * {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+            body {
+                font-family: system-ui, sans-serif;
+                background: #f8fafc;
+                color: #1e293b;
+            }
+            .container {
+                max-width: 800px;
+                margin: 0 auto;
+                padding: 2rem;
+            }
+            h1 {
+                margin-bottom: 1rem;
+            }
+            a {
+                color: #2563eb;
+            }
+            .form-group {
+                margin-bottom: 1rem;
+            }
+            label {
+                display: block;
+                margin-bottom: 0.25rem;
+                font-weight: 600;
+                font-size: 0.875rem;
+            }
+            input[type="text"] {
+                width: 100%;
+                padding: 0.5rem;
+                border: 1px solid #cbd5e1;
+                border-radius: 0.375rem;
+                font-size: 1rem;
+            }
+            button {
+                padding: 0.5rem 1rem;
+                background: #2563eb;
+                color: white;
+                border: none;
+                border-radius: 0.375rem;
+                cursor: pointer;
+                font-size: 0.875rem;
+            }
+            button:hover {
+                background: #1d4ed8;
+            }
+            .rooms-list {
+                list-style: none;
+            }
+            .rooms-list li {
+                margin-bottom: 0.5rem;
+            }
+            .rooms-list a {
+                display: block;
+                padding: 0.75rem 1rem;
+                background: white;
+                border: 1px solid #e2e8f0;
+                border-radius: 0.375rem;
+                text-decoration: none;
+                color: #1e293b;
+            }
+            .rooms-list a:hover {
+                background: #f1f5f9;
+            }
+            .chat-container {
+                display: flex;
+                flex-direction: column;
+                height: calc(100vh - 10rem);
+            }
+            .messages {
+                flex: 1;
+                overflow-y: auto;
+                padding: 1rem;
+                background: white;
+                border: 1px solid #e2e8f0;
+                border-radius: 0.375rem 0.375rem 0 0;
+            }
+            .message {
+                margin-bottom: 0.75rem;
+            }
+            .message .meta {
+                font-size: 0.75rem;
+                color: #64748b;
+                margin-bottom: 0.125rem;
+            }
+            .message .meta .username {
+                font-weight: 600;
+                color: #1e293b;
+            }
+            .message .text {
+                font-size: 0.9rem;
+            }
+            .message-form {
+                display: flex;
+                gap: 0.5rem;
+                padding: 0.75rem;
+                background: white;
+                border: 1px solid #e2e8f0;
+                border-top: none;
+                border-radius: 0 0 0.375rem 0.375rem;
+            }
+            .message-form input {
+                flex: 1;
+            }
+            .nav {
+                display: flex;
+                gap: 1rem;
+                align-items: center;
+                margin-bottom: 1.5rem;
+                padding-bottom: 1rem;
+                border-bottom: 1px solid #e2e8f0;
+            }
+            .nav .user {
+                margin-left: auto;
+                font-size: 0.875rem;
+                color: #64748b;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">{% block content %}{% endblock %}</div>
+        {% block scripts %}{% endblock %}
+    </body>
 </html>
 ```
 
 - [ ] **Step 5: Create login page template**
 
 ```html
-{# examples/sse-chat/templates/pages/login.html #}
-{% extends "layouts/base.html" %}
-{% block title %}Login — SSE Chat{% endblock %}
-{% block content %}
+{# examples/sse-chat/templates/pages/login.html #} {% extends "layouts/base.html" %} {% block title %}Login — SSE Chat{%
+endblock %} {% block content %}
 <h1>Enter your username</h1>
 <form method="POST" action="/login">
     <div class="form-group">
         <label for="username">Username</label>
-        <input type="text" id="username" name="username" placeholder="Your name" required minlength="2" maxlength="30" autofocus>
+        <input
+            type="text"
+            id="username"
+            name="username"
+            placeholder="Your name"
+            required
+            minlength="2"
+            maxlength="30"
+            autofocus
+        />
     </div>
     <button type="submit">Join Chat</button>
 </form>
@@ -2234,10 +2402,8 @@ database:
 - [ ] **Step 6: Create rooms page template**
 
 ```html
-{# examples/sse-chat/templates/pages/rooms.html #}
-{% extends "layouts/base.html" %}
-{% block title %}Rooms — SSE Chat{% endblock %}
-{% block content %}
+{# examples/sse-chat/templates/pages/rooms.html #} {% extends "layouts/base.html" %} {% block title %}Rooms — SSE Chat{%
+endblock %} {% block content %}
 <div class="nav">
     <h1>Chat Rooms</h1>
     <span class="user">Logged in as <strong>{{ username }}</strong> · <a href="/logout">Logout</a></span>
@@ -2253,35 +2419,33 @@ database:
 - [ ] **Step 7: Create chat page template**
 
 ```html
-{# examples/sse-chat/templates/pages/chat.html #}
-{% extends "layouts/base.html" %}
-{% block title %}{{ room }} — SSE Chat{% endblock %}
-{% block content %}
+{# examples/sse-chat/templates/pages/chat.html #} {% extends "layouts/base.html" %} {% block title %}{{ room }} — SSE
+Chat{% endblock %} {% block content %}
 <div class="nav">
     <a href="/rooms">&larr; Rooms</a>
     <h1>{{ room }}</h1>
     <span class="user">{{ username }}</span>
 </div>
 <div class="chat-container">
-    <div class="messages" id="messages"
-         hx-ext="sse"
-         sse-connect="/chat/{{ room }}/events"
-         sse-swap="message"
-         hx-swap="beforeend">
-        {% for msg in messages %}
-        {{ msg }}
-        {% endfor %}
+    <div
+        class="messages"
+        id="messages"
+        hx-ext="sse"
+        sse-connect="/chat/{{ room }}/events"
+        sse-swap="message"
+        hx-swap="beforeend"
+    >
+        {% for msg in messages %} {{ msg }} {% endfor %}
     </div>
     <form class="message-form" hx-post="/chat/{{ room }}/send" hx-swap="none" hx-on::after-request="this.reset()">
-        <input type="text" name="text" placeholder="Type a message..." required autocomplete="off" autofocus>
+        <input type="text" name="text" placeholder="Type a message..." required autocomplete="off" autofocus />
         <button type="submit">Send</button>
     </form>
 </div>
-{% endblock %}
-{% block scripts %}
+{% endblock %} {% block scripts %}
 <script>
     // Auto-scroll to bottom on new messages
-    const messages = document.getElementById('messages');
+    const messages = document.getElementById("messages");
     const observer = new MutationObserver(() => {
         messages.scrollTop = messages.scrollHeight;
     });

--- a/docs/superpowers/specs/2026-03-11-sse-design.md
+++ b/docs/superpowers/specs/2026-03-11-sse-design.md
@@ -92,6 +92,35 @@ impl SseConfig {
 
 Uses `u64` seconds (not `Duration`) for YAML deserialization, matching the pattern used by `CsrfConfig.cookie_max_age`.
 
+### `LastEventId`
+
+Extractor for the `Last-Event-ID` header sent by the browser's `EventSource` on reconnection. Follows modo's extractor pattern (like `Auth<User>`, `Tenant<T>`).
+
+```rust
+/// Extracts the `Last-Event-ID` header from the request.
+/// Contains `None` on first connection (header absent).
+pub struct LastEventId(pub Option<String>);
+```
+
+Implements `FromRequestParts` — extracts the raw header value as a `String`. No parsing or validation (event IDs are application-defined, could be ULIDs, sequence numbers, timestamps, etc.).
+
+Usage:
+
+```rust
+#[modo::handler(GET, "/chat/{id}/events")]
+async fn chat_stream(
+    id: String,
+    last_event_id: LastEventId,
+    Service(chat): Service<SseBroadcastManager<String, ChatMessage>>,
+) -> SseResponse {
+    let mut stream = chat.subscribe(&id);
+    if let Some(last_id) = last_event_id.0 {
+        // Application logic: replay missed events from storage
+    }
+    modo::sse::from_stream(stream.sse_map(|msg| Ok(SseEvent::from(msg))))
+}
+```
+
 ### `SseSender`
 
 Channel sender for imperative message production within a `modo::sse::channel()` closure.
@@ -236,7 +265,7 @@ pub mod sse;
 
 Public items from `modo::sse`:
 - `SseEvent`, `SseResponse`, `SseConfig`
-- `SseSender`
+- `SseSender`, `LastEventId`
 - `SseBroadcastManager`, `SseStream`
 - `SseStreamExt` (trait)
 - `from_stream`, `channel`
@@ -258,6 +287,7 @@ modo/src/sse/
 ├── config.rs           # SseConfig
 ├── sender.rs           # SseSender for channel()
 ├── broadcast.rs        # SseBroadcastManager<K, T>, SseStream<T>
+├── last_event_id.rs    # LastEventId extractor
 └── stream_ext.rs       # SseStreamExt trait
 ```
 
@@ -275,7 +305,7 @@ This interaction should be documented prominently in the module docs.
 
 ### `Last-Event-ID` reconnection flow
 
-When a client reconnects after a disconnect, the browser's `EventSource` sends a `Last-Event-ID` header with the last received event ID. Handlers can read this via `axum::TypedHeader<headers::LastEventId>` (or raw header extraction) to replay missed events. The SSE module does NOT handle replay automatically — this is application logic.
+When a client reconnects after a disconnect, the browser's `EventSource` sends a `Last-Event-ID` header with the last received event ID. Handlers can read this via the `LastEventId` extractor to replay missed events. The SSE module does NOT handle replay automatically — replay logic (e.g., fetching missed messages from a database) is application responsibility.
 
 ## Documentation Requirements
 

--- a/docs/superpowers/specs/2026-03-11-sse-design.md
+++ b/docs/superpowers/specs/2026-03-11-sse-design.md
@@ -33,7 +33,7 @@ No new external crates. The `sse` feature activates `dep:futures-util` (already 
 - `axum::response::sse` — built-in SSE response types (requires axum's `"json"` feature for `Event::json_data()`, which is enabled by axum's default features and already active in modo)
 - `tokio::sync::broadcast` — multi-producer, multi-consumer channels (for `SseBroadcastManager`)
 - `tokio::sync::mpsc` — single-producer channel (for `SseSender` in `channel()`)
-- `tokio::sync::RwLock` — concurrent access to channel registry
+- `std::sync::RwLock` — concurrent access to channel registry (safe in async context for brief HashMap ops)
 - `futures-util` — `Stream` trait and combinators
 
 ## Types

--- a/docs/superpowers/specs/2026-03-11-sse-design.md
+++ b/docs/superpowers/specs/2026-03-11-sse-design.md
@@ -28,18 +28,19 @@ Add Server-Sent Events support to the `modo` core crate as an opt-in feature fla
 
 ## Dependencies
 
-No new external crates required:
+No new external crates. The `sse` feature activates `dep:futures-util` (already an optional dep used by `templates` and `i18n`):
 
-- `axum::response::sse` — built-in SSE response types
-- `tokio::sync::broadcast` — multi-producer, multi-consumer channels
+- `axum::response::sse` — built-in SSE response types (requires axum's `"json"` feature for `Event::json_data()`, which is enabled by axum's default features and already active in modo)
+- `tokio::sync::broadcast` — multi-producer, multi-consumer channels (for `SseBroadcastManager`)
+- `tokio::sync::mpsc` — single-producer channel (for `SseSender` in `channel()`)
 - `tokio::sync::RwLock` — concurrent access to channel registry
-- `futures-util` — `Stream` trait and combinators (already a dependency)
+- `futures-util` — `Stream` trait and combinators
 
 ## Types
 
 ### `SseEvent`
 
-Builder for a single SSE event. Wraps `axum::response::sse::Event`.
+Builder for a single SSE event. Wraps `axum::response::sse::Event`. Annotated with `#[must_use]` to catch unchained builder calls.
 
 ```rust
 SseEvent::new()
@@ -48,7 +49,7 @@ SseEvent::new()
     .json(&my_struct)?                   // JSON-serialized payload (mutually exclusive with .data/.html)
     .html("<div>fragment</div>")         // HTML fragment payload (mutually exclusive with .data/.json)
     .id("evt-123")                       // last-event-id for reconnection (optional)
-    .retry(Duration::from_secs(5))       // client reconnect hint (optional)
+    .retry(Duration::from_secs(5))       // client reconnect hint (serialized as milliseconds per SSE spec)
 ```
 
 - `.data()`, `.json()`, `.html()` are mutually exclusive — each sets the data payload
@@ -61,56 +62,76 @@ Handler return type. Wraps `axum::response::sse::Sse<S>` with automatic keep-ali
 
 Implements `IntoResponse` so handlers can return it directly.
 
+Keep-alive interval is read from `SseConfig` at construction time. If no config is available, uses the hardcoded default (15 seconds). An `.with_keep_alive(interval)` method on `SseResponse` allows per-handler override.
+
 ### `SseConfig`
 
-Optional YAML-deserializable configuration. Auto-registered in `AppBuilder::run()`.
+Optional YAML-deserializable configuration. Added as a field on `AppConfig` (gated with `#[cfg(feature = "sse")]`), auto-registered as a service in `AppBuilder::run()`.
 
 ```yaml
 sse:
-  keep_alive_interval: 15s   # default: 15 seconds
+  keep_alive_interval_secs: 15   # default: 15 seconds
 ```
 
 ```rust
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct SseConfig {
-    #[serde(default = "default_keep_alive_interval")]
-    pub keep_alive_interval: Duration,  // default: 15s
+    /// Keep-alive interval in seconds. Converted to `Duration` internally.
+    /// Default: 15 seconds.
+    #[serde(default = "default_keep_alive_interval_secs")]
+    pub keep_alive_interval_secs: u64,
+}
+
+impl SseConfig {
+    pub fn keep_alive_interval(&self) -> Duration {
+        Duration::from_secs(self.keep_alive_interval_secs)
+    }
 }
 ```
+
+Uses `u64` seconds (not `Duration`) for YAML deserialization, matching the pattern used by `CsrfConfig.cookie_max_age`.
 
 ### `SseSender`
 
 Channel sender for imperative message production within a `modo::sse::channel()` closure.
 
+Backed by `tokio::sync::mpsc::Sender<SseEvent>`. The receiver end is held by the `SseResponse` stream. When the client disconnects, axum drops the response body, which drops the receiver. Subsequent `send()` calls return `Err` immediately.
+
 ```rust
 impl SseSender {
+    /// Send an event to the connected client.
+    ///
+    /// # Errors
+    /// Returns an error if the client has disconnected (receiver dropped).
     async fn send(&self, event: SseEvent) -> Result<(), Error>;
 }
 ```
 
-Returns an error if the client has disconnected — no sending into the void.
-
 ### `SseBroadcastManager<K, T>`
 
-Registry of keyed broadcast channels. One manager per domain concept, registered as a service.
+Registry of keyed broadcast channels. One manager per domain concept, registered as a service via `app.service(manager)` (the service registry handles `Arc` wrapping — do not wrap in `Arc` yourself).
 
 ```rust
 impl<K, T> SseBroadcastManager<K, T>
 where
     K: Hash + Eq + Clone + Send + Sync + 'static,
-    T: Into<SseEvent> + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
 {
     /// Create a new manager with the given per-channel buffer size.
     fn new(buffer: usize) -> Self;
 
     /// Subscribe to a keyed channel.
     /// Creates the channel lazily on first subscription.
+    /// Returns a stream of raw `T` values (not yet converted to `SseEvent`).
     fn subscribe(&self, key: &K) -> SseStream<T>;
 
     /// Send an event to all subscribers of a keyed channel.
     /// Returns the number of receivers that got the message.
     /// Returns Ok(0) if no subscribers exist for the key.
+    ///
+    /// **Does NOT create a channel** — only `subscribe()` creates channels lazily.
+    /// Sending to a nonexistent key is a silent no-op returning Ok(0).
     fn send(&self, key: &K, event: T) -> Result<usize, Error>;
 
     /// Number of active subscribers for a key.
@@ -122,11 +143,13 @@ where
 }
 ```
 
-**Internals:** `Arc<RwLock<HashMap<K, broadcast::Sender<T>>>>`. Channels created lazily on first `subscribe()`. Auto-removed when the last subscriber's `SseStream` is dropped (detected via `broadcast::Sender::receiver_count() == 0` on next operation, or a background cleanup).
+**Internals:** `Arc<RwLock<HashMap<K, broadcast::Sender<T>>>>`. Channels created lazily on first `subscribe()`. Auto-cleanup strategy: on each `send()` or `subscribe()` call, prune channels where `broadcast::Sender::receiver_count() == 0`. This means the map may briefly hold empty entries between operations, which is harmless.
 
 ### `SseStream<T>`
 
-Wraps `broadcast::Receiver<T>`, implements `Stream<Item = Result<SseEvent, Error>>`. Converts `T` to `SseEvent` via `Into<SseEvent>` on each poll.
+Wraps `broadcast::Receiver<T>`, implements `Stream<Item = Result<T, Error>>`.
+
+**Important:** `SseStream<T>` yields raw `T` values, NOT `SseEvent`. The `Into<SseEvent>` conversion happens downstream — either in `from_stream()` or via `SseStreamExt` combinators. This allows handlers to filter and map on the original domain type before conversion.
 
 Handles `RecvError::Lagged` gracefully — logs a warning and continues (slow consumers skip missed messages rather than disconnecting).
 
@@ -141,7 +164,9 @@ where
     E: Into<Error>,
 ```
 
-Main entry point. Wraps any stream as an SSE response with auto keep-alive.
+Main entry point. Wraps any stream of `SseEvent`s as an SSE response with auto keep-alive.
+
+The stream must yield `Result<SseEvent, E>`. Use `SseStreamExt` combinators or `.map()` to convert domain types to `SseEvent` before passing to `from_stream`.
 
 ### `modo::sse::channel`
 
@@ -152,7 +177,9 @@ where
     Fut: Future<Output = Result<(), Error>> + Send,
 ```
 
-Spawns the closure as a tokio task, returns an `SseResponse` backed by the receiver end. When the closure returns or the client disconnects, everything cleans up.
+Spawns the closure as a tokio task, returns an `SseResponse` backed by the `mpsc::Receiver` end.
+
+**Cleanup is cooperative:** The spawned task runs until the closure returns or a `tx.send()` call fails (because the client disconnected and the receiver was dropped). Handlers producing messages in a loop should check the `send()` result and break on error. The task is NOT automatically aborted on client disconnect — it runs until it attempts to send and detects the closed channel.
 
 ## Stream Ergonomics
 
@@ -161,12 +188,16 @@ Spawns the closure as a tokio task, returns an `SseResponse` backed by the recei
 Extension trait on `Stream` for ergonomic event mapping.
 
 ```rust
-pub trait SseStreamExt: Stream {
-    /// Set event name on each item (item must impl Into<SseEvent>).
-    fn sse_event(self, name: &'static str) -> impl Stream<Item = Result<SseEvent, Error>>;
+pub trait SseStreamExt: Stream + Sized {
+    /// Set event name on each item and convert to SseEvent.
+    fn sse_event(self, name: &'static str) -> impl Stream<Item = Result<SseEvent, Error>>
+    where
+        Self::Item: Into<SseEvent>;
 
-    /// Serialize each item as JSON data.
-    fn sse_json(self) -> impl Stream<Item = Result<SseEvent, Error>>;
+    /// Serialize each item as JSON data in an SseEvent.
+    fn sse_json(self) -> impl Stream<Item = Result<SseEvent, Error>>
+    where
+        Self::Item: Serialize;
 
     /// Map each item to an SseEvent with a custom closure.
     fn sse_map<F>(self, f: F) -> impl Stream<Item = Result<SseEvent, Error>>
@@ -177,11 +208,21 @@ pub trait SseStreamExt: Stream {
 
 ## Integration with `modo` Core
 
+### `AppConfig` changes
+
+Add `SseConfig` field gated by feature flag:
+
+```rust
+#[cfg(feature = "sse")]
+#[serde(default)]
+pub sse: crate::sse::SseConfig,
+```
+
 ### `AppBuilder::run()` changes
 
 Within `#[cfg(feature = "sse")]`:
 
-1. Load `SseConfig` from app config (with defaults)
+1. Read `SseConfig` from `AppConfig` (with defaults via `#[serde(default)]`)
 2. Register `SseConfig` as a service
 
 No middleware or layers needed — SSE responses are self-contained.
@@ -204,10 +245,8 @@ Public items from `modo::sse`:
 
 ```toml
 [features]
-sse = []  # no extra deps — uses axum's built-in SSE + tokio broadcast
+sse = ["dep:futures-util"]  # futures-util already an optional dep
 ```
-
-No new dependencies. Everything needed is already in `axum` and `tokio`.
 
 ## File Structure
 
@@ -222,6 +261,22 @@ modo/src/sse/
 └── stream_ext.rs       # SseStreamExt trait
 ```
 
+## Gotchas
+
+### Request timeout layer terminates SSE connections
+
+The global `TimeoutLayer` in `AppBuilder::run()` will kill SSE connections after the configured timeout. Keep-alive events do NOT reset the timer — the timer is set at request start for the full response lifecycle.
+
+**Mitigation:** Apps using SSE should either:
+- Set a long request timeout (e.g., `http.request_timeout: 3600` for 1 hour)
+- Disable the global timeout and apply per-route timeouts to non-SSE handlers instead
+
+This interaction should be documented prominently in the module docs.
+
+### `Last-Event-ID` reconnection flow
+
+When a client reconnects after a disconnect, the browser's `EventSource` sends a `Last-Event-ID` header with the last received event ID. Handlers can read this via `axum::TypedHeader<headers::LastEventId>` (or raw header extraction) to replay missed events. The SSE module does NOT handle replay automatically — this is application logic.
+
 ## Documentation Requirements
 
 Every public type, method, and function must have:
@@ -232,6 +287,7 @@ Every public type, method, and function must have:
 - **`# Examples`** sections: Compilable doc examples for all primary APIs
 - **`# Panics`** / **`# Errors`** sections: Where applicable
 - **Cross-references**: Link related types (e.g., `SseEvent` docs reference `SseBroadcastManager`)
+- **Gotchas section** in module docs: Request timeout interaction, `Last-Event-ID` reconnection flow
 
 ## Examples
 
@@ -256,8 +312,15 @@ async fn chat_stream(
     Service(chat): Service<SseBroadcastManager<String, ChatMessage>>,
 ) -> SseResponse {
     let user_id = auth.user.id.clone();
+    // SseStream<ChatMessage> yields Result<ChatMessage, Error>,
+    // so we can filter on the raw domain type before converting
     let stream = chat.subscribe(&id)
-        .filter(move |msg| msg.sender != user_id)
+        .filter_map(move |result| {
+            match result {
+                Ok(msg) if msg.sender != user_id => Some(msg),
+                _ => None,
+            }
+        })
         .map(move |msg| {
             let html = view.render_to_string(ChatBubbleView::from(&msg))?;
             Ok(SseEvent::new().event("message").html(html))
@@ -295,7 +358,11 @@ async fn dashboard(
     tenant: Tenant<MyTenant>,
     Service(uptime): Service<SseBroadcastManager<TenantId, UptimeCheck>>,
 ) -> SseResponse {
-    modo::sse::from_stream(uptime.subscribe(&tenant.id))
+    // subscribe() yields Result<UptimeCheck, Error>,
+    // sse_map converts each to SseEvent
+    let stream = uptime.subscribe(&tenant.id)
+        .sse_map(|check| Ok(SseEvent::from(check)));
+    modo::sse::from_stream(stream)
 }
 ```
 
@@ -307,7 +374,10 @@ async fn notifications(
     auth: Auth<User>,
     Service(notif): Service<SseBroadcastManager<UserId, Notification>>,
 ) -> SseResponse {
-    modo::sse::from_stream(notif.subscribe(&auth.user.id))
+    // Using SseStreamExt to convert directly
+    modo::sse::from_stream(
+        notif.subscribe(&auth.user.id).sse_json()
+    )
 }
 ```
 
@@ -338,3 +408,4 @@ async fn job_progress(
 - **WebSocket support** — separate feature if ever needed
 - **Authentication/authorization** — use existing `Auth<User>` / `Tenant<T>` extractors
 - **Client-side library** — HTMX `hx-ext="sse"` or native `EventSource` API
+- **Automatic event replay on reconnect** — application logic using `Last-Event-ID` header

--- a/docs/superpowers/specs/2026-03-11-sse-design.md
+++ b/docs/superpowers/specs/2026-03-11-sse-design.md
@@ -1,0 +1,340 @@
+# SSE (Server-Sent Events) Feature Design
+
+**Date:** 2026-03-11
+**Status:** Approved
+**Location:** `modo/` core crate, feature = `"sse"`
+
+## Overview
+
+Add Server-Sent Events support to the `modo` core crate as an opt-in feature flag. The module provides a clean streaming primitive for real-time event delivery over HTTP, with ergonomic helpers for broadcasting to multiple clients.
+
+## Use Cases
+
+- **Support chat:** Per-conversation channels, multiple participants (user, agent, AI bot), participants can change mid-conversation
+- **Uptime monitoring dashboard:** Per-tenant broadcast, one data source to many viewers
+- **Real-time notifications:** Per-user channels, multiple tabs receive the same events
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Module location | `modo/` core crate, feature = `"sse"` | SSE is an HTTP response type, belongs with `Json`, `ViewResponse` |
+| Room/channel management | Not included | Domain logic — varies per use case |
+| Format selection | Per-handler | Each endpoint explicitly chooses JSON, HTML, or text |
+| Template rendering in SSE | Handler responsibility | SSE module is format-agnostic; handler uses `ViewRenderer::render_to_string()` |
+| Broadcast model | All subscribers of a key receive all messages | Filter on consumer side via stream combinators |
+| Global broadcast (`send_all`) | Not included | Rare in multi-tenant SaaS; YAGNI |
+| Send to specific subscriber | Not included | No compelling use case within a keyed channel |
+
+## Dependencies
+
+No new external crates required:
+
+- `axum::response::sse` — built-in SSE response types
+- `tokio::sync::broadcast` — multi-producer, multi-consumer channels
+- `tokio::sync::RwLock` — concurrent access to channel registry
+- `futures-util` — `Stream` trait and combinators (already a dependency)
+
+## Types
+
+### `SseEvent`
+
+Builder for a single SSE event. Wraps `axum::response::sse::Event`.
+
+```rust
+SseEvent::new()
+    .event("message")                    // named event type (optional)
+    .data("plain text")                  // string payload
+    .json(&my_struct)?                   // JSON-serialized payload (mutually exclusive with .data/.html)
+    .html("<div>fragment</div>")         // HTML fragment payload (mutually exclusive with .data/.json)
+    .id("evt-123")                       // last-event-id for reconnection (optional)
+    .retry(Duration::from_secs(5))       // client reconnect hint (optional)
+```
+
+- `.data()`, `.json()`, `.html()` are mutually exclusive — each sets the data payload
+- `.html()` is semantically identical to `.data()` but communicates intent; may gain escaping/wrapping behavior later
+- `.json()` is fallible (returns `Result`) because serialization can fail
+
+### `SseResponse`
+
+Handler return type. Wraps `axum::response::sse::Sse<S>` with automatic keep-alive configured from `SseConfig`.
+
+Implements `IntoResponse` so handlers can return it directly.
+
+### `SseConfig`
+
+Optional YAML-deserializable configuration. Auto-registered in `AppBuilder::run()`.
+
+```yaml
+sse:
+  keep_alive_interval: 15s   # default: 15 seconds
+```
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SseConfig {
+    #[serde(default = "default_keep_alive_interval")]
+    pub keep_alive_interval: Duration,  // default: 15s
+}
+```
+
+### `SseSender`
+
+Channel sender for imperative message production within a `modo::sse::channel()` closure.
+
+```rust
+impl SseSender {
+    async fn send(&self, event: SseEvent) -> Result<(), Error>;
+}
+```
+
+Returns an error if the client has disconnected — no sending into the void.
+
+### `SseBroadcastManager<K, T>`
+
+Registry of keyed broadcast channels. One manager per domain concept, registered as a service.
+
+```rust
+impl<K, T> SseBroadcastManager<K, T>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    T: Into<SseEvent> + Clone + Send + Sync + 'static,
+{
+    /// Create a new manager with the given per-channel buffer size.
+    fn new(buffer: usize) -> Self;
+
+    /// Subscribe to a keyed channel.
+    /// Creates the channel lazily on first subscription.
+    fn subscribe(&self, key: &K) -> SseStream<T>;
+
+    /// Send an event to all subscribers of a keyed channel.
+    /// Returns the number of receivers that got the message.
+    /// Returns Ok(0) if no subscribers exist for the key.
+    fn send(&self, key: &K, event: T) -> Result<usize, Error>;
+
+    /// Number of active subscribers for a key.
+    fn subscriber_count(&self, key: &K) -> usize;
+
+    /// Manually remove a channel. Typically not needed — channels
+    /// auto-cleanup when the last subscriber drops.
+    fn remove(&self, key: &K);
+}
+```
+
+**Internals:** `Arc<RwLock<HashMap<K, broadcast::Sender<T>>>>`. Channels created lazily on first `subscribe()`. Auto-removed when the last subscriber's `SseStream` is dropped (detected via `broadcast::Sender::receiver_count() == 0` on next operation, or a background cleanup).
+
+### `SseStream<T>`
+
+Wraps `broadcast::Receiver<T>`, implements `Stream<Item = Result<SseEvent, Error>>`. Converts `T` to `SseEvent` via `Into<SseEvent>` on each poll.
+
+Handles `RecvError::Lagged` gracefully — logs a warning and continues (slow consumers skip missed messages rather than disconnecting).
+
+## Entry Points
+
+### `modo::sse::from_stream`
+
+```rust
+pub fn from_stream<S, E>(stream: S) -> SseResponse
+where
+    S: Stream<Item = Result<SseEvent, E>> + Send + 'static,
+    E: Into<Error>,
+```
+
+Main entry point. Wraps any stream as an SSE response with auto keep-alive.
+
+### `modo::sse::channel`
+
+```rust
+pub fn channel<F, Fut>(f: F) -> SseResponse
+where
+    F: FnOnce(SseSender) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<(), Error>> + Send,
+```
+
+Spawns the closure as a tokio task, returns an `SseResponse` backed by the receiver end. When the closure returns or the client disconnects, everything cleans up.
+
+## Stream Ergonomics
+
+### `SseStreamExt` trait
+
+Extension trait on `Stream` for ergonomic event mapping.
+
+```rust
+pub trait SseStreamExt: Stream {
+    /// Set event name on each item (item must impl Into<SseEvent>).
+    fn sse_event(self, name: &'static str) -> impl Stream<Item = Result<SseEvent, Error>>;
+
+    /// Serialize each item as JSON data.
+    fn sse_json(self) -> impl Stream<Item = Result<SseEvent, Error>>;
+
+    /// Map each item to an SseEvent with a custom closure.
+    fn sse_map<F>(self, f: F) -> impl Stream<Item = Result<SseEvent, Error>>
+    where
+        F: FnMut(Self::Item) -> Result<SseEvent, Error>;
+}
+```
+
+## Integration with `modo` Core
+
+### `AppBuilder::run()` changes
+
+Within `#[cfg(feature = "sse")]`:
+
+1. Load `SseConfig` from app config (with defaults)
+2. Register `SseConfig` as a service
+
+No middleware or layers needed — SSE responses are self-contained.
+
+### `lib.rs` re-exports
+
+```rust
+#[cfg(feature = "sse")]
+pub mod sse;
+```
+
+Public items from `modo::sse`:
+- `SseEvent`, `SseResponse`, `SseConfig`
+- `SseSender`
+- `SseBroadcastManager`, `SseStream`
+- `SseStreamExt` (trait)
+- `from_stream`, `channel`
+
+### `Cargo.toml` feature
+
+```toml
+[features]
+sse = []  # no extra deps — uses axum's built-in SSE + tokio broadcast
+```
+
+No new dependencies. Everything needed is already in `axum` and `tokio`.
+
+## File Structure
+
+```
+modo/src/sse/
+├── mod.rs              # Public re-exports, module docs, entry point functions
+├── event.rs            # SseEvent builder
+├── response.rs         # SseResponse wrapper
+├── config.rs           # SseConfig
+├── sender.rs           # SseSender for channel()
+├── broadcast.rs        # SseBroadcastManager<K, T>, SseStream<T>
+└── stream_ext.rs       # SseStreamExt trait
+```
+
+## Documentation Requirements
+
+Every public type, method, and function must have:
+
+- **Module-level doc** (`mod.rs`): Overview of the SSE feature, when to use it, quick-start example covering all three patterns (from_stream, channel, broadcast manager)
+- **Type-level docs**: Purpose, when to use, complete example
+- **Method-level docs**: What it does, parameters, return value, error conditions, example where non-obvious
+- **`# Examples`** sections: Compilable doc examples for all primary APIs
+- **`# Panics`** / **`# Errors`** sections: Where applicable
+- **Cross-references**: Link related types (e.g., `SseEvent` docs reference `SseBroadcastManager`)
+
+## Examples
+
+### Chat (HTML via HTMX)
+
+```rust
+struct ChatMessage { sender: String, text: String }
+
+impl From<ChatMessage> for SseEvent {
+    fn from(msg: ChatMessage) -> Self {
+        SseEvent::new()
+            .event("message")
+            .data(format!("{}: {}", msg.sender, msg.text))
+    }
+}
+
+#[modo::handler(GET, "/chat/{id}/events")]
+async fn chat_stream(
+    id: String,
+    auth: Auth<User>,
+    view: ViewRenderer,
+    Service(chat): Service<SseBroadcastManager<String, ChatMessage>>,
+) -> SseResponse {
+    let user_id = auth.user.id.clone();
+    let stream = chat.subscribe(&id)
+        .filter(move |msg| msg.sender != user_id)
+        .map(move |msg| {
+            let html = view.render_to_string(ChatBubbleView::from(&msg))?;
+            Ok(SseEvent::new().event("message").html(html))
+        });
+    modo::sse::from_stream(stream)
+}
+
+#[modo::handler(POST, "/chat/{id}/send")]
+async fn chat_send(
+    id: String,
+    Json(msg): Json<SendMessage>,
+    Service(chat): Service<SseBroadcastManager<String, ChatMessage>>,
+) -> HandlerResult<()> {
+    chat.send(&id, ChatMessage::from(msg))?;
+    Ok(())
+}
+```
+
+### Dashboard (JSON)
+
+```rust
+struct UptimeCheck { service: String, status: String, latency_ms: u64 }
+
+impl From<UptimeCheck> for SseEvent {
+    fn from(check: UptimeCheck) -> Self {
+        SseEvent::new()
+            .event("check")
+            .json(&check)
+            .unwrap()
+    }
+}
+
+#[modo::handler(GET, "/dashboard/events")]
+async fn dashboard(
+    tenant: Tenant<MyTenant>,
+    Service(uptime): Service<SseBroadcastManager<TenantId, UptimeCheck>>,
+) -> SseResponse {
+    modo::sse::from_stream(uptime.subscribe(&tenant.id))
+}
+```
+
+### Notifications (per-user, multiple tabs)
+
+```rust
+#[modo::handler(GET, "/notifications/events")]
+async fn notifications(
+    auth: Auth<User>,
+    Service(notif): Service<SseBroadcastManager<UserId, Notification>>,
+) -> SseResponse {
+    modo::sse::from_stream(notif.subscribe(&auth.user.id))
+}
+```
+
+### Imperative channel (job progress)
+
+```rust
+#[modo::handler(GET, "/jobs/{id}/progress")]
+async fn job_progress(
+    id: String,
+    Service(jobs): Service<JobService>,
+) -> SseResponse {
+    modo::sse::channel(|tx| async move {
+        while let Some(status) = jobs.poll_status(&id).await {
+            tx.send(SseEvent::new().event("progress").json(&status)?).await?;
+            if status.is_done() { break; }
+        }
+        Ok(())
+    })
+}
+```
+
+## What's NOT Included
+
+- **Room/membership management** — domain logic, not framework concern
+- **Global broadcast (`send_all`)** — rare in multi-tenant SaaS
+- **Send to specific subscriber** — no use case within keyed channels
+- **Message persistence** — application concern
+- **WebSocket support** — separate feature if ever needed
+- **Authentication/authorization** — use existing `Auth<User>` / `Tenant<T>` extractors
+- **Client-side library** — HTMX `hx-ext="sse"` or native `EventSource` API

--- a/docs/superpowers/specs/2026-03-11-sse-design.md
+++ b/docs/superpowers/specs/2026-03-11-sse-design.md
@@ -16,15 +16,15 @@ Add Server-Sent Events support to the `modo` core crate as an opt-in feature fla
 
 ## Design Decisions
 
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Module location | `modo/` core crate, feature = `"sse"` | SSE is an HTTP response type, belongs with `Json`, `ViewResponse` |
-| Room/channel management | Not included | Domain logic — varies per use case |
-| Format selection | Per-handler | Each endpoint explicitly chooses JSON, HTML, or text |
-| Template rendering in SSE | Handler responsibility | SSE module is format-agnostic; handler uses `ViewRenderer::render_to_string()` |
-| Broadcast model | All subscribers of a key receive all messages | Filter on consumer side via stream combinators |
-| Global broadcast (`send_all`) | Not included | Rare in multi-tenant SaaS; YAGNI |
-| Send to specific subscriber | Not included | No compelling use case within a keyed channel |
+| Decision                      | Choice                                        | Rationale                                                                      |
+| ----------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------ |
+| Module location               | `modo/` core crate, feature = `"sse"`         | SSE is an HTTP response type, belongs with `Json`, `ViewResponse`              |
+| Room/channel management       | Not included                                  | Domain logic — varies per use case                                             |
+| Format selection              | Per-handler                                   | Each endpoint explicitly chooses JSON, HTML, or text                           |
+| Template rendering in SSE     | Handler responsibility                        | SSE module is format-agnostic; handler uses `ViewRenderer::render_to_string()` |
+| Broadcast model               | All subscribers of a key receive all messages | Filter on consumer side via stream combinators                                 |
+| Global broadcast (`send_all`) | Not included                                  | Rare in multi-tenant SaaS; YAGNI                                               |
+| Send to specific subscriber   | Not included                                  | No compelling use case within a keyed channel                                  |
 
 ## Dependencies
 
@@ -70,7 +70,7 @@ Optional YAML-deserializable configuration. Added as a field on `AppConfig` (gat
 
 ```yaml
 sse:
-  keep_alive_interval_secs: 15   # default: 15 seconds
+    keep_alive_interval_secs: 15 # default: 15 seconds
 ```
 
 ```rust
@@ -264,6 +264,7 @@ pub mod sse;
 ```
 
 Public items from `modo::sse`:
+
 - `SseEvent`, `SseResponse`, `SseConfig`
 - `SseSender`, `LastEventId`
 - `SseBroadcastManager`, `SseStream`
@@ -298,6 +299,7 @@ modo/src/sse/
 The global `TimeoutLayer` in `AppBuilder::run()` will kill SSE connections after the configured timeout. Keep-alive events do NOT reset the timer — the timer is set at request start for the full response lifecycle.
 
 **Mitigation:** Apps using SSE should either:
+
 - Set a long request timeout (e.g., `http.request_timeout: 3600` for 1 hour)
 - Disable the global timeout and apply per-route timeouts to non-SSE handlers instead
 
@@ -306,6 +308,12 @@ This interaction should be documented prominently in the module docs.
 ### `Last-Event-ID` reconnection flow
 
 When a client reconnects after a disconnect, the browser's `EventSource` sends a `Last-Event-ID` header with the last received event ID. Handlers can read this via the `LastEventId` extractor to replay missed events. The SSE module does NOT handle replay automatically — replay logic (e.g., fetching missed messages from a database) is application responsibility.
+
+### Multi-line HTML partials
+
+Axum's `Event::data()` automatically handles multi-line content per the SSE spec — each line is prefixed with `data:` and the browser's `EventSource` reassembles them (joining with `\n`) before firing the event. The `.html()` method delegates to `.data()`, so no special handling is needed.
+
+However, SSE has no built-in chunking or compression — the entire event is buffered and sent as one unit. **Best practice: keep SSE HTML partials small.** Send individual components (a single chat bubble, one table row, one notification card), not entire page sections. For large updates, send a JSON event that triggers an HTMX swap via a separate fetch.
 
 ## Documentation Requirements
 

--- a/examples/sse-chat/Cargo.toml
+++ b/examples/sse-chat/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sse-chat"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+modo = { path = "../../modo", features = ["templates", "sse", "csrf"] }
+modo-db = { path = "../../modo-db", features = ["sqlite"] }
+modo-session = { path = "../../modo-session" }
+chrono = "0.4"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse", "csrf"))'] }

--- a/examples/sse-chat/Cargo.toml
+++ b/examples/sse-chat/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-modo = { path = "../../modo", features = ["templates", "sse", "csrf"] }
+modo = { path = "../../modo", features = ["templates", "sse", "csrf", "static-embed"] }
 modo-db = { path = "../../modo-db", features = ["sqlite"] }
 modo-session = { path = "../../modo-session" }
 chrono = "0.4"
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse", "csrf"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse", "csrf", "static-embed"))'] }

--- a/examples/sse-chat/config/development.yaml
+++ b/examples/sse-chat/config/development.yaml
@@ -3,6 +3,10 @@ server:
     secret_key: ${SECRET_KEY:-sse-chat-dev-secret-key-change-in-production-please}
     http:
         timeout: 3600
+    security_headers:
+        content_security_policy: "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'"
+    static_files:
+        prefix: /static
 templates:
     path: templates
 database:

--- a/examples/sse-chat/config/development.yaml
+++ b/examples/sse-chat/config/development.yaml
@@ -1,0 +1,11 @@
+server:
+    port: 3003
+    secret_key: ${SECRET_KEY:-sse-chat-dev-secret-key-change-in-production-please}
+    http:
+        timeout: 3600
+templates:
+    path: templates
+database:
+    url: ${DATABASE_URL:-sqlite://chat.db?mode=rwc}
+    max_connections: 5
+    min_connections: 1

--- a/examples/sse-chat/config/development.yaml
+++ b/examples/sse-chat/config/development.yaml
@@ -9,6 +9,8 @@ server:
         prefix: /static
 templates:
     path: templates
+cookie:
+    secure: false
 database:
     url: ${DATABASE_URL:-sqlite://chat.db?mode=rwc}
     max_connections: 5

--- a/examples/sse-chat/src/main.rs
+++ b/examples/sse-chat/src/main.rs
@@ -1,0 +1,276 @@
+use modo::AppConfig;
+use modo::extractors::service::Service;
+use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+use modo::templates::ViewRenderer;
+use modo_db::{DatabaseConfig, Db};
+use modo_session::SessionManager;
+use serde::Deserialize;
+
+// --- Config ---
+
+#[derive(Default, Deserialize)]
+struct Config {
+    #[serde(flatten)]
+    core: AppConfig,
+    database: DatabaseConfig,
+}
+
+// --- Entity ---
+
+#[modo_db::entity(table = "messages")]
+#[entity(timestamps)]
+pub struct Message {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    #[entity(indexed)]
+    pub room: String,
+    pub username: String,
+    pub text: String,
+}
+
+// --- Domain types ---
+
+#[derive(Debug, Clone)]
+struct ChatEvent {
+    username: String,
+    text: String,
+    created_at: String,
+}
+
+// --- Broadcaster ---
+
+type ChatBroadcaster = SseBroadcastManager<String, ChatEvent>;
+
+// --- View structs ---
+
+#[modo::view("pages/login.html")]
+struct LoginPage {}
+
+#[modo::view("pages/rooms.html")]
+struct RoomsPage {
+    username: String,
+    rooms: Vec<&'static str>,
+}
+
+#[modo::view("pages/chat.html")]
+struct ChatPage {
+    room: String,
+    username: String,
+    messages: Vec<String>,
+}
+
+#[modo::view("partials/message.html")]
+struct MessagePartial {
+    username: String,
+    text: String,
+    created_at: String,
+}
+
+// --- Form ---
+
+#[derive(Deserialize)]
+struct LoginForm {
+    username: String,
+}
+
+#[derive(Deserialize)]
+struct SendForm {
+    text: String,
+}
+
+// --- Constants ---
+
+const ROOMS: &[&str] = &["general", "random", "support", "dev"];
+
+// --- Handlers ---
+
+#[modo::handler(GET, "/")]
+async fn index(session: SessionManager) -> modo::ViewResult {
+    if session.is_authenticated().await {
+        Ok(modo::ViewResponse::redirect("/rooms"))
+    } else {
+        Ok(modo::ViewResponse::redirect("/login"))
+    }
+}
+
+#[modo::handler(GET, "/login")]
+async fn login_page(session: SessionManager, view: ViewRenderer) -> modo::ViewResult {
+    if session.is_authenticated().await {
+        return view.redirect("/rooms");
+    }
+    view.render(LoginPage {})
+}
+
+#[modo::handler(POST, "/login")]
+async fn login_submit(
+    session: SessionManager,
+    form: modo::extractors::Form<LoginForm>,
+) -> modo::ViewResult {
+    let username = form.username.trim().to_string();
+    if username.len() < 2 || username.len() > 30 {
+        return Ok(modo::ViewResponse::redirect("/login"));
+    }
+    session.authenticate(&username).await?;
+    Ok(modo::ViewResponse::redirect("/rooms"))
+}
+
+#[modo::handler(GET, "/logout")]
+async fn logout(session: SessionManager) -> modo::ViewResult {
+    session.logout().await?;
+    Ok(modo::ViewResponse::redirect("/login"))
+}
+
+#[modo::handler(GET, "/rooms")]
+async fn rooms_page(session: SessionManager, view: ViewRenderer) -> modo::ViewResult {
+    let username = match session.user_id().await {
+        Some(u) => u,
+        None => return view.redirect("/login"),
+    };
+    view.render(RoomsPage {
+        username,
+        rooms: ROOMS.to_vec(),
+    })
+}
+
+#[modo::handler(GET, "/chat/{room}")]
+async fn chat_page(
+    room: String,
+    session: SessionManager,
+    view: ViewRenderer,
+    Db(db): Db,
+) -> modo::ViewResult {
+    let username = match session.user_id().await {
+        Some(u) => u,
+        None => return view.redirect("/login"),
+    };
+
+    if !ROOMS.contains(&room.as_str()) {
+        return view.redirect("/rooms");
+    }
+
+    // Load last 50 messages from DB
+    use modo_db::sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+    let db_messages = message::Entity::find()
+        .filter(message::Column::Room.eq(&room))
+        .order_by_asc(message::Column::CreatedAt)
+        .all(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to load messages: {e}")))?;
+
+    // Take last 50
+    let db_messages: Vec<_> = if db_messages.len() > 50 {
+        db_messages[db_messages.len() - 50..].to_vec()
+    } else {
+        db_messages
+    };
+
+    // Render each message as HTML
+    let rendered: Vec<String> = db_messages
+        .into_iter()
+        .map(|m| {
+            view.render_to_string(MessagePartial {
+                username: m.username,
+                text: m.text,
+                created_at: m.created_at.format("%H:%M:%S").to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    view.render(ChatPage {
+        room,
+        username,
+        messages: rendered,
+    })
+}
+
+#[modo::handler(GET, "/chat/{room}/events")]
+async fn chat_events(
+    room: String,
+    view: ViewRenderer,
+    Service(bc): Service<ChatBroadcaster>,
+) -> SseResponse {
+    let stream = bc.subscribe(&room).sse_map(move |evt| {
+        let html = view.render_to_string(MessagePartial {
+            username: evt.username,
+            text: evt.text,
+            created_at: evt.created_at,
+        })?;
+        Ok(SseEvent::new().event("message").html(html))
+    });
+    modo::sse::from_stream(stream)
+}
+
+#[modo::handler(POST, "/chat/{room}/send")]
+async fn chat_send(
+    room: String,
+    session: SessionManager,
+    Db(db): Db,
+    Service(bc): Service<ChatBroadcaster>,
+    form: modo::extractors::Form<SendForm>,
+) -> modo::HandlerResult<modo::axum::http::StatusCode> {
+    let username = session
+        .user_id()
+        .await
+        .ok_or(modo::HttpError::Unauthorized)?;
+
+    if !ROOMS.contains(&room.as_str()) {
+        return Err(modo::HttpError::NotFound.into());
+    }
+
+    let text = form.text.trim().to_string();
+    if text.is_empty() {
+        return Err(modo::HttpError::BadRequest.with_message("message text is required"));
+    }
+
+    // Save to DB
+    use modo_db::sea_orm::{ActiveModelTrait, Set};
+    let model = message::ActiveModel {
+        room: Set(room.clone()),
+        username: Set(username.clone()),
+        text: Set(text.clone()),
+        ..Default::default()
+    };
+    let saved = model
+        .insert(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to save message: {e}")))?;
+
+    // Broadcast to SSE subscribers
+    let _ = bc.send(
+        &room,
+        ChatEvent {
+            username,
+            text,
+            created_at: saved.created_at.format("%H:%M:%S").to_string(),
+        },
+    );
+
+    Ok(modo::axum::http::StatusCode::NO_CONTENT)
+}
+
+// --- Entry point ---
+
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let db = modo_db::connect(&config.database).await?;
+    modo_db::sync_and_migrate(&db).await?;
+
+    let session_store = modo_session::SessionStore::new(
+        &db,
+        modo_session::SessionConfig::default(),
+        modo::CookieConfig::default(),
+    );
+
+    let bc: ChatBroadcaster = SseBroadcastManager::new(128);
+
+    app.config(config.core)
+        .managed_service(db)
+        .service(session_store.clone())
+        .service(bc)
+        .layer(modo_session::layer(session_store))
+        .run()
+        .await
+}

--- a/examples/sse-chat/src/main.rs
+++ b/examples/sse-chat/src/main.rs
@@ -1,6 +1,6 @@
 use modo::AppConfig;
 use modo::extractors::service::Service;
-use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+use modo::sse::{Sse, SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
 use modo::templates::ViewRenderer;
 use modo_db::{DatabaseConfig, Db};
 use modo_session::SessionManager;
@@ -196,10 +196,15 @@ async fn chat_page(
 #[modo::handler(GET, "/chat/{room}/events")]
 async fn chat_events(
     room: String,
+    sse: Sse,
     session: SessionManager,
     view: ViewRenderer,
     Service(bc): Service<ChatBroadcaster>,
-) -> SseResponse {
+) -> modo::HandlerResult<SseResponse> {
+    if !ROOMS.contains(&room.as_str()) {
+        return Err(modo::HttpError::NotFound.into());
+    }
+
     let current_user = session.user_id().await.unwrap_or_default();
     let stream = bc.subscribe(&room).sse_map(move |evt| {
         let is_own = evt.username == current_user;
@@ -211,7 +216,7 @@ async fn chat_events(
         })?;
         Ok(SseEvent::new().event("message").html(html))
     });
-    modo::sse::from_stream(stream)
+    Ok(sse.from_stream(stream))
 }
 
 #[modo::handler(POST, "/chat/{room}/send")]
@@ -273,11 +278,8 @@ async fn main(
     let db = modo_db::connect(&config.database).await?;
     modo_db::sync_and_migrate(&db).await?;
 
-    let session_store = modo_session::SessionStore::new(
-        &db,
-        modo_session::SessionConfig::default(),
-        config.cookie,
-    );
+    let session_store =
+        modo_session::SessionStore::new(&db, modo_session::SessionConfig::default(), config.cookie);
 
     let bc: ChatBroadcaster = SseBroadcastManager::new(128);
 

--- a/examples/sse-chat/src/main.rs
+++ b/examples/sse-chat/src/main.rs
@@ -13,6 +13,8 @@ struct Config {
     #[serde(flatten)]
     core: AppConfig,
     database: DatabaseConfig,
+    #[serde(default)]
+    cookie: modo::CookieConfig,
 }
 
 // --- Entity ---
@@ -66,6 +68,12 @@ struct MessagePartial {
     username: String,
     text: String,
     created_at: String,
+    is_own: bool,
+}
+
+#[modo::view("partials/send_form.html")]
+struct SendFormPartial {
+    room: String,
 }
 
 // --- Form ---
@@ -116,7 +124,7 @@ async fn login_submit(
         });
     }
     session.authenticate(&username).await?;
-    Ok(modo::ViewResponse::redirect("/rooms"))
+    view.redirect("/rooms")
 }
 
 #[modo::handler(GET, "/logout")]
@@ -168,10 +176,12 @@ async fn chat_page(
     let rendered: Vec<String> = db_messages
         .into_iter()
         .map(|m| {
+            let is_own = m.username == username;
             view.render_to_string(MessagePartial {
                 username: m.username,
                 text: m.text,
                 created_at: m.created_at.format("%H:%M:%S").to_string(),
+                is_own,
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -186,14 +196,18 @@ async fn chat_page(
 #[modo::handler(GET, "/chat/{room}/events")]
 async fn chat_events(
     room: String,
+    session: SessionManager,
     view: ViewRenderer,
     Service(bc): Service<ChatBroadcaster>,
 ) -> SseResponse {
+    let current_user = session.user_id().await.unwrap_or_default();
     let stream = bc.subscribe(&room).sse_map(move |evt| {
+        let is_own = evt.username == current_user;
         let html = view.render_to_string(MessagePartial {
             username: evt.username,
             text: evt.text,
             created_at: evt.created_at,
+            is_own,
         })?;
         Ok(SseEvent::new().event("message").html(html))
     });
@@ -204,10 +218,11 @@ async fn chat_events(
 async fn chat_send(
     room: String,
     session: SessionManager,
+    view: ViewRenderer,
     Db(db): Db,
     Service(bc): Service<ChatBroadcaster>,
     form: modo::extractors::Form<SendForm>,
-) -> modo::HandlerResult<modo::axum::http::StatusCode> {
+) -> modo::ViewResult {
     let username = session
         .user_id()
         .await
@@ -245,7 +260,7 @@ async fn chat_send(
         },
     );
 
-    Ok(modo::axum::http::StatusCode::NO_CONTENT)
+    view.render(SendFormPartial { room })
 }
 
 // --- Entry point ---
@@ -261,7 +276,7 @@ async fn main(
     let session_store = modo_session::SessionStore::new(
         &db,
         modo_session::SessionConfig::default(),
-        modo::CookieConfig::default(),
+        config.cookie,
     );
 
     let bc: ChatBroadcaster = SseBroadcastManager::new(128);

--- a/examples/sse-chat/src/main.rs
+++ b/examples/sse-chat/src/main.rs
@@ -43,8 +43,10 @@ type ChatBroadcaster = SseBroadcastManager<String, ChatEvent>;
 
 // --- View structs ---
 
-#[modo::view("pages/login.html")]
-struct LoginPage {}
+#[modo::view("pages/login.html", htmx = "partials/login_form.html")]
+struct LoginPage {
+    error: Option<String>,
+}
 
 #[modo::view("pages/rooms.html")]
 struct RoomsPage {
@@ -98,17 +100,20 @@ async fn login_page(session: SessionManager, view: ViewRenderer) -> modo::ViewRe
     if session.is_authenticated().await {
         return view.redirect("/rooms");
     }
-    view.render(LoginPage {})
+    view.render(LoginPage { error: None })
 }
 
 #[modo::handler(POST, "/login")]
 async fn login_submit(
     session: SessionManager,
+    view: ViewRenderer,
     form: modo::extractors::Form<LoginForm>,
 ) -> modo::ViewResult {
     let username = form.username.trim().to_string();
     if username.len() < 2 || username.len() > 30 {
-        return Ok(modo::ViewResponse::redirect("/login"));
+        return view.render(LoginPage {
+            error: Some("Username must be between 2 and 30 characters".into()),
+        });
     }
     session.authenticate(&username).await?;
     Ok(modo::ViewResponse::redirect("/rooms"))
@@ -148,21 +153,16 @@ async fn chat_page(
         return view.redirect("/rooms");
     }
 
-    // Load last 50 messages from DB
-    use modo_db::sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
-    let db_messages = message::Entity::find()
+    // Load last 50 messages from DB (newest first, then reverse for chronological order)
+    use modo_db::sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+    let mut db_messages = message::Entity::find()
         .filter(message::Column::Room.eq(&room))
-        .order_by_asc(message::Column::CreatedAt)
+        .order_by_desc(message::Column::CreatedAt)
+        .limit(50)
         .all(&*db)
         .await
         .map_err(|e| modo::Error::internal(format!("Failed to load messages: {e}")))?;
-
-    // Take last 50
-    let db_messages: Vec<_> = if db_messages.len() > 50 {
-        db_messages[db_messages.len() - 50..].to_vec()
-    } else {
-        db_messages
-    };
+    db_messages.reverse();
 
     // Render each message as HTML
     let rendered: Vec<String> = db_messages

--- a/examples/sse-chat/static/chat.js
+++ b/examples/sse-chat/static/chat.js
@@ -1,0 +1,9 @@
+// Auto-scroll to bottom on new messages
+var messages = document.getElementById("messages");
+if (messages) {
+    var observer = new MutationObserver(function () {
+        messages.scrollTop = messages.scrollHeight;
+    });
+    observer.observe(messages, { childList: true });
+    messages.scrollTop = messages.scrollHeight;
+}

--- a/examples/sse-chat/static/style.css
+++ b/examples/sse-chat/static/style.css
@@ -1,0 +1,25 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; }
+.container { max-width: 800px; margin: 0 auto; padding: 2rem; }
+h1 { margin-bottom: 1rem; }
+a { color: #2563eb; }
+.form-group { margin-bottom: 1rem; }
+.error { color: #dc2626; font-size: 0.875rem; margin-bottom: 0.75rem; padding: 0.5rem; background: #fef2f2; border: 1px solid #fecaca; border-radius: 0.375rem; }
+label { display: block; margin-bottom: 0.25rem; font-weight: 600; font-size: 0.875rem; }
+input[type="text"] { width: 100%; padding: 0.5rem; border: 1px solid #cbd5e1; border-radius: 0.375rem; font-size: 1rem; }
+button { padding: 0.5rem 1rem; background: #2563eb; color: white; border: none; border-radius: 0.375rem; cursor: pointer; font-size: 0.875rem; }
+button:hover { background: #1d4ed8; }
+.rooms-list { list-style: none; }
+.rooms-list li { margin-bottom: 0.5rem; }
+.rooms-list a { display: block; padding: 0.75rem 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem; text-decoration: none; color: #1e293b; }
+.rooms-list a:hover { background: #f1f5f9; }
+.chat-container { display: flex; flex-direction: column; height: calc(100vh - 10rem); }
+.messages { flex: 1; overflow-y: auto; padding: 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem 0.375rem 0 0; }
+.message { margin-bottom: 0.75rem; }
+.message .meta { font-size: 0.75rem; color: #64748b; margin-bottom: 0.125rem; }
+.message .meta .username { font-weight: 600; color: #1e293b; }
+.message .text { font-size: 0.9rem; }
+.message-form { display: flex; gap: 0.5rem; padding: 0.75rem; background: white; border: 1px solid #e2e8f0; border-top: none; border-radius: 0 0 0.375rem 0.375rem; }
+.message-form input { flex: 1; }
+.nav { display: flex; gap: 1rem; align-items: center; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid #e2e8f0; }
+.nav .user { margin-left: auto; font-size: 0.875rem; color: #64748b; }

--- a/examples/sse-chat/static/style.css
+++ b/examples/sse-chat/static/style.css
@@ -19,6 +19,8 @@ button:hover { background: #1d4ed8; }
 .message .meta { font-size: 0.75rem; color: #64748b; margin-bottom: 0.125rem; }
 .message .meta .username { font-weight: 600; color: #1e293b; }
 .message .text { font-size: 0.9rem; }
+.message.own { background: #eff6ff; border-radius: 0.375rem; padding: 0.5rem; }
+.message.own .meta .username { color: #2563eb; }
 .message-form { display: flex; gap: 0.5rem; padding: 0.75rem; background: white; border: 1px solid #e2e8f0; border-top: none; border-radius: 0 0 0.375rem 0.375rem; }
 .message-form input { flex: 1; }
 .nav { display: flex; gap: 1rem; align-items: center; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid #e2e8f0; }

--- a/examples/sse-chat/templates/layouts/base.html
+++ b/examples/sse-chat/templates/layouts/base.html
@@ -7,32 +7,7 @@
         <title>{% block title %}SSE Chat{% endblock %}</title>
         <script src="https://unpkg.com/htmx.org@2.0.4"></script>
         <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
-        <style>
-            * { box-sizing: border-box; margin: 0; padding: 0; }
-            body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; }
-            .container { max-width: 800px; margin: 0 auto; padding: 2rem; }
-            h1 { margin-bottom: 1rem; }
-            a { color: #2563eb; }
-            .form-group { margin-bottom: 1rem; }
-            label { display: block; margin-bottom: 0.25rem; font-weight: 600; font-size: 0.875rem; }
-            input[type="text"] { width: 100%; padding: 0.5rem; border: 1px solid #cbd5e1; border-radius: 0.375rem; font-size: 1rem; }
-            button { padding: 0.5rem 1rem; background: #2563eb; color: white; border: none; border-radius: 0.375rem; cursor: pointer; font-size: 0.875rem; }
-            button:hover { background: #1d4ed8; }
-            .rooms-list { list-style: none; }
-            .rooms-list li { margin-bottom: 0.5rem; }
-            .rooms-list a { display: block; padding: 0.75rem 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem; text-decoration: none; color: #1e293b; }
-            .rooms-list a:hover { background: #f1f5f9; }
-            .chat-container { display: flex; flex-direction: column; height: calc(100vh - 10rem); }
-            .messages { flex: 1; overflow-y: auto; padding: 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem 0.375rem 0 0; }
-            .message { margin-bottom: 0.75rem; }
-            .message .meta { font-size: 0.75rem; color: #64748b; margin-bottom: 0.125rem; }
-            .message .meta .username { font-weight: 600; color: #1e293b; }
-            .message .text { font-size: 0.9rem; }
-            .message-form { display: flex; gap: 0.5rem; padding: 0.75rem; background: white; border: 1px solid #e2e8f0; border-top: none; border-radius: 0 0 0.375rem 0.375rem; }
-            .message-form input { flex: 1; }
-            .nav { display: flex; gap: 1rem; align-items: center; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid #e2e8f0; }
-            .nav .user { margin-left: auto; font-size: 0.875rem; color: #64748b; }
-        </style>
+        <link rel="stylesheet" href="/static/style.css" />
     </head>
     <body>
         <div class="container">{% block content %}{% endblock %}</div>

--- a/examples/sse-chat/templates/layouts/base.html
+++ b/examples/sse-chat/templates/layouts/base.html
@@ -1,0 +1,41 @@
+{# examples/sse-chat/templates/layouts/base.html #}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{% block title %}SSE Chat{% endblock %}</title>
+        <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+        <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
+        <style>
+            * { box-sizing: border-box; margin: 0; padding: 0; }
+            body { font-family: system-ui, sans-serif; background: #f8fafc; color: #1e293b; }
+            .container { max-width: 800px; margin: 0 auto; padding: 2rem; }
+            h1 { margin-bottom: 1rem; }
+            a { color: #2563eb; }
+            .form-group { margin-bottom: 1rem; }
+            label { display: block; margin-bottom: 0.25rem; font-weight: 600; font-size: 0.875rem; }
+            input[type="text"] { width: 100%; padding: 0.5rem; border: 1px solid #cbd5e1; border-radius: 0.375rem; font-size: 1rem; }
+            button { padding: 0.5rem 1rem; background: #2563eb; color: white; border: none; border-radius: 0.375rem; cursor: pointer; font-size: 0.875rem; }
+            button:hover { background: #1d4ed8; }
+            .rooms-list { list-style: none; }
+            .rooms-list li { margin-bottom: 0.5rem; }
+            .rooms-list a { display: block; padding: 0.75rem 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem; text-decoration: none; color: #1e293b; }
+            .rooms-list a:hover { background: #f1f5f9; }
+            .chat-container { display: flex; flex-direction: column; height: calc(100vh - 10rem); }
+            .messages { flex: 1; overflow-y: auto; padding: 1rem; background: white; border: 1px solid #e2e8f0; border-radius: 0.375rem 0.375rem 0 0; }
+            .message { margin-bottom: 0.75rem; }
+            .message .meta { font-size: 0.75rem; color: #64748b; margin-bottom: 0.125rem; }
+            .message .meta .username { font-weight: 600; color: #1e293b; }
+            .message .text { font-size: 0.9rem; }
+            .message-form { display: flex; gap: 0.5rem; padding: 0.75rem; background: white; border: 1px solid #e2e8f0; border-top: none; border-radius: 0 0 0.375rem 0.375rem; }
+            .message-form input { flex: 1; }
+            .nav { display: flex; gap: 1rem; align-items: center; margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid #e2e8f0; }
+            .nav .user { margin-left: auto; font-size: 0.875rem; color: #64748b; }
+        </style>
+    </head>
+    <body>
+        <div class="container">{% block content %}{% endblock %}</div>
+        {% block scripts %}{% endblock %}
+    </body>
+</html>

--- a/examples/sse-chat/templates/layouts/base.html
+++ b/examples/sse-chat/templates/layouts/base.html
@@ -5,8 +5,8 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{% block title %}SSE Chat{% endblock %}</title>
-        <script src="https://unpkg.com/htmx.org@2.0.4"></script>
-        <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
+        <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
+        <script src="https://unpkg.com/htmx-ext-sse@2.2.4/sse.js"></script>
         <link rel="stylesheet" href="/static/style.css" />
     </head>
     <body>

--- a/examples/sse-chat/templates/pages/chat.html
+++ b/examples/sse-chat/templates/pages/chat.html
@@ -1,0 +1,33 @@
+{# examples/sse-chat/templates/pages/chat.html #}
+{% extends "layouts/base.html" %}
+{% block title %}{{ room }} — SSE Chat{% endblock %}
+{% block content %}
+<div class="nav">
+    <a href="/rooms">&larr; Rooms</a>
+    <h1>{{ room }}</h1>
+    <span class="user">{{ username }}</span>
+</div>
+<div class="chat-container">
+    <div class="messages" id="messages" hx-ext="sse" sse-connect="/chat/{{ room }}/events" sse-swap="message" hx-swap="beforeend">
+        {% for msg in messages %}
+        {{ msg }}
+        {% endfor %}
+    </div>
+    <form class="message-form" hx-post="/chat/{{ room }}/send" hx-swap="none" hx-on::after-request="this.reset()">
+        <input type="text" name="text" placeholder="Type a message..." required autocomplete="off" autofocus />
+        <button type="submit">Send</button>
+    </form>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+    // Auto-scroll to bottom on new messages
+    const messages = document.getElementById("messages");
+    const observer = new MutationObserver(() => {
+        messages.scrollTop = messages.scrollHeight;
+    });
+    observer.observe(messages, { childList: true });
+    // Scroll to bottom on load
+    messages.scrollTop = messages.scrollHeight;
+</script>
+{% endblock %}

--- a/examples/sse-chat/templates/pages/chat.html
+++ b/examples/sse-chat/templates/pages/chat.html
@@ -10,24 +10,12 @@
 <div class="chat-container">
     <div class="messages" id="messages" hx-ext="sse" sse-connect="/chat/{{ room }}/events" sse-swap="message" hx-swap="beforeend">
         {% for msg in messages %}
-        {{ msg }}
+        {{ msg|safe }}
         {% endfor %}
     </div>
-    <form class="message-form" hx-post="/chat/{{ room }}/send" hx-swap="none" hx-on::after-request="this.reset()">
-        <input type="text" name="text" placeholder="Type a message..." required autocomplete="off" autofocus />
-        <button type="submit">Send</button>
-    </form>
+    {% include "partials/send_form.html" %}
 </div>
 {% endblock %}
 {% block scripts %}
-<script>
-    // Auto-scroll to bottom on new messages
-    const messages = document.getElementById("messages");
-    const observer = new MutationObserver(() => {
-        messages.scrollTop = messages.scrollHeight;
-    });
-    observer.observe(messages, { childList: true });
-    // Scroll to bottom on load
-    messages.scrollTop = messages.scrollHeight;
-</script>
+<script src="/static/chat.js"></script>
 {% endblock %}

--- a/examples/sse-chat/templates/pages/login.html
+++ b/examples/sse-chat/templates/pages/login.html
@@ -1,0 +1,13 @@
+{# examples/sse-chat/templates/pages/login.html #}
+{% extends "layouts/base.html" %}
+{% block title %}Login — SSE Chat{% endblock %}
+{% block content %}
+<h1>Enter your username</h1>
+<form method="POST" action="/login">
+    <div class="form-group">
+        <label for="username">Username</label>
+        <input type="text" id="username" name="username" placeholder="Your name" required minlength="2" maxlength="30" autofocus />
+    </div>
+    <button type="submit">Join Chat</button>
+</form>
+{% endblock %}

--- a/examples/sse-chat/templates/pages/login.html
+++ b/examples/sse-chat/templates/pages/login.html
@@ -3,11 +3,5 @@
 {% block title %}Login — SSE Chat{% endblock %}
 {% block content %}
 <h1>Enter your username</h1>
-<form method="POST" action="/login">
-    <div class="form-group">
-        <label for="username">Username</label>
-        <input type="text" id="username" name="username" placeholder="Your name" required minlength="2" maxlength="30" autofocus />
-    </div>
-    <button type="submit">Join Chat</button>
-</form>
+{% include "partials/login_form.html" %}
 {% endblock %}

--- a/examples/sse-chat/templates/pages/rooms.html
+++ b/examples/sse-chat/templates/pages/rooms.html
@@ -1,0 +1,14 @@
+{# examples/sse-chat/templates/pages/rooms.html #}
+{% extends "layouts/base.html" %}
+{% block title %}Rooms — SSE Chat{% endblock %}
+{% block content %}
+<div class="nav">
+    <h1>Chat Rooms</h1>
+    <span class="user">Logged in as <strong>{{ username }}</strong> · <a href="/logout">Logout</a></span>
+</div>
+<ul class="rooms-list">
+    {% for room in rooms %}
+    <li><a href="/chat/{{ room }}">{{ room }}</a></li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/examples/sse-chat/templates/partials/login_form.html
+++ b/examples/sse-chat/templates/partials/login_form.html
@@ -1,0 +1,11 @@
+{# examples/sse-chat/templates/partials/login_form.html #}
+<form method="POST" action="/login" hx-post="/login" hx-target="#login-form" hx-swap="outerHTML" id="login-form">
+    {% if error %}
+    <div class="error">{{ error }}</div>
+    {% endif %}
+    <div class="form-group">
+        <label for="username">Username</label>
+        <input type="text" id="username" name="username" placeholder="Your name" required minlength="2" maxlength="30" autofocus />
+    </div>
+    <button type="submit">Join Chat</button>
+</form>

--- a/examples/sse-chat/templates/partials/message.html
+++ b/examples/sse-chat/templates/partials/message.html
@@ -1,0 +1,8 @@
+{# examples/sse-chat/templates/partials/message.html #}
+<div class="message">
+    <div class="meta">
+        <span class="username">{{ username }}</span>
+        · {{ created_at }}
+    </div>
+    <div class="text">{{ text }}</div>
+</div>

--- a/examples/sse-chat/templates/partials/message.html
+++ b/examples/sse-chat/templates/partials/message.html
@@ -1,5 +1,5 @@
 {# examples/sse-chat/templates/partials/message.html #}
-<div class="message">
+<div class="message{% if is_own %} own{% endif %}">
     <div class="meta">
         <span class="username">{{ username }}</span>
         · {{ created_at }}

--- a/examples/sse-chat/templates/partials/send_form.html
+++ b/examples/sse-chat/templates/partials/send_form.html
@@ -1,0 +1,5 @@
+{# examples/sse-chat/templates/partials/send_form.html #}
+<form class="message-form" id="send-form" hx-post="/chat/{{ room }}/send" hx-target="#send-form" hx-swap="outerHTML">
+    <input type="text" name="text" placeholder="Type a message..." required autocomplete="off" autofocus />
+    <button type="submit">Send</button>
+</form>

--- a/examples/sse-dashboard/Cargo.toml
+++ b/examples/sse-dashboard/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sse-dashboard"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+modo = { path = "../../modo", features = ["templates", "sse"] }
+chrono = "0.4"
+rand = "0.9"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse"))'] }

--- a/examples/sse-dashboard/Cargo.toml
+++ b/examples/sse-dashboard/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2024"
 publish = false
 
 [dependencies]
-modo = { path = "../../modo", features = ["templates", "sse"] }
+modo = { path = "../../modo", features = ["templates", "sse", "static-embed"] }
 chrono = "0.4"
 rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse", "static-embed"))'] }

--- a/examples/sse-dashboard/config/development.yaml
+++ b/examples/sse-dashboard/config/development.yaml
@@ -1,0 +1,7 @@
+server:
+  port: 3002
+  secret_key: ${SECRET_KEY:-sse-dashboard-dev-secret-key-change-in-prod-please}
+  http:
+    timeout: 3600
+templates:
+  path: templates

--- a/examples/sse-dashboard/config/development.yaml
+++ b/examples/sse-dashboard/config/development.yaml
@@ -3,5 +3,9 @@ server:
   secret_key: ${SECRET_KEY:-sse-dashboard-dev-secret-key-change-in-prod-please}
   http:
     timeout: 3600
+  security_headers:
+    content_security_policy: "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'"
+  static_files:
+    prefix: /static
 templates:
   path: templates

--- a/examples/sse-dashboard/src/main.rs
+++ b/examples/sse-dashboard/src/main.rs
@@ -1,0 +1,124 @@
+use modo::AppConfig;
+use modo::extractors::service::Service;
+use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+use modo::templates::ViewRenderer;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+// --- Config ---
+
+#[derive(Default, Deserialize)]
+struct Config {
+    #[serde(flatten)]
+    core: AppConfig,
+}
+
+// --- Domain types ---
+
+#[derive(Debug, Clone, Serialize)]
+struct ServerStatus {
+    name: String,
+    status: String, // "up", "down", "degraded"
+    cpu: u32,
+    memory: u32,
+    latency_ms: u32,
+}
+
+// --- Broadcaster type alias ---
+
+type StatusBroadcaster = SseBroadcastManager<(), Vec<ServerStatus>>;
+
+// --- Background task: generate fake server statuses ---
+
+async fn fake_monitor(bc: StatusBroadcaster) {
+    let servers = [
+        "api-gateway",
+        "auth-service",
+        "payment-service",
+        "notification-service",
+        "database-primary",
+        "cache-redis",
+    ];
+
+    loop {
+        let statuses: Vec<ServerStatus> = {
+            let mut rng = rand::rng();
+            servers
+                .iter()
+                .map(|name| {
+                    let roll: f64 = rng.random();
+                    let (status, cpu, memory, latency) = if roll < 0.05 {
+                        (
+                            "down",
+                            rng.random_range(0..10),
+                            rng.random_range(0..20),
+                            rng.random_range(5000..10000),
+                        )
+                    } else if roll < 0.15 {
+                        (
+                            "degraded",
+                            rng.random_range(70..95),
+                            rng.random_range(70..90),
+                            rng.random_range(500..2000),
+                        )
+                    } else {
+                        (
+                            "up",
+                            rng.random_range(10..60),
+                            rng.random_range(30..70),
+                            rng.random_range(5..100),
+                        )
+                    };
+                    ServerStatus {
+                        name: name.to_string(),
+                        status: status.to_string(),
+                        cpu,
+                        memory,
+                        latency_ms: latency,
+                    }
+                })
+                .collect()
+        };
+
+        let _ = bc.send(&(), statuses);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    }
+}
+
+// --- Handlers ---
+
+#[modo::view("pages/dashboard.html")]
+struct DashboardPage {}
+
+#[modo::handler(GET, "/")]
+async fn dashboard() -> DashboardPage {
+    DashboardPage {}
+}
+
+#[modo::handler(GET, "/events")]
+async fn events(view: ViewRenderer, Service(bc): Service<StatusBroadcaster>) -> SseResponse {
+    let stream = bc.subscribe(&()).sse_map(move |servers| {
+        let html = view.render_to_string(StatusCards { servers })?;
+        Ok(SseEvent::new().event("status_update").html(html))
+    });
+    modo::sse::from_stream(stream)
+}
+
+#[modo::view("partials/status_card.html")]
+struct StatusCards {
+    servers: Vec<ServerStatus>,
+}
+
+// --- Entry point ---
+
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bc: StatusBroadcaster = SseBroadcastManager::new(16);
+
+    tokio::spawn(fake_monitor(bc.clone()));
+
+    app.config(config.core).service(bc).run().await
+}

--- a/examples/sse-dashboard/src/main.rs
+++ b/examples/sse-dashboard/src/main.rs
@@ -1,6 +1,6 @@
 use modo::AppConfig;
 use modo::extractors::service::Service;
-use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+use modo::sse::{Sse, SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
 use modo::templates::ViewRenderer;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -96,12 +96,16 @@ async fn dashboard() -> DashboardPage {
 }
 
 #[modo::handler(GET, "/events")]
-async fn events(view: ViewRenderer, Service(bc): Service<StatusBroadcaster>) -> SseResponse {
+async fn events(
+    sse: Sse,
+    view: ViewRenderer,
+    Service(bc): Service<StatusBroadcaster>,
+) -> SseResponse {
     let stream = bc.subscribe(&()).sse_map(move |servers| {
         let html = view.render_to_string(StatusCards { servers })?;
         Ok(SseEvent::new().event("status_update").html(html))
     });
-    modo::sse::from_stream(stream)
+    sse.from_stream(stream)
 }
 
 #[modo::view("partials/status_card.html")]

--- a/examples/sse-dashboard/static/style.css
+++ b/examples/sse-dashboard/static/style.css
@@ -1,0 +1,16 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; padding: 2rem; }
+h1 { margin-bottom: 1.5rem; font-size: 1.5rem; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem; }
+.card { background: #1e293b; border-radius: 0.5rem; padding: 1.25rem; border-left: 4px solid #475569; }
+.card.up { border-left-color: #22c55e; }
+.card.down { border-left-color: #ef4444; }
+.card.degraded { border-left-color: #f59e0b; }
+.card h2 { font-size: 1rem; margin-bottom: 0.75rem; }
+.card .status { font-size: 0.875rem; font-weight: 600; text-transform: uppercase; }
+.card .status.up { color: #22c55e; }
+.card .status.down { color: #ef4444; }
+.card .status.degraded { color: #f59e0b; }
+.card .metrics { display: flex; gap: 1rem; margin-top: 0.75rem; font-size: 0.8rem; color: #94a3b8; }
+.card .metric span { font-weight: 600; color: #e2e8f0; }
+.connected { color: #22c55e; font-size: 0.8rem; margin-bottom: 1rem; }

--- a/examples/sse-dashboard/templates/layouts/base.html
+++ b/examples/sse-dashboard/templates/layouts/base.html
@@ -1,0 +1,85 @@
+{# examples/sse-dashboard/templates/layouts/base.html #}
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{% block title %}SSE Dashboard{% endblock %}</title>
+        <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+        <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
+        <style>
+            * {
+                box-sizing: border-box;
+                margin: 0;
+                padding: 0;
+            }
+            body {
+                font-family: system-ui, sans-serif;
+                background: #0f172a;
+                color: #e2e8f0;
+                padding: 2rem;
+            }
+            h1 {
+                margin-bottom: 1.5rem;
+                font-size: 1.5rem;
+            }
+            .grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+                gap: 1rem;
+            }
+            .card {
+                background: #1e293b;
+                border-radius: 0.5rem;
+                padding: 1.25rem;
+                border-left: 4px solid #475569;
+            }
+            .card.up {
+                border-left-color: #22c55e;
+            }
+            .card.down {
+                border-left-color: #ef4444;
+            }
+            .card.degraded {
+                border-left-color: #f59e0b;
+            }
+            .card h2 {
+                font-size: 1rem;
+                margin-bottom: 0.75rem;
+            }
+            .card .status {
+                font-size: 0.875rem;
+                font-weight: 600;
+                text-transform: uppercase;
+            }
+            .card .status.up {
+                color: #22c55e;
+            }
+            .card .status.down {
+                color: #ef4444;
+            }
+            .card .status.degraded {
+                color: #f59e0b;
+            }
+            .card .metrics {
+                display: flex;
+                gap: 1rem;
+                margin-top: 0.75rem;
+                font-size: 0.8rem;
+                color: #94a3b8;
+            }
+            .card .metric span {
+                font-weight: 600;
+                color: #e2e8f0;
+            }
+            .connected {
+                color: #22c55e;
+                font-size: 0.8rem;
+                margin-bottom: 1rem;
+            }
+        </style>
+    </head>
+    <body>
+        {% block content %}{% endblock %}
+    </body>
+</html>

--- a/examples/sse-dashboard/templates/layouts/base.html
+++ b/examples/sse-dashboard/templates/layouts/base.html
@@ -7,77 +7,7 @@
         <title>{% block title %}SSE Dashboard{% endblock %}</title>
         <script src="https://unpkg.com/htmx.org@2.0.4"></script>
         <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
-        <style>
-            * {
-                box-sizing: border-box;
-                margin: 0;
-                padding: 0;
-            }
-            body {
-                font-family: system-ui, sans-serif;
-                background: #0f172a;
-                color: #e2e8f0;
-                padding: 2rem;
-            }
-            h1 {
-                margin-bottom: 1.5rem;
-                font-size: 1.5rem;
-            }
-            .grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-                gap: 1rem;
-            }
-            .card {
-                background: #1e293b;
-                border-radius: 0.5rem;
-                padding: 1.25rem;
-                border-left: 4px solid #475569;
-            }
-            .card.up {
-                border-left-color: #22c55e;
-            }
-            .card.down {
-                border-left-color: #ef4444;
-            }
-            .card.degraded {
-                border-left-color: #f59e0b;
-            }
-            .card h2 {
-                font-size: 1rem;
-                margin-bottom: 0.75rem;
-            }
-            .card .status {
-                font-size: 0.875rem;
-                font-weight: 600;
-                text-transform: uppercase;
-            }
-            .card .status.up {
-                color: #22c55e;
-            }
-            .card .status.down {
-                color: #ef4444;
-            }
-            .card .status.degraded {
-                color: #f59e0b;
-            }
-            .card .metrics {
-                display: flex;
-                gap: 1rem;
-                margin-top: 0.75rem;
-                font-size: 0.8rem;
-                color: #94a3b8;
-            }
-            .card .metric span {
-                font-weight: 600;
-                color: #e2e8f0;
-            }
-            .connected {
-                color: #22c55e;
-                font-size: 0.8rem;
-                margin-bottom: 1rem;
-            }
-        </style>
+        <link rel="stylesheet" href="/static/style.css" />
     </head>
     <body>
         {% block content %}{% endblock %}

--- a/examples/sse-dashboard/templates/layouts/base.html
+++ b/examples/sse-dashboard/templates/layouts/base.html
@@ -5,8 +5,8 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{% block title %}SSE Dashboard{% endblock %}</title>
-        <script src="https://unpkg.com/htmx.org@2.0.4"></script>
-        <script src="https://unpkg.com/htmx-ext-sse@2.3.0/sse.js"></script>
+        <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
+        <script src="https://unpkg.com/htmx-ext-sse@2.2.4/sse.js"></script>
         <link rel="stylesheet" href="/static/style.css" />
     </head>
     <body>

--- a/examples/sse-dashboard/templates/pages/dashboard.html
+++ b/examples/sse-dashboard/templates/pages/dashboard.html
@@ -1,0 +1,9 @@
+{# examples/sse-dashboard/templates/pages/dashboard.html #}
+{% extends "layouts/base.html" %}
+{% block content %}
+<h1>Server Status Dashboard</h1>
+<p class="connected">Live — updates via SSE</p>
+<div class="grid" hx-ext="sse" sse-connect="/events" sse-swap="status_update" hx-swap="innerHTML">
+    <p style="color: #94a3b8;">Waiting for data...</p>
+</div>
+{% endblock %}

--- a/examples/sse-dashboard/templates/partials/status_card.html
+++ b/examples/sse-dashboard/templates/partials/status_card.html
@@ -1,0 +1,12 @@
+{# examples/sse-dashboard/templates/partials/status_card.html #}
+{% for server in servers %}
+<div class="card {{ server.status }}">
+    <h2>{{ server.name }}</h2>
+    <div class="status {{ server.status }}">{{ server.status }}</div>
+    <div class="metrics">
+        <div class="metric">CPU: <span>{{ server.cpu }}%</span></div>
+        <div class="metric">MEM: <span>{{ server.memory }}%</span></div>
+        <div class="metric">Latency: <span>{{ server.latency_ms }}ms</span></div>
+    </div>
+</div>
+{% endfor %}

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -63,6 +63,7 @@ default = []
 templates = ["dep:minijinja", "dep:futures-util", "dep:http"]
 csrf = ["dep:rand", "dep:hmac", "dep:sha2", "dep:subtle", "dep:form_urlencoded", "dep:http"]
 i18n = ["dep:futures-util", "dep:http"]
+sse = ["dep:futures-util"]
 static-fs = ["tower-http/fs"]
 static-embed = ["dep:rust-embed", "dep:mime_guess", "modo-macros/static-embed"]
 

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -75,3 +75,4 @@ http = "1"
 minijinja = "2"
 serde = { version = "1", features = ["derive"] }
 tempfile = "3"
+futures-util = "0.3"

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -366,6 +366,13 @@ impl AppBuilder {
             Arc::new(app_config.csrf.clone()),
         );
 
+        // --- Auto-wire SseConfig ---
+        #[cfg(feature = "sse")]
+        self.services.insert(
+            TypeId::of::<crate::sse::SseConfig>(),
+            Arc::new(app_config.sse.clone()),
+        );
+
         // --- Pre-parse trusted proxies (avoids per-request CIDR parsing) ---
         self.services.insert(
             TypeId::of::<middleware::TrustedProxies>(),

--- a/modo/src/config.rs
+++ b/modo/src/config.rs
@@ -236,6 +236,9 @@ pub struct AppConfig {
     pub i18n: crate::i18n::I18nConfig,
     #[cfg(feature = "csrf")]
     pub csrf: crate::csrf::CsrfConfig,
+    #[cfg(feature = "sse")]
+    #[serde(default)]
+    pub sse: crate::sse::SseConfig,
 }
 
 // ---------------------------------------------------------------------------

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -28,6 +28,8 @@ pub mod request_id;
 pub mod router;
 pub mod sanitize;
 pub mod shutdown;
+#[cfg(feature = "sse")]
+pub mod sse;
 #[cfg(any(feature = "static-fs", feature = "static-embed"))]
 pub(crate) mod static_files;
 #[cfg(feature = "templates")]

--- a/modo/src/sse/broadcast.rs
+++ b/modo/src/sse/broadcast.rs
@@ -104,10 +104,9 @@ where
             let mut channels = channels_ref.write().unwrap_or_else(|e| e.into_inner());
             if let std::collections::hash_map::Entry::Occupied(entry) =
                 channels.entry(key_owned.clone())
+                && entry.get().receiver_count() == 0
             {
-                if entry.get().receiver_count() == 0 {
-                    entry.remove();
-                }
+                entry.remove();
             }
         };
 
@@ -133,10 +132,9 @@ where
                     let mut channels = self.channels.write().unwrap_or_else(|e| e.into_inner());
                     if let std::collections::hash_map::Entry::Occupied(entry) =
                         channels.entry(key.clone())
+                        && entry.get().receiver_count() == 0
                     {
-                        if entry.get().receiver_count() == 0 {
-                            entry.remove();
-                        }
+                        entry.remove();
                     }
                     Ok(0)
                 }
@@ -208,16 +206,17 @@ pub struct SseStream<T> {
 }
 
 impl<T: Clone + Send + 'static> SseStream<T> {
-    pub(crate) fn with_cleanup(rx: broadcast::Receiver<T>, cleanup: impl FnOnce() + Send + 'static) -> Self {
+    pub(crate) fn with_cleanup(
+        rx: broadcast::Receiver<T>,
+        cleanup: impl FnOnce() + Send + 'static,
+    ) -> Self {
         Self {
             inner: Box::pin(Self::unfold_stream(rx)),
             _cleanup: Some(Box::new(cleanup)),
         }
     }
 
-    fn unfold_stream(
-        rx: broadcast::Receiver<T>,
-    ) -> impl Stream<Item = Result<T, Error>> {
+    fn unfold_stream(rx: broadcast::Receiver<T>) -> impl Stream<Item = Result<T, Error>> {
         futures_util::stream::unfold(rx, |mut rx| async move {
             loop {
                 match rx.recv().await {

--- a/modo/src/sse/broadcast.rs
+++ b/modo/src/sse/broadcast.rs
@@ -75,7 +75,7 @@ where
     /// raw `T` values -- convert to [`SseEvent`](super::SseEvent) downstream
     /// using [`SseStreamExt`](super::SseStreamExt) or `.map()`.
     pub fn subscribe(&self, key: &K) -> SseStream<T> {
-        let mut channels = self.channels.write().unwrap();
+        let mut channels = self.channels.write().unwrap_or_else(|e| e.into_inner());
 
         // Prune dead channels while we have the lock
         channels.retain(|_, sender| sender.receiver_count() > 0);
@@ -95,7 +95,7 @@ where
     /// **Does NOT create a channel** -- only [`subscribe()`](Self::subscribe)
     /// creates channels lazily. Sending to a nonexistent key is a silent no-op.
     pub fn send(&self, key: &K, event: T) -> Result<usize, Error> {
-        let mut channels = self.channels.write().unwrap();
+        let mut channels = self.channels.write().unwrap_or_else(|e| e.into_inner());
 
         // Prune dead channels
         channels.retain(|_, sender| sender.receiver_count() > 0);
@@ -114,7 +114,7 @@ where
     ///
     /// Returns 0 if the key has no channel.
     pub fn subscriber_count(&self, key: &K) -> usize {
-        let channels = self.channels.read().unwrap();
+        let channels = self.channels.read().unwrap_or_else(|e| e.into_inner());
         channels.get(key).map(|s| s.receiver_count()).unwrap_or(0)
     }
 
@@ -123,7 +123,7 @@ where
     /// Typically not needed -- channels auto-clean when the last subscriber
     /// drops. Use this for explicit teardown (e.g., deleting a chat room).
     pub fn remove(&self, key: &K) {
-        let mut channels = self.channels.write().unwrap();
+        let mut channels = self.channels.write().unwrap_or_else(|e| e.into_inner());
         channels.remove(key);
     }
 }

--- a/modo/src/sse/broadcast.rs
+++ b/modo/src/sse/broadcast.rs
@@ -29,8 +29,10 @@ use tokio::sync::broadcast;
 /// # Channel lifecycle
 ///
 /// - Channels are created lazily on first [`subscribe()`](Self::subscribe)
-/// - Channels are auto-cleaned when the last subscriber drops (detected on
-///   next [`send()`](Self::send) or [`subscribe()`](Self::subscribe) call)
+/// - Channels are auto-cleaned when the last subscriber's [`SseStream`] is
+///   dropped — each stream carries a cleanup closure that removes the channel
+///   entry if `receiver_count() == 0`
+/// - [`send()`](Self::send) also removes a channel on send failure (O(1) targeted)
 /// - [`remove()`](Self::remove) forces immediate cleanup
 ///
 /// # Filtering
@@ -74,17 +76,42 @@ where
     /// Creates the channel lazily on first subscription. Returns a stream of
     /// raw `T` values -- convert to [`SseEvent`](super::SseEvent) downstream
     /// using [`SseStreamExt`](super::SseStreamExt) or `.map()`.
+    ///
+    /// The returned [`SseStream`] carries a cleanup closure that removes the
+    /// channel entry when the last subscriber is dropped — no O(n) scan needed.
     pub fn subscribe(&self, key: &K) -> SseStream<T> {
         let mut channels = self.channels.write().unwrap_or_else(|e| e.into_inner());
-
-        // Prune dead channels while we have the lock
-        channels.retain(|_, sender| sender.receiver_count() > 0);
 
         let sender = channels
             .entry(key.clone())
             .or_insert_with(|| broadcast::channel(self.buffer).0);
         let rx = sender.subscribe();
-        SseStream::new(rx)
+
+        let channels_ref = Arc::clone(&self.channels);
+        let key_owned = key.clone();
+        let cleanup = move || {
+            // Read-lock fast path: if receivers remain, nothing to do
+            {
+                let channels = channels_ref.read().unwrap_or_else(|e| e.into_inner());
+                if channels
+                    .get(&key_owned)
+                    .is_none_or(|s| s.receiver_count() > 0)
+                {
+                    return;
+                }
+            }
+            // Write-lock: double-check before removing (a new subscriber may have joined)
+            let mut channels = channels_ref.write().unwrap_or_else(|e| e.into_inner());
+            if let std::collections::hash_map::Entry::Occupied(entry) =
+                channels.entry(key_owned.clone())
+            {
+                if entry.get().receiver_count() == 0 {
+                    entry.remove();
+                }
+            }
+        };
+
+        SseStream::with_cleanup(rx, cleanup)
     }
 
     /// Send an event to all subscribers of a keyed channel.
@@ -101,10 +128,16 @@ where
             match sender.send(event) {
                 Ok(count) => Ok(count),
                 Err(_) => {
-                    // All receivers dropped — upgrade to write lock and prune
+                    // All receivers dropped — targeted removal (O(1))
                     drop(channels);
                     let mut channels = self.channels.write().unwrap_or_else(|e| e.into_inner());
-                    channels.retain(|_, s| s.receiver_count() > 0);
+                    if let std::collections::hash_map::Entry::Occupied(entry) =
+                        channels.entry(key.clone())
+                    {
+                        if entry.get().receiver_count() == 0 {
+                            entry.remove();
+                        }
+                    }
                     Ok(0)
                 }
             }
@@ -160,13 +193,32 @@ where
 ///
 /// The stream ends (`None`) when the broadcast sender is dropped -- either
 /// via [`SseBroadcastManager::remove()`] or when the manager itself is dropped.
+///
+/// # Cleanup
+///
+/// When created via [`SseBroadcastManager::subscribe()`], the stream carries a
+/// cleanup closure that fires on drop. If this was the last subscriber, the
+/// closure removes the channel entry from the manager — no O(n) scan needed.
 pub struct SseStream<T> {
+    // IMPORTANT: `inner` must be declared before `_cleanup`. Rust drops fields
+    // in declaration order — the broadcast `Receiver` inside `inner` must drop
+    // first (decrementing `receiver_count`) before the cleanup closure checks it.
     inner: Pin<Box<dyn Stream<Item = Result<T, Error>> + Send>>,
+    _cleanup: Option<Box<dyn FnOnce() + Send>>,
 }
 
 impl<T: Clone + Send + 'static> SseStream<T> {
-    pub(crate) fn new(rx: broadcast::Receiver<T>) -> Self {
-        let stream = futures_util::stream::unfold(rx, |mut rx| async move {
+    pub(crate) fn with_cleanup(rx: broadcast::Receiver<T>, cleanup: impl FnOnce() + Send + 'static) -> Self {
+        Self {
+            inner: Box::pin(Self::unfold_stream(rx)),
+            _cleanup: Some(Box::new(cleanup)),
+        }
+    }
+
+    fn unfold_stream(
+        rx: broadcast::Receiver<T>,
+    ) -> impl Stream<Item = Result<T, Error>> {
+        futures_util::stream::unfold(rx, |mut rx| async move {
             loop {
                 match rx.recv().await {
                     Ok(item) => return Some((Ok(item), rx)),
@@ -177,9 +229,14 @@ impl<T: Clone + Send + 'static> SseStream<T> {
                     Err(broadcast::error::RecvError::Closed) => return None,
                 }
             }
-        });
-        Self {
-            inner: Box::pin(stream),
+        })
+    }
+}
+
+impl<T> Drop for SseStream<T> {
+    fn drop(&mut self) {
+        if let Some(cleanup) = self._cleanup.take() {
+            cleanup();
         }
     }
 }

--- a/modo/src/sse/broadcast.rs
+++ b/modo/src/sse/broadcast.rs
@@ -115,10 +115,7 @@ where
     /// Returns 0 if the key has no channel.
     pub fn subscriber_count(&self, key: &K) -> usize {
         let channels = self.channels.read().unwrap();
-        channels
-            .get(key)
-            .map(|s| s.receiver_count())
-            .unwrap_or(0)
+        channels.get(key).map(|s| s.receiver_count()).unwrap_or(0)
     }
 
     /// Manually remove a channel and disconnect all its subscribers.
@@ -171,10 +168,7 @@ impl<T: Clone + Send + 'static> SseStream<T> {
                 match rx.recv().await {
                     Ok(item) => return Some((Ok(item), rx)),
                     Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!(
-                            skipped = n,
-                            "SSE subscriber lagged, skipping {n} messages"
-                        );
+                        tracing::warn!(skipped = n, "SSE subscriber lagged, skipping {n} messages");
                         continue;
                     }
                     Err(broadcast::error::RecvError::Closed) => return None,

--- a/modo/src/sse/broadcast.rs
+++ b/modo/src/sse/broadcast.rs
@@ -1,0 +1,196 @@
+use crate::error::Error;
+use futures_util::Stream;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+use tokio::sync::broadcast;
+
+/// Registry of keyed broadcast channels for fan-out SSE delivery.
+///
+/// Each key maps to an independent broadcast channel. All subscribers of a key
+/// receive every message sent to that key. Use one manager per domain concept
+/// (e.g., chat messages, uptime checks, notifications).
+///
+/// # Construction
+///
+/// ```rust
+/// use modo::sse::SseBroadcastManager;
+///
+/// let chat: SseBroadcastManager<String, String> = SseBroadcastManager::new(128);
+/// ```
+///
+/// Register as a service -- the service registry handles `Arc` wrapping:
+/// ```rust,ignore
+/// app.service(chat);
+/// ```
+///
+/// # Channel lifecycle
+///
+/// - Channels are created lazily on first [`subscribe()`](Self::subscribe)
+/// - Channels are auto-cleaned when the last subscriber drops (detected on
+///   next [`send()`](Self::send) or [`subscribe()`](Self::subscribe) call)
+/// - [`remove()`](Self::remove) forces immediate cleanup
+///
+/// # Filtering
+///
+/// All subscribers receive all messages. Filter on the consumer side:
+/// ```rust,ignore
+/// let stream = mgr.subscribe(&room_id)
+///     .filter_map(|result| match result {
+///         Ok(msg) if msg.sender != my_id => Some(msg),
+///         _ => None,
+///     });
+/// ```
+pub struct SseBroadcastManager<K, T>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+{
+    channels: Arc<RwLock<HashMap<K, broadcast::Sender<T>>>>,
+    buffer: usize,
+}
+
+impl<K, T> SseBroadcastManager<K, T>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+{
+    /// Create a new manager with the given per-channel buffer size.
+    ///
+    /// The buffer size determines how many messages can be buffered before
+    /// slow subscribers start lagging (skipping missed messages with a warning).
+    /// Typical values: 64-256 for chat, 16-64 for dashboards.
+    pub fn new(buffer: usize) -> Self {
+        Self {
+            channels: Arc::new(RwLock::new(HashMap::new())),
+            buffer,
+        }
+    }
+
+    /// Subscribe to a keyed channel.
+    ///
+    /// Creates the channel lazily on first subscription. Returns a stream of
+    /// raw `T` values -- convert to [`SseEvent`](super::SseEvent) downstream
+    /// using [`SseStreamExt`](super::SseStreamExt) or `.map()`.
+    pub fn subscribe(&self, key: &K) -> SseStream<T> {
+        let mut channels = self.channels.write().unwrap();
+
+        // Prune dead channels while we have the lock
+        channels.retain(|_, sender| sender.receiver_count() > 0);
+
+        let sender = channels
+            .entry(key.clone())
+            .or_insert_with(|| broadcast::channel(self.buffer).0);
+        let rx = sender.subscribe();
+        SseStream::new(rx)
+    }
+
+    /// Send an event to all subscribers of a keyed channel.
+    ///
+    /// Returns the number of receivers that got the message. Returns `Ok(0)`
+    /// if no subscribers exist for the key.
+    ///
+    /// **Does NOT create a channel** -- only [`subscribe()`](Self::subscribe)
+    /// creates channels lazily. Sending to a nonexistent key is a silent no-op.
+    pub fn send(&self, key: &K, event: T) -> Result<usize, Error> {
+        let mut channels = self.channels.write().unwrap();
+
+        // Prune dead channels
+        channels.retain(|_, sender| sender.receiver_count() > 0);
+
+        if let Some(sender) = channels.get(key) {
+            match sender.send(event) {
+                Ok(count) => Ok(count),
+                Err(_) => Ok(0), // All receivers dropped between retain and send
+            }
+        } else {
+            Ok(0)
+        }
+    }
+
+    /// Number of active subscribers for a key.
+    ///
+    /// Returns 0 if the key has no channel.
+    pub fn subscriber_count(&self, key: &K) -> usize {
+        let channels = self.channels.read().unwrap();
+        channels
+            .get(key)
+            .map(|s| s.receiver_count())
+            .unwrap_or(0)
+    }
+
+    /// Manually remove a channel and disconnect all its subscribers.
+    ///
+    /// Typically not needed -- channels auto-clean when the last subscriber
+    /// drops. Use this for explicit teardown (e.g., deleting a chat room).
+    pub fn remove(&self, key: &K) {
+        let mut channels = self.channels.write().unwrap();
+        channels.remove(key);
+    }
+}
+
+// Clone so it can be shared via Arc in the service registry
+impl<K, T> Clone for SseBroadcastManager<K, T>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            channels: Arc::clone(&self.channels),
+            buffer: self.buffer,
+        }
+    }
+}
+
+/// A stream of events from a broadcast channel.
+///
+/// Yields raw `T` values (not [`SseEvent`](super::SseEvent)). Convert
+/// downstream using [`SseStreamExt`](super::SseStreamExt) combinators or
+/// standard stream methods (`.map()`, `.filter_map()`, etc.).
+///
+/// # Lagging
+///
+/// If a subscriber falls behind (buffer full), missed messages are skipped
+/// with a warning log. The stream continues with the next available message.
+///
+/// # End of stream
+///
+/// The stream ends (`None`) when the broadcast sender is dropped -- either
+/// via [`SseBroadcastManager::remove()`] or when the manager itself is dropped.
+pub struct SseStream<T> {
+    inner: Pin<Box<dyn Stream<Item = Result<T, Error>> + Send>>,
+}
+
+impl<T: Clone + Send + 'static> SseStream<T> {
+    pub(crate) fn new(rx: broadcast::Receiver<T>) -> Self {
+        let stream = futures_util::stream::unfold(rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(item) => return Some((Ok(item), rx)),
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(
+                            skipped = n,
+                            "SSE subscriber lagged, skipping {n} messages"
+                        );
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        });
+        Self {
+            inner: Box::pin(stream),
+        }
+    }
+}
+
+impl<T> Stream for SseStream<T> {
+    type Item = Result<T, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}

--- a/modo/src/sse/broadcast.rs
+++ b/modo/src/sse/broadcast.rs
@@ -95,15 +95,18 @@ where
     /// **Does NOT create a channel** -- only [`subscribe()`](Self::subscribe)
     /// creates channels lazily. Sending to a nonexistent key is a silent no-op.
     pub fn send(&self, key: &K, event: T) -> Result<usize, Error> {
-        let mut channels = self.channels.write().unwrap_or_else(|e| e.into_inner());
-
-        // Prune dead channels
-        channels.retain(|_, sender| sender.receiver_count() > 0);
-
+        // Read lock for the happy path — avoids serializing concurrent senders
+        let channels = self.channels.read().unwrap_or_else(|e| e.into_inner());
         if let Some(sender) = channels.get(key) {
             match sender.send(event) {
                 Ok(count) => Ok(count),
-                Err(_) => Ok(0), // All receivers dropped between retain and send
+                Err(_) => {
+                    // All receivers dropped — upgrade to write lock and prune
+                    drop(channels);
+                    let mut channels = self.channels.write().unwrap_or_else(|e| e.into_inner());
+                    channels.retain(|_, s| s.receiver_count() > 0);
+                    Ok(0)
+                }
             }
         } else {
             Ok(0)

--- a/modo/src/sse/config.rs
+++ b/modo/src/sse/config.rs
@@ -1,0 +1,50 @@
+use serde::Deserialize;
+use std::time::Duration;
+
+fn default_keep_alive_interval_secs() -> u64 {
+    15
+}
+
+/// Configuration for Server-Sent Events.
+///
+/// Controls keep-alive behavior for SSE connections. Loaded from the `sse`
+/// section of your application config YAML.
+///
+/// # Example
+///
+/// ```yaml
+/// sse:
+///     keep_alive_interval_secs: 30
+/// ```
+///
+/// # Defaults
+///
+/// | Field | Default |
+/// |-------|---------|
+/// | `keep_alive_interval_secs` | `15` |
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SseConfig {
+    /// Keep-alive interval in seconds. The server sends a comment line (`:`)
+    /// at this interval to prevent proxies and browsers from closing idle
+    /// connections.
+    ///
+    /// Converted to [`Duration`] via [`keep_alive_interval()`](Self::keep_alive_interval).
+    #[serde(default = "default_keep_alive_interval_secs")]
+    pub keep_alive_interval_secs: u64,
+}
+
+impl Default for SseConfig {
+    fn default() -> Self {
+        Self {
+            keep_alive_interval_secs: default_keep_alive_interval_secs(),
+        }
+    }
+}
+
+impl SseConfig {
+    /// Returns the keep-alive interval as a [`Duration`].
+    pub fn keep_alive_interval(&self) -> Duration {
+        Duration::from_secs(self.keep_alive_interval_secs)
+    }
+}

--- a/modo/src/sse/event.rs
+++ b/modo/src/sse/event.rs
@@ -1,0 +1,162 @@
+use crate::error::Error;
+use serde::Serialize;
+use std::time::Duration;
+
+/// A Server-Sent Event to be delivered to a connected client.
+///
+/// Uses a builder pattern to construct events with optional fields.
+/// At minimum, an event should have data (via [`data()`](Self::data),
+/// [`json()`](Self::json), or [`html()`](Self::html)).
+///
+/// # Examples
+///
+/// ```rust
+/// use modo::sse::SseEvent;
+///
+/// // Plain text event
+/// let event = SseEvent::new()
+///     .event("message")
+///     .data("Hello, world!");
+///
+/// // JSON event
+/// # use serde::Serialize;
+/// # #[derive(Serialize)]
+/// # struct Status { ok: bool }
+/// let event = SseEvent::new()
+///     .event("status")
+///     .json(&Status { ok: true })
+///     .unwrap();
+///
+/// // HTML partial (for HTMX)
+/// let event = SseEvent::new()
+///     .event("update")
+///     .html("<div class=\"card\">New content</div>");
+/// ```
+///
+/// # Data methods
+///
+/// [`data()`](Self::data), [`json()`](Self::json), and [`html()`](Self::html) are
+/// mutually exclusive — each sets the event's data payload, replacing any
+/// previous value. [`json()`](Self::json) is fallible because serialization can fail.
+///
+/// # SSE protocol fields
+///
+/// | Method | SSE field | Purpose |
+/// |--------|-----------|---------|
+/// | [`event()`](Self::event) | `event:` | Named event type for client-side listeners |
+/// | [`id()`](Self::id) | `id:` | Last-event-id for reconnection (see [`LastEventId`](super::LastEventId)) |
+/// | [`retry()`](Self::retry) | `retry:` | Client reconnect delay hint (serialized as milliseconds) |
+#[must_use]
+#[derive(Debug, Clone)]
+pub struct SseEvent {
+    pub(crate) event_name: Option<String>,
+    pub(crate) data: Option<String>,
+    pub(crate) id: Option<String>,
+    pub(crate) retry: Option<Duration>,
+}
+
+impl SseEvent {
+    /// Create a new empty SSE event.
+    pub fn new() -> Self {
+        Self {
+            event_name: None,
+            data: None,
+            id: None,
+            retry: None,
+        }
+    }
+
+    /// Set the event type name.
+    ///
+    /// Clients can listen for specific event types. In JavaScript:
+    /// `eventSource.addEventListener("message", handler)`.
+    /// In HTMX: `hx-trigger="sse:message"`.
+    pub fn event(mut self, name: impl Into<String>) -> Self {
+        self.event_name = Some(name.into());
+        self
+    }
+
+    /// Set the data payload as a plain string.
+    ///
+    /// Multi-line strings are handled automatically — each line gets its own
+    /// `data:` prefix per the SSE spec. The browser reassembles them with `\n`.
+    pub fn data(mut self, data: impl Into<String>) -> Self {
+        self.data = Some(data.into());
+        self
+    }
+
+    /// Set the data payload as JSON-serialized data.
+    ///
+    /// Mutually exclusive with [`data()`](Self::data) and [`html()`](Self::html)
+    /// — replaces any previously set data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `serde_json` serialization fails (e.g., the value
+    /// contains `f64::NAN`).
+    pub fn json<T: Serialize>(mut self, data: &T) -> Result<Self, Error> {
+        let json = serde_json::to_string(data)
+            .map_err(|e| Error::internal(format!("SSE JSON serialization failed: {e}")))?;
+        self.data = Some(json);
+        Ok(self)
+    }
+
+    /// Set the data payload as an HTML fragment.
+    ///
+    /// Semantically identical to [`data()`](Self::data) — the SSE protocol
+    /// treats all data as text. This method communicates intent and may gain
+    /// additional behavior (e.g., escaping) in the future.
+    ///
+    /// **Best practice:** Keep HTML partials small — send individual components
+    /// (a chat bubble, a table row, a notification card), not entire page sections.
+    /// SSE has no built-in chunking or compression.
+    pub fn html(self, html: impl Into<String>) -> Self {
+        self.data(html)
+    }
+
+    /// Set the event ID for client reconnection.
+    ///
+    /// When a client reconnects, the browser sends a `Last-Event-ID` header
+    /// with this value. Use [`LastEventId`](super::LastEventId) to read it
+    /// in the handler and replay missed events.
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Set the reconnection delay hint for the client.
+    ///
+    /// Tells the browser how long to wait before reconnecting after a
+    /// disconnect. Serialized as milliseconds in the SSE `retry:` field.
+    pub fn retry(mut self, duration: Duration) -> Self {
+        self.retry = Some(duration);
+        self
+    }
+}
+
+impl Default for SseEvent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<SseEvent> for axum::response::sse::Event {
+    type Error = Error;
+
+    fn try_from(sse: SseEvent) -> Result<Self, Self::Error> {
+        let mut event = axum::response::sse::Event::default();
+        if let Some(name) = sse.event_name {
+            event = event.event(name);
+        }
+        if let Some(data) = sse.data {
+            event = event.data(data);
+        }
+        if let Some(id) = sse.id {
+            event = event.id(id);
+        }
+        if let Some(retry) = sse.retry {
+            event = event.retry(retry);
+        }
+        Ok(event)
+    }
+}

--- a/modo/src/sse/extractor.rs
+++ b/modo/src/sse/extractor.rs
@@ -1,0 +1,84 @@
+use super::config::SseConfig;
+use super::event::SseEvent;
+use super::response::SseResponse;
+use super::sender::SseSender;
+use crate::app::AppState;
+use crate::error::Error;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use futures_util::Stream;
+
+/// SSE extractor that auto-applies [`SseConfig`] from the service registry.
+///
+/// Use this in handlers to create SSE responses with the application's
+/// configured keep-alive interval instead of the hardcoded default.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use modo::sse::{Sse, SseEvent, SseResponse, SseStreamExt};
+///
+/// #[modo::handler(GET, "/events")]
+/// async fn events(
+///     sse: Sse,
+///     Service(bc): Service<SseBroadcastManager<String, MyEvent>>,
+/// ) -> SseResponse {
+///     sse.from_stream(bc.subscribe(&"topic".into()).sse_json())
+/// }
+/// ```
+///
+/// # Config
+///
+/// The keep-alive interval is read from `sse.keep_alive_interval_secs` in
+/// your application config YAML. Falls back to 15 seconds if not configured.
+///
+/// ```yaml
+/// sse:
+///     keep_alive_interval_secs: 30
+/// ```
+pub struct Sse {
+    config: SseConfig,
+}
+
+impl FromRequestParts<AppState> for Sse {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let config = state
+            .services
+            .get::<SseConfig>()
+            .map(|arc| (*arc).clone())
+            .unwrap_or_default();
+        Ok(Sse { config })
+    }
+}
+
+impl Sse {
+    /// Create an [`SseResponse`] from any stream of [`SseEvent`]s.
+    ///
+    /// Applies the configured keep-alive interval automatically.
+    /// Chain [`.with_keep_alive()`](SseResponse::with_keep_alive) to override
+    /// for a specific handler.
+    pub fn from_stream<S, E>(&self, stream: S) -> SseResponse
+    where
+        S: Stream<Item = Result<SseEvent, E>> + Send + 'static,
+        E: Into<Error> + Send + 'static,
+    {
+        super::response::from_stream(stream).with_keep_alive(self.config.keep_alive_interval())
+    }
+
+    /// Create an [`SseResponse`] with an imperative sender.
+    ///
+    /// Applies the configured keep-alive interval automatically.
+    /// See [`channel()`](super::channel) for full documentation.
+    pub fn channel<F, Fut>(&self, f: F) -> SseResponse
+    where
+        F: FnOnce(SseSender) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<(), Error>> + Send,
+    {
+        super::sender::channel(f).with_keep_alive(self.config.keep_alive_interval())
+    }
+}

--- a/modo/src/sse/last_event_id.rs
+++ b/modo/src/sse/last_event_id.rs
@@ -1,0 +1,54 @@
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+
+/// Extracts the `Last-Event-ID` header from the request.
+///
+/// When a client reconnects after a disconnect, the browser's `EventSource`
+/// sends a `Last-Event-ID` header with the ID of the last event it received.
+/// Use this extractor to detect reconnections and replay missed events.
+///
+/// Contains `None` on first connection (header absent).
+///
+/// # Replay is application logic
+///
+/// The SSE module does NOT replay events automatically. Your handler is
+/// responsible for fetching missed events (e.g., from a database) and sending
+/// them before subscribing to the live stream.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[modo::handler(GET, "/events")]
+/// async fn events(
+///     last_event_id: LastEventId,
+///     Service(bc): Service<SseBroadcastManager<String, MyEvent>>,
+///     Db(db): Db,
+/// ) -> SseResponse {
+///     let stream = if let Some(last_id) = last_event_id.0 {
+///         // Replay missed events from DB, then subscribe to live
+///         let missed = load_events_after(&db, &last_id).await?;
+///         let live = bc.subscribe(&"topic".into());
+///         missed.chain(live)
+///     } else {
+///         bc.subscribe(&"topic".into())
+///     };
+///     modo::sse::from_stream(stream.sse_map(|e| Ok(SseEvent::from(e))))
+/// }
+/// ```
+pub struct LastEventId(pub Option<String>);
+
+impl<S> FromRequestParts<S> for LastEventId
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let value = parts
+            .headers
+            .get("last-event-id")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        Ok(LastEventId(value))
+    }
+}

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -4,6 +4,7 @@ pub mod event;
 pub mod last_event_id;
 pub mod response;
 pub mod sender;
+pub mod stream_ext;
 
 pub use broadcast::{SseBroadcastManager, SseStream};
 pub use config::SseConfig;
@@ -11,3 +12,4 @@ pub use event::SseEvent;
 pub use last_event_id::LastEventId;
 pub use response::{SseResponse, from_stream};
 pub use sender::{SseSender, channel};
+pub use stream_ext::SseStreamExt;

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -1,0 +1,3 @@
+pub mod config;
+
+pub use config::SseConfig;

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -1,7 +1,9 @@
 pub mod config;
 pub mod event;
 pub mod response;
+pub mod sender;
 
 pub use config::SseConfig;
 pub use event::SseEvent;
 pub use response::{SseResponse, from_stream};
+pub use sender::{SseSender, channel};

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -1,3 +1,116 @@
+//! Server-Sent Events (SSE) support for modo.
+//!
+//! This module provides a streaming primitive for real-time event delivery
+//! over HTTP. Events flow from server to client over a long-lived connection
+//! using the [SSE protocol](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).
+//!
+//! # Quick start
+//!
+//! Enable the `sse` feature in your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! modo = { path = "../../modo", features = ["sse"] }
+//! ```
+//!
+//! ## Stream from a broadcast channel
+//!
+//! ```rust,ignore
+//! use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+//!
+//! // Register a broadcast manager as a service in main()
+//! let notifications: SseBroadcastManager<UserId, Notification> =
+//!     SseBroadcastManager::new(64);
+//! app.service(notifications);
+//!
+//! // Subscribe in a handler
+//! #[modo::handler(GET, "/notifications/events")]
+//! async fn events(
+//!     auth: Auth<User>,
+//!     Service(bc): Service<SseBroadcastManager<UserId, Notification>>,
+//! ) -> SseResponse {
+//!     modo::sse::from_stream(bc.subscribe(&auth.user.id).sse_json())
+//! }
+//! ```
+//!
+//! ## Imperative channel
+//!
+//! ```rust,ignore
+//! #[modo::handler(GET, "/jobs/{id}/progress")]
+//! async fn progress(id: String, Service(jobs): Service<JobService>) -> SseResponse {
+//!     modo::sse::channel(|tx| async move {
+//!         while let Some(status) = jobs.poll_status(&id).await {
+//!             tx.send(SseEvent::new().event("progress").json(&status)?).await?;
+//!             if status.is_done() { break; }
+//!         }
+//!         Ok(())
+//!     })
+//! }
+//! ```
+//!
+//! ## HTML partials (HTMX)
+//!
+//! ```rust,ignore
+//! #[modo::handler(GET, "/chat/{id}/events")]
+//! async fn chat(
+//!     id: String,
+//!     view: ViewRenderer,
+//!     Service(bc): Service<SseBroadcastManager<String, ChatMessage>>,
+//! ) -> SseResponse {
+//!     let stream = bc.subscribe(&id).sse_map(move |msg| {
+//!         let html = view.render_to_string(MessageView::from(&msg))?;
+//!         Ok(SseEvent::new().event("message").html(html))
+//!     });
+//!     modo::sse::from_stream(stream)
+//! }
+//! ```
+//!
+//! # Architecture
+//!
+//! | Type | Purpose |
+//! |------|---------|
+//! | [`SseEvent`] | Builder for a single event (data/json/html + metadata) |
+//! | [`SseResponse`] | Handler return type — wraps a stream with keep-alive |
+//! | [`SseBroadcastManager`] | Keyed broadcast channels for fan-out delivery |
+//! | [`SseStream`] | Stream of raw `T` values from a broadcast channel |
+//! | [`SseSender`] | Imperative sender for [`channel()`] closures |
+//! | [`LastEventId`] | Extractor for the `Last-Event-ID` reconnection header |
+//! | [`SseStreamExt`] | Ergonomic stream-to-event conversion methods |
+//! | [`SseConfig`] | Keep-alive configuration |
+//!
+//! # Entry points
+//!
+//! | Function | Use case |
+//! |----------|----------|
+//! | [`from_stream()`] | Wrap any `Stream<Item = Result<SseEvent, E>>` as SSE |
+//! | [`channel()`] | Imperative event production via closure + sender |
+//!
+//! # Gotchas
+//!
+//! ## Request timeout
+//!
+//! The global `TimeoutLayer` will terminate SSE connections after the
+//! configured request timeout. SSE connections are long-lived, so you must
+//! either set a long timeout or disable it for SSE routes.
+//!
+//! ```yaml
+//! server:
+//!     http:
+//!         request_timeout: 3600  # 1 hour, suitable for SSE
+//! ```
+//!
+//! ## Reconnection and `Last-Event-ID`
+//!
+//! When a client reconnects, the browser sends a `Last-Event-ID` header.
+//! Use [`LastEventId`] to read it and replay missed events from your
+//! data store. The SSE module does NOT replay automatically.
+//!
+//! ## Multi-line HTML
+//!
+//! Multi-line data (including HTML partials) is handled automatically per
+//! the SSE spec. Keep partials small — send individual components, not
+//! entire page sections.
+
 pub mod broadcast;
 pub mod config;
 pub mod event;

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -1,3 +1,5 @@
 pub mod config;
+pub mod event;
 
 pub use config::SseConfig;
+pub use event::SseEvent;

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -1,9 +1,11 @@
+pub mod broadcast;
 pub mod config;
 pub mod event;
 pub mod last_event_id;
 pub mod response;
 pub mod sender;
 
+pub use broadcast::{SseBroadcastManager, SseStream};
 pub use config::SseConfig;
 pub use event::SseEvent;
 pub use last_event_id::LastEventId;

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -1,5 +1,7 @@
 pub mod config;
 pub mod event;
+pub mod response;
 
 pub use config::SseConfig;
 pub use event::SseEvent;
+pub use response::{SseResponse, from_stream};

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -16,20 +16,21 @@
 //! ## Stream from a broadcast channel
 //!
 //! ```rust,ignore
-//! use modo::sse::{SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
+//! use modo::sse::{Sse, SseBroadcastManager, SseEvent, SseResponse, SseStreamExt};
 //!
 //! // Register a broadcast manager as a service in main()
 //! let notifications: SseBroadcastManager<UserId, Notification> =
 //!     SseBroadcastManager::new(64);
 //! app.service(notifications);
 //!
-//! // Subscribe in a handler
+//! // Subscribe in a handler — Sse extractor auto-applies keep-alive config
 //! #[modo::handler(GET, "/notifications/events")]
 //! async fn events(
+//!     sse: Sse,
 //!     auth: Auth<User>,
 //!     Service(bc): Service<SseBroadcastManager<UserId, Notification>>,
 //! ) -> SseResponse {
-//!     modo::sse::from_stream(bc.subscribe(&auth.user.id).sse_json())
+//!     sse.from_stream(bc.subscribe(&auth.user.id).sse_json())
 //! }
 //! ```
 //!
@@ -37,8 +38,8 @@
 //!
 //! ```rust,ignore
 //! #[modo::handler(GET, "/jobs/{id}/progress")]
-//! async fn progress(id: String, Service(jobs): Service<JobService>) -> SseResponse {
-//!     modo::sse::channel(|tx| async move {
+//! async fn progress(sse: Sse, id: String, Service(jobs): Service<JobService>) -> SseResponse {
+//!     sse.channel(|tx| async move {
 //!         while let Some(status) = jobs.poll_status(&id).await {
 //!             tx.send(SseEvent::new().event("progress").json(&status)?).await?;
 //!             if status.is_done() { break; }
@@ -53,6 +54,7 @@
 //! ```rust,ignore
 //! #[modo::handler(GET, "/chat/{id}/events")]
 //! async fn chat(
+//!     sse: Sse,
 //!     id: String,
 //!     view: ViewRenderer,
 //!     Service(bc): Service<SseBroadcastManager<String, ChatMessage>>,
@@ -61,7 +63,7 @@
 //!         let html = view.render_to_string(MessageView::from(&msg))?;
 //!         Ok(SseEvent::new().event("message").html(html))
 //!     });
-//!     modo::sse::from_stream(stream)
+//!     sse.from_stream(stream)
 //! }
 //! ```
 //!
@@ -71,6 +73,7 @@
 //! |------|---------|
 //! | [`SseEvent`] | Builder for a single event (data/json/html + metadata) |
 //! | [`SseResponse`] | Handler return type — wraps a stream with keep-alive |
+//! | [`Sse`] | Extractor — auto-applies [`SseConfig`] to responses |
 //! | [`SseBroadcastManager`] | Keyed broadcast channels for fan-out delivery |
 //! | [`SseStream`] | Stream of raw `T` values from a broadcast channel |
 //! | [`SseSender`] | Imperative sender for [`channel()`] closures |
@@ -105,6 +108,33 @@
 //! Use [`LastEventId`] to read it and replay missed events from your
 //! data store. The SSE module does NOT replay automatically.
 //!
+//! ## Reverse proxy buffering (nginx)
+//!
+//! Nginx buffers responses by default, which breaks SSE entirely. The
+//! framework automatically sets the `X-Accel-Buffering: no` header on all
+//! SSE responses. If you use a different reverse proxy, ensure response
+//! buffering is disabled for SSE routes:
+//!
+//! ```nginx
+//! location /events {
+//!     proxy_buffering off;
+//!     proxy_pass http://backend;
+//! }
+//! ```
+//!
+//! ## HTTP compression
+//!
+//! Enabling `http.compression` in your server config applies
+//! `CompressionLayer` globally, which buffers response data before sending.
+//! This prevents SSE events from flushing to the client in real time.
+//! Disable compression if you use SSE:
+//!
+//! ```yaml
+//! server:
+//!     http:
+//!         compression: false
+//! ```
+//!
 //! ## Multi-line HTML
 //!
 //! Multi-line data (including HTML partials) is handled automatically per
@@ -114,6 +144,7 @@
 pub mod broadcast;
 pub mod config;
 pub mod event;
+pub mod extractor;
 pub mod last_event_id;
 pub mod response;
 pub mod sender;
@@ -122,6 +153,7 @@ pub mod stream_ext;
 pub use broadcast::{SseBroadcastManager, SseStream};
 pub use config::SseConfig;
 pub use event::SseEvent;
+pub use extractor::Sse;
 pub use last_event_id::LastEventId;
 pub use response::{SseResponse, from_stream};
 pub use sender::{SseSender, channel};

--- a/modo/src/sse/mod.rs
+++ b/modo/src/sse/mod.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod event;
+pub mod last_event_id;
 pub mod response;
 pub mod sender;
 
 pub use config::SseConfig;
 pub use event::SseEvent;
+pub use last_event_id::LastEventId;
 pub use response::{SseResponse, from_stream};
 pub use sender::{SseSender, channel};

--- a/modo/src/sse/response.rs
+++ b/modo/src/sse/response.rs
@@ -67,7 +67,10 @@ impl IntoResponse for SseResponse {
             .keep_alive(axum::response::sse::KeepAlive::new().interval(self.keep_alive_interval))
             .into_response();
         resp.headers_mut()
-            .insert("X-Accel-Buffering", http::HeaderValue::from_static("no"));
+            .insert(
+                "X-Accel-Buffering",
+                axum::http::HeaderValue::from_static("no"),
+            );
         resp
     }
 }

--- a/modo/src/sse/response.rs
+++ b/modo/src/sse/response.rs
@@ -66,11 +66,10 @@ impl IntoResponse for SseResponse {
         let mut resp = axum::response::sse::Sse::new(self.stream)
             .keep_alive(axum::response::sse::KeepAlive::new().interval(self.keep_alive_interval))
             .into_response();
-        resp.headers_mut()
-            .insert(
-                "X-Accel-Buffering",
-                axum::http::HeaderValue::from_static("no"),
-            );
+        resp.headers_mut().insert(
+            "X-Accel-Buffering",
+            axum::http::HeaderValue::from_static("no"),
+        );
         resp
     }
 }

--- a/modo/src/sse/response.rs
+++ b/modo/src/sse/response.rs
@@ -63,9 +63,12 @@ impl SseResponse {
 
 impl IntoResponse for SseResponse {
     fn into_response(self) -> Response {
-        axum::response::sse::Sse::new(self.stream)
+        let mut resp = axum::response::sse::Sse::new(self.stream)
             .keep_alive(axum::response::sse::KeepAlive::new().interval(self.keep_alive_interval))
-            .into_response()
+            .into_response();
+        resp.headers_mut()
+            .insert("X-Accel-Buffering", http::HeaderValue::from_static("no"));
+        resp
     }
 }
 

--- a/modo/src/sse/response.rs
+++ b/modo/src/sse/response.rs
@@ -1,0 +1,110 @@
+use super::event::SseEvent;
+use crate::error::Error;
+use axum::response::{IntoResponse, Response};
+use futures_util::{Stream, StreamExt};
+use std::{pin::Pin, time::Duration};
+
+const DEFAULT_KEEP_ALIVE_SECS: u64 = 15;
+
+/// SSE response type for handlers.
+///
+/// Wraps an event stream with automatic keep-alive. Return this from any
+/// handler to start an SSE connection.
+///
+/// # Construction
+///
+/// Use [`from_stream()`](super::from_stream) or [`channel()`](super::channel)
+/// to create an `SseResponse`. Do not construct directly.
+///
+/// # Keep-alive
+///
+/// By default, sends a comment line (`:`) every 15 seconds to keep the
+/// connection alive through proxies. Override with
+/// [`with_keep_alive()`](Self::with_keep_alive).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use modo::sse::{SseEvent, SseResponse};
+///
+/// #[modo::handler(GET, "/events")]
+/// async fn events() -> SseResponse {
+///     let stream = futures_util::stream::repeat_with(|| {
+///         Ok(SseEvent::new().data("ping"))
+///     });
+///     modo::sse::from_stream(stream)
+/// }
+/// ```
+pub struct SseResponse {
+    stream: Pin<Box<dyn Stream<Item = Result<axum::response::sse::Event, axum::Error>> + Send>>,
+    keep_alive_interval: Duration,
+}
+
+impl SseResponse {
+    pub(crate) fn new<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<axum::response::sse::Event, axum::Error>> + Send + 'static,
+    {
+        Self {
+            stream: Box::pin(stream),
+            keep_alive_interval: Duration::from_secs(DEFAULT_KEEP_ALIVE_SECS),
+        }
+    }
+
+    /// Override the keep-alive interval for this response.
+    ///
+    /// The default is 15 seconds. Set a shorter interval if your clients are
+    /// behind aggressive proxies, or longer to reduce overhead.
+    pub fn with_keep_alive(mut self, interval: Duration) -> Self {
+        self.keep_alive_interval = interval;
+        self
+    }
+}
+
+impl IntoResponse for SseResponse {
+    fn into_response(self) -> Response {
+        axum::response::sse::Sse::new(self.stream)
+            .keep_alive(axum::response::sse::KeepAlive::new().interval(self.keep_alive_interval))
+            .into_response()
+    }
+}
+
+/// Create an [`SseResponse`] from any stream of [`SseEvent`]s.
+///
+/// This is the main entry point for SSE handlers. The stream is wrapped with
+/// automatic keep-alive (configurable via [`SseResponse::with_keep_alive()`]).
+///
+/// # Type requirements
+///
+/// The stream must yield `Result<SseEvent, E>` where `E: Into<Error>`.
+/// Use [`SseStreamExt`](super::SseStreamExt) combinators or `.map()` to
+/// convert domain types to `SseEvent` before passing to this function.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use modo::sse::{SseEvent, SseResponse};
+///
+/// #[modo::handler(GET, "/events")]
+/// async fn events() -> SseResponse {
+///     let stream = futures_util::stream::repeat_with(|| {
+///         Ok(SseEvent::new().data("ping"))
+///     });
+///     modo::sse::from_stream(stream)
+/// }
+/// ```
+pub fn from_stream<S, E>(stream: S) -> SseResponse
+where
+    S: Stream<Item = Result<SseEvent, E>> + Send + 'static,
+    E: Into<Error> + Send + 'static,
+{
+    let mapped = stream.map(|result| {
+        result
+            .map_err(|e| {
+                let err: Error = e.into();
+                axum::Error::new(err)
+            })
+            .and_then(|event| axum::response::sse::Event::try_from(event).map_err(axum::Error::new))
+    });
+    SseResponse::new(mapped)
+}

--- a/modo/src/sse/sender.rs
+++ b/modo/src/sse/sender.rs
@@ -1,0 +1,107 @@
+use super::event::SseEvent;
+use super::response::SseResponse;
+use crate::error::Error;
+use futures_util::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::mpsc;
+
+const CHANNEL_BUFFER: usize = 32;
+
+/// Sender for imperative SSE event production.
+///
+/// Used within [`channel()`](super::channel) closures to push events to the
+/// connected client. When the client disconnects, [`send()`](Self::send)
+/// returns an error.
+///
+/// # Cleanup
+///
+/// Cleanup is cooperative: the spawned task runs until the closure returns
+/// or a `send()` call fails. Handlers producing messages in a loop should
+/// check the `send()` result and break on error.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// modo::sse::channel(|tx| async move {
+///     for i in 0..10 {
+///         tx.send(SseEvent::new().data(format!("count: {i}"))).await?;
+///         tokio::time::sleep(Duration::from_secs(1)).await;
+///     }
+///     Ok(())
+/// })
+/// ```
+pub struct SseSender {
+    tx: mpsc::Sender<SseEvent>,
+}
+
+impl SseSender {
+    /// Send an event to the connected client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the client has disconnected (the response stream
+    /// was dropped). Use this as a signal to stop producing events.
+    pub async fn send(&self, event: SseEvent) -> Result<(), Error> {
+        self.tx
+            .send(event)
+            .await
+            .map_err(|_| Error::internal("SSE client disconnected"))
+    }
+}
+
+/// Receiver stream that wraps `mpsc::Receiver<SseEvent>` for use in `SseResponse`.
+struct ReceiverStream {
+    rx: mpsc::Receiver<SseEvent>,
+}
+
+impl Stream for ReceiverStream {
+    type Item = Result<SseEvent, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx).map(|opt| opt.map(Ok))
+    }
+}
+
+/// Create an [`SseResponse`] with an imperative sender.
+///
+/// Spawns the closure as a tokio task and returns an SSE response backed by
+/// the receiver end of an internal channel. The closure receives an
+/// [`SseSender`] for pushing events.
+///
+/// The task runs until:
+/// - The closure returns `Ok(())` — stream ends cleanly
+/// - The closure returns `Err(e)` — error is logged, stream ends
+/// - A `tx.send()` call fails — client disconnected
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[modo::handler(GET, "/jobs/{id}/progress")]
+/// async fn job_progress(id: String, Service(jobs): Service<JobService>) -> SseResponse {
+///     modo::sse::channel(|tx| async move {
+///         while let Some(status) = jobs.poll_status(&id).await {
+///             tx.send(SseEvent::new().event("progress").json(&status)?).await?;
+///             if status.is_done() { break; }
+///         }
+///         Ok(())
+///     })
+/// }
+/// ```
+pub fn channel<F, Fut>(f: F) -> SseResponse
+where
+    F: FnOnce(SseSender) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = Result<(), Error>> + Send,
+{
+    let (tx, rx) = mpsc::channel(CHANNEL_BUFFER);
+    let sender = SseSender { tx };
+
+    tokio::spawn(async move {
+        if let Err(e) = f(sender).await {
+            tracing::debug!(error = %e, "SSE channel closure ended with error");
+        }
+    });
+
+    let stream = ReceiverStream { rx };
+    super::response::from_stream(stream)
+}

--- a/modo/src/sse/sender.rs
+++ b/modo/src/sse/sender.rs
@@ -1,7 +1,8 @@
 use super::event::SseEvent;
 use super::response::SseResponse;
 use crate::error::Error;
-use futures_util::Stream;
+use futures_util::{FutureExt, Stream};
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::sync::mpsc;
@@ -97,8 +98,11 @@ where
     let sender = SseSender { tx };
 
     tokio::spawn(async move {
-        if let Err(e) = f(sender).await {
-            tracing::debug!(error = %e, "SSE channel closure ended with error");
+        let result = AssertUnwindSafe(f(sender)).catch_unwind().await;
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::debug!(error = %e, "SSE channel closure ended with error"),
+            Err(_) => tracing::error!("SSE channel closure panicked"),
         }
     });
 

--- a/modo/src/sse/stream_ext.rs
+++ b/modo/src/sse/stream_ext.rs
@@ -84,7 +84,7 @@ where
         E: Send,
         Self: Send,
     {
-        self.map(move |result| result.map_err(Into::into).and_then(|item| f(item)))
+        self.map(move |result| result.map_err(Into::into).and_then(&mut f))
     }
 }
 

--- a/modo/src/sse/stream_ext.rs
+++ b/modo/src/sse/stream_ext.rs
@@ -32,7 +32,10 @@ where
     /// Items must already be [`SseEvent`]s (or convertible via `Into<SseEvent>`).
     /// This is useful when you have a stream of pre-built events and want to
     /// override or set the event name uniformly.
-    fn sse_event(self, name: &'static str) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+    fn with_event_name(
+        self,
+        name: &'static str,
+    ) -> impl Stream<Item = Result<SseEvent, Error>> + Send
     where
         T: Into<SseEvent> + Send,
         E: Send,

--- a/modo/src/sse/stream_ext.rs
+++ b/modo/src/sse/stream_ext.rs
@@ -1,0 +1,97 @@
+use super::event::SseEvent;
+use crate::error::Error;
+use futures_util::{Stream, StreamExt};
+use serde::Serialize;
+
+/// Extension trait for converting streams into SSE event streams.
+///
+/// Operates on streams of `Result<T, E>` -- errors pass through unchanged,
+/// and the conversion closure/trait only operates on `Ok` values.
+///
+/// # Usage
+///
+/// Import the trait and call methods on any compatible stream:
+///
+/// ```rust,ignore
+/// use modo::sse::SseStreamExt;
+///
+/// // JSON conversion
+/// let stream = bc.subscribe(&key).sse_json();
+///
+/// // Custom mapping
+/// let stream = bc.subscribe(&key).sse_map(|item| {
+///     Ok(SseEvent::new().event("update").json(&item)?)
+/// });
+/// ```
+pub trait SseStreamExt<T, E>: Stream<Item = Result<T, E>> + Sized
+where
+    E: Into<Error>,
+{
+    /// Set event name on each item and pass through.
+    ///
+    /// Items must already be [`SseEvent`]s (or convertible via `Into<SseEvent>`).
+    /// This is useful when you have a stream of pre-built events and want to
+    /// override or set the event name uniformly.
+    fn sse_event(self, name: &'static str) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+    where
+        T: Into<SseEvent> + Send,
+        E: Send,
+        Self: Send,
+    {
+        self.map(move |result| {
+            result
+                .map_err(Into::into)
+                .map(|item| item.into().event(name))
+        })
+    }
+
+    /// Serialize each item as JSON data in an [`SseEvent`].
+    ///
+    /// Equivalent to `.sse_map(|item| SseEvent::new().json(&item))`.
+    ///
+    /// # Errors
+    ///
+    /// Yields an error if JSON serialization fails for any item.
+    fn sse_json(self) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+    where
+        T: Serialize + Send,
+        E: Send,
+        Self: Send,
+    {
+        self.map(|result| {
+            result
+                .map_err(Into::into)
+                .and_then(|item| SseEvent::new().json(&item))
+        })
+    }
+
+    /// Map each item to an [`SseEvent`] with a custom closure.
+    ///
+    /// The closure receives the unwrapped `Ok` value. Stream errors pass
+    /// through unchanged.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let stream = bc.subscribe(&room_id).sse_map(|msg| {
+    ///     let html = view.render_to_string(MessageView::from(&msg))?;
+    ///     Ok(SseEvent::new().event("message").html(html))
+    /// });
+    /// ```
+    fn sse_map<F>(self, mut f: F) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+    where
+        F: FnMut(T) -> Result<SseEvent, Error> + Send,
+        E: Send,
+        Self: Send,
+    {
+        self.map(move |result| result.map_err(Into::into).and_then(|item| f(item)))
+    }
+}
+
+// Blanket implementation for all compatible streams
+impl<S, T, E> SseStreamExt<T, E> for S
+where
+    S: Stream<Item = Result<T, E>> + Sized,
+    E: Into<Error>,
+{
+}

--- a/modo/tests/sse_broadcast.rs
+++ b/modo/tests/sse_broadcast.rs
@@ -110,3 +110,44 @@ async fn broadcast_lagging_subscriber_skips_and_continues() {
     assert!(item.is_some(), "stream should still yield after lagging");
     assert!(item.unwrap().is_ok(), "lagged stream item should be Ok");
 }
+
+#[tokio::test]
+async fn broadcast_cleanup_on_stream_drop() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let s = mgr.subscribe(&"room".into());
+    assert_eq!(mgr.subscriber_count(&"room".into()), 1);
+
+    drop(s);
+
+    // Channel should be removed immediately by the drop cleanup — no send() needed
+    assert_eq!(mgr.subscriber_count(&"room".into()), 0);
+}
+
+#[tokio::test]
+async fn broadcast_drop_with_remaining_subscribers_keeps_channel() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let s1 = mgr.subscribe(&"room".into());
+    let _s2 = mgr.subscribe(&"room".into());
+    assert_eq!(mgr.subscriber_count(&"room".into()), 2);
+
+    drop(s1);
+
+    // One subscriber remains — channel must stay
+    assert_eq!(mgr.subscriber_count(&"room".into()), 1);
+}
+
+#[tokio::test]
+async fn broadcast_cleanup_targets_only_dropped_channel() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let s_a = mgr.subscribe(&"a".into());
+    let _s_b = mgr.subscribe(&"b".into());
+
+    assert_eq!(mgr.subscriber_count(&"a".into()), 1);
+    assert_eq!(mgr.subscriber_count(&"b".into()), 1);
+
+    drop(s_a);
+
+    // Only "a" should be cleaned up, "b" untouched
+    assert_eq!(mgr.subscriber_count(&"a".into()), 0);
+    assert_eq!(mgr.subscriber_count(&"b".into()), 1);
+}

--- a/modo/tests/sse_broadcast.rs
+++ b/modo/tests/sse_broadcast.rs
@@ -94,3 +94,19 @@ async fn broadcast_stream_closed_when_sender_dropped() {
     let next = stream.next().await;
     assert!(next.is_none());
 }
+
+#[tokio::test]
+async fn broadcast_lagging_subscriber_skips_and_continues() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(2);
+    let mut stream = mgr.subscribe(&"room".into());
+
+    // Send 4 messages without reading — buffer is 2, so subscriber will lag
+    for i in 0..4 {
+        let _ = mgr.send(&"room".into(), format!("msg-{i}"));
+    }
+
+    // Stream should still yield values (lagged messages are skipped, not errored)
+    let item = stream.next().await;
+    assert!(item.is_some(), "stream should still yield after lagging");
+    assert!(item.unwrap().is_ok(), "lagged stream item should be Ok");
+}

--- a/modo/tests/sse_broadcast.rs
+++ b/modo/tests/sse_broadcast.rs
@@ -63,10 +63,7 @@ async fn broadcast_auto_cleanup_on_last_unsubscribe() {
 
     drop(s);
 
-    // Trigger cleanup via send
-    let count = mgr.send(&"temp".into(), "test".into()).unwrap();
-    assert_eq!(count, 0);
-    // Channel should be pruned
+    // Drop cleanup closure removes the channel immediately — no send() needed
     assert_eq!(mgr.subscriber_count(&"temp".into()), 0);
 }
 

--- a/modo/tests/sse_broadcast.rs
+++ b/modo/tests/sse_broadcast.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "sse")]
+
+use futures_util::StreamExt;
+use modo::sse::SseBroadcastManager;
+
+// Verify SseStream is publicly exported.
+#[allow(unused_imports)]
+use modo::sse::SseStream;
+
+#[tokio::test]
+async fn broadcast_subscribe_and_send() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let mut stream = mgr.subscribe(&"room1".into());
+
+    let count = mgr.send(&"room1".into(), "hello".into()).unwrap();
+    assert_eq!(count, 1);
+
+    let item = stream.next().await.unwrap().unwrap();
+    assert_eq!(item, "hello");
+}
+
+#[tokio::test]
+async fn broadcast_multiple_subscribers() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let mut s1 = mgr.subscribe(&"room".into());
+    let mut s2 = mgr.subscribe(&"room".into());
+
+    let count = mgr.send(&"room".into(), "msg".into()).unwrap();
+    assert_eq!(count, 2);
+
+    assert_eq!(s1.next().await.unwrap().unwrap(), "msg");
+    assert_eq!(s2.next().await.unwrap().unwrap(), "msg");
+}
+
+#[tokio::test]
+async fn broadcast_send_to_nonexistent_key_is_noop() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let count = mgr.send(&"nobody".into(), "hello".into()).unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn broadcast_subscriber_count() {
+    let mgr: SseBroadcastManager<String, i32> = SseBroadcastManager::new(16);
+    assert_eq!(mgr.subscriber_count(&"k".into()), 0);
+
+    let _s1 = mgr.subscribe(&"k".into());
+    assert_eq!(mgr.subscriber_count(&"k".into()), 1);
+
+    let _s2 = mgr.subscribe(&"k".into());
+    assert_eq!(mgr.subscriber_count(&"k".into()), 2);
+
+    drop(_s1);
+    // After drop, count may still be 2 until next operation triggers cleanup.
+    // Force cleanup by subscribing or sending.
+    let _ = mgr.send(&"k".into(), 0);
+    // tokio broadcast receiver_count decrements on drop
+    assert_eq!(mgr.subscriber_count(&"k".into()), 1);
+}
+
+#[tokio::test]
+async fn broadcast_auto_cleanup_on_last_unsubscribe() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let s = mgr.subscribe(&"temp".into());
+    assert_eq!(mgr.subscriber_count(&"temp".into()), 1);
+
+    drop(s);
+
+    // Trigger cleanup via send
+    let count = mgr.send(&"temp".into(), "test".into()).unwrap();
+    assert_eq!(count, 0);
+    // Channel should be pruned
+    assert_eq!(mgr.subscriber_count(&"temp".into()), 0);
+}
+
+#[tokio::test]
+async fn broadcast_remove() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let _s = mgr.subscribe(&"room".into());
+    assert_eq!(mgr.subscriber_count(&"room".into()), 1);
+
+    mgr.remove(&"room".into());
+    assert_eq!(mgr.subscriber_count(&"room".into()), 0);
+}
+
+#[tokio::test]
+async fn broadcast_stream_closed_when_sender_dropped() {
+    let mgr: SseBroadcastManager<String, String> = SseBroadcastManager::new(16);
+    let mut stream = mgr.subscribe(&"room".into());
+
+    mgr.remove(&"room".into());
+
+    // Stream should end (return None)
+    let next = stream.next().await;
+    assert!(next.is_none());
+}

--- a/modo/tests/sse_broadcast.rs
+++ b/modo/tests/sse_broadcast.rs
@@ -51,10 +51,7 @@ async fn broadcast_subscriber_count() {
     assert_eq!(mgr.subscriber_count(&"k".into()), 2);
 
     drop(_s1);
-    // After drop, count may still be 2 until next operation triggers cleanup.
-    // Force cleanup by subscribing or sending.
-    let _ = mgr.send(&"k".into(), 0);
-    // tokio broadcast receiver_count decrements on drop
+    // receiver_count decrements immediately on drop; channel stays because _s2 is alive
     assert_eq!(mgr.subscriber_count(&"k".into()), 1);
 }
 

--- a/modo/tests/sse_channel.rs
+++ b/modo/tests/sse_channel.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "sse")]
+
+use axum::response::IntoResponse;
+use modo::sse::SseEvent;
+
+#[tokio::test]
+async fn channel_sends_events() {
+    let resp = modo::sse::channel(|tx| async move {
+        tx.send(SseEvent::new().event("msg").data("hello")).await?;
+        tx.send(SseEvent::new().event("msg").data("world")).await?;
+        Ok(())
+    })
+    .into_response();
+
+    assert_eq!(resp.status(), http::StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(text.contains("data: hello"), "body: {text}");
+    assert!(text.contains("data: world"), "body: {text}");
+}
+
+#[tokio::test]
+async fn channel_sender_error_on_drop() {
+    // When the response is dropped, the sender should get an error
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+    let resp = modo::sse::channel(|tx| async move {
+        // First send should succeed (response exists)
+        let _ = tx.send(SseEvent::new().data("first")).await;
+        // Wait a bit for the response to be dropped
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let send_result = tx.send(SseEvent::new().data("after-drop")).await;
+        let _ = result_tx.send(send_result.is_err());
+        Ok(())
+    });
+
+    // Drop the response immediately
+    drop(resp);
+
+    // The sender should eventually detect the drop
+    let was_err = tokio::time::timeout(std::time::Duration::from_secs(1), result_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(was_err, "send after response drop should fail");
+}

--- a/modo/tests/sse_config.rs
+++ b/modo/tests/sse_config.rs
@@ -1,0 +1,23 @@
+#![cfg(feature = "sse")]
+
+#[test]
+fn sse_config_default_values() {
+    let config: modo::sse::SseConfig = serde_yaml_ng::from_str("{}").unwrap();
+    assert_eq!(config.keep_alive_interval_secs, 15);
+}
+
+#[test]
+fn sse_config_custom_values() {
+    let config: modo::sse::SseConfig =
+        serde_yaml_ng::from_str("keep_alive_interval_secs: 30").unwrap();
+    assert_eq!(config.keep_alive_interval_secs, 30);
+}
+
+#[test]
+fn sse_config_keep_alive_interval_method() {
+    let config = modo::sse::SseConfig::default();
+    assert_eq!(
+        config.keep_alive_interval(),
+        std::time::Duration::from_secs(15),
+    );
+}

--- a/modo/tests/sse_event.rs
+++ b/modo/tests/sse_event.rs
@@ -27,9 +27,7 @@ fn event_with_json() {
 
 #[test]
 fn event_with_html() {
-    let event = SseEvent::new()
-        .event("update")
-        .html("<div>hello</div>");
+    let event = SseEvent::new().event("update").html("<div>hello</div>");
     let _axum_event: axum::response::sse::Event = event.try_into().unwrap();
 }
 

--- a/modo/tests/sse_event.rs
+++ b/modo/tests/sse_event.rs
@@ -70,3 +70,95 @@ fn event_default_has_no_data() {
     // Converting event without data should still work (axum allows it)
     let _axum_event: axum::response::sse::Event = event.try_into().unwrap();
 }
+
+// --- Wire format tests ---
+
+#[tokio::test]
+async fn event_wire_format_data_only() {
+    use axum::response::IntoResponse;
+    use futures_util::stream;
+
+    let s = stream::iter(vec![Ok::<_, modo::Error>(SseEvent::new().data("hello"))]);
+    let response = modo::sse::from_stream(s).into_response();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        text.contains("data: hello"),
+        "expected 'data: hello' in: {text}"
+    );
+}
+
+#[tokio::test]
+async fn event_wire_format_with_event_name_and_id() {
+    use axum::response::IntoResponse;
+    use futures_util::stream;
+
+    let s = stream::iter(vec![Ok::<_, modo::Error>(
+        SseEvent::new().event("update").data("payload").id("evt-1"),
+    )]);
+    let response = modo::sse::from_stream(s).into_response();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        text.contains("event: update"),
+        "expected 'event: update' in: {text}"
+    );
+    assert!(
+        text.contains("data: payload"),
+        "expected 'data: payload' in: {text}"
+    );
+    assert!(
+        text.contains("id: evt-1"),
+        "expected 'id: evt-1' in: {text}"
+    );
+}
+
+#[tokio::test]
+async fn event_wire_format_multiline_data() {
+    use axum::response::IntoResponse;
+    use futures_util::stream;
+
+    let s = stream::iter(vec![Ok::<_, modo::Error>(
+        SseEvent::new().data("line1\nline2\nline3"),
+    )]);
+    let response = modo::sse::from_stream(s).into_response();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        text.contains("data: line1"),
+        "expected 'data: line1' in: {text}"
+    );
+    assert!(
+        text.contains("data: line2"),
+        "expected 'data: line2' in: {text}"
+    );
+    assert!(
+        text.contains("data: line3"),
+        "expected 'data: line3' in: {text}"
+    );
+}
+
+#[tokio::test]
+async fn event_wire_format_with_retry() {
+    use axum::response::IntoResponse;
+    use futures_util::stream;
+
+    let s = stream::iter(vec![Ok::<_, modo::Error>(
+        SseEvent::new().data("hi").retry(Duration::from_secs(5)),
+    )]);
+    let response = modo::sse::from_stream(s).into_response();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        text.contains("retry: 5000"),
+        "expected 'retry: 5000' in: {text}"
+    );
+}

--- a/modo/tests/sse_event.rs
+++ b/modo/tests/sse_event.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "sse")]
+
+use modo::sse::SseEvent;
+use std::time::Duration;
+
+#[test]
+fn event_with_data() {
+    let event = SseEvent::new().data("hello");
+    let _axum_event: axum::response::sse::Event = event.try_into().unwrap();
+    // Event has data set — we verify it doesn't panic during conversion
+}
+
+#[test]
+fn event_with_json() {
+    #[derive(serde::Serialize)]
+    struct Msg {
+        text: String,
+    }
+    let event = SseEvent::new()
+        .event("message")
+        .json(&Msg {
+            text: "hello".into(),
+        })
+        .unwrap();
+    let _axum_event: axum::response::sse::Event = event.try_into().unwrap();
+}
+
+#[test]
+fn event_with_html() {
+    let event = SseEvent::new()
+        .event("update")
+        .html("<div>hello</div>");
+    let _axum_event: axum::response::sse::Event = event.try_into().unwrap();
+}
+
+#[test]
+fn event_with_id_and_retry() {
+    let event = SseEvent::new()
+        .data("hello")
+        .id("evt-1")
+        .retry(Duration::from_secs(5));
+    let _axum_event: axum::response::sse::Event = event.try_into().unwrap();
+}
+
+#[test]
+fn event_json_overrides_data() {
+    #[derive(serde::Serialize)]
+    struct Msg {
+        n: i32,
+    }
+    // json() after data() should override
+    let event = SseEvent::new().data("old").json(&Msg { n: 42 }).unwrap();
+    let _: axum::response::sse::Event = event.try_into().unwrap();
+}
+
+#[test]
+fn event_json_serialization_error() {
+    // Custom type that always fails to serialize
+    struct AlwaysFail;
+    impl serde::Serialize for AlwaysFail {
+        fn serialize<S: serde::Serializer>(&self, _s: S) -> Result<S::Ok, S::Error> {
+            Err(serde::ser::Error::custom("intentional failure"))
+        }
+    }
+    let result = SseEvent::new().json(&AlwaysFail);
+    assert!(result.is_err());
+}
+
+#[test]
+fn event_default_has_no_data() {
+    let event = SseEvent::new();
+    // Converting event without data should still work (axum allows it)
+    let _axum_event: axum::response::sse::Event = event.try_into().unwrap();
+}

--- a/modo/tests/sse_last_event_id.rs
+++ b/modo/tests/sse_last_event_id.rs
@@ -50,3 +50,21 @@ async fn last_event_id_present() {
         .unwrap();
     assert_eq!(&body[..], b"reconnect:evt-42");
 }
+
+#[tokio::test]
+async fn last_event_id_none_for_non_utf8_header() {
+    let resp = app()
+        .oneshot(
+            Request::get("/events")
+                .header("Last-Event-ID", b"\xff\xfe".as_slice())
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"first-connect");
+}

--- a/modo/tests/sse_last_event_id.rs
+++ b/modo/tests/sse_last_event_id.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "sse")]
+
+use axum::{Router, response::IntoResponse, routing::get};
+use http::{Request, StatusCode};
+use modo::sse::LastEventId;
+use tower::ServiceExt;
+
+async fn handler(last_id: LastEventId) -> impl IntoResponse {
+    match last_id.0 {
+        Some(id) => format!("reconnect:{id}"),
+        None => "first-connect".to_string(),
+    }
+}
+
+fn app() -> Router {
+    Router::new().route("/events", get(handler))
+}
+
+#[tokio::test]
+async fn last_event_id_absent() {
+    let resp = app()
+        .oneshot(
+            Request::get("/events")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"first-connect");
+}
+
+#[tokio::test]
+async fn last_event_id_present() {
+    let resp = app()
+        .oneshot(
+            Request::get("/events")
+                .header("Last-Event-ID", "evt-42")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"reconnect:evt-42");
+}

--- a/modo/tests/sse_response.rs
+++ b/modo/tests/sse_response.rs
@@ -40,3 +40,16 @@ async fn sse_response_with_keep_alive_override() {
         .into_response();
     assert_eq!(resp.status(), http::StatusCode::OK);
 }
+
+#[tokio::test]
+async fn sse_response_has_x_accel_buffering_header() {
+    let s = stream::empty::<Result<SseEvent, modo::Error>>();
+    let resp = modo::sse::from_stream(s).into_response();
+    let val = resp
+        .headers()
+        .get("x-accel-buffering")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(val, "no");
+}

--- a/modo/tests/sse_response.rs
+++ b/modo/tests/sse_response.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "sse")]
+
+use axum::response::IntoResponse;
+use futures_util::stream;
+use modo::sse::SseEvent;
+
+#[tokio::test]
+async fn sse_response_has_correct_content_type() {
+    let s = stream::empty::<Result<SseEvent, modo::Error>>();
+    let resp = modo::sse::from_stream(s).into_response();
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(ct.contains("text/event-stream"), "got: {ct}");
+}
+
+#[tokio::test]
+async fn sse_response_has_cache_control() {
+    let s = stream::empty::<Result<SseEvent, modo::Error>>();
+    let resp = modo::sse::from_stream(s).into_response();
+    let cc = resp
+        .headers()
+        .get("cache-control")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_eq!(cc, "no-cache");
+}
+
+#[tokio::test]
+async fn sse_response_with_keep_alive_override() {
+    use std::time::Duration;
+    let s = stream::empty::<Result<SseEvent, modo::Error>>();
+    // Should not panic
+    let resp = modo::sse::from_stream(s)
+        .with_keep_alive(Duration::from_secs(60))
+        .into_response();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+}

--- a/modo/tests/sse_stream_ext.rs
+++ b/modo/tests/sse_stream_ext.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "sse")]
+
+use futures_util::{StreamExt, stream};
+use modo::sse::{SseEvent, SseStreamExt};
+
+#[tokio::test]
+async fn sse_json_converts_serializable_items() {
+    #[derive(Clone, serde::Serialize)]
+    struct Msg {
+        text: String,
+    }
+
+    let items = vec![
+        Ok::<_, modo::Error>(Msg {
+            text: "hello".into(),
+        }),
+        Ok(Msg {
+            text: "world".into(),
+        }),
+    ];
+    let s = stream::iter(items);
+    let events: Vec<_> = s.sse_json().collect().await;
+    assert_eq!(events.len(), 2);
+    assert!(events[0].is_ok());
+    assert!(events[1].is_ok());
+}
+
+#[tokio::test]
+async fn sse_map_transforms_items() {
+    let items = vec![Ok::<_, modo::Error>(42i32), Ok(99)];
+    let s = stream::iter(items);
+    let events: Vec<_> = s
+        .sse_map(|n| Ok(SseEvent::new().event("number").data(n.to_string())))
+        .collect()
+        .await;
+    assert_eq!(events.len(), 2);
+    assert!(events[0].is_ok());
+}
+
+#[tokio::test]
+async fn sse_map_propagates_stream_errors() {
+    let items = vec![
+        Ok::<_, modo::Error>(1i32),
+        Err(modo::Error::internal("fail")),
+        Ok(3),
+    ];
+    let s = stream::iter(items);
+    let events: Vec<_> = s
+        .sse_map(|n| Ok(SseEvent::new().data(n.to_string())))
+        .collect()
+        .await;
+    assert_eq!(events.len(), 3);
+    assert!(events[0].is_ok());
+    assert!(events[1].is_err());
+    assert!(events[2].is_ok());
+}
+
+#[tokio::test]
+async fn sse_event_sets_name_and_converts() {
+    let items = vec![Ok::<_, modo::Error>(SseEvent::new().data("hello"))];
+    let s = stream::iter(items);
+    let events: Vec<_> = s.sse_event("ping").collect().await;
+    assert_eq!(events.len(), 1);
+    assert!(events[0].is_ok());
+}

--- a/modo/tests/sse_stream_ext.rs
+++ b/modo/tests/sse_stream_ext.rs
@@ -56,10 +56,10 @@ async fn sse_map_propagates_stream_errors() {
 }
 
 #[tokio::test]
-async fn sse_event_sets_name_and_converts() {
+async fn with_event_name_sets_name_and_converts() {
     let items = vec![Ok::<_, modo::Error>(SseEvent::new().data("hello"))];
     let s = stream::iter(items);
-    let events: Vec<_> = s.sse_event("ping").collect().await;
+    let events: Vec<_> = s.with_event_name("ping").collect().await;
     assert_eq!(events.len(), 1);
     assert!(events[0].is_ok());
 }


### PR DESCRIPTION
## Summary

- Add feature-flagged `sse` module to `modo/` core crate with opt-in `sse = ["dep:futures-util"]` feature
- Core types: `SseEvent` (builder), `SseResponse` (handler return type with auto keep-alive), `SseBroadcastManager<K,T>` (keyed multi-subscriber channels), `SseStream<T>`, `SseSender` + `channel()`, `LastEventId` extractor, `SseStreamExt` trait
- Two entry points: `from_stream()` for any stream, `channel()` for imperative producers
- `SseConfig` integrated into `AppConfig` and auto-registered in `AppBuilder::run()`
- 28 integration tests across 7 test files
- Two example applications: SSE Dashboard (HTMX + fake monitoring) and SSE Chat (rooms, SQLite, sessions, HTMX)
- Comprehensive module documentation with examples and gotchas

## Test Plan

- [x] 28 SSE tests pass
- [x] Both examples compile
- [x] Clippy clean with -D warnings
- [x] Tests pass without SSE feature
- [ ] Manual test: run sse-dashboard and verify live updates
- [ ] Manual test: run sse-chat and verify chat