### PR TITLE
feat(claude-plugin): add modo-dev skill plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+    "name": "modo",
+    "owner": {
+        "name": "Dmytro Momot"
+    },
+    "plugins": [
+        {
+            "name": "modo-dev",
+            "source": {
+                "source": "git-subdir",
+                "url": "https://github.com/dmitrymomot/modo.git",
+                "path": "claude-plugin"
+            },
+            "description": "Skills for building apps with the modo Rust web framework"
+        }
+    ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Rust web framework for micro-SaaS. Single binary, compile-time magic, multi-DB s
 - HTMX views: htmx template rendered on HX-Request, always HTTP 200, non-200 skips render
 - Template layers: auto-registered when `TemplateEngine` is a service — no manual `.layer()` needed
 - File organization: `mod.rs` is ONLY for `mod` imports and re-exports — all code (handlers, views, tasks) goes in separate files
+- Extractors: always import with `use modo::extractors::{Json, Form};` and use short form in handler signatures — never inline `modo::extractors::Json<T>`
 
 ## Gotchas
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+    "name": "modo-dev",
+    "description": "Skills for building applications with the modo Rust web framework",
+    "version": "0.1.0",
+    "author": { "name": "Dmytro Momot" },
+    "repository": "https://github.com/dmitrymomot/modo",
+    "license": "Apache-2.0"
+}

--- a/claude-plugin/skills/modo/SKILL.md
+++ b/claude-plugin/skills/modo/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: modo-dev
+description: >
+    This skill should be used when the user is building an application with the
+    modo Rust web framework, asks about modo handlers, modules, middleware,
+    database entities, migrations, jobs, email, sessions, authentication,
+    templates, HTMX, SSE, uploads, multi-tenancy, configuration, or testing
+    patterns. Also use when the user references modo macros like #[handler],
+    #[module], #[main], #[entity], #[job], #[view], or FromMultipart.
+---
+
+## Hard Rules
+
+These two rules are non-negotiable and apply to every task regardless of
+apparent simplicity or how clear the request seems.
+
+**Requirement-gathering gate.** Before writing any code, use AskUserQuestion to
+clarify what the user wants to build — endpoint, entity, job, auth flow, upload
+handler, etc. Understand the specifics: field types, relations, validation rules,
+which modules are involved, and how errors should be surfaced to the caller.
+After gathering answers, describe the planned approach in plain language and wait
+for explicit approval. Do not skip this step, not even for a two-line handler.
+
+**Use built-in functionality first.** Always prefer modo's built-in macros,
+extractors, middleware, config helpers, and error types over manual
+implementations or third-party crates. Concretely: use `#[entity]` not
+handwritten SeaORM model boilerplate; use `HandlerResult<T>` (or `JsonResult<T>`
+for JSON endpoints) not custom error enums; use `modo::Json` not `axum::Json`;
+use `#[derive(Sanitize)]` and `#[derive(Validate)]` for input processing; use
+the session and auth middleware provided by modo rather than rolling custom
+token logic. Only reach for a manual or external approach when no built-in
+equivalent exists, and call that choice out explicitly in the plan.
+
+## Assumed Starting Point
+
+The project has been scaffolded by `modo-cli` with all required feature modules
+enabled (database, jobs, email, sessions, uploads, templates, etc.). The
+workspace compiles cleanly. The developer is adding or modifying a feature
+inside this existing project.
+
+## Macro Cheat Sheet
+
+All macros listed below have been verified against the proc-macro source files
+(`modo-macros`, `modo-db-macros`, `modo-jobs-macros`, `modo-upload-macros`).
+
+| Macro | Crate | Purpose |
+|---|---|---|
+| `#[handler(METHOD, "/path")]` | modo-macros | Route registration; supports partial path-param extraction; optional `middleware = [...]` arg |
+| `#[module(prefix = "/path")]` | modo-macros | Groups handlers under a URL prefix; optional `middleware = [...]` for module-scoped middleware |
+| `#[main]` / `#[main(static_assets = "path/")]` | modo-macros | App bootstrap, Tokio runtime, tracing init; optional embedded static assets via `rust_embed` |
+| `#[error_handler]` | modo-macros | Registers a sync `fn(modo::Error, &modo::ErrorContext) -> Response` as the app-wide error handler |
+| `#[view("tmpl.html")]` / `#[view("tmpl.html", htmx = "partial.html")]` | modo-macros | Derives `IntoResponse` via MiniJinja; HTMX requests render the partial when provided |
+| `#[template_function]` / `#[template_function(name = "fn_name")]` | modo-macros | Registers a custom MiniJinja global function via `inventory` |
+| `#[template_filter]` / `#[template_filter(name = "filter_name")]` | modo-macros | Registers a custom MiniJinja filter via `inventory` |
+| `t!(i18n, "key")` / `t!(i18n, "key", name = expr)` | modo-macros | i18n translation lookup; adding `count =` switches to plural form |
+| `#[derive(Sanitize)]` | modo-macros | Input sanitization; use `#[clean(trim, lowercase, ...)]` on fields |
+| `#[derive(Validate)]` | modo-macros | Input validation; use `#[validate(required, email, min_length = N, ...)]` on fields |
+| `#[modo_db::entity(table = "name")]` | modo-db-macros | Declares a SeaORM entity with auto-registration; struct-level options: `timestamps`, `soft_delete`; optional `group` |
+| `#[modo_db::migration(version = N, description = "text")]` | modo-db-macros | Versioned escape-hatch SQL migration; async fn accepting `&impl ConnectionTrait`; optional `group` |
+| `#[job(queue = "name")]` / `#[job(cron = "* * * * * *")]` | modo-jobs-macros | Defines a background job or in-memory cron job; additional args: `priority`, `max_attempts`, `timeout` |
+| `#[derive(FromMultipart)]` | modo-upload-macros | Parses `multipart/form-data` into a struct; use `#[upload(max_size, accept, min_count, max_count)]` on file fields |
+
+## Topic Index
+
+Read the listed reference file before writing code for the corresponding task.
+All paths are relative to the `references/` directory inside this skill folder.
+
+| Task | Read |
+|---|---|
+| File organization, error patterns, custom error handlers, gotchas | `references/conventions.md` |
+| Handlers, routing, modules, middleware, rate limiting, CORS, security headers, static files | `references/handlers.md` |
+| Entities, migrations, queries, pagination | `references/database.md` |
+| Background jobs, cron scheduling | `references/jobs.md` |
+| Email templates, transports | `references/email.md` |
+| Authentication, sessions, password hashing | `references/auth-sessions.md` |
+| Templates, HTMX, SSE, CSRF, i18n | `references/templates-htmx.md` |
+| File uploads, multipart, storage backends | `references/upload.md` |
+| Multi-tenancy resolver patterns | `references/tenant.md` |
+| YAML config, env interpolation, feature flags | `references/config.md` |
+| Testing middleware, cookies, inventory | `references/testing.md` |
+
+## Common Multi-Module Workflows
+
+For tasks that span multiple topics, read the listed reference files in the
+given order before writing any code. Never skip a file in the chain — each
+one builds context that the next depends on.
+
+| Workflow | Reference files to read (in order) |
+|---|---|
+| Authenticated CRUD API | `conventions.md` → `database.md` → `handlers.md` → `auth-sessions.md` |
+| Web form with validation | `conventions.md` → `handlers.md` → `templates-htmx.md` |
+| Background email on user action | `handlers.md` → `jobs.md` → `email.md` |
+| File upload with auth | `auth-sessions.md` → `upload.md` → `handlers.md` |
+| Multi-tenant web app | `tenant.md` → `database.md` → `templates-htmx.md` |
+| HTMX live dashboard | `templates-htmx.md` → `auth-sessions.md` |
+| Full-stack feature (entity → API → job → email) | `conventions.md` → `database.md` → `handlers.md` → `jobs.md` → `email.md` |

--- a/claude-plugin/skills/modo/SKILL.md
+++ b/claude-plugin/skills/modo/SKILL.md
@@ -51,7 +51,7 @@ All macros listed below have been verified against the proc-macro source files
 
 | Macro | Crate | Purpose |
 |---|---|---|
-| `#[handler(METHOD, "/path")]` | modo-macros | Route registration; supports partial path-param extraction; optional `middleware = [...]` arg |
+| `#[handler(METHOD, "/path")]` | modo-macros | Route registration; supports partial path-param extraction; handler-level middleware uses a separate `#[middleware(...)]` attribute on the function |
 | `#[module(prefix = "/path")]` | modo-macros | Groups handlers under a URL prefix; optional `middleware = [...]` for module-scoped middleware |
 | `#[main]` / `#[main(static_assets = "path/")]` | modo-macros | App bootstrap, Tokio runtime, tracing init; optional embedded static assets via `rust_embed` |
 | `#[error_handler]` | modo-macros | Registers a sync `fn(modo::Error, &modo::ErrorContext) -> Response` as the app-wide error handler |

--- a/claude-plugin/skills/modo/SKILL.md
+++ b/claude-plugin/skills/modo/SKILL.md
@@ -6,7 +6,9 @@ description: >
     database entities, migrations, jobs, email, sessions, authentication,
     templates, HTMX, SSE, uploads, multi-tenancy, configuration, or testing
     patterns. Also use when the user references modo macros like #[handler],
-    #[module], #[main], #[entity], #[job], #[view], or FromMultipart.
+    #[module], #[main], #[entity], #[job], #[view], #[error_handler],
+    #[template_function], #[template_filter], #[modo_db::migration], t!(),
+    #[derive(Sanitize)], #[derive(Validate)], or #[derive(FromMultipart)].
 ---
 
 ## Hard Rules
@@ -32,6 +34,10 @@ token logic. Only reach for a manual or external approach when no built-in
 equivalent exists, and call that choice out explicitly in the plan.
 
 ## Assumed Starting Point
+
+> **Version target:** These reference docs are written against **modo 0.1.x**
+> and **SeaORM v2 RC**. If the project uses a different version, verify API
+> signatures against the actual source before generating code.
 
 The project has been scaffolded by `modo-cli` with all required feature modules
 enabled (database, jobs, email, sessions, uploads, templates, etc.). The

--- a/claude-plugin/skills/modo/references/auth-sessions.md
+++ b/claude-plugin/skills/modo/references/auth-sessions.md
@@ -415,6 +415,7 @@ This pattern from the sse-chat example shows a complete session-based auth flow 
 `UserProvider` (the "user" is identified only by their session-stored ID).
 
 ```rust
+use modo::extractors::Form;
 use modo_session::SessionManager;
 
 // Login
@@ -422,7 +423,7 @@ use modo_session::SessionManager;
 async fn login_submit(
     session: SessionManager,
     view: ViewRenderer,
-    form: modo::extractors::Form<LoginForm>,
+    form: Form<LoginForm>,
 ) -> modo::ViewResult {
     // Validate form fields...
     session.authenticate(&form.username).await?;

--- a/claude-plugin/skills/modo/references/auth-sessions.md
+++ b/claude-plugin/skills/modo/references/auth-sessions.md
@@ -1,0 +1,503 @@
+# Authentication and Sessions Reference
+
+The `modo-auth` crate provides session-based authentication extractors, password hashing via
+Argon2id, and an optional Tower middleware that injects the authenticated user into the
+minijinja template context. The `modo-session` crate provides the underlying database-backed
+session management: cryptographically random tokens, SHA-256 hashed storage, ULID identifiers,
+server-side fingerprint validation, LRU eviction, and an optional cleanup cron job.
+
+---
+
+## Documentation
+
+- modo-auth crate: https://docs.rs/modo-auth
+- modo-session crate: https://docs.rs/modo-session
+
+---
+
+## UserProvider Trait
+
+`UserProvider` is the pluggable interface between the auth system and your user storage.
+Implement it on any type that can look up a user by the ID stored in the session.
+
+```rust
+use modo_auth::{UserProvider, UserProviderService};
+
+pub struct UserRepo {
+    db: DbPool,
+}
+
+impl UserProvider for UserRepo {
+    type User = User; // your user struct
+
+    async fn find_by_id(&self, id: &str) -> Result<Option<User>, modo::Error> {
+        // Query your database. Return Ok(None) when the user does not exist.
+        // Return Err only for infrastructure failures such as DB errors.
+        User::find_by_id(id, &self.db).await
+    }
+}
+```
+
+### Trait bounds
+
+```rust
+pub trait UserProvider: Send + Sync + 'static {
+    type User: Clone + Send + Sync + 'static;
+
+    fn find_by_id(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = Result<Option<Self::User>, modo::Error>> + Send;
+}
+```
+
+`UserProvider` uses the RPITIT `impl Future` syntax, so ordinary `async fn` works directly.
+
+### Registering the provider
+
+Wrap your implementation in `UserProviderService` and register it as an app service.
+The service is stored keyed by user type `U` so both `Auth<U>` and `OptionalAuth<U>`
+can retrieve it at request time.
+
+```rust
+use modo_auth::UserProviderService;
+
+app.service(UserProviderService::new(UserRepo { db: db.clone() }))
+```
+
+---
+
+## Authentication Extractors
+
+### `Auth<U>`
+
+Requires an authenticated session. Returns `401 Unauthorized` when no session is active
+or when the session's user ID is not found by the provider. Returns `500 Internal Server Error`
+if session middleware or `UserProviderService<U>` is not registered, or if the provider fails.
+
+```rust
+use modo_auth::Auth;
+
+#[modo::handler(GET, "/dashboard")]
+async fn dashboard(Auth(user): Auth<User>) -> modo::HandlerResult<Json<Profile>> {
+    Ok(Json(user.profile()))
+}
+```
+
+`Auth<U>` implements `Deref<Target = U>`, so you can call methods on the inner user directly
+through the extractor without unwrapping.
+
+### `OptionalAuth<U>`
+
+Never rejects. Yields `OptionalAuth(Some(user))` when authenticated and `OptionalAuth(None)`
+when not. Still returns `500` on infrastructure errors.
+
+```rust
+use modo_auth::OptionalAuth;
+
+#[modo::handler(GET, "/home")]
+async fn home(OptionalAuth(user): OptionalAuth<User>) -> modo::HandlerResult<Json<HomeData>> {
+    let greeting = user.map(|u| u.name.clone()).unwrap_or("Guest".into());
+    Ok(Json(HomeData { greeting }))
+}
+```
+
+`OptionalAuth<U>` implements `Deref<Target = Option<U>>`.
+
+### Resolution caching
+
+Both extractors cache the resolved user in request extensions the first time a lookup is
+performed. Subsequent calls within the same request — including from `UserContextLayer` — reuse
+the cached value without triggering another database query.
+
+---
+
+## Password Hashing
+
+`PasswordHasher` is an Argon2id hashing service. Both `hash_password` and `verify_password`
+run on a blocking thread via `tokio::task::spawn_blocking` to avoid stalling the async runtime.
+
+### `PasswordConfig`
+
+Argon2id parameters. Defaults follow OWASP recommendations. Deserializes from YAML/TOML with
+`#[serde(default)]`, so unset fields keep their defaults.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `memory_cost_kib` | `u32` | `19456` (19 MiB) | Memory cost in kibibytes |
+| `time_cost` | `u32` | `2` | Number of iterations |
+| `parallelism` | `u32` | `1` | Degree of parallelism |
+
+### `PasswordHasher`
+
+```rust
+use modo_auth::{PasswordHasher, PasswordConfig};
+
+// Default: OWASP-recommended parameters
+let hasher = PasswordHasher::default();
+
+// Custom parameters
+let config = PasswordConfig {
+    memory_cost_kib: 32768,
+    time_cost: 3,
+    parallelism: 2,
+};
+let hasher = PasswordHasher::new(config)?;
+
+// Hash — each call produces a different PHC-formatted string (random salt)
+let hash = hasher.hash_password("hunter2").await?;
+
+// Verify — uses parameters embedded in the hash string
+let ok = hasher.verify_password("hunter2", &hash).await?;
+assert!(ok);
+```
+
+`PasswordHasher::new` returns `Result<_, modo::Error>` and rejects invalid parameters
+(e.g. zero memory cost). `PasswordHasher::default()` panics only if the compile-time defaults
+are invalid, which cannot happen with the shipped values.
+
+### Registering and using the hasher
+
+Register `PasswordHasher` as a service, then extract it in handlers with `Service<PasswordHasher>`.
+
+```rust
+use modo::extractors::service::Service;
+use modo_auth::PasswordHasher;
+
+app.service(PasswordHasher::default())
+
+// In a handler:
+#[modo::handler(POST, "/register")]
+async fn register(
+    Service(hasher): Service<PasswordHasher>,
+    Json(body): Json<RegisterRequest>,
+) -> modo::JsonResult<()> {
+    let hash = hasher.hash_password(&body.password).await?;
+    // store hash in DB
+    Ok(Json(()))
+}
+```
+
+---
+
+## Session Management
+
+### Setup
+
+Create a `SessionStore`, register it as a service, and install the middleware layer.
+
+```rust
+use modo_session::{SessionStore, SessionConfig, layer};
+
+let session_store = SessionStore::new(
+    &db,
+    SessionConfig::default(),
+    config.core.cookies.clone(),
+);
+
+app.service(session_store.clone())
+   .layer(layer(session_store))
+   .run()
+   .await?;
+```
+
+Both the service registration and the layer call are required. The service makes
+`SessionStore` available to background jobs; the layer installs the request/response
+middleware that reads and writes session cookies.
+
+### `SessionConfig`
+
+All fields are optional in YAML/TOML config (`#[serde(default)]`).
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `session_ttl_secs` | `u64` | `2_592_000` (30 days) | Session lifetime |
+| `cookie_name` | `String` | `"_session"` | HTTP cookie name |
+| `validate_fingerprint` | `bool` | `true` | Reject sessions with a changed fingerprint |
+| `touch_interval_secs` | `u64` | `300` (5 min) | Minimum time between expiry-renewal DB writes |
+| `max_sessions_per_user` | `usize` | `10` | Active session cap per user before LRU eviction |
+| `trusted_proxies` | `Vec<String>` | `[]` | CIDR ranges of trusted reverse proxies |
+
+### `SessionManager` extractor
+
+Inject `SessionManager` as a handler parameter to read or modify the session. The middleware
+must be installed or the extractor returns `500`.
+
+All changes — authentication, logout, token rotation, data writes — are applied to the HTTP
+response cookie automatically after the handler returns.
+
+```rust
+use modo_session::SessionManager;
+
+// Authenticate: creates a new session, destroying any existing one (fixation prevention)
+session.authenticate("user-123").await?;
+
+// Authenticate with custom JSON data attached
+session.authenticate_with("user-123", serde_json::json!({"role": "admin"})).await?;
+
+// Check authentication state
+if session.is_authenticated().await { /* ... */ }
+
+// Get current user ID
+let user_id: Option<String> = session.user_id().await;
+
+// Access full session record
+let data: Option<SessionData> = session.current().await;
+
+// Destroy the current session
+session.logout().await?;
+
+// Destroy all sessions for the current user (e.g. "sign out everywhere")
+session.logout_all().await?;
+
+// Destroy all other sessions, keep the current one (e.g. "remove other devices")
+session.logout_other().await?;
+
+// Revoke a specific session by ID (for "manage my devices" UI)
+session.revoke(&session_id).await?;
+
+// Rotate the session token without changing the session ID
+session.rotate().await?;
+
+// Read a typed value from the session JSON payload
+let role: Option<String> = session.get("role").await?;
+
+// Write a value into the session JSON payload (immediate DB write)
+session.set("onboarded", &true).await?;
+
+// Remove a key from the session JSON payload (immediate DB write)
+session.remove_key("temp_code").await?;
+
+// List all active sessions for the current user
+let sessions: Vec<SessionData> = session.list_my_sessions().await?;
+```
+
+### `SessionData`
+
+The full session record loaded from the `modo_sessions` table. Available via
+`session.current().await` and items in `session.list_my_sessions().await`.
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `SessionId` | ULID session identifier |
+| `user_id` | `String` | ID of the authenticated user |
+| `ip_address` | `String` | Client IP at session creation time |
+| `user_agent` | `String` | Raw User-Agent header |
+| `device_name` | `String` | Parsed device name, e.g. `"Chrome on macOS"` |
+| `device_type` | `String` | `"desktop"`, `"mobile"`, or `"tablet"` |
+| `fingerprint` | `String` | SHA-256 fingerprint for hijack detection |
+| `data` | `serde_json::Value` | Arbitrary JSON payload |
+| `created_at` | `DateTime<Utc>` | When the session was created |
+| `last_active_at` | `DateTime<Utc>` | Last touch timestamp |
+| `expires_at` | `DateTime<Utc>` | Expiry timestamp |
+
+---
+
+## Session Security
+
+### Token storage
+
+`SessionToken` holds 32 cryptographically random bytes. The cookie carries the token
+as a 64-character lowercase hex string. Only the SHA-256 hash of the token is stored in the
+database. A compromised database row cannot be used to replay a session because the hash is
+not reversible.
+
+`Debug` and `Display` for `SessionToken` emit `****` to prevent accidental logging.
+
+### Fingerprinting
+
+At session creation the middleware captures a server-side fingerprint: SHA-256 of
+`User-Agent + \x00 + Accept-Language + \x00 + Accept-Encoding`. On each subsequent request the
+fingerprint is recomputed and compared with the stored value. A mismatch causes the session to
+be immediately destroyed and the request treated as unauthenticated — this guards against
+session token theft.
+
+Fingerprint validation is enabled by default (`validate_fingerprint: true`). Disable it for
+users behind rotating IPs or aggressive proxies that strip or modify headers.
+
+### LRU eviction
+
+After each new session is created the store counts active (non-expired) sessions for that user.
+If the count exceeds `max_sessions_per_user`, the least-recently-active sessions are deleted
+until the count is back at the limit. Default limit is 10.
+
+### Sliding expiry
+
+The middleware compares `last_active_at` against `touch_interval_secs` (default: 5 minutes).
+When the interval has elapsed the store updates `last_active_at` and extends `expires_at` by
+`session_ttl_secs`. This prevents active users from being logged out while avoiding a DB write
+on every single request.
+
+### `SessionId`
+
+Session identifiers are ULIDs, not UUIDs. `SessionId::new()` generates a new ULID.
+
+---
+
+## Integration Patterns
+
+### Auth user in templates (`UserContextLayer`)
+
+The `templates` feature of `modo-auth` provides `UserContextLayer`, a Tower middleware that
+injects the authenticated user into the minijinja template context under the key `"user"`. It
+also caches the user in request extensions so that subsequent `Auth<U>` or `OptionalAuth<U>`
+extractors skip a second DB lookup.
+
+`UserContextLayer` is graceful: if there is no session or the user is not found, the request
+passes through unchanged without any rejection.
+
+The user type `U` must implement `serde::Serialize` (in addition to the usual `Clone + Send + Sync`).
+
+```rust
+use modo_auth::{UserProviderService, UserContextLayer};
+
+let user_svc = UserProviderService::new(UserRepo { db: db.clone() });
+
+app.service(user_svc.clone())
+   .layer(UserContextLayer::new(user_svc))
+   .layer(modo_session::layer(session_store))
+```
+
+In Jinja templates the user is available as `{{ user.name }}`, `{{ user.email }}`, etc.
+When the user is not authenticated, `user` is undefined (use `{% if user %}` guards).
+
+`UserContextLayer` uses `user_id_from_extensions` internally to read the user ID from the
+session extensions without going through the full `SessionManager` extractor.
+
+### Auth backed by a database entity
+
+The canonical pattern is to implement `UserProvider` on a repository struct that holds a
+`DbPool` and queries a SeaORM `#[entity]`.
+
+```rust
+use modo_auth::{UserProvider, UserProviderService};
+use modo_db::DbPool;
+
+pub struct UserRepo {
+    db: DbPool,
+}
+
+impl UserProvider for UserRepo {
+    type User = User; // generated by #[entity]
+
+    async fn find_by_id(&self, id: &str) -> Result<Option<User>, modo::Error> {
+        use modo_db::sea_orm::{EntityTrait, PrimaryKeyTrait};
+        entity::user::Entity::find_by_id(id)
+            .one(self.db.connection())
+            .await
+            .map_err(|e| modo::Error::internal(e.to_string()))
+    }
+}
+
+// Registration in main:
+app.service(UserProviderService::new(UserRepo { db: db.clone() }))
+```
+
+### Session cleanup job
+
+Enable the `cleanup-job` feature on `modo-session` to register an automatic cron job that
+deletes expired sessions every 15 minutes. The job requires the `modo-jobs` crate and a running
+job runner.
+
+In `Cargo.toml`:
+```toml
+modo-session = { version = "0.1", features = ["cleanup-job"] }
+```
+
+The job is named `cleanup_expired_sessions`, runs on the cron expression `0 */15 * * * *`,
+and has a 2-minute timeout. It extracts `SessionStore` as `Service<SessionStore>` and calls
+`store.cleanup_expired()`. The job is auto-registered via `inventory` — no explicit startup call
+is needed, but `SessionStore` must be registered as a service with `app.service(session_store)`.
+
+### Full login/logout flow
+
+This pattern from the sse-chat example shows a complete session-based auth flow without a
+`UserProvider` (the "user" is identified only by their session-stored ID).
+
+```rust
+use modo_session::SessionManager;
+
+// Login
+#[modo::handler(POST, "/login")]
+async fn login_submit(
+    session: SessionManager,
+    view: ViewRenderer,
+    form: modo::extractors::Form<LoginForm>,
+) -> modo::ViewResult {
+    // Validate form fields...
+    session.authenticate(&form.username).await?;
+    view.redirect("/dashboard")
+}
+
+// Logout
+#[modo::handler(GET, "/logout")]
+async fn logout(session: SessionManager) -> modo::ViewResult {
+    session.logout().await?;
+    Ok(modo::ViewResponse::redirect("/login"))
+}
+
+// Protected page
+#[modo::handler(GET, "/dashboard")]
+async fn dashboard(session: SessionManager, view: ViewRenderer) -> modo::ViewResult {
+    let username = match session.user_id().await {
+        Some(u) => u,
+        None => return view.redirect("/login"),
+    };
+    view.render(DashboardPage { username })
+}
+```
+
+When a richer user type is needed — e.g. to check roles or load profile data — use `Auth<U>`
+in place of `SessionManager` after registering a `UserProviderService`.
+
+---
+
+## Gotchas
+
+- `user_id_from_extensions` returns `Option<String>`. The function uses `try_lock` to avoid
+  deadlocks when `SessionManager::set` or `remove_key` hold the mutex across `.await`. It
+  returns `None` (not an error) when the lock is contended — do not treat `None` as "not
+  authenticated" without considering retry semantics in middleware code.
+
+- Session IDs are ULIDs, never UUIDs. Do not store or compare session IDs expecting UUID
+  format. `SessionId::new()` generates a 26-character ULID string.
+
+- `Auth<U>` returns `500` (not `401`) when `UserProviderService<U>` is not registered. If
+  you see `500 Internal Server Error` on protected routes, verify that
+  `app.service(UserProviderService::new(...))` is present in your application entry point.
+
+- `UserContextLayer` must be added **after** the session layer in the layer chain because
+  Tower layers are applied innermost-first. Add the session layer last (outermost):
+  `.layer(UserContextLayer::new(user_svc)).layer(modo_session::layer(session_store))`.
+
+- The `cleanup-job` feature registers a cron job that is in-memory only — it is not persisted
+  to the database. If the process restarts, the job re-registers on startup as usual.
+
+- `PasswordHasher::verify_password` returns `Ok(false)` on a wrong password, not `Err`.
+  Only malformed hash strings cause an `Err`. Always check the boolean return value.
+
+- Fingerprint validation compares `User-Agent`, `Accept-Language`, and `Accept-Encoding`.
+  Clients that change these headers between requests (e.g. after a browser update or behind a
+  proxy that modifies `Accept-Encoding`) will have their session destroyed. Set
+  `validate_fingerprint: false` if this is problematic for your user base.
+
+---
+
+## docs.rs Links
+
+| Type | Link |
+|---|---|
+| `UserProvider` | https://docs.rs/modo-auth/latest/modo_auth/trait.UserProvider.html |
+| `UserProviderService` | https://docs.rs/modo-auth/latest/modo_auth/struct.UserProviderService.html |
+| `Auth<U>` | https://docs.rs/modo-auth/latest/modo_auth/struct.Auth.html |
+| `OptionalAuth<U>` | https://docs.rs/modo-auth/latest/modo_auth/struct.OptionalAuth.html |
+| `PasswordHasher` | https://docs.rs/modo-auth/latest/modo_auth/struct.PasswordHasher.html |
+| `PasswordConfig` | https://docs.rs/modo-auth/latest/modo_auth/struct.PasswordConfig.html |
+| `UserContextLayer` | https://docs.rs/modo-auth/latest/modo_auth/context_layer/struct.UserContextLayer.html |
+| `SessionManager` | https://docs.rs/modo-session/latest/modo_session/struct.SessionManager.html |
+| `SessionStore` | https://docs.rs/modo-session/latest/modo_session/struct.SessionStore.html |
+| `SessionConfig` | https://docs.rs/modo-session/latest/modo_session/struct.SessionConfig.html |
+| `SessionData` | https://docs.rs/modo-session/latest/modo_session/struct.SessionData.html |
+| `SessionId` | https://docs.rs/modo-session/latest/modo_session/struct.SessionId.html |
+| `SessionToken` | https://docs.rs/modo-session/latest/modo_session/struct.SessionToken.html |
+| `user_id_from_extensions` | https://docs.rs/modo-session/latest/modo_session/fn.user_id_from_extensions.html |

--- a/claude-plugin/skills/modo/references/auth-sessions.md
+++ b/claude-plugin/skills/modo/references/auth-sessions.md
@@ -161,7 +161,7 @@ are invalid, which cannot happen with the shipped values.
 Register `PasswordHasher` as a service, then extract it in handlers with `Service<PasswordHasher>`.
 
 ```rust
-use modo::extractors::service::Service;
+use modo::Service;
 use modo_auth::PasswordHasher;
 
 app.service(PasswordHasher::default())

--- a/claude-plugin/skills/modo/references/config.md
+++ b/claude-plugin/skills/modo/references/config.md
@@ -1,0 +1,446 @@
+# modo Config Reference
+
+## Documentation
+
+- **modo (umbrella crate):** https://docs.rs/modo
+
+The `AppConfig` and all config structs are re-exported through the `modo` crate. When checking field types or defaults, use the docs.rs page for `modo::config` as the canonical reference.
+
+---
+
+## Config Loading
+
+modo loads configuration from YAML files stored in a `config/` directory at the project root. The file to load is selected by the `MODO_ENV` environment variable.
+
+### File path resolution
+
+```
+config/{MODO_ENV}.yaml
+```
+
+If `MODO_ENV` is not set, it defaults to `development`, so `config/development.yaml` is loaded.
+
+### Recognized MODO_ENV values
+
+| `MODO_ENV` value | Resolves to |
+|---|---|
+| `development` or `dev` | `Environment::Development` |
+| `production` or `prod` | `Environment::Production` |
+| `test` | `Environment::Test` |
+| anything else | `Environment::Custom(s)` |
+
+The `Environment` enum is stored in `ServerConfig::environment` but is marked `#[serde(skip)]` — it is populated at runtime by `detect_env()`, not from the YAML file.
+
+### Load functions
+
+Three functions are available for loading config:
+
+- `modo::config::load::<T>()` — loads `.env` via `dotenvy`, detects `MODO_ENV`, reads the YAML file, substitutes env vars, and deserializes. Returns `ConfigError` if the file is missing or parse fails.
+- `modo::config::load_for_env::<T>(env: &str)` — same as `load` but takes an explicit environment name. Useful for testing specific environment configs.
+- `modo::config::load_or_default::<T>()` — same as `load` but returns `T::default()` if the config directory or specific file is missing. Treats `DirectoryNotFound` and `FileRead` errors as "use defaults" rather than failures.
+
+All three require `T: DeserializeOwned`. In most apps, `T` is `AppConfig`.
+
+### Config directory requirement
+
+The `config/` directory must exist at the process working directory when using `load` or `load_for_env`. `load_or_default` bypasses this requirement. If the directory does not exist and you call `load`, you get `ConfigError::DirectoryNotFound`.
+
+---
+
+## Environment Variable Interpolation
+
+Before YAML parsing, all environment variable references in the raw file text are substituted. This substitution applies to every string value in the YAML file.
+
+### Syntax
+
+```yaml
+# Substitute from env var — expands to empty string if unset
+port: ${PORT}
+
+# Substitute with fallback default if env var is unset or empty
+secret_key: ${SECRET_KEY:-my-dev-secret}
+
+# Escape to produce a literal ${...} in the output
+password_pattern: \${NOT_A_VAR}
+```
+
+Rules:
+- `${VAR}` — replaced with the environment variable value, or empty string if unset.
+- `${VAR:-default}` — replaced with the env var value, or `default` if the var is unset or empty.
+- `\${VAR}` — produces the literal text `${VAR}` without substitution.
+- Variable names must be non-empty and contain only ASCII alphanumeric characters and underscores. Variables with hyphens like `${my-var}` are passed through literally.
+- No nested `${...}` and no multiline defaults.
+
+### Practical example
+
+```yaml
+server:
+  port: ${PORT:-3000}
+  secret_key: ${SECRET_KEY:-dev-only-insecure-key}
+
+database:
+  url: ${DATABASE_URL:-sqlite://app.db?mode=rwc}
+```
+
+This pattern makes development configs work without a `.env` file while production uses real secrets from the environment.
+
+---
+
+## Config Sections
+
+### AppConfig (top-level)
+
+`AppConfig` is the root type passed to `AppBuilder::config()`. It aggregates all section structs.
+
+```rust
+pub struct AppConfig {
+    pub server: ServerConfig,
+    pub cookies: CookieConfig,
+    // feature-gated sections below
+}
+```
+
+YAML key names correspond directly to struct field names. All sections use `#[serde(default)]`, so any absent section gets its defaults.
+
+---
+
+### server
+
+Type: `ServerConfig`
+
+Controls the HTTP server, middleware stack, and health check endpoints.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `port` | `u16` | `3000` | TCP port to listen on |
+| `host` | `String` | `"0.0.0.0"` | Bind address |
+| `secret_key` | `String` | `""` | Key for signing and encrypting cookies. Empty generates a random key per restart — sessions will not survive restarts. Set in production. |
+| `log_level` | `String` | `"info"` | Log level filter: `trace`, `debug`, `info`, `warn`, `error` |
+| `trusted_proxies` | `Vec<String>` | `[]` | CIDR ranges for trusted proxy IP extraction (e.g. `["10.0.0.0/8"]`) |
+| `shutdown_timeout_secs` | `u64` | `30` | Graceful shutdown timeout in seconds |
+| `cors` | `Option<CorsYamlConfig>` | `None` | CORS policy. Absent = no CORS middleware applied |
+| `liveness_path` | `String` | `"/_live"` | Path for the liveness health check endpoint |
+| `readiness_path` | `String` | `"/_ready"` | Path for the readiness health check endpoint |
+| `http` | `HttpConfig` | see below | HTTP-level middleware settings |
+| `security_headers` | `SecurityHeadersConfig` | see below | Security response header settings |
+| `rate_limit` | `Option<RateLimitConfig>` | `None` | Global IP-based rate limit. Absent = disabled |
+| `static_files` | `Option<StaticConfig>` | `None` | Static file serving (feature `static-fs` or `static-embed` required) |
+| `show_banner` | `bool` | `true` | Show startup banner with version, environment, and route info |
+| `environment` | `Environment` | (from env) | Runtime environment — populated by `detect_env()`, not from YAML (`#[serde(skip)]`) |
+
+#### server.http
+
+Type: `HttpConfig`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `timeout` | `Option<u64>` | `None` | Request timeout in seconds. `None` disables the timeout |
+| `body_limit` | `Option<String>` | `None` | Max request body size: `"2mb"`, `"512kb"`, `"1gb"`, or bare bytes. `None` = unlimited |
+| `compression` | `bool` | `false` | Enable response compression (`CompressionLayer`) |
+| `catch_panic` | `bool` | `true` | Convert handler panics into HTTP 500 responses |
+| `trailing_slash` | `TrailingSlash` | `none` | Trailing slash policy: `none`, `strip`, `add` |
+| `maintenance` | `bool` | `false` | Return 503 for all requests when enabled |
+| `maintenance_message` | `Option<String>` | `None` | Custom maintenance mode response message |
+| `sensitive_headers` | `bool` | `true` | Redact `Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization` from logs |
+
+`TrailingSlash` values (snake_case in YAML):
+- `none` — no modification (default)
+- `strip` — redirect trailing-slash URLs to non-trailing-slash
+- `add` — redirect non-trailing-slash URLs to trailing-slash
+
+#### server.security_headers
+
+Type: `SecurityHeadersConfig`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `bool` | `true` | Enable the security headers middleware |
+| `x_content_type_options` | `Option<String>` | `"nosniff"` | Value for `X-Content-Type-Options` |
+| `x_frame_options` | `Option<String>` | `"DENY"` | Value for `X-Frame-Options` |
+| `referrer_policy` | `Option<String>` | `"strict-origin-when-cross-origin"` | Value for `Referrer-Policy` |
+| `permissions_policy` | `Option<String>` | `"camera=(), microphone=(), geolocation=()"` | Value for `Permissions-Policy` |
+| `content_security_policy` | `Option<String>` | `"default-src 'self'"` | Value for `Content-Security-Policy` |
+| `hsts` | `bool` | `true` | Enable `Strict-Transport-Security` header |
+| `hsts_max_age` | `u64` | `31536000` | HSTS max-age in seconds (default is one year) |
+
+The restrictive default CSP (`default-src 'self'`) blocks inline scripts and external resources. Override it for apps using CDN assets or HTMX:
+
+```yaml
+server:
+  security_headers:
+    content_security_policy: "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline'"
+```
+
+#### server.rate_limit
+
+Type: `RateLimitConfig` (token-bucket, applied globally by IP)
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `requests` | `u32` | `100` | Max requests per window |
+| `window_secs` | `u64` | `60` | Window duration in seconds |
+
+Rate limiting is disabled by default. To enable it, add a `rate_limit` section under `server`:
+
+```yaml
+server:
+  rate_limit:
+    requests: 200
+    window_secs: 60
+```
+
+#### server.cors
+
+Type: `CorsYamlConfig`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `origins` | `Vec<String>` | `[]` | Allowed origins. Empty list = mirror request origin |
+| `credentials` | `bool` | `false` | Allow `Access-Control-Allow-Credentials` |
+| `max_age_secs` | `Option<u64>` | `3600` | Preflight cache duration |
+
+When `origins` is empty, the CORS layer mirrors the request `Origin` header back (permissive but avoids `*`). When non-empty, only the listed origins are allowed.
+
+#### server.static_files
+
+Type: `StaticConfig` (requires feature `static-fs` or `static-embed`)
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `dir` | `String` | `"static"` | Filesystem directory to serve from (`static-fs` only) |
+| `prefix` | `String` | `"/static"` | URL prefix where files are mounted. Must start with `/` |
+| `cache_control` | `Option<String>` | `None` | `Cache-Control` header value. `None` = backend default (1h for `static-fs`, immutable for `static-embed`) |
+
+---
+
+### cookies
+
+Type: `CookieConfig`
+
+Global cookie defaults applied to all cookies set by the framework (sessions, CSRF, language preference, etc.).
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `domain` | `Option<String>` | `None` | Cookie domain attribute. `None` = omit domain |
+| `path` | `String` | `"/"` | Cookie path scope |
+| `secure` | `bool` | `true` | Require HTTPS (`Secure` flag) |
+| `http_only` | `bool` | `true` | Prevent JavaScript access (`HttpOnly` flag) |
+| `same_site` | `SameSite` | `lax` | SameSite policy: `strict`, `lax`, `none` |
+| `max_age` | `Option<u64>` | `None` | Cookie max age in seconds. `None` = session cookie |
+
+---
+
+### templates
+
+Type: `TemplateConfig` — requires feature `templates`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `path` | `String` | `"templates"` | Directory containing Jinja2 template files |
+| `strict` | `bool` | `true` | Treat access to undefined template variables as an error |
+
+---
+
+### i18n
+
+Type: `I18nConfig` — requires feature `i18n`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `path` | `String` | `"locales"` | Directory containing translation files |
+| `default_lang` | `String` | `"en"` | Language code used when no preference is detected |
+| `cookie_name` | `String` | `"lang"` | Cookie name used to persist the user's language choice |
+| `query_param` | `String` | `"lang"` | URL query parameter used to detect language preference |
+
+---
+
+### csrf
+
+Type: `CsrfConfig` — requires feature `csrf`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `cookie_name` | `String` | `"_csrf"` | Cookie name for storing the CSRF token |
+| `field_name` | `String` | `"_csrf_token"` | Form field name for the CSRF token |
+| `header_name` | `String` | `"x-csrf-token"` | HTTP header name for the CSRF token |
+| `cookie_max_age` | `u64` | `86400` | CSRF cookie max age in seconds (24 hours) |
+| `token_length` | `usize` | `32` | Length of the generated CSRF token in bytes |
+| `secure` | `bool` | `true` | Set `Secure` flag on the CSRF cookie |
+| `max_body_bytes` | `usize` | `1048576` | Max request body to read when extracting CSRF token (1 MiB) |
+
+Cookie name, field name, and header name are validated — they must contain only alphanumeric characters, hyphens, and underscores.
+
+---
+
+### sse
+
+Type: `SseConfig` — requires feature `sse`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `keep_alive_interval_secs` | `u64` | `15` | Keep-alive comment interval in seconds. Prevents proxy and browser timeouts on idle SSE connections |
+
+---
+
+## Feature-Gated Fields
+
+Several sections in `AppConfig` and `ServerConfig` are guarded by feature flags. Fields that do not exist when the feature is disabled are simply absent from the struct.
+
+```rust
+// AppConfig — feature-gated sections
+#[cfg(feature = "templates")]
+pub templates: crate::templates::TemplateConfig,
+
+#[cfg(feature = "i18n")]
+pub i18n: crate::i18n::I18nConfig,
+
+#[cfg(feature = "csrf")]
+pub csrf: crate::csrf::CsrfConfig,
+
+#[cfg(feature = "sse")]
+pub sse: crate::sse::SseConfig,
+
+// ServerConfig — feature-gated field
+#[cfg(any(feature = "static-fs", feature = "static-embed"))]
+pub static_files: Option<crate::static_files::StaticConfig>,
+```
+
+When adding a feature-gated config field to a custom config struct:
+
+1. Gate the field with `#[cfg(feature = "...")]` in the struct definition.
+2. Add the same gate in the `Default` impl — do not leave the field present in `Default` but absent from the struct, or vice versa.
+3. If you implement a custom `from_env()` or builder method, add the same gate there.
+
+Proc macros cannot inspect `cfg` flags at expansion time. If you generate code that reads config fields, emit both `#[cfg(feature = "x")]` and `#[cfg(not(feature = "x"))]` branches rather than relying on conditional compilation to drop the read silently.
+
+---
+
+## Integration Patterns
+
+### Wiring config into AppBuilder
+
+The `#[modo::main]` macro loads config automatically and passes it to `AppBuilder::config()`. The `run()` method on `AppBuilder` then extracts relevant sections and wires them into the middleware stack and service registry:
+
+```rust
+#[modo::main]
+async fn main(app: AppBuilder, config: AppConfig) {
+    app.config(config).run().await.unwrap();
+}
+```
+
+Inside `AppBuilder::run()`, config sections are consumed as follows:
+
+| Config section | What happens |
+|---|---|
+| `server` | Used to configure binding address, log level, cookie key, and all middleware layers |
+| `cookies` | Auto-registered as `CookieConfig` service — accessible via `Service<CookieConfig>` extractor |
+| `templates` | Auto-wires `TemplateEngine` service, applies `RenderLayer` and `ContextLayer` (feature `templates`) |
+| `i18n` | Auto-wires `TranslationStore` service and `i18n` middleware (feature `i18n`) |
+| `csrf` | Auto-registers `CsrfConfig` as a service (feature `csrf`) |
+| `sse` | Auto-registers `SseConfig` as a service (feature `sse`) |
+| `server.cors` | Converted from `CorsYamlConfig` to `CorsConfig` and applied as outermost middleware |
+| `server.static_files` | Mounts static file service at the configured prefix (features `static-fs` or `static-embed`) |
+| `server.rate_limit` | Creates in-memory token bucket limiter applied globally by IP |
+
+### Builder method overrides
+
+All `server.http` fields and most `server` fields have corresponding `AppBuilder` methods that override the YAML config at runtime. Overrides take precedence over the loaded file:
+
+```rust
+app.config(config)
+   .timeout(30)          // overrides server.http.timeout
+   .body_limit("4mb")    // overrides server.http.body_limit
+   .compression(true)    // overrides server.http.compression
+   .maintenance(false)   // overrides server.http.maintenance
+   .no_rate_limit()      // disables rate limiting regardless of YAML
+   .run()
+   .await
+```
+
+This lets you toggle behaviour programmatically (e.g., enable maintenance mode from a feature flag) while keeping the base config in YAML.
+
+### Accessing config in handlers
+
+`ServerConfig` is stored on `AppState` and accessible in handlers via state extraction. Feature-specific config structs (`CookieConfig`, `CsrfConfig`, `SseConfig`) are stored in the service registry and accessible via the `Service<T>` extractor:
+
+```rust
+use modo::{Service, handler};
+use modo::cookies::CookieConfig;
+
+#[handler]
+async fn my_handler(Service(cookie_cfg): Service<CookieConfig>) {
+    // use cookie_cfg.domain, cookie_cfg.secure, etc.
+}
+```
+
+### Custom config sections
+
+You can extend `AppConfig` by defining your own struct and adding it alongside the standard sections. Load it with `modo::config::load::<MyConfig>()` at startup and register it as a service:
+
+```rust
+#[derive(Deserialize, Default)]
+struct MyConfig {
+    pub app: AppConfig,
+    pub feature_flags: FeatureFlagsConfig,
+}
+
+#[modo::main]
+async fn main(app: AppBuilder, config: MyConfig) {
+    app.config(config.app)
+       .service(config.feature_flags)
+       .run()
+       .await
+       .unwrap();
+}
+```
+
+The `feature_flags` key in `config/development.yaml` then deserializes into `FeatureFlagsConfig`.
+
+---
+
+## Gotchas
+
+**Empty `secret_key` generates a random key per restart.** A warning is logged at startup. Sessions and signed cookies from previous processes will be invalid after restart. Always set a stable `secret_key` in production.
+
+**`MODO_ENV` is not loaded from `.env` files.** The `load()` function calls `dotenvy::dotenv()` first, so `.env` values are available for `${VAR}` interpolation in the YAML. But `MODO_ENV` itself must already be set in the process environment before `load()` runs — it is read before dotenv is applied when constructing the file path.
+
+**Config directory must exist relative to the process working directory.** When running with `cargo run`, the working directory is the workspace root. For tests run with `cargo test`, the working directory may differ. Use `load_or_default` in test contexts or set up the `config/` directory appropriately.
+
+**Feature flags: use `dep:name` for optional dependency syntax in `Cargo.toml`.** When gating a config field on an optional dependency feature, declare `optional = true` and reference it as `dep:the-crate` in feature definitions. Inside Rust code, use `#[cfg(feature = "the-crate")]`.
+
+**`Default` and feature-gated code must match.** If a struct field is feature-gated with `#[cfg(feature = "x")]`, the `Default` impl must have the same gate on that field's initialization. A field that exists in the struct but is missing from `Default` causes a compile error. A field initialized in `Default` but absent from the struct also causes a compile error.
+
+**YAML interpolation applies to the raw bytes before parsing.** This means if a default value contains YAML special characters (`:`, `{`, `}`), they will be interpreted as YAML after substitution. Wrap values in quotes in your YAML where needed:
+
+```yaml
+server:
+  secret_key: "${SECRET_KEY:-my:colon:secret}"
+```
+
+**`static_files.prefix` must start with `/`.** `AppBuilder::run()` validates this at startup and returns an error if the prefix does not start with a slash.
+
+**The `environment` field is not deserialized from YAML.** It is marked `#[serde(skip)]` and populated at runtime via `detect_env()`. Any `environment:` key in your YAML file is silently ignored.
+
+---
+
+## Quick Reference: Key Types
+
+| Type | Module path | docs.rs |
+|---|---|---|
+| `AppConfig` | `modo::config::AppConfig` | https://docs.rs/modo |
+| `ServerConfig` | `modo::config::ServerConfig` | https://docs.rs/modo |
+| `HttpConfig` | `modo::config::HttpConfig` | https://docs.rs/modo |
+| `SecurityHeadersConfig` | `modo::config::SecurityHeadersConfig` | https://docs.rs/modo |
+| `RateLimitConfig` | `modo::config::RateLimitConfig` | https://docs.rs/modo |
+| `TrailingSlash` | `modo::config::TrailingSlash` | https://docs.rs/modo |
+| `Environment` | `modo::config::Environment` | https://docs.rs/modo |
+| `ConfigError` | `modo::config::ConfigError` | https://docs.rs/modo |
+| `CookieConfig` | `modo::cookies::CookieConfig` | https://docs.rs/modo |
+| `CorsYamlConfig` | `modo::cors::CorsYamlConfig` | https://docs.rs/modo |
+| `CorsConfig` | `modo::cors::CorsConfig` | https://docs.rs/modo |
+| `TemplateConfig` | `modo::templates::TemplateConfig` | https://docs.rs/modo |
+| `I18nConfig` | `modo::i18n::I18nConfig` | https://docs.rs/modo |
+| `CsrfConfig` | `modo::csrf::CsrfConfig` | https://docs.rs/modo |
+| `SseConfig` | `modo::sse::SseConfig` | https://docs.rs/modo |
+| `StaticConfig` | `modo::static_files::StaticConfig` | https://docs.rs/modo |
+| `parse_size` | `modo::config::parse_size` | https://docs.rs/modo |

--- a/claude-plugin/skills/modo/references/config.md
+++ b/claude-plugin/skills/modo/references/config.md
@@ -367,7 +367,7 @@ This lets you toggle behaviour programmatically (e.g., enable maintenance mode f
 use modo::{Service, handler};
 use modo::cookies::CookieConfig;
 
-#[handler]
+#[handler(GET, "/config")]
 async fn my_handler(Service(cookie_cfg): Service<CookieConfig>) {
     // use cookie_cfg.domain, cookie_cfg.secure, etc.
 }
@@ -380,6 +380,7 @@ You can extend `AppConfig` by defining your own struct and adding it alongside t
 ```rust
 #[derive(Deserialize, Default)]
 struct MyConfig {
+    #[serde(flatten)]
     pub app: AppConfig,
     pub feature_flags: FeatureFlagsConfig,
 }
@@ -402,7 +403,7 @@ The `feature_flags` key in `config/development.yaml` then deserializes into `Fea
 
 **Empty `secret_key` generates a random key per restart.** A warning is logged at startup. Sessions and signed cookies from previous processes will be invalid after restart. Always set a stable `secret_key` in production.
 
-**`MODO_ENV` is not loaded from `.env` files.** The `load()` function calls `dotenvy::dotenv()` first, so `.env` values are available for `${VAR}` interpolation in the YAML. But `MODO_ENV` itself must already be set in the process environment before `load()` runs — it is read before dotenv is applied when constructing the file path.
+**`MODO_ENV` and dotenvy ordering.** `load()` calls `dotenvy::dotenv()` first, so `.env` values — including `MODO_ENV` — are available for file path selection and `${VAR}` interpolation in the YAML. However, `load_for_env()` does NOT call dotenvy — if you use it directly, only process-level env vars are available for `${VAR}` interpolation.
 
 **Config directory must exist relative to the process working directory.** When running with `cargo run`, the working directory is the workspace root. For tests run with `cargo test`, the working directory may differ. Use `load_or_default` in test contexts or set up the `config/` directory appropriately.
 

--- a/claude-plugin/skills/modo/references/config.md
+++ b/claude-plugin/skills/modo/references/config.md
@@ -427,12 +427,12 @@ server:
 
 | Type | Module path | docs.rs |
 |---|---|---|
-| `AppConfig` | `modo::config::AppConfig` | https://docs.rs/modo |
-| `ServerConfig` | `modo::config::ServerConfig` | https://docs.rs/modo |
-| `HttpConfig` | `modo::config::HttpConfig` | https://docs.rs/modo |
-| `SecurityHeadersConfig` | `modo::config::SecurityHeadersConfig` | https://docs.rs/modo |
-| `RateLimitConfig` | `modo::config::RateLimitConfig` | https://docs.rs/modo |
-| `TrailingSlash` | `modo::config::TrailingSlash` | https://docs.rs/modo |
+| `AppConfig` | `modo::AppConfig` | https://docs.rs/modo |
+| `ServerConfig` | `modo::ServerConfig` | https://docs.rs/modo |
+| `HttpConfig` | `modo::HttpConfig` | https://docs.rs/modo |
+| `SecurityHeadersConfig` | `modo::SecurityHeadersConfig` | https://docs.rs/modo |
+| `RateLimitConfig` | `modo::RateLimitConfig` | https://docs.rs/modo |
+| `TrailingSlash` | `modo::TrailingSlash` | https://docs.rs/modo |
 | `Environment` | `modo::config::Environment` | https://docs.rs/modo |
 | `ConfigError` | `modo::config::ConfigError` | https://docs.rs/modo |
 | `CookieConfig` | `modo::cookies::CookieConfig` | https://docs.rs/modo |

--- a/claude-plugin/skills/modo/references/conventions.md
+++ b/claude-plugin/skills/modo/references/conventions.md
@@ -1,0 +1,443 @@
+# modo Conventions Reference
+
+**Documentation:** https://docs.rs/modo
+
+---
+
+## File Organization
+
+`mod.rs` has exactly one purpose in modo: it is the module import and re-export hub. No handler logic, view logic, task logic, or business code belongs there.
+
+Rules:
+- `mod.rs` — only `mod` declarations and `pub use` re-exports
+- `handlers.rs` (or `handlers/`) — all `#[handler]`-annotated functions
+- `views.rs` (or `views/`) — all `#[view]`-annotated functions and template helpers
+- Tasks, jobs, and other domain code each go in their own files
+
+```
+src/
+  users/
+    mod.rs        ← ONLY: mod handlers; mod views; pub use ...
+    handlers.rs   ← all #[handler] fns for this module
+    views.rs      ← all #[view] fns for this module
+    tasks.rs      ← background task logic
+```
+
+This rule is enforced by convention across the entire codebase. Violating it causes confusion about where code lives and makes the `mod.rs` hard to scan.
+
+---
+
+## Error Handling
+
+### Result Type Aliases
+
+Three result aliases cover all handler scenarios. Each defaults its error type to `modo::Error` but accepts a custom error as a second type parameter.
+
+```rust
+// Generic handler — use when returning non-JSON, non-template responses
+pub type HandlerResult<T, E = Error> = Result<T, E>;
+
+// JSON API handler — wraps the Ok value in axum::Json automatically
+pub type JsonResult<T, E = Error> = Result<axum::Json<T>, E>;
+
+// Template handler — returns ViewResponse (requires "templates" feature)
+pub type ViewResult<E = Error> = Result<crate::templates::ViewResponse, E>;
+```
+
+Source: `modo/src/error.rs`, lines 330–339.
+
+### When to Use Which
+
+| Scenario | Return type |
+|---|---|
+| JSON REST API endpoint | `JsonResult<T>` |
+| HTMX or server-rendered HTML | `ViewResult<>` |
+| Response with custom status, redirect, stream | `HandlerResult<impl IntoResponse>` |
+| Handler with a custom domain error type | `JsonResult<T, MyError>` |
+
+### The `Error` Type
+
+`modo::Error` is a structured HTTP error carrying status code, machine-readable code string, human-readable message, and an optional details map:
+
+```rust
+pub struct Error {
+    status: StatusCode,
+    code: String,
+    message: String,
+    details: HashMap<String, serde_json::Value>,
+    source: Option<Arc<dyn std::error::Error + Send + Sync>>,
+}
+```
+
+Construction methods:
+
+```rust
+// From HttpError variant (most common)
+HttpError::NotFound.into()
+
+// HttpError variant with custom message
+HttpError::Forbidden.with_message("You do not own this resource")
+
+// Convenience for 500
+Error::internal("database connection failed")
+
+// Full builder
+Error::new(StatusCode::UNPROCESSABLE_ENTITY, "validation_failed", "Email is invalid")
+    .detail("field", json!("email"))
+
+// From anyhow — maps to 500
+Error::from(anyhow_error)
+```
+
+### `HttpError` Variants
+
+`HttpError` is a `Copy` enum covering all standard 4xx and 5xx codes. Every variant implements `IntoResponse` and converts to `Error` via `From`. Key variants:
+
+```
+BadRequest, Unauthorized, Forbidden, NotFound, Conflict,
+UnprocessableEntity, TooManyRequests, InternalServerError,
+ServiceUnavailable, GatewayTimeout
+```
+
+Full list in `modo/src/error.rs` lines 12–55.
+
+### JSON Error Response Shape
+
+The default JSON response for a 4xx error:
+
+```json
+{
+  "error": "not_found",
+  "message": "Not found",
+  "status": 404,
+  "details": { ... }
+}
+```
+
+For 5xx errors, `default_response()` always returns the generic `InternalServerError` shape — the actual message is logged server-side but not exposed to the client.
+
+### Custom Error Handlers via `#[error_handler]`
+
+Register one global error handler using the `#[error_handler]` proc macro. It receives the `Error` and an `ErrorContext` (method, URI, headers) and returns a `Response`. The handler is collected via `inventory` and applied automatically through `error_handler_middleware`.
+
+```rust
+use modo::{Error, ErrorContext};
+use axum::response::Response;
+
+#[modo::error_handler]
+fn my_error_handler(err: Error, ctx: &ErrorContext) -> Response {
+    if ctx.accepts_html() {
+        // Return an HTML error page
+        render_error_page(err.status_code(), err.message_str()).into_response()
+    } else {
+        // Fall back to default JSON rendering
+        err.default_response()
+    }
+}
+```
+
+`ErrorContext` helpers:
+- `ctx.accepts_html()` — true when `Accept` contains `text/html`
+- `ctx.is_htmx()` — true when `HX-Request` header is present
+
+The `error_handler_middleware` is only wired into the stack when at least one `ErrorHandlerRegistration` is found via `inventory::iter`. If no `#[error_handler]` is defined, the default `Error::default_response()` is used directly.
+
+---
+
+## Middleware Stacking Order
+
+Middleware in modo is applied in three scopes. When reading execution order, the scope hierarchy is:
+
+```
+Global (outermost) → Module → Handler (innermost)
+```
+
+A request enters Global middleware first, then Module middleware for its route, then Handler-level middleware, and finally reaches the handler. Responses traverse the stack in reverse.
+
+### Framework-Level Stack
+
+`AppBuilder::run()` assembles the full middleware stack. The comment in `app.rs` gives the exact order (outermost to innermost):
+
+```
+CORS
+  Maintenance
+    Catch Panic
+      Request ID
+        Sensitive Headers
+          Tracing
+            Client IP
+              Timeout
+                Trailing Slash
+                  Compression
+                    Body Limit
+                      Security Headers
+                        Error Handler
+                          Rate Limiter
+                            User Global Layers  ← AppBuilder::layer()
+                              Template Context
+                                i18n
+                                  Module Middleware
+                                    Handler Middleware
+                                      Render Layer (innermost)
+```
+
+Source: `modo/src/app.rs`, lines 545–552.
+
+### AppBuilder API
+
+```rust
+#[modo::main]
+async fn main(app: AppBuilder) {
+    app
+        // Register a service accessible via Service<T> extractor
+        .service(my_db_pool)
+        // Register a service that also participates in graceful shutdown
+        .managed_service(my_job_queue)
+        // Add a global Tower layer (applied outside module/handler middleware)
+        .layer(my_auth_layer)
+        // Configure CORS
+        .cors(CorsConfig::permissive())
+        // Override HTTP settings
+        .timeout(30)
+        .body_limit("10mb")
+        .compression(true)
+        // Register a shutdown hook (runs after HTTP draining)
+        .on_shutdown(|| async { cleanup().await })
+        // Add a readiness check exposed at /_ready
+        .readiness_check(|| async { db_ping().await.map_err(Into::into) })
+        .run()
+        .await
+        .unwrap();
+}
+```
+
+### Module-Level Middleware
+
+Declared on the `#[module]` attribute. Applied to all routes within the module's prefix:
+
+```rust
+#[modo::module(prefix = "/api/v1", middleware = [require_auth])]
+pub struct ApiV1Module;
+```
+
+### Handler-Level Middleware
+
+Declared on the `#[handler]` attribute. Applied only to that specific route:
+
+```rust
+#[modo::handler(GET "/users/:id", middleware = [rate_limit_strict])]
+async fn get_user(/* ... */) -> JsonResult<UserResponse> { /* ... */ }
+```
+
+### Stacking Rules
+
+- Multiple middleware on the same scope are applied **last-declared = innermost**. This mirrors axum's `.layer()` semantics where the last call wraps outermost.
+- `AppBuilder::layer()` inserts global layers between the framework infrastructure stack and the template/module layers. Multiple calls to `.layer()` stack the same way: last call = outermost of the user layers.
+- Template layers (`RenderLayer`, `ContextLayer`) are auto-registered when `TemplateEngine` is present as a service — no manual `.layer()` call needed.
+
+---
+
+## API vs Web Error Handling
+
+### JSON API Handlers
+
+Return `JsonResult<T>` and use `HttpError` variants or `Error::internal()` for failures:
+
+```rust
+#[modo::handler(GET "/users/:id")]
+async fn get_user(
+    Path(id): Path<String>,
+    Service(db): Service<DatabaseService>,
+) -> JsonResult<UserResponse> {
+    let user = db.find_user(&id).await
+        .map_err(|e| Error::internal(e.to_string()))?;
+    let user = user.ok_or(HttpError::NotFound)?;
+    Ok(Json(UserResponse::from(user)))
+}
+```
+
+Key points:
+- `JsonResult<T>` wraps the `Ok` value in `axum::Json` — return `Ok(Json(value))` not `Ok(value)`
+- Use `modo::Json`, not `modo::axum::Json` (they are the same type, but the re-export path matters for imports)
+- `?` on `Error` works because `Error` implements `IntoResponse`
+- `HttpError::NotFound` converts to `Error` via `From<HttpError>` and then to a 404 JSON response
+
+### Web / Template Handlers
+
+Return `ViewResult<>` for server-rendered pages:
+
+```rust
+#[modo::handler(GET "/dashboard")]
+async fn dashboard(
+    Service(db): Service<DatabaseService>,
+) -> ViewResult {
+    let data = db.fetch_summary().await
+        .map_err(|e| Error::internal(e.to_string()))?;
+    view!("dashboard.html", { "summary": data })
+}
+```
+
+Key points:
+- HTMX requests (`HX-Request` header present) receive a partial template render, always HTTP 200
+- Non-200 status codes skip HTMX rendering — errors returned from handlers do not attempt to render a template
+- Use `#[error_handler]` with `ctx.is_htmx()` to return HTMX-compatible error fragments
+
+### Content Negotiation in Error Handlers
+
+A single `#[error_handler]` can serve both JSON and HTML clients:
+
+```rust
+#[modo::error_handler]
+fn handle_error(err: Error, ctx: &ErrorContext) -> Response {
+    if ctx.is_htmx() {
+        // Return HTMX-compatible HTML fragment, always 200
+        (StatusCode::OK, Html(format!("<div class='error'>{}</div>", err.message_str())))
+            .into_response()
+    } else if ctx.accepts_html() {
+        // Full-page HTML error response
+        render_error_page(err).into_response()
+    } else {
+        // Default structured JSON
+        err.default_response()
+    }
+}
+```
+
+---
+
+## Common Multi-Module Workflows
+
+| Workflow | Reference files to read (in order) |
+|---|---|
+| Authenticated CRUD API | `conventions.md` → `database.md` → `handlers.md` → `auth-sessions.md` |
+| Web form with validation | `conventions.md` → `handlers.md` → `templates-htmx.md` |
+| Background email on user action | `handlers.md` → `jobs.md` → `email.md` |
+| File upload with auth | `auth-sessions.md` → `upload.md` → `handlers.md` |
+| Multi-tenant web app | `tenant.md` → `database.md` → `templates-htmx.md` |
+| HTMX live dashboard | `templates-htmx.md` → `auth-sessions.md` |
+| Full-stack feature (entity → API → job → email) | `conventions.md` → `database.md` → `handlers.md` → `jobs.md` → `email.md` |
+
+---
+
+## Gotchas
+
+### inventory Linking in Tests
+
+`inventory` registrations from library crates may not link when running unit tests. If `inventory::iter` returns nothing in a test that expects registrations, force the linker to include the registration with a wildcard import:
+
+```rust
+// In your test file or test module
+use crate::entity::my_entity as _;
+```
+
+This is only needed in test binaries. The main binary links correctly.
+
+### SeaORM ExprTrait Conflicts with Ord
+
+SeaORM's `ExprTrait` adds `.max()` and `.min()` methods to expression types, which conflicts with `Ord::max` and `Ord::min`. When you see ambiguity errors, use the fully qualified syntax:
+
+```rust
+// Wrong — ambiguous when ExprTrait is in scope
+let x = a.max(b);
+
+// Correct
+let x = Ord::max(a, b);
+```
+
+### HTMX 200-Only Rendering
+
+The template render layer only renders HTMX responses when the HTTP status is 200. If a handler returns a non-200 status (e.g., a redirect or an error), the HTMX partial template will not be rendered. Design HTMX error flows through `#[error_handler]` returning 200 with an error fragment, not through non-200 handler returns.
+
+### Alphabetical Re-exports in lib.rs
+
+All `pub use` re-exports in `modo/src/lib.rs` must be sorted alphabetically. `cargo fmt` enforces this ordering. If you add a new re-export and `cargo fmt` reorders it, that is correct behavior.
+
+Current public re-exports (from `lib.rs`):
+- `axum::Json` — the canonical JSON extractor/responder
+- `AppConfig`, `HttpConfig`, `RateLimitConfig`, `SecurityHeadersConfig`, `TrailingSlash`
+- `CookieConfig`, `CookieManager`, `CookieOptions`, `SameSite`
+- `CorsConfig`
+- `Error`, `ErrorContext`, `ErrorHandlerFn`, `ErrorHandlerRegistration`, `HandlerResult`, `HttpError`, `JsonResult`
+- `ViewResult` (behind `#[cfg(feature = "templates")]`)
+- `ClientIp`, `RateLimitInfo`
+- `RequestId`
+- `GracefulShutdown`, `ShutdownPhase`
+- `ViewRender`, `ViewRenderer`, `ViewResponse` (behind `#[cfg(feature = "templates")]`)
+
+### Use `modo::Json`, Not `axum::Json`
+
+Always import and use `modo::Json` (which re-exports `axum::Json`). Do not use `modo::axum::Json` even though both resolve to the same type. The re-export path is the convention.
+
+### ULID Session IDs — Never UUID
+
+Session IDs are ULID strings throughout the framework. Never introduce UUID for session or entity identifiers. ULID is re-exported from modo: `use modo::ulid`.
+
+### Feature Flag Syntax
+
+Optional dependencies must use the `dep:name` syntax in `Cargo.toml`:
+
+```toml
+[dependencies]
+some-crate = { version = "...", optional = true }
+
+[features]
+my-feature = ["dep:some-crate"]
+```
+
+In Rust source, gate code with `#[cfg(feature = "my-feature")]`. Proc macros cannot inspect `cfg` flags at expansion time — generated code must emit both branches explicitly:
+
+```rust
+// In proc macro output — emit both branches
+#[cfg(feature = "templates")]
+{ /* template path */ }
+#[cfg(not(feature = "templates"))]
+{ /* non-template path */ }
+```
+
+### `just test` Does Not Use `--all-features`
+
+`just test` runs tests without `--all-features`. Feature-gated code requires targeted test invocations:
+
+```bash
+cargo test -p modo_auth --features session
+```
+
+`just lint` does use `--all-features`, so lint passes even when test doesn't cover feature-gated paths.
+
+### Email Registration in Web Projects
+
+When using `modo-email` in a web application, the mailer is registered as a jobs service — not as an app service:
+
+```rust
+// Correct: register on the jobs builder
+let jobs = JobsBuilder::new()
+    .service(email_service)   // ← on jobs, NOT app
+    .build();
+
+// The app enqueues a payload; the job worker sends the email
+app.service(jobs_client)
+```
+
+Do not call `.service(email)` on the `AppBuilder`. The app enqueues `SendEmailPayload`; the job worker handles delivery.
+
+### Cron Jobs Are In-Memory Only
+
+Cron jobs defined with `modo_jobs` are scheduled in memory and are not persisted to the database. On restart, all cron schedules are re-registered from code. Do not design workflows that depend on cron state surviving a restart.
+
+---
+
+## docs.rs Quick Reference
+
+| Type / Trait | Link |
+|---|---|
+| `AppBuilder` | https://docs.rs/modo/latest/modo/app/struct.AppBuilder.html |
+| `AppState` | https://docs.rs/modo/latest/modo/app/struct.AppState.html |
+| `ServiceRegistry` | https://docs.rs/modo/latest/modo/app/struct.ServiceRegistry.html |
+| `Error` | https://docs.rs/modo/latest/modo/error/struct.Error.html |
+| `HttpError` | https://docs.rs/modo/latest/modo/error/enum.HttpError.html |
+| `HandlerResult` | https://docs.rs/modo/latest/modo/error/type.HandlerResult.html |
+| `JsonResult` | https://docs.rs/modo/latest/modo/error/type.JsonResult.html |
+| `ViewResult` | https://docs.rs/modo/latest/modo/error/type.ViewResult.html |
+| `ErrorContext` | https://docs.rs/modo/latest/modo/error/struct.ErrorContext.html |
+| `ErrorHandlerFn` | https://docs.rs/modo/latest/modo/error/type.ErrorHandlerFn.html |
+| `GracefulShutdown` | https://docs.rs/modo/latest/modo/shutdown/trait.GracefulShutdown.html |

--- a/claude-plugin/skills/modo/references/conventions.md
+++ b/claude-plugin/skills/modo/references/conventions.md
@@ -1,6 +1,10 @@
 # modo Conventions Reference
 
-**Documentation:** https://docs.rs/modo
+## Documentation
+
+- **modo (umbrella crate):** https://docs.rs/modo
+
+The `modo` crate is the umbrella re-export that application code depends on. It re-exports types from internal sub-crates (`modo-macros`, `modo-db`, `modo-jobs`, etc.) so you rarely import sub-crates directly. When in doubt, check the modo docs.rs page for the canonical public API surface. All macro attributes (`#[handler]`, `#[module]`, `#[view]`, etc.) are also re-exported through modo, so the only time you import a sub-crate directly is when using `modo_db`, `modo_jobs`, or similar standalone crate macros.
 
 ---
 

--- a/claude-plugin/skills/modo/references/conventions.md
+++ b/claude-plugin/skills/modo/references/conventions.md
@@ -221,16 +221,20 @@ Declared on the `#[module]` attribute. Applied to all routes within the module's
 
 ```rust
 #[modo::module(prefix = "/api/v1", middleware = [require_auth])]
-pub struct ApiV1Module;
+mod api_v1 {
+    #[modo::handler(GET, "/users")]
+    async fn list_users() -> &'static str { "users" }
+}
 ```
 
 ### Handler-Level Middleware
 
-Declared on the `#[handler]` attribute. Applied only to that specific route:
+Declared via a separate `#[middleware(...)]` attribute on the handler function. Applied only to that specific route:
 
 ```rust
-#[modo::handler(GET "/users/:id", middleware = [rate_limit_strict])]
-async fn get_user(/* ... */) -> JsonResult<UserResponse> { /* ... */ }
+#[modo::handler(GET, "/users/{id}")]
+#[middleware(rate_limit_strict)]
+async fn get_user(id: String, /* ... */) -> JsonResult<UserResponse> { /* ... */ }
 ```
 
 ### Stacking Rules
@@ -248,9 +252,9 @@ async fn get_user(/* ... */) -> JsonResult<UserResponse> { /* ... */ }
 Return `JsonResult<T>` and use `HttpError` variants or `Error::internal()` for failures:
 
 ```rust
-#[modo::handler(GET "/users/:id")]
+#[modo::handler(GET, "/users/{id}")]
 async fn get_user(
-    Path(id): Path<String>,
+    id: String,
     Service(db): Service<DatabaseService>,
 ) -> JsonResult<UserResponse> {
     let user = db.find_user(&id).await

--- a/claude-plugin/skills/modo/references/conventions.md
+++ b/claude-plugin/skills/modo/references/conventions.md
@@ -15,7 +15,7 @@ The `modo` crate is the umbrella re-export that application code depends on. It 
 Rules:
 - `mod.rs` — only `mod` declarations and `pub use` re-exports
 - `handlers.rs` (or `handlers/`) — all `#[handler]`-annotated functions
-- `views.rs` (or `views/`) — all `#[view]`-annotated functions and template helpers
+- `views.rs` (or `views/`) — all `#[view]`-annotated structs and template helpers
 - Tasks, jobs, and other domain code each go in their own files
 
 ```
@@ -23,7 +23,7 @@ src/
   users/
     mod.rs        ← ONLY: mod handlers; mod views; pub use ...
     handlers.rs   ← all #[handler] fns for this module
-    views.rs      ← all #[view] fns for this module
+    views.rs      ← all #[view] structs for this module
     tasks.rs      ← background task logic
 ```
 
@@ -177,12 +177,12 @@ CORS
                       Security Headers
                         Error Handler
                           Rate Limiter
-                            User Global Layers  ← AppBuilder::layer()
+                            i18n
                               Template Context
-                                i18n
-                                  Module Middleware
-                                    Handler Middleware
-                                      Render Layer (innermost)
+                                User Global Layers  ← AppBuilder::layer()
+                                  Render Layer
+                                    Module Middleware
+                                      Handler Middleware (innermost)
 ```
 
 Source: `modo/src/app.rs`, lines 545–552.
@@ -191,7 +191,7 @@ Source: `modo/src/app.rs`, lines 545–552.
 
 ```rust
 #[modo::main]
-async fn main(app: AppBuilder) {
+async fn main(app: AppBuilder, config: AppConfig) {
     app
         // Register a service accessible via Service<T> extractor
         .service(my_db_pool)
@@ -239,7 +239,7 @@ async fn get_user(id: String, /* ... */) -> JsonResult<UserResponse> { /* ... */
 
 ### Stacking Rules
 
-- Multiple middleware on the same scope are applied **last-declared = innermost**. This mirrors axum's `.layer()` semantics where the last call wraps outermost.
+- Multiple middleware on the same scope are applied **last-declared = innermost**. Note: this is the inverse of axum's raw `.layer()` where the last call wraps outermost. The macro achieves this by reversing the declaration order before applying layers.
 - `AppBuilder::layer()` inserts global layers between the framework infrastructure stack and the template/module layers. Multiple calls to `.layer()` stack the same way: last call = outermost of the user layers.
 - Template layers (`RenderLayer`, `ContextLayer`) are auto-registered when `TemplateEngine` is present as a service — no manual `.layer()` call needed.
 
@@ -275,13 +275,14 @@ Key points:
 Return `ViewResult<>` for server-rendered pages:
 
 ```rust
-#[modo::handler(GET "/dashboard")]
+#[modo::handler(GET, "/dashboard")]
 async fn dashboard(
+    view: ViewRenderer,
     Service(db): Service<DatabaseService>,
 ) -> ViewResult {
     let data = db.fetch_summary().await
         .map_err(|e| Error::internal(e.to_string()))?;
-    view!("dashboard.html", { "summary": data })
+    view.render(DashboardPage { summary: data })
 }
 ```
 

--- a/claude-plugin/skills/modo/references/database.md
+++ b/claude-plugin/skills/modo/references/database.md
@@ -281,7 +281,7 @@ use modo_db::sea_orm::{ActiveModelTrait, Set};
 #[modo::handler(POST, "/todos")]
 async fn create_todo(
     Db(db): Db,
-    input: modo::validate::Json<CreateTodo>,
+    input: modo::extractors::Json<CreateTodo>,
 ) -> modo::JsonResult<TodoResponse> {
     input.validate()?;
     let model = todo::ActiveModel {

--- a/claude-plugin/skills/modo/references/database.md
+++ b/claude-plugin/skills/modo/references/database.md
@@ -1,0 +1,698 @@
+# Database Reference
+
+The database layer in modo is powered by SeaORM v2 RC. It provides connection pooling,
+compile-time entity registration via `inventory`, schema synchronization (addition-only),
+versioned migrations, pagination helpers, and group-scoped sync for multi-database setups.
+
+> **Important:** modo uses SeaORM **v2** (release candidate). Do not use v1.x APIs, crate docs,
+> or patterns. Always consult SeaORM v2 documentation.
+
+## Documentation
+
+- modo-db crate: https://docs.rs/modo-db
+- modo-db-macros crate: https://docs.rs/modo-db-macros
+
+---
+
+## Features
+
+| Feature | Effect |
+|---------|--------|
+| `sqlite` *(default)* | Enables SQLite via `sqlx-sqlite`. Applies WAL mode, busy_timeout, and foreign key pragmas on connect. |
+| `postgres` | Enables PostgreSQL via `sqlx-postgres`. |
+
+---
+
+## Setup
+
+### Configuration
+
+`DatabaseConfig` is deserialized from YAML (via `modo::config::load()`). The backend is
+auto-detected from the URL scheme.
+
+```rust
+use modo_db::DatabaseConfig;
+use serde::Deserialize;
+
+#[derive(Default, Deserialize)]
+pub struct Config {
+    #[serde(flatten)]
+    pub core: modo::config::AppConfig,
+    pub database: DatabaseConfig,
+}
+```
+
+`DatabaseConfig` fields:
+
+| Field | Type | Default |
+|-------|------|---------|
+| `url` | `String` | `"sqlite://data/main.db?mode=rwc"` |
+| `max_connections` | `u32` | `5` |
+| `min_connections` | `u32` | `1` |
+
+Example YAML:
+
+```yaml
+url: "sqlite://data/main.db?mode=rwc"
+max_connections: 5
+min_connections: 1
+```
+
+For PostgreSQL:
+
+```yaml
+url: "postgres://user:pass@localhost/myapp"
+max_connections: 10
+min_connections: 2
+```
+
+### Connecting and registering
+
+```rust
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let db = modo_db::connect(&config.database).await?;
+    modo_db::sync_and_migrate(&db).await?;
+    app.config(config.core).managed_service(db).run().await
+}
+```
+
+`modo_db::connect` returns a `DbPool`. Pass it to `app.managed_service(db)` — this registers
+the pool in the service registry and hooks it into graceful shutdown (closes connections on
+`SIGTERM`/`SIGINT`).
+
+`modo_db::sync_and_migrate` synchronizes the schema for all registered entities and runs all
+pending versioned migrations. Call it once at startup, before `app.run()`.
+
+---
+
+## Entity Definition
+
+Use the `#[modo_db::entity(table = "...")]` attribute macro on a plain Rust struct. The macro
+generates a complete SeaORM entity module (model, active model, relation enum, registration)
+and submits an `EntityRegistration` to the `inventory` collector so schema sync discovers it
+automatically at startup.
+
+### Basic entity
+
+```rust
+#[modo_db::entity(table = "todos")]
+#[entity(timestamps)]
+pub struct Todo {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub title: String,
+    #[entity(default_value = false)]
+    pub completed: bool,
+}
+```
+
+The macro generates a module named after the struct in snake_case (e.g., `pub mod todo { ... }`).
+Inside it: `Model`, `ActiveModel`, `Entity`, `Column`, `Relation`, and `ActiveModelBehavior`.
+
+### Macro arguments
+
+**`#[modo_db::entity(...)]`** (outer attribute — table-level):
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `table = "<name>"` | Yes | SQL table name |
+| `group = "<name>"` | No | Named group for multi-database setups (default: `"default"`) |
+
+**`#[entity(...)]`** (second attribute — struct-level options):
+
+| Option | Description |
+|--------|-------------|
+| `timestamps` | Injects `created_at` and `updated_at: DateTime<Utc>`. Set automatically in `before_save`. Do not declare these fields manually. |
+| `soft_delete` | Injects `deleted_at: Option<DateTime<Utc>>`. Generates `find`, `find_by_id`, `with_deleted`, `only_deleted`, `soft_delete`, `restore`, and `force_delete` helpers. |
+| `framework` | Marks entity as framework-internal (non-user schema). |
+| `index(columns = ["col1", "col2"])` | Creates a composite index. Add `unique` to make it a unique index. |
+
+### Field-level options
+
+Applied as `#[entity(...)]` on individual struct fields:
+
+| Option | Description |
+|--------|-------------|
+| `primary_key` | Marks the field as the primary key |
+| `auto_increment = true\|false` | Overrides SeaORM's default auto-increment behavior |
+| `auto = "ulid"\|"nanoid"` | Generates a ULID or NanoID before insert. Only valid on `primary_key` fields. |
+| `unique` | Adds a unique constraint |
+| `indexed` | Creates a single-column index |
+| `nullable` | Accepted but has no effect — SeaORM infers nullability from `Option<T>` |
+| `column_type = "<type>"` | Overrides the inferred SeaORM column type string |
+| `default_value = <literal>` | Sets a column default value |
+| `default_expr = "<expr>"` | Sets a default SQL expression string |
+| `belongs_to = "<Entity>"` | Declares a `BelongsTo` relation to the named entity |
+| `on_delete = "<action>"` | FK action on delete: `Cascade`, `SetNull`, `Restrict`, `NoAction`, `SetDefault` |
+| `on_update = "<action>"` | FK action on update: same values as `on_delete` |
+| `has_many` | Declares a `HasMany` relation (field excluded from model) |
+| `has_one` | Declares a `HasOne` relation (field excluded from model) |
+| `via = "<JoinEntity>"` | Used with `has_many`/`has_one` for many-to-many through a join entity |
+| `renamed_from = "<old_name>"` | Records a rename hint as a column comment |
+
+### Soft-delete helpers
+
+When `soft_delete` is set, the generated entity module exposes:
+
+```rust
+// Excludes soft-deleted records (deleted_at IS NULL)
+todo::find()
+todo::find_by_id(id)
+
+// All records including soft-deleted
+todo::with_deleted()
+
+// Only soft-deleted records
+todo::only_deleted()
+
+// Soft-delete a record (sets deleted_at to now)
+todo::soft_delete(active_model, &db).await?;
+
+// Restore a soft-deleted record (clears deleted_at)
+todo::restore(active_model, &db).await?;
+
+// Permanently delete (hard delete)
+todo::force_delete(model, &db).await?;
+```
+
+### ID generation
+
+The `auto = "ulid"` and `auto = "nanoid"` options on a primary key field cause the
+`ActiveModelBehavior::before_save` hook to call `modo_db::generate_ulid()` or
+`modo_db::generate_nanoid()` before insert if the field is not already set.
+
+- `generate_ulid()` — 26-character Crockford Base32 ULID
+- `generate_nanoid()` — 21-character NanoID (default alphabet)
+
+Session IDs and most entity IDs in modo use ULID. Do not use UUID.
+
+---
+
+## Migrations
+
+### Auto-migration (schema sync)
+
+`sync_and_migrate` runs an addition-only schema sync. It creates tables and columns that do not
+yet exist; it never drops or renames columns. This is suitable for development and simple
+production deployments.
+
+The framework bootstraps a `_modo_migrations` table to track executed versioned migrations.
+
+### Versioned SQL migrations
+
+For data migrations, backfills, index changes, or any operation that schema sync cannot handle,
+use `#[modo_db::migration]`:
+
+```rust
+#[modo_db::migration(version = 1, description = "seed default roles")]
+async fn seed_roles(db: &impl modo_db::sea_orm::ConnectionTrait)
+    -> Result<(), modo_db::sea_orm::DbErr>
+{
+    db.execute_unprepared(
+        "INSERT INTO roles (id, name) VALUES ('admin', 'Administrator')"
+    ).await?;
+    Ok(())
+}
+```
+
+**Required arguments:**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `version = <u64>` | integer | Monotonically increasing migration version |
+| `description = "<text>"` | string | Human-readable description shown in logs |
+
+**Optional argument:**
+
+| Argument | Description |
+|----------|-------------|
+| `group = "<name>"` | Assigns migration to a named group (default: `"default"`) |
+
+The annotated function must be `async`, accept a single `&impl ConnectionTrait` parameter, and
+return `Result<(), DbErr>`. The macro keeps the function as-is and submits a
+`MigrationRegistration` to `inventory`.
+
+Migrations are version-ordered and deduplicated at startup. Duplicate version numbers across
+registrations are a compile-time-detectable runtime error (detected before any migration runs).
+Each executed migration is recorded in `_modo_migrations` with its version, description, and
+timestamp.
+
+---
+
+## Db Extractor
+
+`Db` is an axum extractor that retrieves the `DbPool` from the service registry.
+
+```rust
+use modo_db::Db;
+
+#[modo::handler(GET, "/todos")]
+async fn list_todos(Db(db): Db) -> modo::JsonResult<Vec<TodoResponse>> {
+    // db is a DbPool; deref it with &*db to get &DatabaseConnection
+    let todos = todo::Entity::find()
+        .all(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to list todos: {e}")))?;
+    Ok(modo::Json(todos.into_iter().map(TodoResponse::from).collect()))
+}
+```
+
+`DbPool` implements `Deref<Target = DatabaseConnection>`, so `&*db` gives a
+`&sea_orm::DatabaseConnection` suitable for passing to SeaORM query methods.
+
+`Db` returns a `500 Internal Server Error` if `DbPool` was not registered via
+`app.managed_service(db)`.
+
+---
+
+## CRUD Patterns
+
+Patterns drawn from `examples/todo-api/src/`:
+
+### Create
+
+```rust
+use modo_db::sea_orm::{ActiveModelTrait, Set};
+
+#[modo::handler(POST, "/todos")]
+async fn create_todo(
+    Db(db): Db,
+    input: modo::validate::Json<CreateTodo>,
+) -> modo::JsonResult<TodoResponse> {
+    input.validate()?;
+    let model = todo::ActiveModel {
+        title: Set(input.title.clone()),
+        ..Default::default()
+    };
+    let result = model
+        .insert(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to create todo: {e}")))?;
+    Ok(modo::Json(TodoResponse::from(result)))
+}
+```
+
+- Use `sea_orm::Set(value)` to mark fields for insertion.
+- Fields with `auto = "ulid"` are set automatically by `before_save`; leave them as
+  `Default::default()` (i.e., `NotSet`).
+- Fields with `timestamps` (`created_at`, `updated_at`) are also set by `before_save`.
+- `.insert(&*db)` returns the inserted `Model`.
+
+### Read (list)
+
+```rust
+use modo_db::sea_orm::EntityTrait;
+
+#[modo::handler(GET, "/todos")]
+async fn list_todos(Db(db): Db) -> modo::JsonResult<Vec<TodoResponse>> {
+    let todos = todo::Entity::find()
+        .all(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to list todos: {e}")))?;
+    Ok(modo::Json(todos.into_iter().map(TodoResponse::from).collect()))
+}
+```
+
+### Read (single)
+
+```rust
+use modo_db::sea_orm::EntityTrait;
+
+#[modo::handler(GET, "/todos/{id}")]
+async fn get_todo(Db(db): Db, id: String) -> modo::JsonResult<TodoResponse> {
+    let todo = todo::Entity::find_by_id(&id)
+        .one(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to find todo: {e}")))?
+        .ok_or(modo::HttpError::NotFound)?;
+    Ok(modo::Json(TodoResponse::from(todo)))
+}
+```
+
+### Update
+
+```rust
+use modo_db::sea_orm::{ActiveModelTrait, EntityTrait, Set};
+
+#[modo::handler(PATCH, "/todos/{id}")]
+async fn update_todo(
+    Db(db): Db,
+    id: String,
+    input: modo::Json<UpdateTodo>,
+) -> modo::JsonResult<TodoResponse> {
+    let todo = todo::Entity::find_by_id(&id)
+        .one(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(e.to_string()))?
+        .ok_or(modo::HttpError::NotFound)?;
+
+    let mut active: todo::ActiveModel = todo.into();
+    active.completed = Set(input.completed);
+    let updated = active
+        .update(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(e.to_string()))?;
+    Ok(modo::Json(TodoResponse::from(updated)))
+}
+```
+
+Convert a `Model` to `ActiveModel` with `.into()`, then set only the fields you want to change
+with `Set(value)`. Unset fields (`NotSet`) are not written to the database.
+
+### Delete
+
+```rust
+use modo_db::sea_orm::{EntityTrait, ModelTrait};
+
+#[modo::handler(DELETE, "/todos/{id}")]
+async fn delete_todo(Db(db): Db, id: String) -> modo::JsonResult<serde_json::Value> {
+    let todo = todo::Entity::find_by_id(&id)
+        .one(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to find todo: {e}")))?
+        .ok_or(modo::HttpError::NotFound)?;
+    todo.delete(&*db)
+        .await
+        .map_err(|e| modo::Error::internal(format!("Failed to delete todo: {e}")))?;
+    Ok(modo::Json(serde_json::json!({"deleted": id})))
+}
+```
+
+Call `.delete(&*db)` on the `Model` (requires `ModelTrait` in scope).
+
+---
+
+## Query Building
+
+All SeaORM v2 query builder methods are available via the entity module:
+
+```rust
+use modo_db::sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Order};
+
+// Filter
+let active_todos = todo::Entity::find()
+    .filter(todo::Column::Completed.eq(false))
+    .all(&*db)
+    .await?;
+
+// Order
+let sorted = todo::Entity::find()
+    .order_by(todo::Column::CreatedAt, Order::Desc)
+    .all(&*db)
+    .await?;
+
+// Filter + order
+let results = todo::Entity::find()
+    .filter(todo::Column::Completed.eq(false))
+    .order_by(todo::Column::CreatedAt, Order::Desc)
+    .all(&*db)
+    .await?;
+
+// Find by primary key
+let one = todo::Entity::find_by_id("01J...").one(&*db).await?;
+```
+
+Common traits to import for query building:
+
+| Trait | Purpose |
+|-------|---------|
+| `EntityTrait` | `find()`, `find_by_id()`, `insert()`, `delete_many()` |
+| `ActiveModelTrait` | `.insert()`, `.update()`, `.save()`, `.delete()` on `ActiveModel` |
+| `ModelTrait` | `.delete()`, `.into_active_model()` on `Model` |
+| `QueryFilter` | `.filter(...)` |
+| `QueryOrder` | `.order_by(...)` |
+| `ColumnTrait` | `.eq()`, `.ne()`, `.lt()`, `.gt()`, `.is_null()`, `.contains()`, etc. |
+
+Import these from `modo_db::sea_orm`.
+
+---
+
+## Pagination
+
+### Offset pagination
+
+Use `modo_db::paginate` with `PageParams` for traditional page-number pagination:
+
+```rust
+use modo_db::{Db, PageParams, paginate};
+use modo::axum::extract::Query;
+
+#[modo::handler(GET, "/todos")]
+async fn list_todos(
+    Db(db): Db,
+    Query(params): Query<PageParams>,
+) -> modo::JsonResult<modo_db::PageResult<TodoResponse>> {
+    use modo_db::sea_orm::EntityTrait;
+    let page = paginate(todo::Entity::find(), &*db, &params)
+        .await
+        .map_err(|e| modo::Error::internal(e.to_string()))?;
+    Ok(modo::Json(page.map(TodoResponse::from)))
+}
+```
+
+`PageParams` query-string fields (with defaults):
+
+| Field | Default | Constraint |
+|-------|---------|------------|
+| `page` | `1` | 1-indexed |
+| `per_page` | `20` | Clamped to `[1, 100]` |
+
+`PageResult<T>` response fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `Vec<T>` | Page items |
+| `page` | `u64` | Current page number |
+| `per_page` | `u64` | Items per page (after clamping) |
+| `has_next` | `bool` | Whether a next page exists |
+| `has_prev` | `bool` | Whether a previous page exists |
+
+Uses the limit+1 trick to detect `has_next` without a `COUNT` query.
+
+`PageResult::map<U>(f)` transforms every item in `data` — use it to convert from `Model` to a
+response type.
+
+### Cursor pagination
+
+Use `modo_db::paginate_cursor` with `CursorParams` for keyset/cursor pagination. This is
+preferable for large datasets because it avoids offset scans.
+
+```rust
+use modo_db::{CursorParams, CursorResult, Db, paginate_cursor};
+use modo::axum::extract::Query;
+
+#[modo::handler(GET, "/todos")]
+async fn list_todos(
+    Db(db): Db,
+    Query(params): Query<CursorParams>,
+) -> modo::JsonResult<CursorResult<TodoResponse>> {
+    use modo_db::sea_orm::EntityTrait;
+    let page = paginate_cursor(
+        todo::Entity::find(),
+        todo::Column::Id,
+        |m| m.id.clone(),
+        &*db,
+        &params,
+    )
+    .await
+    .map_err(|e| modo::Error::internal(e.to_string()))?;
+    Ok(modo::Json(page.map(TodoResponse::from)))
+}
+```
+
+`CursorParams<V = String>` query-string fields:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `per_page` | `20` | Clamped to `[1, 100]` |
+| `after` | `None` | Cursor value — fetch records after this position (forward) |
+| `before` | `None` | Cursor value — fetch records before this position (backward) |
+
+When both `after` and `before` are set, `after` takes precedence.
+
+For string-keyed entities (ULID/NanoID), use `CursorParams` (default `String`). For integer
+primary keys, use `CursorParams<i64>`.
+
+`CursorResult<T>` response fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `Vec<T>` | Page items |
+| `per_page` | `u64` | Items per page (after clamping) |
+| `next_cursor` | `Option<String>` | Cursor for `?after=` to get the next page |
+| `prev_cursor` | `Option<String>` | Cursor for `?before=` to get the previous page |
+| `has_next` | `bool` | Whether a next page exists |
+| `has_prev` | `bool` | Whether a previous page exists |
+
+Navigate with `?after=<next_cursor>` (forward) and `?before=<prev_cursor>` (backward).
+
+---
+
+## Group-Scoped Sync
+
+Entities and migrations can be assigned to a named group. The default group is `"default"`.
+`sync_and_migrate` syncs all groups; `sync_and_migrate_group` syncs only the named group.
+
+Use groups when different entity sets live in different databases (e.g., a main app database
+and a separate analytics or jobs database):
+
+```rust
+// Entity in the "analytics" group
+#[modo_db::entity(table = "events", group = "analytics")]
+pub struct Event {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub name: String,
+}
+
+// Migration in the "analytics" group
+#[modo_db::migration(version = 1, description = "seed event types", group = "analytics")]
+async fn seed_event_types(db: &impl modo_db::sea_orm::ConnectionTrait)
+    -> Result<(), modo_db::sea_orm::DbErr>
+{
+    // ...
+    Ok(())
+}
+
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Main database — syncs "default" group entities and migrations
+    let db = modo_db::connect(&config.database).await?;
+    modo_db::sync_and_migrate(&db).await?;
+
+    // Analytics database — syncs only "analytics" group
+    let analytics_db = modo_db::connect(&config.analytics_database).await?;
+    modo_db::sync_and_migrate_group(&analytics_db, "analytics").await?;
+
+    app.config(config.core)
+        .managed_service(db)
+        .managed_service(analytics_db)
+        .run()
+        .await
+}
+```
+
+`sync_and_migrate` with no group filter syncs all registered entities regardless of group
+(which may cause issues if entities from different groups reference different databases). For
+multi-database setups, always use `sync_and_migrate_group` per database.
+
+---
+
+## Integration Patterns
+
+### Multiple databases
+
+Register each `DbPool` as a managed service under a distinct wrapper type (newtype) so they are
+addressable separately from the service registry:
+
+```rust
+// Define newtypes so the service registry can distinguish them
+pub struct MainDb(pub DbPool);
+pub struct AnalyticsDb(pub DbPool);
+
+// In main:
+let main_db = modo_db::connect(&config.database).await?;
+let analytics_db = modo_db::connect(&config.analytics_database).await?;
+modo_db::sync_and_migrate(&main_db).await?;
+modo_db::sync_and_migrate_group(&analytics_db, "analytics").await?;
+
+app.managed_service(MainDb(main_db))
+   .managed_service(AnalyticsDb(analytics_db))
+   .run()
+   .await
+```
+
+Extract the secondary database using `modo::extractors::Service<AnalyticsDb>` in handlers.
+
+### Response mapping
+
+Define a `From<entity::Model>` implementation on your response type to keep handler code clean:
+
+```rust
+#[derive(serde::Serialize)]
+pub struct TodoResponse {
+    id: String,
+    title: String,
+    completed: bool,
+}
+
+impl From<todo::Model> for TodoResponse {
+    fn from(m: todo::Model) -> Self {
+        Self {
+            id: m.id,
+            title: m.title,
+            completed: m.completed,
+        }
+    }
+}
+```
+
+Then use `.map(TodoResponse::from)` on `Vec<Model>` or on `PageResult::map`.
+
+---
+
+## Gotchas
+
+- **SeaORM v2 only**: modo uses SeaORM v2 RC. Do not reference SeaORM v1.x crate docs,
+  migration patterns, or API surface. Key breaking changes include `ActiveModelBehavior::before_save`
+  signature changes and query builder API differences.
+
+- **`ExprTrait` conflicts with `Ord::max`/`Ord::min`**: SeaORM's `ExprTrait` re-exports methods
+  named `max` and `min`. When both `ExprTrait` and Rust's `Ord` trait are in scope, calls to
+  `.max()` on numeric values become ambiguous. Disambiguate with the fully-qualified form:
+  `Ord::max(a, b)`.
+
+- **`inventory` linking in tests**: Entity and migration registrations submitted via
+  `inventory::submit!` may be dropped by the linker in test builds if nothing from the module is
+  directly referenced. Force linking with `use crate::entity::todo as _;` (or similar) in test
+  files.
+
+- **Schema sync is addition-only**: `sync_and_migrate` never drops or renames columns. Use a
+  versioned `#[modo_db::migration]` to rename or drop columns.
+
+- **`auto = "ulid"` only on primary key fields**: Using `auto = "ulid"` or `auto = "nanoid"` on
+  a non-primary-key field is a compile error.
+
+- **Do not declare `created_at`/`updated_at` manually**: If `#[entity(timestamps)]` is set and
+  your struct also declares a `created_at` or `updated_at` field, the macro emits a compile error.
+  Same applies for `deleted_at` with `#[entity(soft_delete)]`.
+
+- **`Db` extractor requires `managed_service`**: If `DbPool` is not registered via
+  `app.managed_service(db)`, extracting `Db` in a handler returns a `500 Internal Server Error`.
+
+- **`&*db` dereference**: `DbPool` implements `Deref<Target = DatabaseConnection>`. SeaORM query
+  methods accept `&impl ConnectionTrait`. Pass `&*db` (or `db.connection()`) to them.
+
+- **Duplicate migration versions**: Two `#[modo_db::migration(version = N)]` entries with the
+  same `N` (in the same group) cause `sync_and_migrate` to return an error before any migrations
+  run. Version numbers must be unique per group.
+
+---
+
+## Key Type Reference
+
+| Type | Path |
+|------|------|
+| `DatabaseConfig` | `modo_db::DatabaseConfig` |
+| `DbPool` | `modo_db::DbPool` |
+| `Db` | `modo_db::Db` |
+| `EntityRegistration` | `modo_db::EntityRegistration` |
+| `MigrationRegistration` | `modo_db::MigrationRegistration` |
+| `PageParams` | `modo_db::PageParams` |
+| `PageResult<T>` | `modo_db::PageResult` |
+| `CursorParams<V>` | `modo_db::CursorParams` |
+| `CursorResult<T>` | `modo_db::CursorResult` |
+| `paginate` | `modo_db::paginate` |
+| `paginate_cursor` | `modo_db::paginate_cursor` |
+| `sync_and_migrate` | `modo_db::sync_and_migrate` |
+| `sync_and_migrate_group` | `modo_db::sync_and_migrate_group` |
+| `connect` | `modo_db::connect` |
+| `generate_ulid` | `modo_db::generate_ulid` |
+| `generate_nanoid` | `modo_db::generate_nanoid` |

--- a/claude-plugin/skills/modo/references/database.md
+++ b/claude-plugin/skills/modo/references/database.md
@@ -276,12 +276,13 @@ Patterns drawn from `examples/todo-api/src/`:
 ### Create
 
 ```rust
+use modo::extractors::Json;
 use modo_db::sea_orm::{ActiveModelTrait, Set};
 
 #[modo::handler(POST, "/todos")]
 async fn create_todo(
     Db(db): Db,
-    input: modo::extractors::Json<CreateTodo>,
+    input: Json<CreateTodo>,
 ) -> modo::JsonResult<TodoResponse> {
     input.validate()?;
     let model = todo::ActiveModel {

--- a/claude-plugin/skills/modo/references/database.md
+++ b/claude-plugin/skills/modo/references/database.md
@@ -209,8 +209,8 @@ use `#[modo_db::migration]`:
 
 ```rust
 #[modo_db::migration(version = 1, description = "seed default roles")]
-async fn seed_roles(db: &impl modo_db::sea_orm::ConnectionTrait)
-    -> Result<(), modo_db::sea_orm::DbErr>
+async fn seed_roles(db: &sea_orm::DatabaseConnection)
+    -> Result<(), modo::Error>
 {
     db.execute_unprepared(
         "INSERT INTO roles (id, name) VALUES ('admin', 'Administrator')"
@@ -232,12 +232,12 @@ async fn seed_roles(db: &impl modo_db::sea_orm::ConnectionTrait)
 |----------|-------------|
 | `group = "<name>"` | Assigns migration to a named group (default: `"default"`) |
 
-The annotated function must be `async`, accept a single `&impl ConnectionTrait` parameter, and
-return `Result<(), DbErr>`. The macro keeps the function as-is and submits a
+The annotated function must be `async`, accept a single `&sea_orm::DatabaseConnection` parameter, and
+return `Result<(), modo::Error>`. The macro keeps the function as-is and submits a
 `MigrationRegistration` to `inventory`.
 
 Migrations are version-ordered and deduplicated at startup. Duplicate version numbers across
-registrations are a compile-time-detectable runtime error (detected before any migration runs).
+registrations are a runtime error (detected before any migration runs).
 Each executed migration is recorded in `_modo_migrations` with its version, description, and
 timestamp.
 
@@ -338,6 +338,7 @@ async fn get_todo(Db(db): Db, id: String) -> modo::JsonResult<TodoResponse> {
 ```rust
 use modo_db::sea_orm::{ActiveModelTrait, EntityTrait, Set};
 
+// Illustrative example — not from the examples directory
 #[modo::handler(PATCH, "/todos/{id}")]
 async fn update_todo(
     Db(db): Db,
@@ -551,8 +552,8 @@ pub struct Event {
 
 // Migration in the "analytics" group
 #[modo_db::migration(version = 1, description = "seed event types", group = "analytics")]
-async fn seed_event_types(db: &impl modo_db::sea_orm::ConnectionTrait)
-    -> Result<(), modo_db::sea_orm::DbErr>
+async fn seed_event_types(db: &sea_orm::DatabaseConnection)
+    -> Result<(), modo::Error>
 {
     // ...
     Ok(())
@@ -563,7 +564,7 @@ async fn main(
     app: modo::app::AppBuilder,
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Main database — syncs "default" group entities and migrations
+    // Main database — syncs all registered entities and runs pending migrations
     let db = modo_db::connect(&config.database).await?;
     modo_db::sync_and_migrate(&db).await?;
 

--- a/claude-plugin/skills/modo/references/database.md
+++ b/claude-plugin/skills/modo/references/database.md
@@ -609,7 +609,7 @@ app.managed_service(MainDb(main_db))
    .await
 ```
 
-Extract the secondary database using `modo::extractors::Service<AnalyticsDb>` in handlers.
+Extract the secondary database using `modo::Service<AnalyticsDb>` in handlers.
 
 ### Response mapping
 

--- a/claude-plugin/skills/modo/references/email.md
+++ b/claude-plugin/skills/modo/references/email.md
@@ -565,7 +565,7 @@ user-supplied data directly into a layout variable (other than `content`) you ar
 responsible for escaping it.
 
 **`TemplateProvider::get` is called synchronously.** `FilesystemProvider` performs
-blocking file I/O inside `MailTransport::send`, which is async. This is acceptable
+blocking I/O inside `Mailer::send` (via `self.render()`, which reads template files synchronously). This is acceptable
 for most workloads, but if templates are loaded from a remote store, implement
 blocking access with a cache rather than making async calls inside `get`.
 

--- a/claude-plugin/skills/modo/references/email.md
+++ b/claude-plugin/skills/modo/references/email.md
@@ -1,0 +1,603 @@
+# Email Reference
+
+`modo-email` provides Markdown-based email templates, responsive HTML rendering,
+plain-text fallback generation, and pluggable delivery transports (SMTP via lettre
+and Resend via HTTP API). The mailer is a cheap-to-clone service designed to be
+registered on the jobs builder and accessed from background job handlers.
+
+---
+
+## Documentation
+
+- modo-email crate: https://docs.rs/modo-email
+
+---
+
+## Email Service Setup
+
+### EmailConfig
+
+`EmailConfig` is a serde-deserializable struct loaded from YAML. All fields have
+defaults so partial YAML is valid.
+
+```rust
+use modo_email::EmailConfig;
+
+#[derive(Default, serde::Deserialize)]
+pub struct Config {
+    // ... other fields
+    #[serde(default)]
+    pub email: EmailConfig,
+}
+```
+
+**Fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `transport` | `TransportBackend` | `"smtp"` | Which backend to use. |
+| `templates_path` | `String` | `"emails"` | Directory containing `.md` template files. |
+| `default_from_name` | `String` | `""` | Display name for the `From` header. |
+| `default_from_email` | `String` | `""` | Email address for the `From` header. |
+| `default_reply_to` | `Option<String>` | `None` | Optional default `Reply-To` address. |
+| `smtp` | `SmtpConfig` | see below | SMTP settings (requires `smtp` feature). |
+| `resend` | `ResendConfig` | see below | Resend API settings (requires `resend` feature). |
+
+`TransportBackend` is an enum serialized as lowercase strings:
+
+```rust
+pub enum TransportBackend {
+    Smtp,    // "smtp" (default)
+    Resend,  // "resend"
+}
+```
+
+Example YAML for SMTP:
+
+```yaml
+email:
+  transport: smtp
+  templates_path: emails
+  default_from_name: "My App"
+  default_from_email: "noreply@myapp.com"
+  default_reply_to: "support@myapp.com"
+  smtp:
+    host: smtp.mailgun.org
+    port: 587
+    username: postmaster@myapp.com
+    password: secret
+    tls: true
+```
+
+### SmtpConfig (requires `smtp` feature)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host` | `String` | `"localhost"` | SMTP server hostname. |
+| `port` | `u16` | `587` | SMTP server port. |
+| `username` | `String` | `""` | SMTP authentication username. |
+| `password` | `String` | `""` | SMTP authentication password. |
+| `tls` | `bool` | `true` | When `true`, uses STARTTLS. When `false`, no TLS. |
+
+STARTTLS (port 587) is the only supported TLS mode. Implicit TLS / SMTPS (port 465)
+is not currently supported. For local development without TLS, set `tls: false`.
+
+### ResendConfig (requires `resend` feature)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `String` | `""` | Resend API key (starts with `re_`). |
+
+Example YAML for Resend:
+
+```yaml
+email:
+  transport: resend
+  templates_path: emails
+  default_from_name: "My App"
+  default_from_email: "noreply@myapp.com"
+  resend:
+    api_key: re_xxxxxxxxxxxxxxxx
+```
+
+### Cargo features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `smtp` | yes | Enables SMTP transport via `lettre`. |
+| `resend` | no | Enables Resend HTTP API transport via `reqwest`. |
+
+Enable Resend in `Cargo.toml`:
+
+```toml
+[dependencies]
+modo-email = { version = "...", default-features = false, features = ["resend"] }
+```
+
+---
+
+## Creating a Mailer
+
+The top-level `mailer` function is the standard entry point. It creates a `Mailer`
+with a `FilesystemProvider` rooted at `config.templates_path` and the transport
+selected by `config.transport`.
+
+```rust
+use modo_email::{mailer, EmailConfig};
+
+let config = EmailConfig::default(); // or deserialized from YAML
+let m = mailer(&config)?;
+```
+
+For custom template sources (database, cache, etc.), use `mailer_with`:
+
+```rust
+use modo_email::{mailer_with, EmailConfig, TemplateProvider};
+use std::sync::Arc;
+
+let provider: Arc<dyn TemplateProvider> = Arc::new(MyDbProvider::new());
+let m = mailer_with(&config, provider)?;
+```
+
+### Mailer
+
+`Mailer` ties together template loading, variable substitution, Markdown rendering,
+layout wrapping, and transport delivery. It is cheaply cloneable via internal `Arc`s,
+making it safe to share across async tasks and register as a service on the jobs
+builder.
+
+Key methods:
+
+- `Mailer::send(&self, email: &SendEmail) -> Result<(), modo::Error>` — render and
+  deliver an email.
+- `Mailer::render(&self, email: &SendEmail) -> Result<MailMessage, modo::Error>` —
+  render to a `MailMessage` without sending (useful for testing and inspection).
+
+---
+
+## Markdown Templates
+
+Templates are `.md` files with YAML frontmatter stored in the directory configured
+by `templates_path` (default: `emails/`).
+
+### File structure
+
+```
+emails/
+  welcome.md          # root template (all locales)
+  reset.md
+  de/
+    welcome.md        # German locale override
+  layouts/
+    default.html      # overrides the built-in default layout
+    branded.html      # custom named layout
+```
+
+### Template format
+
+Every template starts with YAML frontmatter delimited by `---`, followed by a
+Markdown body:
+
+```markdown
+---
+subject: "Welcome {{name}}!"
+layout: default
+---
+
+Hi **{{name}}**,
+
+Thank you for joining. Click below to get started:
+
+[button|Launch Dashboard]({{url}})
+
+If you have questions, [contact support](https://myapp.com/support).
+```
+
+**Frontmatter fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `subject` | yes | Subject line. Supports `{{var}}` placeholders. |
+| `layout` | no | Layout name to wrap the body. Defaults to `"default"`. |
+
+Extra frontmatter fields are silently ignored.
+
+### Variable substitution
+
+Variables use `{{key}}` syntax. Whitespace inside braces is trimmed:
+`{{ name }}` resolves the key `"name"`. Variables are substituted in both the
+subject line and the Markdown body before rendering. Unresolved placeholders are
+left as-is rather than producing an error.
+
+Supported value types: `&str`, `String`, `i64`, `bool`, and any type that converts
+to `serde_json::Value`. Non-string JSON types use their `to_string()` representation.
+
+### Markdown rendering
+
+The Markdown body is rendered to both HTML and plain text in a single pass using
+`pulldown-cmark`. All standard Markdown elements (headings, bold, italic, lists,
+code blocks, links) are supported.
+
+**Button links** use a special syntax and render as email-safe table-based buttons
+in HTML. In plain text, they render as `Label (URL)`:
+
+```markdown
+[button|Click Here](https://example.com/action)
+```
+
+The default button color is `#4F46E5`. Override it by passing `brand_color` as a
+template variable (must be a valid CSS hex color — `#RGB` or `#RRGGBB`). Invalid
+values silently fall back to the default.
+
+### Layout engine
+
+After the Markdown body is rendered to HTML, it is wrapped in a layout using
+MiniJinja. The layout receives all template variables plus two injected keys:
+
+| Variable | Description |
+|----------|-------------|
+| `content` | The rendered HTML body (pre-rendered, auto-escaping disabled). |
+| `subject` | The substituted subject line. |
+
+The built-in `"default"` layout is a responsive, email-client-compatible HTML
+template. It supports optional variables from the template context:
+
+| Variable | Description |
+|----------|-------------|
+| `logo_url` | When set, renders a logo `<img>` above the body. |
+| `product_name` | Used as the `alt` attribute on the logo image. |
+| `footer_text` | Shown in the footer below the body. |
+
+The default layout renders the `<title>` tag using `{{subject}}`.
+
+Place custom layouts as `.html` files in `{templates_path}/layouts/`. A custom
+`default.html` overrides the built-in default. Custom layouts use MiniJinja syntax:
+
+```html
+<!DOCTYPE html>
+<html>
+<head><title>{{ subject }}</title></head>
+<body>
+  <header><img src="{{ logo_url | default(value='') }}"></header>
+  <main>{{ content }}</main>
+  <footer>{{ footer_text | default(value='') }}</footer>
+</body>
+</html>
+```
+
+### Locale support
+
+`FilesystemProvider` resolves localized templates automatically. When a locale is
+set on the `SendEmail` request, the provider looks for
+`{templates_path}/{locale}/{name}.md` first. If not found, it falls back to
+`{templates_path}/{name}.md`. Pass an empty string (the default) to use the root
+template directly.
+
+Path traversal is rejected: template names or locales containing `..`, `/`, or `\`
+return an error immediately.
+
+---
+
+## Sending Email
+
+### SendEmail builder
+
+`SendEmail` is a builder for requesting a templated email send. Construct it with
+`SendEmail::new`, then chain methods before passing to `Mailer::send` or
+`Mailer::render`.
+
+```rust
+use modo_email::SendEmail;
+
+let email = SendEmail::new("welcome", "user@example.com")
+    .var("name", "Alice")
+    .var("url", "https://myapp.com/dashboard")
+    .var("brand_color", "#ff6600")
+    .var("footer_text", "© 2026 My App");
+```
+
+**Builder methods:**
+
+| Method | Description |
+|--------|-------------|
+| `new(template, to)` | Create a request for `template` addressed to `to`. |
+| `.to(address)` | Add an additional recipient. |
+| `.locale(locale)` | Set locale for template resolution. |
+| `.sender(profile)` | Override the default sender with a `SenderProfile`. |
+| `.var(key, value)` | Insert a single template variable. |
+| `.context(map)` | Merge an entire `HashMap<String, serde_json::Value>` into the context. |
+
+Multiple recipients:
+
+```rust
+let email = SendEmail::new("notify", "a@example.com")
+    .to("b@example.com")
+    .to("c@example.com");
+```
+
+### SenderProfile
+
+`SenderProfile` overrides the default sender configured in `EmailConfig`. It is
+serializable so it can be included in job payloads.
+
+```rust
+use modo_email::SenderProfile;
+
+let sender = SenderProfile {
+    from_name: "Support Team".to_string(),
+    from_email: "support@myapp.com".to_string(),
+    reply_to: Some("help@myapp.com".to_string()),
+};
+
+let email = SendEmail::new("ticket", "user@example.com")
+    .sender(&sender)
+    .var("ticket_id", "12345");
+```
+
+`SenderProfile::format_address()` formats the address as `"Name <email>"` for the
+`From` header, stripping control characters and angle brackets from the name to
+prevent header injection.
+
+### MailMessage
+
+`MailMessage` is a fully-rendered email ready for transport. `Mailer::render` returns
+this type without sending.
+
+```rust
+pub struct MailMessage {
+    pub from: String,
+    pub reply_to: Option<String>,
+    pub to: Vec<String>,
+    pub subject: String,
+    pub html: String,
+    pub text: String,
+}
+```
+
+Use `Mailer::render` to inspect the output in tests or to preview the rendered HTML
+before sending.
+
+### SendEmailPayload
+
+`SendEmailPayload` is a serializable mirror of `SendEmail` for use as a job queue
+payload. Convert between them with the provided `From` impls:
+
+```rust
+use modo_email::{SendEmail, SendEmailPayload};
+
+// Convert to payload before enqueuing:
+let payload = SendEmailPayload::from(
+    SendEmail::new("welcome", "user@example.com").var("name", "Alice")
+);
+
+// Convert back to SendEmail inside the job handler:
+let email = SendEmail::from(payload);
+```
+
+`SendEmailPayload` derives `Serialize` and `Deserialize`, making it safe to store
+in the job queue's JSON column.
+
+---
+
+## Integration Patterns
+
+### Mailer on the jobs builder (critical)
+
+The mailer must be registered as a service on the jobs builder with `.service()`,
+not on the app builder. The app enqueues a `SendEmailPayload`; the job worker
+processes the actual sending. This separation keeps HTTP handlers free of slow
+network I/O.
+
+```rust
+use modo_email::{mailer, EmailConfig, SendEmail, SendEmailPayload};
+use modo_jobs::JobQueue;
+use modo::HandlerResult;
+use modo::extractors::service::Service;
+
+// In main — register mailer on the JOBS builder, not on app:
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let db = modo_db::connect(&config.database).await?;
+    modo_db::sync_and_migrate(&db).await?;
+
+    let email = mailer(&config.email)?;
+
+    let jobs = modo_jobs::new(&db, &config.jobs)
+        .service(db.clone())
+        .service(email)       // mailer is a jobs service, NOT an app service
+        .run()
+        .await?;
+
+    app.config(config.core)
+        .managed_service(db)
+        .managed_service(jobs)
+        .run()
+        .await
+}
+```
+
+### Defining the send-email job
+
+```rust
+use modo_email::{Mailer, SendEmail, SendEmailPayload};
+use modo_jobs::job;
+use modo::HandlerResult;
+use modo::extractors::service::Service;
+
+#[job(queue = "mailer", max_attempts = 3, timeout = "30s")]
+async fn send_email(
+    payload: SendEmailPayload,
+    Service(mailer): Service<Mailer>,
+) -> HandlerResult<()> {
+    mailer.send(&SendEmail::from(payload)).await?;
+    Ok(())
+}
+// Generates: SendEmailJob with SendEmailJob::enqueue and SendEmailJob::enqueue_at
+```
+
+### Enqueuing from an HTTP handler
+
+```rust
+use modo_jobs::JobQueue;
+use modo_email::{SendEmail, SendEmailPayload};
+use modo::{Json, JsonResult};
+use serde_json::{Value, json};
+
+#[modo::handler(POST, "/register")]
+async fn register(queue: JobQueue, input: Json<RegisterInput>) -> JsonResult<Value> {
+    // ... create user ...
+
+    let payload = SendEmailPayload::from(
+        SendEmail::new("welcome", &input.email)
+            .var("name", &input.name)
+    );
+    SendEmailJob::enqueue(&queue, &payload).await?;
+
+    Ok(Json(json!({ "status": "ok" })))
+}
+```
+
+### Accessing Db from the email job
+
+If the send-email job needs to look up data from the database (for example, to
+load per-tenant sender profiles), register the database pool as a service on the
+jobs builder and add the `Db` extractor to the job:
+
+```rust
+use modo_email::{Mailer, SendEmail, SendEmailPayload, SenderProfile};
+use modo_jobs::job;
+use modo::HandlerResult;
+use modo::extractors::service::Service;
+use modo_db::extractor::Db;
+
+#[job(queue = "mailer", max_attempts = 3, timeout = "30s")]
+async fn send_email(
+    payload: SendEmailPayload,
+    Service(mailer): Service<Mailer>,
+    Db(db): Db,
+) -> HandlerResult<()> {
+    // db is Arc<DbPool> — query SeaORM entities as normal
+    mailer.send(&SendEmail::from(payload)).await?;
+    Ok(())
+}
+```
+
+The database pool must be registered with `.service(db.clone())` on the jobs builder
+for the `Db` extractor to resolve. See the jobs reference for full details.
+
+### Custom TemplateProvider
+
+To load templates from a database or cache instead of the filesystem, implement the
+`TemplateProvider` trait and pass it to `mailer_with`:
+
+```rust
+use modo_email::{EmailTemplate, TemplateProvider};
+
+struct DbTemplateProvider { /* db pool */ }
+
+impl TemplateProvider for DbTemplateProvider {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, modo::Error> {
+        // load raw template string from database, then:
+        EmailTemplate::parse(&raw)
+    }
+}
+
+let provider = Arc::new(DbTemplateProvider { /* ... */ });
+let m = mailer_with(&config, provider)?;
+```
+
+---
+
+## Template Variable Syntax Overlap
+
+Templates use `{{key}}` for runtime variable substitution. The modo-cli scaffolding
+tool also uses Jinja `{{ project_name }}` syntax at scaffold time. If a template file
+is generated from a scaffold and contains both scaffold-time Jinja variables and
+runtime email variables, the scaffold will attempt to expand `{{name}}` as a Jinja
+expression at generation time.
+
+**Cross-reference table:**
+
+| Context | Syntax | Expansion time |
+|---------|--------|----------------|
+| modo-email template body/subject | `{{name}}` | Runtime (when email is sent) |
+| modo-cli scaffold template | `{{ project_name }}` | Scaffold time (when `modo new` runs) |
+| Layout `.html` files | `{{ content }}` | Runtime (MiniJinja, when email is rendered) |
+
+To include literal `{{ ... }}` in a scaffold-generated file that should survive
+to runtime, wrap the runtime variable in a Jinja `{% raw %}` block:
+
+```
+{% raw %}{{name}}{% endraw %}
+```
+
+This is only relevant when a `.md` email template is generated by the CLI scaffold
+and contains runtime variables. Templates authored by hand outside the scaffold
+tool are unaffected.
+
+---
+
+## Gotchas
+
+**Mailer on jobs builder, not app.** The most common integration error is calling
+`.service(email)` on the app builder instead of the jobs builder. The app builder
+has no `.service()` method for this purpose. The mailer must be on the jobs builder
+for job handlers to resolve it via `Service<Mailer>`.
+
+**SMTPS (port 465) not supported.** Only STARTTLS (port 587) is available when
+`tls: true`. Connecting to port 465 with `tls: true` will fail at connection time.
+
+**`brand_color` is validated.** Only `#RGB` and `#RRGGBB` hex strings are accepted.
+Any other value (e.g. `"red"`, `"#zzzzzz"`, or a CSS injection attempt) silently
+falls back to the default `#4F46E5`. Do not expect validation errors.
+
+**Template names must not include the `.md` extension.** Pass `"welcome"` to
+`SendEmail::new`, not `"welcome.md"`. The provider appends `.md` automatically.
+Passing `"welcome.md"` causes the provider to look for `"welcome.md.md"`, which will
+not be found.
+
+**Layout auto-escaping is disabled.** Layout `.html` files are rendered with MiniJinja
+auto-escaping turned off because `content` is already rendered HTML. If you insert
+user-supplied data directly into a layout variable (other than `content`) you are
+responsible for escaping it.
+
+**`TemplateProvider::get` is called synchronously.** `FilesystemProvider` performs
+blocking file I/O inside `MailTransport::send`, which is async. This is acceptable
+for most workloads, but if templates are loaded from a remote store, implement
+blocking access with a cache rather than making async calls inside `get`.
+
+**Unresolved variables are left as-is.** The `vars::substitute` function leaves
+`{{missing_key}}` in the output rather than replacing it with an empty string or
+returning an error. A typo in a variable name produces visible `{{typo}}` text in
+the rendered email.
+
+**`SendEmailPayload` must be registered on a configured queue.** The job consuming
+`SendEmailPayload` must reference a queue listed in `JobsConfig.queues`. If the
+`"mailer"` queue is not in the configuration, `JobsBuilder::run()` returns an error
+at startup.
+
+---
+
+## Key Types Quick Reference
+
+| Type | docs.rs | Description |
+|------|---------|-------------|
+| `EmailConfig` | https://docs.rs/modo-email/latest/modo_email/struct.EmailConfig.html | Top-level email configuration. |
+| `SmtpConfig` | https://docs.rs/modo-email/latest/modo_email/struct.SmtpConfig.html | SMTP connection settings (`smtp` feature). |
+| `ResendConfig` | https://docs.rs/modo-email/latest/modo_email/struct.ResendConfig.html | Resend API key config (`resend` feature). |
+| `TransportBackend` | https://docs.rs/modo-email/latest/modo_email/enum.TransportBackend.html | `Smtp` or `Resend` transport selector. |
+| `Mailer` | https://docs.rs/modo-email/latest/modo_email/struct.Mailer.html | High-level email service (clone-safe). |
+| `SendEmail` | https://docs.rs/modo-email/latest/modo_email/struct.SendEmail.html | Builder for requesting a templated send. |
+| `SendEmailPayload` | https://docs.rs/modo-email/latest/modo_email/struct.SendEmailPayload.html | Serializable job queue payload. |
+| `SenderProfile` | https://docs.rs/modo-email/latest/modo_email/struct.SenderProfile.html | Sender identity (name, address, reply-to). |
+| `MailMessage` | https://docs.rs/modo-email/latest/modo_email/struct.MailMessage.html | Fully-rendered email ready for transport. |
+| `EmailTemplate` | https://docs.rs/modo-email/latest/modo_email/template/struct.EmailTemplate.html | Parsed frontmatter + body. |
+| `TemplateProvider` | https://docs.rs/modo-email/latest/modo_email/template/trait.TemplateProvider.html | Trait for custom template sources. |
+| `FilesystemProvider` | https://docs.rs/modo-email/latest/modo_email/template/filesystem/struct.FilesystemProvider.html | Default filesystem-based provider. |
+| `LayoutEngine` | https://docs.rs/modo-email/latest/modo_email/template/layout/struct.LayoutEngine.html | MiniJinja layout renderer. |
+| `MailTransport` | https://docs.rs/modo-email/latest/modo_email/transport/trait.MailTransport.html | Trait for custom delivery backends. |
+| `mailer` | https://docs.rs/modo-email/latest/modo_email/fn.mailer.html | Factory: filesystem provider + configured transport. |
+| `mailer_with` | https://docs.rs/modo-email/latest/modo_email/fn.mailer_with.html | Factory: custom provider + configured transport. |

--- a/claude-plugin/skills/modo/references/email.md
+++ b/claude-plugin/skills/modo/references/email.md
@@ -392,7 +392,7 @@ network I/O.
 use modo_email::{mailer, EmailConfig, SendEmail, SendEmailPayload};
 use modo_jobs::JobQueue;
 use modo::HandlerResult;
-use modo::extractors::service::Service;
+use modo::Service;
 
 // In main — register mailer on the JOBS builder, not on app:
 #[modo::main]
@@ -425,7 +425,7 @@ async fn main(
 use modo_email::{Mailer, SendEmail, SendEmailPayload};
 use modo_jobs::job;
 use modo::HandlerResult;
-use modo::extractors::service::Service;
+use modo::Service;
 
 #[job(queue = "mailer", max_attempts = 3, timeout = "30s")]
 async fn send_email(
@@ -470,7 +470,7 @@ jobs builder and add the `Db` extractor to the job:
 use modo_email::{Mailer, SendEmail, SendEmailPayload, SenderProfile};
 use modo_jobs::job;
 use modo::HandlerResult;
-use modo::extractors::service::Service;
+use modo::Service;
 use modo_db::extractor::Db;
 
 #[job(queue = "mailer", max_attempts = 3, timeout = "30s")]

--- a/claude-plugin/skills/modo/references/handlers.md
+++ b/claude-plugin/skills/modo/references/handlers.md
@@ -165,12 +165,18 @@ async fn list_items(Query(pagination): Query<Pagination>) -> String {
 
 ### JSON Body
 
-Use `modo::Json<T>` (not `modo::axum::Json`). `modo::Json` auto-sanitizes if `#[derive(Sanitize)]`
-is present on `T`, and exposes `.validate()` if `#[derive(Validate)]` is present:
+Two JSON extractors are available:
+
+- `modo::Json<T>` (re-export of `axum::Json<T>`) — plain JSON extraction/response with no sanitization or validation.
+- `modo::extractors::Json<T>` — auto-sanitizes if `#[derive(Sanitize)]` is present on `T`, and exposes `.validate()` if `#[derive(Validate)]` is present.
+
+Use `modo::extractors::Json<T>` when you need sanitization and validation:
 
 ```rust
+use modo::extractors::Json;
+
 #[modo::handler(POST, "/users")]
-async fn create_user(body: modo::Json<CreateUser>) -> modo::JsonResult<User> {
+async fn create_user(body: Json<CreateUser>) -> modo::JsonResult<User> {
     body.validate()?;
     // body.0 gives the inner T; or use Deref: body.email
     Ok(modo::Json(User { /* ... */ }))
@@ -306,7 +312,7 @@ email: String,
 ### `#[derive(Sanitize)]`
 
 Generates `impl modo::sanitize::Sanitize` and auto-registers it. Sanitization runs
-automatically when data is extracted via `modo::Json<T>` or `modo::extractors::Form<T>`.
+automatically when data is extracted via `modo::extractors::Json<T>` or `modo::extractors::Form<T>`.
 
 Field attribute: `#[clean(rule1, rule2, ...)]`
 
@@ -320,7 +326,7 @@ Available rules:
 | `strip_html_tags` | Remove HTML tags |
 | `collapse_whitespace` | Replace multiple spaces with one |
 | `truncate = N` | Truncate to N characters |
-| `normalize_email` | Lowercase + trim the email |
+| `normalize_email` | Lowercase + strip `+tag` from local part (e.g. `user+tag@ex.com` → `user@ex.com`) |
 | `custom = "fn_path"` | `fn(String) -> String` |
 
 ```rust
@@ -359,7 +365,7 @@ async fn protected() -> &'static str {
     "secret"
 }
 
-// Multiple middleware, applied innermost-first
+// Multiple middleware, applied outermost-first (last-declared = innermost)
 #[modo::handler(POST, "/admin/action")]
 #[middleware(require_auth, require_role("admin"))]
 async fn admin_action() -> &'static str {
@@ -524,7 +530,7 @@ Configure in YAML (defaults shown):
 
 ```yaml
 server:
-  static:
+  static_files:
     dir: "static"           # filesystem directory to serve
     prefix: "/static"       # URL prefix
     cache_control: null     # optional override, default: "max-age=3600"
@@ -560,7 +566,7 @@ default folder when `static_assets` is omitted is `"static/"`.
 The embedded backend adds SHA-256-based ETags and returns `304 Not Modified` when
 `If-None-Match` matches. Cache-Control defaults to `max-age=31536000, immutable`.
 
-The URL prefix under which static files are served comes from `server.static.prefix` in the
+The URL prefix under which static files are served comes from `server.static_files.prefix` in the
 config (default `/static`).
 
 ---
@@ -640,8 +646,8 @@ mod api_v1 {
 
 ## Gotchas
 
-- **`modo::Json` vs `modo::axum::Json`**: Always use `modo::Json` for both request extraction
-  and response bodies. `modo::axum::Json` bypasses auto-sanitization.
+- **`modo::Json` vs `modo::extractors::Json`**: `modo::Json` is `axum::Json` — it does NOT auto-sanitize.
+  Use `modo::extractors::Json<T>` for auto-sanitization. `modo::extractors::Form<T>` similarly auto-sanitizes forms.
 
 - **Path param partial extraction**: Declare only the params you need in the function
   signature. The macro generates a struct with all params; missing ones default to `String`
@@ -659,7 +665,7 @@ mod api_v1 {
   compile error if the `static-embed` feature is not enabled.
 
 - **`#[derive(Sanitize)]` auto-registers globally**: The macro submits a `SanitizerRegistration`
-  to `inventory`. This means sanitization applies automatically via `modo::Json` and
+  to `inventory`. This means sanitization applies automatically via `modo::extractors::Json` and
   `modo::extractors::Form` without any explicit call in the handler.
 
 - **`TrailingSlash::Strip`/`Add` issues 301 redirects**: This means POST bodies are lost on
@@ -685,11 +691,12 @@ mod api_v1 {
 | `SecurityHeadersConfig` | `modo::config::SecurityHeadersConfig` |
 | `TrailingSlash` | `modo::config::TrailingSlash` |
 | `HttpConfig` | `modo::config::HttpConfig` |
-| `StaticConfig` | `modo::static_files::StaticConfig` |
+| `StaticConfig` | `modo::static_files::StaticConfig` (`pub(crate)` — access via `AppConfig.server.static_files`) |
 | `ClientIp` | `modo::middleware::ClientIp` |
 | `RequestId` | `modo::RequestId` |
 | `Service<T>` | `modo::Service` |
-| `Json<T>` | `modo::Json` |
+| `Json<T>` (plain) | `modo::Json` |
+| `Json<T>` (sanitizing) | `modo::extractors::Json` |
 | `Form<T>` | `modo::extractors::Form` |
 | `HandlerResult<T>` | `modo::HandlerResult` |
 | `JsonResult<T>` | `modo::JsonResult` |

--- a/claude-plugin/skills/modo/references/handlers.md
+++ b/claude-plugin/skills/modo/references/handlers.md
@@ -242,12 +242,12 @@ Fields: `remaining: u32`, `limit: u32`, `reset_secs: u64`.
 
 ### Service Extractor
 
-`modo::extractors::Service<T>` retrieves a registered service from the `ServiceRegistry` by
+`modo::Service<T>` retrieves a registered service from the `ServiceRegistry` by
 type. Returns `500 Internal Server Error` if the service is not registered. The inner `Arc<T>`
 is accessible via `Deref` or by destructuring:
 
 ```rust
-use modo::extractors::Service;
+use modo::Service;
 
 #[modo::handler(GET, "/status")]
 async fn status(Service(cache): Service<MyCache>) -> String {
@@ -546,8 +546,8 @@ Use the `static_assets` argument in `#[modo::main]` to embed a directory at comp
 ```rust
 #[modo::main(static_assets = "static/")]
 async fn main(
-    app: modo::app::AppBuilder,
-    config: modo::config::AppConfig,
+    app: modo::AppBuilder,
+    config: modo::AppConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     app.config(config).run().await
 }
@@ -598,8 +598,8 @@ For embedded assets in production:
 ```rust
 #[modo::main(static_assets = "static/")]
 async fn main(
-    app: modo::app::AppBuilder,
-    config: modo::config::AppConfig,
+    app: modo::AppBuilder,
+    config: modo::AppConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     app.config(config).run().await
 }
@@ -675,9 +675,9 @@ mod api_v1 {
 
 | Type | Crate path |
 |------|-----------|
-| `AppBuilder` | `modo::app::AppBuilder` |
-| `AppState` | `modo::app::AppState` |
-| `ServiceRegistry` | `modo::app::ServiceRegistry` |
+| `AppBuilder` | `modo::AppBuilder` |
+| `AppState` | `modo::AppState` |
+| `ServiceRegistry` | `modo::ServiceRegistry` |
 | `CorsConfig` | `modo::cors::CorsConfig` |
 | `CorsOrigins` | `modo::cors::CorsOrigins` |
 | `RateLimitConfig` | `modo::config::RateLimitConfig` |
@@ -688,7 +688,7 @@ mod api_v1 {
 | `StaticConfig` | `modo::static_files::StaticConfig` |
 | `ClientIp` | `modo::middleware::ClientIp` |
 | `RequestId` | `modo::RequestId` |
-| `Service<T>` | `modo::extractors::Service` |
+| `Service<T>` | `modo::Service` |
 | `Json<T>` | `modo::Json` |
 | `Form<T>` | `modo::extractors::Form` |
 | `HandlerResult<T>` | `modo::HandlerResult` |

--- a/claude-plugin/skills/modo/references/handlers.md
+++ b/claude-plugin/skills/modo/references/handlers.md
@@ -1,0 +1,695 @@
+# Handlers Reference
+
+Handlers are the core building block of a modo application. They are plain async functions
+annotated with `#[modo::handler]` and discovered at compile time via `inventory`. No manual
+route registration is required — attach the attribute and the route appears.
+
+## Documentation
+
+- modo crate: https://docs.rs/modo
+- modo-macros crate: https://docs.rs/modo-macros
+
+---
+
+## Handler Registration
+
+The `#[modo::handler(METHOD, "/path")]` attribute registers an async function as an HTTP route.
+Registration happens at compile time; the route is submitted to the `inventory` collector and
+wired automatically when `AppBuilder::run()` is called.
+
+```rust
+#[modo::handler(GET, "/")]
+async fn index() -> &'static str {
+    "Hello, modo!"
+}
+```
+
+Supported HTTP methods (case-insensitive in the attribute, normalized to uppercase):
+
+| Attribute token | HTTP method |
+|----------------|-------------|
+| `GET`          | GET         |
+| `POST`         | POST        |
+| `PUT`          | PUT         |
+| `PATCH`        | PATCH       |
+| `DELETE`       | DELETE      |
+| `HEAD`         | HEAD        |
+| `OPTIONS`      | OPTIONS     |
+
+### Return Types
+
+Handlers may return any type that implements `axum::response::IntoResponse`. Common patterns:
+
+```rust
+// Plain string
+#[modo::handler(GET, "/ping")]
+async fn ping() -> &'static str { "pong" }
+
+// Fallible result with HTTP error
+#[modo::handler(GET, "/item/{id}")]
+async fn get_item(id: String) -> Result<String, modo::HttpError> {
+    Err(modo::HttpError::NotFound)
+}
+
+// HandlerResult<T> — shorthand for Result<T, modo::Error>
+#[modo::handler(GET, "/item/{id}")]
+async fn get_item(id: String) -> modo::HandlerResult<String> {
+    Ok(format!("item {id}"))
+}
+
+// JsonResult<T> — shorthand for Result<modo::Json<T>, modo::Error>
+#[modo::handler(GET, "/items")]
+async fn list_items() -> modo::JsonResult<Vec<String>> {
+    Ok(modo::Json(vec!["a".into(), "b".into()]))
+}
+```
+
+Use `modo::Json` (not `modo::axum::Json`) for JSON responses. `modo::HandlerResult<T>` and
+`modo::JsonResult<T>` both accept an optional second type parameter for a custom error type.
+
+---
+
+## Modules
+
+`#[modo::module(prefix = "/api")]` groups handlers under a shared URL prefix and optional
+module-level middleware. Place it on a `mod` block containing `#[modo::handler]` functions.
+
+```rust
+#[modo::module(prefix = "/api/v1")]
+mod api {
+    #[modo::handler(GET, "/users")]
+    async fn list_users() -> &'static str { "users" }
+
+    #[modo::handler(POST, "/users")]
+    async fn create_user() -> &'static str { "created" }
+}
+```
+
+The module macro rewrites each inner `#[handler]` attribute to inject `module = "api"` so the
+router knows which prefix applies. The final mounted paths become `/api/v1/users`, etc.
+
+Module-level middleware applies to all routes in the module:
+
+```rust
+#[modo::module(prefix = "/admin", middleware = [require_admin])]
+mod admin {
+    #[modo::handler(GET, "/dashboard")]
+    async fn dashboard() -> &'static str { "admin" }
+}
+```
+
+Both `prefix` and `middleware` are named arguments. `prefix` is required; `middleware` is
+optional and takes a bracket-enclosed comma-separated list.
+
+---
+
+## Path Parameters
+
+Path parameters are declared with `{name}` syntax in the route path. The macro extracts them
+automatically — declare only the parameters you need in the function signature; undeclared
+parameters default to `String` and are ignored via the `..` destructuring pattern generated
+inside the proc macro.
+
+```rust
+// Extract only `id`; any other path params would be ignored
+#[modo::handler(GET, "/users/{id}")]
+async fn get_user(id: String) -> String {
+    format!("user {id}")
+}
+
+// Declare a typed path param
+#[modo::handler(DELETE, "/todos/{id}")]
+async fn delete_todo(id: String) -> modo::JsonResult<serde_json::Value> {
+    Ok(modo::Json(serde_json::json!({"deleted": id})))
+}
+
+// Partial extraction: only declare params you need
+#[modo::handler(GET, "/org/{org_id}/repo/{repo_id}/file/{name}")]
+async fn get_file(name: String) -> String {
+    // org_id and repo_id are present in the struct but ignored via `..`
+    format!("file: {name}")
+}
+```
+
+The macro generates a private `__HandlerNamePathParams` struct with all path parameters as
+fields, using the declared type for named params and `String` for the rest. The handler
+receives only the fields it declared.
+
+Wildcard path parameters use `{*name}` syntax in the route path and capture the rest of the
+URL segment.
+
+---
+
+## Extractors
+
+Extractors appear as function parameters and are resolved by axum before the handler body runs.
+
+### Query Parameters
+
+Use `axum::extract::Query<T>` directly (re-exported via `modo::axum`):
+
+```rust
+use modo::axum::extract::Query;
+
+#[derive(serde::Deserialize)]
+struct Pagination {
+    page: Option<u32>,
+    per_page: Option<u32>,
+}
+
+#[modo::handler(GET, "/items")]
+async fn list_items(Query(pagination): Query<Pagination>) -> String {
+    format!("page {:?}", pagination.page)
+}
+```
+
+### JSON Body
+
+Use `modo::Json<T>` (not `modo::axum::Json`). `modo::Json` auto-sanitizes if `#[derive(Sanitize)]`
+is present on `T`, and exposes `.validate()` if `#[derive(Validate)]` is present:
+
+```rust
+#[modo::handler(POST, "/users")]
+async fn create_user(body: modo::Json<CreateUser>) -> modo::JsonResult<User> {
+    body.validate()?;
+    // body.0 gives the inner T; or use Deref: body.email
+    Ok(modo::Json(User { /* ... */ }))
+}
+```
+
+### Form Data
+
+`modo::extractors::Form<T>` deserializes `application/x-www-form-urlencoded`, auto-sanitizes,
+and provides `.validate()`:
+
+```rust
+use modo::extractors::Form;
+
+#[modo::handler(POST, "/contact")]
+async fn contact(form: Form<ContactForm>) -> modo::HandlerResult<&'static str> {
+    form.validate()?;
+    Ok("submitted")
+}
+```
+
+### Request ID
+
+`modo::RequestId` extracts the per-request ULID injected by the request ID middleware. The ID
+is read from or generated for the `X-Request-ID` header and propagated to the response:
+
+```rust
+#[modo::handler(GET, "/")]
+async fn index(request_id: modo::RequestId) -> String {
+    format!("request: {request_id}")
+}
+```
+
+`RequestId` implements `Display` and exposes `.as_str() -> &str`.
+
+### Client IP
+
+`modo::middleware::ClientIp` provides the resolved client IP address, accounting for trusted
+proxy headers (`CF-Connecting-IP`, `X-Real-IP`, `X-Forwarded-For`). It is populated by the
+`client_ip_middleware` which reads trusted proxy CIDRs from the service registry:
+
+```rust
+use modo::middleware::ClientIp;
+
+#[modo::handler(GET, "/whoami")]
+async fn whoami(ClientIp(ip): ClientIp) -> String {
+    ip.to_string()
+}
+```
+
+`ClientIp` wraps `std::net::IpAddr` and implements `FromRequestParts<AppState>`.
+
+### Rate Limit Info
+
+`modo::middleware::RateLimitInfo` extracts rate limiting state injected into request extensions
+by the rate limit middleware. Use it when you need to surface `X-RateLimit-*` values manually
+or make decisions based on remaining quota:
+
+```rust
+use modo::middleware::RateLimitInfo;
+
+#[modo::handler(GET, "/api/data")]
+async fn get_data(rate: RateLimitInfo) -> String {
+    format!("{}/{} remaining", rate.remaining, rate.limit)
+}
+```
+
+Fields: `remaining: u32`, `limit: u32`, `reset_secs: u64`.
+
+### Service Extractor
+
+`modo::extractors::Service<T>` retrieves a registered service from the `ServiceRegistry` by
+type. Returns `500 Internal Server Error` if the service is not registered. The inner `Arc<T>`
+is accessible via `Deref` or by destructuring:
+
+```rust
+use modo::extractors::Service;
+
+#[modo::handler(GET, "/status")]
+async fn status(Service(cache): Service<MyCache>) -> String {
+    cache.stats()
+}
+```
+
+Register services in `main` via `app.service(my_value)` or `app.managed_service(my_value)`.
+
+---
+
+## Validation and Sanitization
+
+### `#[derive(Validate)]`
+
+Generates `impl modo::validate::Validate` with per-field rules. Call `.validate()` after
+extracting to return a structured `400 Bad Request` on failure.
+
+Field attribute: `#[validate(rule1, rule2, ...)]`
+
+Available rules:
+
+| Rule | Usage | Notes |
+|------|-------|-------|
+| `required` | `#[validate(required)]` | `None` or empty `String` fails |
+| `min_length` | `#[validate(min_length = 5)]` | String length |
+| `max_length` | `#[validate(max_length = 255)]` | String length |
+| `email` | `#[validate(email)]` | Checks for `@` and `.` after `@` |
+| `min` | `#[validate(min = 0)]` | Numeric minimum |
+| `max` | `#[validate(max = 100)]` | Numeric maximum |
+| `custom` | `#[validate(custom = "my_fn")]` | `fn(&T) -> Result<(), String>` |
+
+Custom per-rule message: add `(message = "...")` after the rule value:
+
+```rust
+#[derive(serde::Deserialize, modo::Validate)]
+struct SignupForm {
+    #[validate(required(message = "Email is required"), email(message = "Invalid email"))]
+    email: String,
+
+    #[validate(required, min_length = 8, max_length = 72)]
+    password: String,
+
+    #[validate(min = 18, max = 120)]
+    age: u32,
+}
+```
+
+Field-level message (applied once across all rules for the field):
+
+```rust
+#[validate(required, email, message = "Provide a valid email")]
+email: String,
+```
+
+### `#[derive(Sanitize)]`
+
+Generates `impl modo::sanitize::Sanitize` and auto-registers it. Sanitization runs
+automatically when data is extracted via `modo::Json<T>` or `modo::extractors::Form<T>`.
+
+Field attribute: `#[clean(rule1, rule2, ...)]`
+
+Available rules:
+
+| Rule | Effect |
+|------|--------|
+| `trim` | Remove leading/trailing whitespace |
+| `lowercase` | Convert to lowercase |
+| `uppercase` | Convert to uppercase |
+| `strip_html_tags` | Remove HTML tags |
+| `collapse_whitespace` | Replace multiple spaces with one |
+| `truncate = N` | Truncate to N characters |
+| `normalize_email` | Lowercase + trim the email |
+| `custom = "fn_path"` | `fn(String) -> String` |
+
+```rust
+#[derive(serde::Deserialize, modo::Sanitize, modo::Validate)]
+struct ContactForm {
+    #[clean(trim, normalize_email)]
+    #[validate(required, email)]
+    email: String,
+
+    #[clean(trim, strip_html_tags, truncate = 1000)]
+    #[validate(required, min_length = 5, max_length = 1000)]
+    message: String,
+}
+```
+
+`Sanitize` only applies to named-field structs.
+
+---
+
+## Middleware
+
+### Stacking Order
+
+Global (outermost) → Module → Handler (innermost). A request passes through global middleware
+first, then module middleware if the route belongs to a module, then handler middleware.
+
+### Per-Handler Middleware
+
+Use `#[middleware(fn_name)]` on the handler function. Bare paths are wrapped with
+`axum::middleware::from_fn`; paths with arguments are called as layer factories:
+
+```rust
+#[modo::handler(GET, "/protected")]
+#[middleware(require_auth)]
+async fn protected() -> &'static str {
+    "secret"
+}
+
+// Multiple middleware, applied innermost-first
+#[modo::handler(POST, "/admin/action")]
+#[middleware(require_auth, require_role("admin"))]
+async fn admin_action() -> &'static str {
+    "done"
+}
+```
+
+### Module-Level Middleware
+
+Pass `middleware = [...]` to `#[modo::module]`:
+
+```rust
+#[modo::module(prefix = "/api", middleware = [cors_layer, rate_limit_fn])]
+mod api {
+    // all routes here inherit the middleware
+}
+```
+
+### Global Middleware via AppBuilder
+
+```rust
+app.layer(my_tower_layer)
+   .cors(CorsConfig::with_origins(&["https://app.example.com"]))
+   .rate_limit(RateLimitConfig { requests: 100, window_secs: 60 })
+   .security_headers(SecurityHeadersConfig::default())
+   .trailing_slash(TrailingSlash::Strip)
+```
+
+### CORS — `CorsConfig`
+
+```rust
+use modo::cors::{CorsConfig, CorsOrigins};
+
+// Mirror request origin (default — permissive but not *)
+let cors = CorsConfig::permissive();
+
+// Fixed origin list
+let cors = CorsConfig::with_origins(&["https://example.com", "https://app.example.com"]);
+
+// Custom predicate
+let cors = CorsConfig::with_custom_check(|origin| origin.ends_with(".example.com"));
+
+// Fields
+pub struct CorsConfig {
+    pub origins: CorsOrigins,     // Any | List | Custom | Mirror
+    pub credentials: bool,        // default: false
+    pub max_age_secs: Option<u64>, // default: Some(3600)
+}
+```
+
+CORS can also be set in YAML under `server.cors`:
+
+```yaml
+server:
+  cors:
+    origins: ["https://example.com"]
+    credentials: false
+    max_age_secs: 3600
+```
+
+### Rate Limiting — `RateLimitConfig`
+
+Token-bucket rate limiting, applied globally by IP. Configured via `AppBuilder::rate_limit` or
+under `server.rate_limit` in YAML:
+
+```rust
+use modo::config::RateLimitConfig;
+
+app.rate_limit(RateLimitConfig {
+    requests: 200,
+    window_secs: 60,
+})
+```
+
+```yaml
+server:
+  rate_limit:
+    requests: 100
+    window_secs: 60
+```
+
+Default: 100 requests per 60-second window. The middleware automatically sets
+`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and `Retry-After` headers.
+
+### Security Headers — `SecurityHeadersConfig`
+
+Configured via `AppBuilder::security_headers` or `server.security_headers` in YAML. Defaults
+enable `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+`Referrer-Policy: strict-origin-when-cross-origin`,
+`Content-Security-Policy: default-src 'self'`, and HSTS (production only):
+
+```rust
+use modo::config::SecurityHeadersConfig;
+
+app.security_headers(SecurityHeadersConfig {
+    enabled: true,
+    content_security_policy: Some("default-src 'self'; script-src 'nonce-...'".into()),
+    ..Default::default()
+})
+```
+
+```rust
+pub struct SecurityHeadersConfig {
+    pub enabled: bool,
+    pub x_content_type_options: Option<String>,
+    pub x_frame_options: Option<String>,
+    pub referrer_policy: Option<String>,
+    pub permissions_policy: Option<String>,
+    pub content_security_policy: Option<String>,
+    pub hsts: bool,          // only applied in Production environment
+    pub hsts_max_age: u64,   // default: 31_536_000
+}
+```
+
+### Trailing Slash — `TrailingSlash`
+
+```rust
+use modo::config::TrailingSlash;
+
+app.trailing_slash(TrailingSlash::Strip)   // redirect /foo/ → /foo
+// or
+app.trailing_slash(TrailingSlash::Add)     // redirect /foo → /foo/
+// or
+app.trailing_slash(TrailingSlash::None)    // default: no modification
+```
+
+Configured in YAML under `server.http.trailing_slash` with values `none`, `strip`, or `add`.
+
+### Catch Panic
+
+Enabled by default (`catch_panic: true`). Converts handler panics into `500 Internal Server
+Error` JSON responses and logs the panic message. Disable via `app.catch_panic(false)` or
+`server.http.catch_panic: false` in YAML.
+
+### Maintenance Mode
+
+When enabled, all routes except `/_live` and `/_ready` return `503 Service Unavailable`.
+Configure via `app.maintenance(true)` or `server.http.maintenance: true` in YAML. Set a custom
+message with `server.http.maintenance_message`.
+
+---
+
+## Static Files
+
+Two mutually exclusive features control static file serving:
+
+| Feature | Use case | Cache |
+|---------|----------|-------|
+| `static-fs` | Development — serves from a filesystem directory | `max-age=3600` |
+| `static-embed` | Production — embeds files at compile time via `rust-embed` | `max-age=31536000, immutable` + ETag/304 |
+
+### `static-fs` (Development)
+
+Enable the feature in `Cargo.toml`:
+
+```toml
+[dependencies]
+modo = { version = "...", features = ["static-fs"] }
+```
+
+Configure in YAML (defaults shown):
+
+```yaml
+server:
+  static:
+    dir: "static"           # filesystem directory to serve
+    prefix: "/static"       # URL prefix
+    cache_control: null     # optional override, default: "max-age=3600"
+```
+
+`StaticConfig` fields: `dir: String`, `prefix: String`, `cache_control: Option<String>`.
+
+### `static-embed` (Production)
+
+Enable the feature:
+
+```toml
+[dependencies]
+modo = { version = "...", features = ["static-embed"] }
+```
+
+Use the `static_assets` argument in `#[modo::main]` to embed a directory at compile time:
+
+```rust
+#[modo::main(static_assets = "static/")]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: modo::config::AppConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    app.config(config).run().await
+}
+```
+
+The macro generates a `#[derive(rust_embed::Embed)] struct __ModoStaticAssets` with the folder
+set to the provided path, then calls `app.embed_static_files::<__ModoStaticAssets>()`. The
+default folder when `static_assets` is omitted is `"static/"`.
+
+The embedded backend adds SHA-256-based ETags and returns `304 Not Modified` when
+`If-None-Match` matches. Cache-Control defaults to `max-age=31536000, immutable`.
+
+The URL prefix under which static files are served comes from `server.static.prefix` in the
+config (default `/static`).
+
+---
+
+## Health Check Endpoints
+
+`AppBuilder::run()` automatically mounts:
+
+- `GET /_live` — liveness probe, always `200 OK`
+- `GET /_ready` — readiness probe, runs all registered checks
+
+Register async readiness checks:
+
+```rust
+app.readiness_check(|| async {
+    db_ping().await.map_err(|e| Box::new(e) as _)
+})
+```
+
+The liveness and readiness paths can be configured via `server.liveness_path` and
+`server.readiness_path` in YAML (defaults: `/_live`, `/_ready`).
+
+---
+
+## Integration Patterns
+
+### Static Files + Templates
+
+When both `templates` and `static-embed` (or `static-fs`) features are enabled, register
+static files before calling `run()`. The template engine is auto-registered as a service when
+`modo-templates` is wired in; no manual `.layer()` call is needed for template rendering.
+
+For embedded assets in production:
+
+```rust
+#[modo::main(static_assets = "static/")]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: modo::config::AppConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    app.config(config).run().await
+}
+```
+
+### JSON API with Validation
+
+```rust
+#[derive(serde::Deserialize, modo::Sanitize, modo::Validate)]
+struct CreateTodo {
+    #[clean(trim)]
+    #[validate(required, min_length = 1, max_length = 255)]
+    title: String,
+}
+
+#[modo::handler(POST, "/todos")]
+async fn create_todo(input: modo::Json<CreateTodo>) -> modo::JsonResult<TodoResponse> {
+    input.validate()?;
+    // ...
+    Ok(modo::Json(TodoResponse { /* ... */ }))
+}
+```
+
+### Grouped API Module with Rate Limit
+
+```rust
+#[modo::module(prefix = "/api/v1", middleware = [api_rate_limit_layer])]
+mod api_v1 {
+    #[modo::handler(GET, "/users")]
+    async fn list_users() -> modo::JsonResult<Vec<User>> { /* ... */ }
+
+    #[modo::handler(GET, "/users/{id}")]
+    async fn get_user(id: String) -> modo::JsonResult<User> { /* ... */ }
+}
+```
+
+---
+
+## Gotchas
+
+- **`modo::Json` vs `modo::axum::Json`**: Always use `modo::Json` for both request extraction
+  and response bodies. `modo::axum::Json` bypasses auto-sanitization.
+
+- **Path param partial extraction**: Declare only the params you need in the function
+  signature. The macro generates a struct with all params; missing ones default to `String`
+  and are discarded via `..`. You do not need `axum::extract::Path` manually.
+
+- **Middleware stacking order**: Global layers (via `app.layer(...)`) are outermost. Module
+  middleware wraps the module router. Handler middleware (via `#[middleware(...)]`) is innermost
+  via `route_layer`. A request encounters global → module → handler layers in that order.
+
+- **`inventory` linking in tests**: Handlers registered via `inventory::submit!` may not link
+  in integration tests without a direct use. Force linking with `use crate::handlers::my_handler as _;`
+  if routes disappear in tests.
+
+- **`static-embed` requires the feature**: `#[modo::main(static_assets = "...")]` is a
+  compile error if the `static-embed` feature is not enabled.
+
+- **`#[derive(Sanitize)]` auto-registers globally**: The macro submits a `SanitizerRegistration`
+  to `inventory`. This means sanitization applies automatically via `modo::Json` and
+  `modo::extractors::Form` without any explicit call in the handler.
+
+- **`TrailingSlash::Strip`/`Add` issues 301 redirects**: This means POST bodies are lost on
+  redirect. Prefer consistent URL shapes in your API rather than relying on redirect normalization.
+
+- **`RateLimitInfo` extractor requires the middleware**: Extracting `RateLimitInfo` in a
+  handler fails with a 500 if the rate limit middleware is not configured. Guard with
+  `Option<RateLimitInfo>` if the middleware is optional.
+
+---
+
+## Key Type Reference
+
+| Type | Crate path |
+|------|-----------|
+| `AppBuilder` | `modo::app::AppBuilder` |
+| `AppState` | `modo::app::AppState` |
+| `ServiceRegistry` | `modo::app::ServiceRegistry` |
+| `CorsConfig` | `modo::cors::CorsConfig` |
+| `CorsOrigins` | `modo::cors::CorsOrigins` |
+| `RateLimitConfig` | `modo::config::RateLimitConfig` |
+| `RateLimitInfo` | `modo::middleware::RateLimitInfo` |
+| `SecurityHeadersConfig` | `modo::config::SecurityHeadersConfig` |
+| `TrailingSlash` | `modo::config::TrailingSlash` |
+| `HttpConfig` | `modo::config::HttpConfig` |
+| `StaticConfig` | `modo::static_files::StaticConfig` |
+| `ClientIp` | `modo::middleware::ClientIp` |
+| `RequestId` | `modo::RequestId` |
+| `Service<T>` | `modo::extractors::Service` |
+| `Json<T>` | `modo::Json` |
+| `Form<T>` | `modo::extractors::Form` |
+| `HandlerResult<T>` | `modo::HandlerResult` |
+| `JsonResult<T>` | `modo::JsonResult` |

--- a/claude-plugin/skills/modo/references/jobs.md
+++ b/claude-plugin/skills/modo/references/jobs.md
@@ -1,0 +1,512 @@
+# Background Jobs Reference
+
+The `modo-jobs` crate provides persistent, database-backed background job processing.
+Jobs are defined with the `#[job]` attribute macro, enqueued via the `JobQueue` extractor
+in HTTP handlers, and executed by a runner that polls the database on configurable intervals.
+Cron jobs run in-memory on a schedule but are not persisted to the database.
+
+---
+
+## Documentation
+
+- modo-jobs crate: https://docs.rs/modo-jobs
+- modo-jobs-macros crate: https://docs.rs/modo-jobs-macros
+
+---
+
+## Job Definition
+
+Use the `#[job]` attribute from `modo_jobs` to annotate an `async` function.
+
+The macro generates:
+- A unit struct `<FnName>Job` (PascalCase of the function name) implementing `JobHandler`.
+- A `JOB_NAME` constant on the struct set to the function name string.
+- `enqueue` and `enqueue_at` associated functions on the struct (omitted for cron jobs).
+- An `inventory` registration entry — no explicit startup call is needed.
+
+### Attribute Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `queue` | string | `"default"` | Target queue name. Must match a configured queue in `JobsConfig`. |
+| `priority` | integer | `0` | Higher values run first within the same queue. |
+| `max_attempts` | integer | `3` | Retry limit before the job is marked `dead`. |
+| `timeout` | string (`"Xs"`, `"Xm"`, `"Xh"`) | `"5m"` | Per-execution timeout. |
+| `cron` | string (cron expression) | — | Recurring in-memory schedule. Mutually exclusive with `queue`, `priority`, and `max_attempts`. |
+
+### Function Signature Rules
+
+- The function must be `async`.
+- Return type must be `Result<(), modo::Error>` or any alias thereof (e.g. `HandlerResult<()`).
+- At most one plain parameter is treated as the **payload** (deserialized from JSON).
+- Use `Service<T>` to inject a registered service into the job handler.
+- Use `Db` to inject the database pool.
+- Multiple payload parameters are a compile error.
+
+### Payload-based job
+
+```rust
+use modo_jobs::job;
+use modo::HandlerResult;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct WelcomePayload {
+    email: String,
+}
+
+#[job(queue = "default", max_attempts = 5, timeout = "30s")]
+async fn send_welcome(payload: WelcomePayload) -> HandlerResult<()> {
+    tracing::info!(email = %payload.email, "Sending welcome email");
+    Ok(())
+}
+// Generates: SendWelcomeJob with SendWelcomeJob::enqueue and SendWelcomeJob::enqueue_at
+```
+
+### Job with service injection
+
+```rust
+use modo_jobs::job;
+use modo::HandlerResult;
+use modo::extractors::service::Service;
+
+#[job(queue = "mailer", timeout = "1m")]
+async fn send_report(
+    payload: ReportPayload,
+    Service(mailer): Service<MyMailer>,
+) -> HandlerResult<()> {
+    mailer.send(payload.to, payload.subject).await?;
+    Ok(())
+}
+```
+
+### Job with database access
+
+```rust
+use modo_jobs::job;
+use modo::HandlerResult;
+use modo_db::extractor::Db;
+
+#[job(queue = "default")]
+async fn sync_user(payload: SyncPayload, Db(db): Db) -> HandlerResult<()> {
+    // use db (Arc<DbPool>) directly
+    Ok(())
+}
+```
+
+### Cron job (no payload, no queue)
+
+```rust
+#[job(cron = "0 */1 * * * *", timeout = "30s")]
+async fn heartbeat() -> HandlerResult<()> {
+    tracing::info!("heartbeat tick");
+    Ok(())
+}
+```
+
+Cron expressions use the `cron` crate's six-field format: `second minute hour day month weekday`.
+The `cron` attribute is mutually exclusive with `queue`, `priority`, and `max_attempts` — specifying
+both is a compile error.
+
+---
+
+## Enqueuing Jobs
+
+`JobQueue` is an Axum extractor that implements `FromRequestParts<AppState>`. It resolves from
+the `JobsHandle` registered as a managed service. Add it as a parameter to any handler.
+
+```rust
+use modo_jobs::JobQueue;
+use crate::jobs::SayHelloJob;
+use crate::payloads::GreetingPayload;
+use modo::{Json, JsonResult};
+use serde_json::{Value, json};
+
+#[modo::handler(POST, "/jobs/greet")]
+async fn enqueue_greet(queue: JobQueue, input: Json<GreetingPayload>) -> JsonResult<Value> {
+    let job_id = SayHelloJob::enqueue(&queue, &input).await?;
+    Ok(Json(json!({ "job_id": job_id.to_string() })))
+}
+```
+
+### Enqueue for future execution
+
+Use `enqueue_at` to schedule a job to run no earlier than a specific UTC timestamp:
+
+```rust
+#[modo::handler(POST, "/jobs/remind")]
+async fn enqueue_remind(queue: JobQueue, input: Json<ReminderPayload>) -> JsonResult<Value> {
+    let run_at = chrono::Utc::now() + chrono::Duration::seconds(10);
+    let job_id = RemindJob::enqueue_at(&queue, &input, run_at).await?;
+    Ok(Json(json!({ "job_id": job_id.to_string(), "run_at": run_at.to_rfc3339() })))
+}
+```
+
+### Cancel a pending job
+
+```rust
+queue.cancel(&job_id).await?;
+```
+
+Only jobs in the `Pending` state can be cancelled. Returns an error if the job is not found
+or is already `Running`, `Completed`, or `Dead`.
+
+### JobId
+
+`JobId` is a ULID-backed string identifier returned by `enqueue` and `enqueue_at`.
+
+```rust
+let job_id: JobId = SayHelloJob::enqueue(&queue, &payload).await?;
+println!("{}", job_id); // prints ULID string
+```
+
+---
+
+## Configuration
+
+Add `JobsConfig` to your app config struct and deserialize it from YAML.
+
+```rust
+use modo_db::DatabaseConfig;
+use modo_jobs::JobsConfig;
+use serde::Deserialize;
+
+#[derive(Default, Deserialize)]
+pub struct Config {
+    #[serde(flatten)]
+    pub core: modo::config::AppConfig,
+    pub database: DatabaseConfig,
+    #[serde(default)]
+    pub jobs: JobsConfig,
+}
+```
+
+### JobsConfig fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `poll_interval_secs` | `u64` | `1` | How often each queue polls for new jobs. |
+| `stale_threshold_secs` | `u64` | `600` | Jobs locked longer than this are re-queued. |
+| `drain_timeout_secs` | `u64` | `30` | Max time to wait for in-flight jobs at shutdown. |
+| `queues` | `Vec<QueueConfig>` | `[{name: "default", concurrency: 4}]` | Per-queue configuration. |
+| `cleanup` | `CleanupConfig` | see below | Automatic cleanup of finished jobs. |
+| `max_payload_bytes` | `Option<usize>` | `None` (unlimited) | Optional cap on serialized payload size. |
+
+### QueueConfig fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Queue name (must match `#[job(queue = "...")]`). |
+| `concurrency` | `usize` | Maximum concurrent jobs on this queue. Must be > 0. |
+
+### CleanupConfig fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `interval_secs` | `u64` | `3600` | How often the cleanup task runs. |
+| `retention_secs` | `u64` | `86400` | Jobs older than this are eligible for deletion. |
+| `statuses` | `Vec<JobState>` | `[Completed, Dead, Cancelled]` | Which states to clean up. |
+
+Example YAML:
+
+```yaml
+jobs:
+  poll_interval_secs: 1
+  stale_threshold_secs: 600
+  drain_timeout_secs: 30
+  queues:
+    - name: default
+      concurrency: 4
+    - name: mailer
+      concurrency: 2
+  cleanup:
+    interval_secs: 3600
+    retention_secs: 86400
+    statuses: [completed, dead, cancelled]
+```
+
+---
+
+## Starting the Runner
+
+Call `modo_jobs::new()` to create a `JobsBuilder`, register services, and call `.run()`.
+Register the resulting `JobsHandle` as a managed service so the framework calls graceful
+shutdown on it.
+
+```rust
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let db = modo_db::connect(&config.database).await?;
+    modo_db::sync_and_migrate(&db).await?;
+
+    let jobs = modo_jobs::new(&db, &config.jobs)
+        .service(db.clone())
+        .run()
+        .await?;
+
+    app.config(config.core)
+        .managed_service(db)
+        .managed_service(jobs)
+        .run()
+        .await
+}
+```
+
+`JobsBuilder::service<T>` registers any `Send + Sync + 'static` value into a `ServiceRegistry`
+that is passed to every job handler via `JobContext`. Call `.service()` as many times as needed
+before calling `.run()`.
+
+`JobsBuilder::run()` starts per-queue poll loops, a stale reaper, a cleanup task, and the
+cron scheduler — all as separate Tokio tasks. It returns an error if configuration validation
+fails or if a registered job references a queue that is not in `config.queues`.
+
+---
+
+## Retry and Exponential Backoff
+
+When a job handler returns an `Err(_)` or times out, the runner checks `attempts` against
+`max_attempts`:
+
+- If `attempts < max_attempts`: the job is rescheduled to `Pending` with exponential backoff.
+- If `attempts >= max_attempts`: the job is marked `Dead` and will not be retried.
+
+The backoff formula is:
+
+```
+backoff_secs = min(5 * 2^(attempt - 1), 3600)
+```
+
+| Attempt | Delay |
+|---------|-------|
+| 1st retry | 5 s |
+| 2nd retry | 10 s |
+| 3rd retry | 20 s |
+| 4th retry | 40 s |
+| ... | doubles each time |
+| cap | 3600 s (1 hour) |
+
+The `last_error` field on the `Job` entity stores the error message from the most recent
+failed attempt.
+
+Configure `max_attempts` on the job itself:
+
+```rust
+#[job(queue = "default", max_attempts = 5)]
+async fn flaky_task(payload: TaskPayload) -> HandlerResult<()> {
+    // ...
+}
+```
+
+The default is 3. Set `max_attempts = 1` to disable retries entirely.
+
+---
+
+## Job State Machine
+
+`JobState` tracks the lifecycle of every job in the `modo_jobs` table.
+
+| State | Meaning |
+|-------|---------|
+| `Pending` | Waiting to be picked up by a worker. |
+| `Running` | Currently executing on a worker. |
+| `Completed` | Finished successfully. |
+| `Dead` | Exhausted all retry attempts without success. |
+| `Cancelled` | Cancelled before execution via `JobQueue::cancel`. |
+
+States are stored as lowercase strings in the database (`"pending"`, `"running"`, etc.).
+The `JobState` enum implements `Display`, `FromStr`, and `Serialize`/`Deserialize`.
+
+---
+
+## Cron Scheduling
+
+Cron jobs are declared with `#[job(cron = "...")]`. They run entirely in-memory — no record
+is written to the `modo_jobs` table for individual executions.
+
+```rust
+#[job(cron = "0 */5 * * * *", timeout = "1m")]
+async fn cleanup_expired_sessions() -> HandlerResult<()> {
+    tracing::info!("Cleaning up expired sessions");
+    Ok(())
+}
+```
+
+The cron expression uses six fields: `second minute hour day month weekday`.
+
+**Execution semantics:**
+- One goroutine-equivalent Tokio task is spawned per cron job at startup.
+- At most one instance of each cron job runs at a time.
+- If the handler takes longer than the interval between ticks, the next tick is skipped rather
+  than firing concurrently.
+- Each execution receives a fresh `JobContext` with `attempt = 1` and `payload_json = "null"`.
+- If a cron job fails five consecutive times, a warning is logged.
+- Cron tasks respect the `CancellationToken` and stop cleanly on shutdown.
+
+**Cron jobs do not support `Service<T>` or `Db` parameter injection directly in the function
+signature** when they have no payload parameter — but services registered via `.service()` on
+the builder are available through `ctx.service::<T>()` if you use the `JobContext` API
+manually. In practice, use a no-argument cron function and call `ctx.service()` inside the
+body if service access is needed.
+
+---
+
+## Graceful Shutdown
+
+`JobsHandle` implements `modo::GracefulShutdown` at the `Drain` shutdown phase. Registering
+it via `app.managed_service(jobs)` is all that is required — the framework calls
+`JobsHandle::shutdown()` automatically.
+
+Shutdown sequence:
+1. `CancellationToken` is cancelled, signalling all poll loops, the stale reaper, the cleanup
+   task, and all cron tasks to stop accepting new work.
+2. The runner waits up to `drain_timeout_secs` for all in-flight jobs to finish by acquiring
+   all semaphore permits for each queue.
+3. If the drain timeout expires before all jobs complete, a warning is logged and the process
+   proceeds with shutdown regardless.
+
+To get the cancellation token for custom use:
+
+```rust
+let token = jobs.cancel_token();
+```
+
+---
+
+## Integration Patterns
+
+### Accessing the database in a job
+
+Register the `DbPool` as a service and use the `Db` extractor:
+
+```rust
+// In main:
+let jobs = modo_jobs::new(&db, &config.jobs)
+    .service(db.clone())
+    .run()
+    .await?;
+
+// In job definition:
+#[job(queue = "default")]
+async fn process_record(payload: RecordPayload, Db(db): Db) -> HandlerResult<()> {
+    let pool = db.clone(); // Arc<DbPool>
+    // query using SeaORM via pool.connection()
+    Ok(())
+}
+```
+
+### Accessing a custom service (e.g. Mailer)
+
+```rust
+// In main:
+let mailer = MyMailer::new(&config.mailer);
+let jobs = modo_jobs::new(&db, &config.jobs)
+    .service(db.clone())
+    .service(mailer)
+    .run()
+    .await?;
+
+// In job definition:
+#[job(queue = "mailer")]
+async fn send_notification(
+    payload: NotificationPayload,
+    Service(mailer): Service<MyMailer>,
+) -> HandlerResult<()> {
+    mailer.send(&payload.to, &payload.body).await?;
+    Ok(())
+}
+```
+
+### Enqueuing from outside HTTP handlers
+
+`JobsHandle` derefs to `JobQueue`, so you can call enqueue methods directly on the handle:
+
+```rust
+let job_id = SayHelloJob::enqueue(&*jobs, &payload).await?;
+```
+
+Or pass the `JobsHandle` (or a cloned `JobQueue`) wherever needed.
+
+### Email integration (modo-email)
+
+The mailer is registered as a jobs service (`.service(email)` on the jobs builder), not on
+the app. The app enqueues a `SendEmailPayload`; the job worker sends the email.
+
+```rust
+// Register mailer as a jobs service:
+let jobs = modo_jobs::new(&db, &config.jobs)
+    .service(db.clone())
+    .service(mailer.clone())  // mailer is a jobs service, NOT an app service
+    .run()
+    .await?;
+
+// In the send-email job:
+#[job(queue = "mailer")]
+async fn send_email(
+    payload: SendEmailPayload,
+    Service(mailer): Service<Mailer>,
+) -> HandlerResult<()> {
+    mailer.send(payload).await?;
+    Ok(())
+}
+```
+
+---
+
+## Gotchas
+
+**Cron jobs are not persisted.** Individual cron executions never appear in the `modo_jobs`
+table. If the process restarts between ticks, the cron schedule resets from the next upcoming
+time rather than catching up on missed ticks.
+
+**Queue names must be configured.** Every job whose `queue` parameter does not match a name in
+`config.queues` causes `JobsBuilder::run()` to return an error at startup. Cron jobs bypass
+this check.
+
+**`inventory` registration in tests.** Jobs are registered via `inventory::submit!` at link
+time. In test binaries, the linker may not include the library object file unless there is a
+direct reference to it. Force inclusion with:
+
+```rust
+use crate::jobs::send_welcome as _;
+```
+
+This applies whenever `cargo test` fails to discover jobs that work in normal builds.
+
+**Payload size limit.** If `max_payload_bytes` is set in `JobsConfig`, `enqueue` returns an
+error when the serialized payload exceeds that limit. The default is `None` (unlimited).
+
+**`max_attempts` is per-job, not per-queue.** Each `#[job]` declaration sets its own
+`max_attempts`. There is no global override in `JobsConfig`.
+
+**Stale job reaping.** Jobs locked longer than `stale_threshold_secs` (default 600 s) are
+reset to `Pending` and their attempt counter is decremented. This handles crashed workers.
+The reaper runs every 60 seconds.
+
+**Cron timeout panics on invalid expressions.** A malformed cron expression causes a `panic!`
+at startup rather than returning an error. Verify expressions before deploying.
+
+**`JobQueue` requires `JobsHandle` to be registered.** If `JobsHandle` is not in the service
+registry, the `JobQueue` extractor returns a 500 error with the message:
+`"JobQueue not configured. Start the job runner and register JobsHandle as a service."`
+
+---
+
+## Key Types Quick Reference
+
+| Type | Crate | Description |
+|------|-------|-------------|
+| `JobsConfig` | `modo_jobs::config` | Top-level configuration (queues, timeouts, cleanup). |
+| `QueueConfig` | `modo_jobs::config` | Per-queue name and concurrency. |
+| `CleanupConfig` | `modo_jobs::config` | Cleanup interval, retention, and target states. |
+| `JobsBuilder` | `modo_jobs::runner` | Builder returned by `modo_jobs::new()`. |
+| `JobsHandle` | `modo_jobs::runner` | Live handle returned by `JobsBuilder::run()`. Derefs to `JobQueue`. |
+| `JobQueue` | `modo_jobs::queue` | Enqueue / cancel operations. Axum extractor. |
+| `JobId` | `modo_jobs::types` | ULID-backed job identifier. |
+| `JobState` | `modo_jobs::types` | `Pending`, `Running`, `Completed`, `Dead`, `Cancelled`. |
+| `JobContext` | `modo_jobs::handler` | Runtime context passed to a job handler. |
+| `JobHandler` | `modo_jobs::handler` | Trait implemented by the `#[job]` macro. |
+| `JobHandlerDyn` | `modo_jobs::handler` | Object-safe bridge for `Box<dyn JobHandlerDyn>`. |
+| `JobRegistration` | `modo_jobs::handler` | Inventory entry created by `#[job]`. |

--- a/claude-plugin/skills/modo/references/jobs.md
+++ b/claude-plugin/skills/modo/references/jobs.md
@@ -68,7 +68,7 @@ async fn send_welcome(payload: WelcomePayload) -> HandlerResult<()> {
 ```rust
 use modo_jobs::job;
 use modo::HandlerResult;
-use modo::extractors::service::Service;
+use modo::Service;
 
 #[job(queue = "mailer", timeout = "1m")]
 async fn send_report(

--- a/claude-plugin/skills/modo/references/jobs.md
+++ b/claude-plugin/skills/modo/references/jobs.md
@@ -345,11 +345,10 @@ The cron expression uses six fields: `second minute hour day month weekday`.
 - If a cron job fails five consecutive times, a warning is logged.
 - Cron tasks respect the `CancellationToken` and stop cleanly on shutdown.
 
-**Cron jobs do not support `Service<T>` or `Db` parameter injection directly in the function
-signature** when they have no payload parameter — but services registered via `.service()` on
-the builder are available through `ctx.service::<T>()` if you use the `JobContext` API
-manually. In practice, use a no-argument cron function and call `ctx.service()` inside the
-body if service access is needed.
+**Cron jobs support the same parameter injection as regular jobs** (`Service<T>`, `Db`, etc.).
+The macro generates the same extraction code for all job types. The cron runner creates a fresh
+`JobContext` with all registered services for each execution, so `Service<T>` and `Db` work
+identically in cron job function signatures.
 
 ---
 

--- a/claude-plugin/skills/modo/references/templates-htmx.md
+++ b/claude-plugin/skills/modo/references/templates-htmx.md
@@ -1,0 +1,831 @@
+# Templates, HTMX, SSE, CSRF, and i18n
+
+## Documentation
+
+- docs.rs: `https://docs.rs/modo/latest/modo/` (enable features: `templates`, `sse`, `csrf`, `i18n`)
+- Cargo.toml: `modo = { version = "...", features = ["templates", "sse", "csrf", "i18n"] }`
+
+---
+
+## Template Engine
+
+### Overview
+
+modo uses MiniJinja as its template engine. The `TemplateEngine` struct wraps a
+`minijinja::Environment<'static>` behind an `RwLock` to support concurrent rendering.
+
+**Dev mode** (`debug_assertions`): templates are loaded from the filesystem on every render
+(auto-reload via `clear_templates()` + `path_loader`).
+
+**Prod mode**: no filesystem loader — templates must be embedded into the binary with
+`minijinja-embed`. Call `engine.env_mut()` during setup (inside the `templates` callback)
+to load them.
+
+### Auto-Registration
+
+When the `templates` feature is enabled, `AppBuilder::run()` performs the following
+automatically — no manual `.layer()` calls are needed:
+
+1. Builds `TemplateEngine` from `TemplateConfig` (reads from `config.templates`).
+2. Iterates `inventory::iter::<TemplateFunctionEntry>` and registers all
+   `#[template_function]`-annotated functions.
+3. Iterates `inventory::iter::<TemplateFilterEntry>` and registers all
+   `#[template_filter]`-annotated functions.
+4. If `i18n` feature is also enabled: registers the `t()` template function.
+5. If `csrf` feature is also enabled: registers `csrf_field()` and `csrf_token()` functions.
+6. Runs the user-supplied `templates(|engine| { ... })` callback (for advanced setup).
+7. Registers `TemplateEngine` as a service in the `ServiceRegistry`.
+8. Installs `RenderLayer` (renders `View` responses) and `ContextLayer` (creates `TemplateContext`) as global middleware layers.
+9. Installs `i18n` middleware layer if `TranslationStore` is registered.
+
+### Configuration
+
+```yaml
+# config.yaml
+templates:
+  path: "templates"   # directory containing .html files (default: "templates")
+  strict: true        # error on undefined variables (default: true)
+```
+
+The `TemplateConfig` struct:
+```rust
+pub struct TemplateConfig {
+    pub path: String,   // default: "templates"
+    pub strict: bool,   // default: true
+}
+```
+
+### `#[view]` Macro
+
+The `#[view]` macro is the primary way to define template-rendering response types. Apply it
+to a struct to derive `Serialize`, `IntoResponse`, and `ViewRender`.
+
+**Syntax:**
+
+```rust
+#[modo::view("template/path.html")]
+struct MyPage {
+    field: String,
+}
+
+// With HTMX partial:
+#[modo::view("pages/home.html", htmx = "partials/clock.html")]
+struct HomePage {
+    time: String,
+    date: String,
+    time_hour: u32,
+}
+```
+
+**What the macro generates:**
+
+- `#[derive(serde::Serialize)]` on the struct.
+- `impl IntoResponse` — serializes `self` into a `minijinja::Value`, wraps it in a `View`,
+  and stashes the `View` in response extensions (picked up by `RenderLayer`).
+- `impl ViewRender` — for use with `ViewRenderer::render()`. Selects the htmx template when
+  `is_htmx == true`, falls back to the main template otherwise.
+
+**Using as a handler return type (auto-render path):**
+
+```rust
+#[modo::handler(GET, "/")]
+async fn home() -> HomePage {
+    HomePage { time: "12:00".into(), date: "Monday".into(), time_hour: 12 }
+}
+```
+
+The `RenderLayer` intercepts the response, reads the `View` from extensions, merges the
+`TemplateContext` with the struct's serialized fields, and renders the template.
+
+### `ViewRenderer` Extractor
+
+`ViewRenderer` is a request extractor for explicit rendering. Use it when you need to:
+- Render different view types from different code branches.
+- Compose multiple views.
+- Perform smart redirects.
+- Render to a string (for SSE events or email).
+
+```rust
+pub struct ViewRenderer {
+    engine: Arc<TemplateEngine>,
+    context: TemplateContext,
+    is_htmx: bool,
+}
+```
+
+Key methods:
+
+```rust
+// Render one or more views (single view or tuple)
+fn render(&self, views: impl ViewRender) -> Result<ViewResponse, Error>
+
+// Smart redirect: 302 for normal requests, HX-Redirect header + 200 for HTMX
+fn redirect(&self, url: &str) -> Result<ViewResponse, Error>
+
+// Render to string — always uses main template (not HTMX partial)
+fn render_to_string(&self, view: impl ViewRender) -> Result<String, Error>
+
+// Whether current request has HX-Request header
+fn is_htmx(&self) -> bool
+```
+
+Handler example:
+
+```rust
+#[modo::handler(GET, "/chat/{room}")]
+async fn chat_page(
+    room: String,
+    session: SessionManager,
+    view: ViewRenderer,
+) -> modo::ViewResult {
+    let username = match session.user_id().await {
+        Some(u) => u,
+        None => return view.redirect("/login"),
+    };
+    view.render(ChatPage { room, username, messages: vec![] })
+}
+```
+
+### `TemplateContext`
+
+`TemplateContext` is a per-request key-value store in request extensions. Middleware layers
+add values here; `RenderLayer` merges it with the view's serialized struct before rendering.
+
+```rust
+pub struct TemplateContext {
+    values: BTreeMap<String, Value>,
+}
+```
+
+Built-in values injected by `ContextLayer`:
+- `current_url` — the full request URI string.
+
+Additional values injected automatically by other middleware (when features are enabled):
+- `locale` — resolved language tag (i18n middleware).
+- `csrf_token` — raw CSRF token (CSRF middleware, `templates` + `csrf` features).
+- `csrf_field_name` — CSRF form field name (CSRF middleware).
+
+User context from the `#[view]` struct takes precedence over context values on key collision.
+
+---
+
+## Template Functions and Filters
+
+### `#[template_function]`
+
+Registers a Rust function as a MiniJinja template function via `inventory`. The function is
+automatically discovered and registered when `AppBuilder::run()` starts.
+
+```rust
+#[modo::template_function]
+fn greeting(hour: u32) -> String {
+    match hour {
+        0..=11 => "Good morning".to_string(),
+        12..=17 => "Good afternoon".to_string(),
+        _ => "Good evening".to_string(),
+    }
+}
+```
+
+Template usage:
+```jinja
+{{ greeting(time_hour) }}
+```
+
+The macro uses the function name as the template function name by default. Override:
+```rust
+#[modo::template_function("my_alias")]
+fn some_fn(...) -> ...
+```
+
+Under the hood, the macro emits an `inventory::submit!` block with a `TemplateFunctionEntry`.
+This works only when the `templates` feature is enabled. The `#[cfg(feature = "templates")]`
+guard is emitted by the macro.
+
+### `#[template_filter]`
+
+Registers a Rust function as a MiniJinja template filter (same mechanism as functions, but
+uses `env.add_filter()`).
+
+```rust
+#[modo::template_filter]
+fn truncate(s: String, max: usize) -> String {
+    if s.len() > max { format!("{}...", &s[..max]) } else { s }
+}
+```
+
+Template usage:
+```jinja
+{{ description | truncate(100) }}
+```
+
+### Inventory and Linking
+
+`TemplateFunctionEntry` and `TemplateFilterEntry` use `inventory::collect!` and
+`inventory::submit!` for auto-discovery. When writing library crates that define functions
+or filters, force the linker to include the registration by adding a use statement:
+
+```rust
+use my_crate::some_module as _;
+```
+
+---
+
+## HTMX Rendering
+
+### Detection
+
+`RenderLayer` and `ViewRenderer` both detect HTMX requests by checking for the presence
+of the `hx-request` request header (lowercase). There is no value check — presence alone
+is sufficient.
+
+### Template Selection
+
+When a `#[view]` struct has a dual template (`htmx = "partials/foo.html"`):
+
+- Normal request → renders `template` (full page).
+- HTMX request → renders `htmx_template` (partial fragment).
+- If no `htmx` parameter is provided, both paths render the same template.
+
+`ViewRender::has_dual_template()` returns `true` when an htmx template is set. When
+`ViewRenderer::render()` sees this, it adds a `Vary: HX-Request` response header.
+
+### HTMX Always Returns HTTP 200
+
+**Critical behavior**: `RenderLayer` always sends `StatusCode::OK` (200) for HTMX responses.
+
+HTMX ignores non-200 responses by default and does not swap content. Therefore, validation
+errors and other "error" states that should update the UI must be returned as `200` with
+an error partial rendered into the template. Use a non-200 status only when you deliberately
+want HTMX to skip rendering (e.g., to trigger out-of-band HTMX behavior via response headers).
+
+The exact behavior in `RenderLayer`:
+
+```rust
+// HTMX rule: non-200 status -> don't render, pass through
+if is_htmx && status != StatusCode::OK {
+    return Ok(response); // no template rendered
+}
+// ...
+// HTMX responses are always forced to 200
+if is_htmx {
+    *resp.status_mut() = StatusCode::OK;
+}
+```
+
+Non-200 on HTMX: the response passes through with no HTML body rendered, allowing you to
+use `HX-Redirect` headers and similar HTMX-specific mechanisms.
+
+### Redirect Pattern
+
+`ViewRenderer::redirect()` handles the HTMX redirect case automatically:
+
+- Normal request: returns a `302 Found` redirect.
+- HTMX request: returns `200 OK` with an `HX-Redirect` header.
+
+---
+
+## Server-Sent Events
+
+### Overview
+
+The `sse` feature provides streaming primitives for real-time event delivery over HTTP.
+All types live in `modo::sse`.
+
+Key types:
+
+| Type | Purpose |
+|------|---------|
+| `SseEvent` | Builder for a single event (data / json / html + metadata) |
+| `SseResponse` | Handler return type — wraps a stream with keep-alive |
+| `Sse` | Extractor — auto-applies `SseConfig` (keep-alive interval) |
+| `SseBroadcastManager<K, T>` | Keyed broadcast channels for fan-out delivery |
+| `SseStream<T>` | Stream of raw `T` values from a broadcast channel |
+| `SseSender` | Imperative sender for the `channel()` closure pattern |
+| `LastEventId` | Extractor for the `Last-Event-ID` reconnection header |
+| `SseStreamExt` | Trait: stream-to-event conversion combinators |
+| `SseConfig` | Keep-alive configuration |
+
+### `SseBroadcastManager`
+
+```rust
+pub struct SseBroadcastManager<K, T>
+where
+    K: Hash + Eq + Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+```
+
+Create and register as a service:
+
+```rust
+// In main():
+let bc: SseBroadcastManager<String, MyEvent> = SseBroadcastManager::new(128);
+app.service(bc)
+```
+
+Key methods:
+
+```rust
+// Subscribe to a keyed channel (created lazily on first subscribe)
+fn subscribe(&self, key: &K) -> SseStream<T>
+
+// Send to all subscribers of a key (returns receiver count, Ok(0) if none)
+fn send(&self, key: &K, event: T) -> Result<usize, Error>
+
+// Number of active subscribers for a key
+fn subscriber_count(&self, key: &K) -> usize
+
+// Force-remove a channel and disconnect all subscribers
+fn remove(&self, key: &K)
+```
+
+Channels are created lazily on first `subscribe()`. They auto-clean when the last subscriber
+drops. `send()` also cleans up if all receivers have been dropped.
+
+### `SseEvent`
+
+Builder for a single SSE event:
+
+```rust
+let event = SseEvent::new()
+    .event("message")        // sets event: field (for HTMX: hx-trigger="sse:message")
+    .data("plain text");     // sets data: field
+
+let event = SseEvent::new()
+    .event("status")
+    .json(&my_struct)?;      // fallible: serializes to JSON
+
+let event = SseEvent::new()
+    .event("update")
+    .html("<div>fragment</div>"); // same as data(), communicates intent for partials
+
+// With reconnection metadata:
+let event = SseEvent::new()
+    .id("evt-123")                           // Last-Event-ID for reconnect replay
+    .retry(std::time::Duration::from_secs(5)); // client reconnect delay
+```
+
+`data()`, `json()`, and `html()` are mutually exclusive — each replaces the previous data.
+`json()` returns `Result<Self, Error>`.
+
+### `Sse` Extractor
+
+`Sse` is a request extractor that reads `SseConfig` from the service registry and provides
+configured factory methods:
+
+```rust
+impl Sse {
+    fn from_stream<S, E>(&self, stream: S) -> SseResponse
+    fn channel<F, Fut>(&self, f: F) -> SseResponse
+}
+```
+
+Always prefer `Sse` over calling `modo::sse::from_stream()` directly — it applies the
+configured keep-alive interval automatically.
+
+### `SseStreamExt` Trait
+
+Extension trait on `Stream<Item = Result<T, E>>`:
+
+```rust
+// Serialize each item as JSON
+fn sse_json(self) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+
+// Custom mapping closure
+fn sse_map<F>(self, f: F) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+
+// Set event name on pre-built SseEvent items
+fn with_event_name(self, name: &'static str) -> impl Stream<Item = Result<SseEvent, Error>> + Send
+```
+
+### Broadcast fan-out pattern (most common)
+
+```rust
+#[modo::handler(GET, "/{room}/events")]
+async fn chat_events(
+    room: String,
+    sse: Sse,
+    view: ViewRenderer,
+    Service(bc): Service<SseBroadcastManager<String, ChatEvent>>,
+) -> modo::HandlerResult<SseResponse> {
+    let stream = bc.subscribe(&room).sse_map(move |evt| {
+        let html = view.render_to_string(MessagePartial {
+            username: evt.username,
+            text: evt.text,
+        })?;
+        Ok(SseEvent::new().event("message").html(html))
+    });
+    Ok(sse.from_stream(stream))
+}
+```
+
+### Imperative channel pattern
+
+```rust
+#[modo::handler(GET, "/jobs/{id}/progress")]
+async fn progress(
+    sse: Sse,
+    id: String,
+    Service(jobs): Service<JobService>,
+) -> SseResponse {
+    sse.channel(|tx| async move {
+        while let Some(status) = jobs.poll_status(&id).await {
+            tx.send(SseEvent::new().event("progress").json(&status)?).await?;
+            if status.is_done() { break; }
+        }
+        Ok(())
+    })
+}
+```
+
+### SSE Configuration
+
+```yaml
+sse:
+  keep_alive_interval_secs: 30  # default: 15
+```
+
+### SSE Gotchas
+
+- The global `TimeoutLayer` terminates long-lived connections. Set a long timeout or disable
+  it for SSE routes: `server.http.timeout: 3600`.
+- `SseResponse` automatically sets `X-Accel-Buffering: no` to prevent nginx buffering.
+  For other proxies, disable buffering at the proxy layer.
+- Do not enable `server.http.compression: true` with SSE — `CompressionLayer` buffers
+  responses before sending, which breaks real-time delivery.
+- `LastEventId` extractor reads the `Last-Event-ID` reconnect header. The framework does
+  NOT automatically replay missed events — implement replay logic manually using your data
+  store.
+
+---
+
+## CSRF Protection
+
+### Overview
+
+The `csrf` feature provides double-submit cookie protection. The `csrf_protection` function
+is an Axum middleware function (not a Tower layer) that must be wired via
+`axum::middleware::from_fn_with_state`.
+
+### How It Works
+
+**Safe methods** (GET, HEAD, OPTIONS, TRACE):
+1. Reads the existing signed CSRF cookie (if present and valid, re-uses token).
+2. Generates a new random token if no valid cookie found.
+3. Injects `CsrfToken(raw_token)` into request extensions.
+4. If `templates` feature is enabled, also injects `csrf_token` and `csrf_field_name` into `TemplateContext`.
+5. Sets a signed, `HttpOnly` cookie (`_csrf` by default) on the response.
+
+**Mutating methods** (POST, PUT, PATCH, DELETE):
+1. Reads and verifies the signed cookie.
+2. Reads the submitted token from `x-csrf-token` header first.
+3. Falls back to reading `_csrf_token` field from a URL-encoded form body.
+4. Performs a constant-time comparison between cookie token and submitted token.
+5. Returns `403 Forbidden` on any validation failure.
+
+### `CsrfToken` Extractor
+
+```rust
+#[derive(Debug, Clone)]
+pub struct CsrfToken(pub String);
+```
+
+Extract the raw token in a handler:
+
+```rust
+use modo::csrf::CsrfToken;
+
+#[modo::handler(GET, "/form")]
+async fn show_form(
+    Extension(CsrfToken(token)): Extension<CsrfToken>,
+) -> impl IntoResponse {
+    // use token manually if not using template integration
+}
+```
+
+When the `templates` feature is enabled, the middleware automatically injects `csrf_token`
+and `csrf_field_name` into `TemplateContext`, so most handlers do not need to extract
+`CsrfToken` directly.
+
+### Configuration
+
+```yaml
+csrf:
+  cookie_name: "_csrf"           # default
+  field_name: "_csrf_token"      # default (form field name)
+  header_name: "x-csrf-token"    # default
+  cookie_max_age: 86400          # seconds, default: 86400 (1 day)
+  token_length: 32               # bytes, default: 32
+  secure: true                   # default: true (set Secure on cookie)
+  max_body_bytes: 1048576        # max form body size in bytes
+```
+
+### Template Functions (auto-registered with `templates` + `csrf` features)
+
+```jinja
+{# Render a hidden input field — use inside any form #}
+{{ csrf_field() }}
+{# Renders: <input type="hidden" name="_csrf_token" value="..."> #}
+
+{# Get the raw token for meta tags or fetch() calls #}
+<meta name="csrf-token" content="{{ csrf_token() }}">
+```
+
+Both functions error if `csrf_token` is not in the template context (i.e., CSRF middleware
+is not active for the route).
+
+### Wiring CSRF Middleware
+
+```rust
+// In AppBuilder setup (inside a module or at app level):
+router.layer(axum::middleware::from_fn_with_state(state.clone(), modo::csrf::csrf_protection))
+```
+
+---
+
+## Internationalization
+
+### Overview
+
+The `i18n` feature provides per-request language resolution, a `TranslationStore` for
+YAML-based translation files, and an `I18n` extractor for use in handlers.
+
+### `I18nConfig`
+
+```yaml
+i18n:
+  path: "locales"         # directory of per-language YAML files (default: "locales")
+  default_lang: "en"      # fallback language (default: "en")
+  cookie_name: "lang"     # cookie for persisting language choice (default: "lang")
+  query_param: "lang"     # query parameter for switching language (default: "lang")
+```
+
+Directory layout: `locales/{lang}/{namespace}.yml`
+
+```yaml
+# locales/en/common.yml
+greeting: "Hello, {name}!"
+items_count:
+  zero: "No items"
+  one: "One item"
+  other: "{count} items"
+```
+
+### Language Resolution
+
+The i18n middleware resolves locale per-request using this priority chain:
+
+1. Custom source (if `layer_with_source` is used)
+2. Query parameter (`?lang=fr`)
+3. Cookie (`lang=fr`)
+4. `Accept-Language` header
+5. Default language from config
+
+When the query parameter resolves a new language and no cookie was present, the middleware
+sets a `lang` cookie (1-year max-age) to persist the choice.
+
+### `I18n` Extractor
+
+```rust
+pub struct I18n {
+    store: Arc<TranslationStore>,
+    lang: String,
+    default_lang: String,
+}
+```
+
+Methods:
+
+```rust
+// Current resolved language for this request
+fn lang(&self) -> &str
+
+// All available languages loaded from disk
+fn available_langs(&self) -> &[String]
+
+// Look up key with variable interpolation ({name} placeholders)
+fn t(&self, key: &str, vars: &[(&str, &str)]) -> String
+
+// Plural lookup — uses zero/one/other sub-keys
+fn t_plural(&self, key: &str, count: u64, vars: &[(&str, &str)]) -> String
+```
+
+Fallback chain for both methods: user lang → default lang → key as-is.
+
+Handler example:
+
+```rust
+#[modo::handler(GET, "/dashboard")]
+async fn dashboard(i18n: I18n) -> impl IntoResponse {
+    let title = i18n.t("page.dashboard.title", &[]);
+    let items_label = i18n.t_plural("items_count", 5, &[("count", "5")]);
+    // ...
+}
+```
+
+### `t()` in Templates
+
+When both `templates` and `i18n` features are enabled, a `t` template function is
+automatically registered on the MiniJinja environment. The function reads the `locale`
+value from the template context (injected by the i18n middleware via `TemplateContext`).
+
+```jinja
+{# Plain key #}
+{{ t("auth.login.title") }}
+
+{# With variable interpolation #}
+{{ t("greeting", name="Alice") }}
+
+{# Plural form — pass count as keyword argument #}
+{{ t("items_count", count=5) }}
+```
+
+The `count` kwarg triggers plural form selection (`zero` / `one` / `other`) and is also
+available for `{count}` interpolation in the translation string.
+
+---
+
+## Integration Patterns
+
+### i18n Values in Templates
+
+The i18n middleware automatically inserts `locale` into `TemplateContext` when both
+`templates` and `i18n` features are enabled. This means the `t()` function is available
+in every template without any extra work in the handler.
+
+```jinja
+{# Available in every template when i18n + templates features are enabled #}
+<html lang="{{ locale }}">
+<title>{{ t("page.title") }}</title>
+```
+
+### CSRF in HTMX Forms
+
+Use `csrf_field()` inside any form tag. HTMX submits forms as `application/x-www-form-urlencoded`,
+so the CSRF middleware will find the token in the form body automatically.
+
+```jinja
+<form hx-post="/submit" hx-target="#result">
+    {{ csrf_field() }}
+    <input name="text" type="text">
+    <button type="submit">Send</button>
+</form>
+```
+
+For fetch-based HTMX requests that use JSON bodies, include the token in the `x-csrf-token`
+header instead:
+
+```html
+<meta name="csrf-token" content="{{ csrf_token() }}">
+<script>
+htmx.on("htmx:configRequest", (e) => {
+    e.detail.headers["x-csrf-token"] =
+        document.querySelector('meta[name="csrf-token"]').content;
+});
+</script>
+```
+
+### HTMX + Non-200 Status
+
+Non-200 responses on HTMX requests cause `RenderLayer` to skip template rendering and pass
+the response through unchanged. This means:
+
+- Returning a `#[view]` struct with `.with_status(StatusCode::NOT_FOUND)` from an HTMX
+  handler will produce an empty-body 404 response — the template will NOT be rendered.
+- Use this intentionally when you want HTMX to use `HX-Redirect` or trigger HTMX error
+  handling via `htmx:responseError`.
+- For form validation errors that should re-render the form, always return `200 OK` with
+  a view containing the error state.
+
+Example — validation error pattern (correct approach):
+
+```rust
+#[modo::handler(POST, "/register")]
+async fn register(
+    view: ViewRenderer,
+    form: Form<RegisterForm>,
+) -> modo::ViewResult {
+    if form.email.is_empty() {
+        // Return 200 OK — renders the form partial with error message
+        return view.render(RegisterForm { error: Some("Email required".into()) });
+    }
+    // On success, smart redirect (302 or HX-Redirect)
+    view.redirect("/dashboard")
+}
+```
+
+### SSE + HTMX HTML Partials
+
+`ViewRenderer::render_to_string()` always uses the main template (ignores `htmx` partial).
+Use a partial-only `#[view]` struct (no full-page template needed) for SSE-delivered HTML.
+
+```rust
+// Define a partial-only view:
+#[modo::view("partials/status_card.html")]
+struct StatusCards {
+    servers: Vec<ServerStatus>,
+}
+
+// Render it to a string inside an SSE handler:
+#[modo::handler(GET, "/events")]
+async fn events(
+    sse: Sse,
+    view: ViewRenderer,
+    Service(bc): Service<StatusBroadcaster>,
+) -> SseResponse {
+    let stream = bc.subscribe(&()).sse_map(move |servers| {
+        let html = view.render_to_string(StatusCards { servers })?;
+        Ok(SseEvent::new().event("status_update").html(html))
+    });
+    sse.from_stream(stream)
+}
+```
+
+In the HTMX template, listen for the named SSE event:
+
+```html
+<div hx-ext="sse" sse-connect="/events"
+     hx-trigger="sse:status_update"
+     hx-swap="innerHTML">
+</div>
+```
+
+---
+
+## Gotchas
+
+### Auto-Layer — No Manual `.layer()` Needed
+
+`RenderLayer`, `ContextLayer`, and the i18n middleware layer are all installed automatically
+by `AppBuilder::run()` when the relevant features are enabled. Do NOT add them manually —
+doing so results in duplicate layers.
+
+### HTMX 200-Only Rendering
+
+`RenderLayer` enforces: if the request has `HX-Request` header and response status is not
+`200 OK`, the template is NOT rendered. The raw response (empty body) passes through.
+Design form validation, auth checks, and error states to return `200 OK` with an
+appropriate partial rather than non-200 status codes.
+
+### Template Strict Mode
+
+`TemplateConfig::strict` defaults to `true`. Accessing undefined template variables causes
+a render error (logged as `error!` and returned as 500 to the client in prod). Ensure all
+template variables are present in either the `TemplateContext` or the `#[view]` struct.
+
+### SSE and Compression
+
+Enabling `server.http.compression: true` applies `CompressionLayer` globally and breaks SSE
+event delivery. Disable compression at the server level if you use SSE routes.
+
+### SSE and Timeouts
+
+The default request timeout (typically 30 seconds) terminates SSE connections. Set
+`server.http.timeout` to a high value (e.g., `3600`) for SSE routes, or use route-specific
+timeout overrides.
+
+### CSRF and HTTPS
+
+`CsrfConfig::secure` defaults to `true`, which sets the `Secure` flag on the CSRF cookie.
+In local development over HTTP, set `secure: false` in your dev config or the cookie will
+not be sent.
+
+### inventory Registration from Library Crates
+
+`#[template_function]` and `#[template_filter]` use `inventory::submit!` for registration.
+When defined in a library crate, the linker may dead-strip the registration unless the
+module is forced to link. Add a use statement in the crate root or main to force linking:
+
+```rust
+use my_templates::functions as _;
+```
+
+---
+
+## docs.rs Quick Reference
+
+- `TemplateEngine` — `modo::templates::TemplateEngine`
+- `TemplateConfig` — `modo::templates::TemplateConfig`
+- `TemplateContext` — `modo::templates::TemplateContext`
+- `View` — `modo::templates::View`
+- `ViewRender` — `modo::templates::ViewRender`
+- `ViewRenderer` — `modo::templates::ViewRenderer`
+- `RenderLayer` — `modo::templates::RenderLayer`
+- `ContextLayer` — `modo::templates::ContextLayer`
+- `TemplateFunctionEntry` — `modo::templates::TemplateFunctionEntry`
+- `TemplateFilterEntry` — `modo::templates::TemplateFilterEntry`
+- `SseBroadcastManager` — `modo::sse::SseBroadcastManager`
+- `SseEvent` — `modo::sse::SseEvent`
+- `SseResponse` — `modo::sse::SseResponse`
+- `Sse` — `modo::sse::Sse`
+- `SseStream` — `modo::sse::SseStream`
+- `SseSender` — `modo::sse::SseSender`
+- `SseStreamExt` — `modo::sse::SseStreamExt`
+- `LastEventId` — `modo::sse::LastEventId`
+- `SseConfig` — `modo::sse::SseConfig`
+- `CsrfToken` — `modo::csrf::CsrfToken`
+- `CsrfConfig` — `modo::csrf::CsrfConfig`
+- `csrf_protection` — `modo::csrf::csrf_protection`
+- `I18n` — `modo::i18n::I18n`
+- `I18nConfig` — `modo::i18n::I18nConfig`
+- `TranslationStore` — `modo::i18n::TranslationStore`

--- a/claude-plugin/skills/modo/references/templates-htmx.md
+++ b/claude-plugin/skills/modo/references/templates-htmx.md
@@ -581,8 +581,8 @@ The i18n middleware resolves locale per-request using this priority chain:
 4. `Accept-Language` header
 5. Default language from config
 
-When the query parameter resolves a new language and no cookie was present, the middleware
-sets a `lang` cookie (1-year max-age) to persist the choice.
+When the query parameter resolves a language that differs from the current cookie value, the middleware
+sets (or updates) a `lang` cookie (1-year max-age) to persist the choice.
 
 ### `I18n` Extractor
 
@@ -642,6 +642,28 @@ value from the template context (injected by the i18n middleware via `TemplateCo
 
 The `count` kwarg triggers plural form selection (`zero` / `one` / `other`) and is also
 available for `{count}` interpolation in the translation string.
+
+### `t!()` in Rust Handlers
+
+The `t!()` proc macro (re-exported as `modo::t!`, gated on `i18n` feature) provides
+a concise syntax for translation lookups in handler code:
+
+```rust
+use modo::t;
+
+// Simple key lookup — calls i18n.t("key", &[])
+let title = t!(i18n, "page.title");
+
+// With variable interpolation — calls i18n.t("greeting", &[("name", &name.to_string())])
+let msg = t!(i18n, "greeting", name = user.name);
+
+// Plural form — presence of `count =` switches to i18n.t_plural()
+let label = t!(i18n, "items_count", count = items.len());
+```
+
+The macro accepts an `I18n` extractor expression, a string key, and optional
+`name = expr` pairs. When a `count` named argument is present, it calls
+`i18n.t_plural()` instead of `i18n.t()`.
 
 ---
 

--- a/claude-plugin/skills/modo/references/templates-htmx.md
+++ b/claude-plugin/skills/modo/references/templates-htmx.md
@@ -493,7 +493,7 @@ pub struct CsrfToken(pub String);
 Extract the raw token in a handler:
 
 ```rust
-use modo::csrf::CsrfToken;
+use modo::CsrfToken;
 
 #[modo::handler(GET, "/form")]
 async fn show_form(
@@ -804,12 +804,12 @@ use my_templates::functions as _;
 
 ## docs.rs Quick Reference
 
-- `TemplateEngine` — `modo::templates::TemplateEngine`
-- `TemplateConfig` — `modo::templates::TemplateConfig`
-- `TemplateContext` — `modo::templates::TemplateContext`
+- `TemplateEngine` — `modo::TemplateEngine`
+- `TemplateConfig` — `modo::TemplateConfig`
+- `TemplateContext` — `modo::TemplateContext`
 - `View` — `modo::templates::View`
-- `ViewRender` — `modo::templates::ViewRender`
-- `ViewRenderer` — `modo::templates::ViewRenderer`
+- `ViewRender` — `modo::ViewRender`
+- `ViewRenderer` — `modo::ViewRenderer`
 - `RenderLayer` — `modo::templates::RenderLayer`
 - `ContextLayer` — `modo::templates::ContextLayer`
 - `TemplateFunctionEntry` — `modo::templates::TemplateFunctionEntry`
@@ -823,9 +823,9 @@ use my_templates::functions as _;
 - `SseStreamExt` — `modo::sse::SseStreamExt`
 - `LastEventId` — `modo::sse::LastEventId`
 - `SseConfig` — `modo::sse::SseConfig`
-- `CsrfToken` — `modo::csrf::CsrfToken`
-- `CsrfConfig` — `modo::csrf::CsrfConfig`
+- `CsrfToken` — `modo::CsrfToken`
+- `CsrfConfig` — `modo::CsrfConfig`
 - `csrf_protection` — `modo::csrf::csrf_protection`
-- `I18n` — `modo::i18n::I18n`
-- `I18nConfig` — `modo::i18n::I18nConfig`
+- `I18n` — `modo::I18n`
+- `I18nConfig` — `modo::I18nConfig`
 - `TranslationStore` — `modo::i18n::TranslationStore`

--- a/claude-plugin/skills/modo/references/tenant.md
+++ b/claude-plugin/skills/modo/references/tenant.md
@@ -1,0 +1,543 @@
+# Tenant Reference
+
+The `modo-tenant` crate provides multi-tenancy support: tenant resolution from HTTP requests via
+configurable strategies, extractors for use in handlers, and optional template context injection.
+Tenant resolution is pluggable — you supply the lookup logic, and the crate wires it into the
+request lifecycle. There is no automatic database filtering; tenant-scoped queries require manual
+WHERE clauses.
+
+---
+
+## Documentation
+
+- modo-tenant crate: https://docs.rs/modo-tenant
+
+---
+
+## Tenant Resolution
+
+### `HasTenantId` trait
+
+Every tenant type must implement `HasTenantId` to expose its unique identifier:
+
+```rust
+pub trait HasTenantId {
+    fn tenant_id(&self) -> &str;
+}
+```
+
+The `Tenant` and `OptionalTenant` extractors and `TenantContextLayer` all require the inner type
+to implement this trait, plus `Clone + Send + Sync + serde::Serialize + 'static`.
+
+### `TenantResolver` trait
+
+`TenantResolver` is the core pluggable strategy trait. Implement it to teach the framework how to
+identify a tenant from any signal in the request:
+
+```rust
+pub trait TenantResolver: Send + Sync + 'static {
+    type Tenant: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static;
+
+    fn resolve(
+        &self,
+        parts: &Parts,
+    ) -> impl Future<Output = Result<Option<Self::Tenant>, modo::Error>> + Send;
+}
+```
+
+Return semantics:
+- `Ok(Some(tenant))` — tenant identified successfully.
+- `Ok(None)` — no tenant found (e.g. a public route). The `Tenant` extractor returns 404.
+- `Err(e)` — infrastructure failure (e.g. database error). Both `Tenant` and `OptionalTenant`
+  return 500.
+
+Example custom resolver:
+
+```rust
+use modo_tenant::{HasTenantId, TenantResolver};
+use modo::axum::http::request::Parts;
+
+#[derive(Clone, serde::Serialize)]
+pub struct Workspace {
+    pub id: String,
+    pub slug: String,
+    pub display_name: String,
+}
+
+impl HasTenantId for Workspace {
+    fn tenant_id(&self) -> &str {
+        &self.id
+    }
+}
+
+pub struct WorkspaceResolver {
+    db: DatabaseConnection,
+}
+
+impl TenantResolver for WorkspaceResolver {
+    type Tenant = Workspace;
+
+    async fn resolve(&self, parts: &Parts) -> Result<Option<Self::Tenant>, modo::Error> {
+        let host = match parts.headers.get("host").and_then(|v| v.to_str().ok()) {
+            Some(h) => h.split(':').next().unwrap_or(h),
+            None => return Ok(None),
+        };
+        let slug = host.strip_suffix(".myapp.com").unwrap_or("");
+        if slug.is_empty() || slug == "www" {
+            return Ok(None);
+        }
+        // Query your database for the workspace
+        let ws = workspace::Entity::find()
+            .filter(workspace::Column::Slug.eq(slug))
+            .one(&self.db)
+            .await
+            .map_err(modo::Error::internal)?;
+        Ok(ws.map(|w| Workspace { id: w.id, slug: w.slug, display_name: w.name }))
+    }
+}
+```
+
+### Built-in Resolution Strategies
+
+Three built-in resolvers cover the most common strategies. All three take a `lookup` closure that
+receives the extracted identifier string and returns the tenant asynchronously.
+
+#### `SubdomainResolver`
+
+Extracts the tenant slug from the subdomain of the `Host` header. Given `base_domain = "myapp.com"`,
+a request to `acme.myapp.com` passes `"acme"` to the lookup closure. The bare domain and the
+`www` subdomain always return `Ok(None)`. Port suffixes are stripped before matching.
+
+```rust
+use modo_tenant::SubdomainResolver;
+
+let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
+    // slug = "acme" for requests to acme.myapp.com
+    let ws = db.find_workspace_by_slug(&slug).await?;
+    Ok(ws)
+});
+```
+
+Multi-level subdomains (e.g. `a.b.myapp.com`) are supported — the entire prefix before the base
+domain (`"a.b"`) is passed to the lookup closure.
+
+#### `HeaderResolver`
+
+Extracts the tenant identifier from a named HTTP header. The header value is trimmed of surrounding
+whitespace before being forwarded. Returns `Ok(None)` when the header is absent or contains only
+whitespace.
+
+```rust
+use modo_tenant::HeaderResolver;
+
+let resolver = HeaderResolver::new("x-tenant-id", |id| async move {
+    // id = trimmed header value
+    let ws = db.find_workspace_by_id(&id).await?;
+    Ok(ws)
+});
+```
+
+Useful for internal or API-only services where the caller controls the headers.
+
+#### `PathPrefixResolver`
+
+Extracts the tenant identifier from the first path segment of the request URI. A request to
+`/acme/dashboard` passes `"acme"` to the lookup closure. The root path `/` returns `Ok(None)`.
+
+```rust
+use modo_tenant::PathPrefixResolver;
+
+let resolver = PathPrefixResolver::new(|slug| async move {
+    // slug = "acme" for /acme/dashboard
+    // Return Ok(None) quickly for non-tenant segments like "assets", "api"
+    if slug == "assets" || slug == "api" {
+        return Ok(None);
+    }
+    let ws = db.find_workspace_by_slug(&slug).await?;
+    Ok(ws)
+});
+```
+
+The lookup closure is called for every request's first segment, including static asset paths and
+API routes — the closure is responsible for returning `Ok(None)` quickly for non-tenant slugs.
+
+---
+
+## Type-Erased Service
+
+### `TenantResolverService<T>`
+
+`TenantResolverService<T>` is a cheaply cloneable, type-erased wrapper around any
+`TenantResolver`. Register one instance with `AppState`'s service registry, and all extractors
+and middleware can retrieve it at request time without knowing the concrete resolver type.
+
+```rust
+pub struct TenantResolverService<T: Clone + Send + Sync + 'static> {
+    inner: Arc<dyn TenantResolverDyn<T>>,
+}
+
+impl<T: Clone + Send + Sync + 'static> TenantResolverService<T> {
+    pub fn new<R: TenantResolver<Tenant = T>>(resolver: R) -> Self { ... }
+    pub async fn resolve(&self, parts: &Parts) -> Result<Option<T>, modo::Error> { ... }
+}
+```
+
+The type erasure happens via an internal `TenantResolverDyn<T>` bridge trait (not public) that
+boxes the future returned by `resolve`. The `Arc` wrapper makes `TenantResolverService<T>` cheap
+to clone across middleware layers.
+
+**Registration:**
+
+```rust
+use modo_tenant::{SubdomainResolver, TenantResolverService};
+
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let resolver = SubdomainResolver::new("myapp.com", {
+        let db = config.db.clone();
+        move |slug| {
+            let db = db.clone();
+            async move { db.find_workspace_by_slug(&slug).await }
+        }
+    });
+    let tenant_svc = TenantResolverService::new(resolver);
+
+    app.config(config.core)
+        .service(tenant_svc)
+        .run()
+        .await
+}
+```
+
+The `AppState::services` registry is keyed by type: `TenantResolverService<Workspace>` and
+`TenantResolverService<Account>` are distinct entries, so multiple tenant types are supported
+simultaneously.
+
+### Resolution Caching
+
+The resolved tenant is cached in the request extensions under `ResolvedTenant<T>` (an internal
+type wrapping `Arc<T>`). Both the `Tenant<T>` and `OptionalTenant<T>` extractors, as well as
+`TenantContextLayer`, call `resolve_and_cache` which checks this cache first. When a handler
+uses both extractors (e.g. `Tenant<Workspace>` and `OptionalTenant<Workspace>`), the underlying
+resolver is only called once per request.
+
+---
+
+## Extractors
+
+### `Tenant<T>`
+
+Requires a resolved tenant. If the resolver returns `Ok(None)`, the request is rejected with
+HTTP 404. If the resolver returns `Err(...)`, the request is rejected with HTTP 500.
+
+```rust
+#[derive(Clone)]
+pub struct Tenant<T: Clone + Send + Sync + 'static>(pub T);
+```
+
+`Tenant<T>` implements `Deref<Target = T>`, so all methods of `T` are directly accessible:
+
+```rust
+use modo_tenant::Tenant;
+
+#[modo::handler(GET, "/dashboard")]
+async fn dashboard(tenant: Tenant<Workspace>) -> HandlerResult<Json<serde_json::Value>> {
+    // Access fields via deref
+    let name = &tenant.display_name;
+    // Or use .0 for the inner value
+    let id = &tenant.0.id;
+    Ok(modo::Json(serde_json::json!({ "workspace": name })))
+}
+```
+
+Use `Tenant<T>` on routes that must always have a tenant — it guards access at the framework
+level before any handler code runs.
+
+### `OptionalTenant<T>`
+
+Resolves a tenant when present, but never rejects the request due to a missing tenant. The inner
+`Option<T>` is `None` when the resolver returns `Ok(None)`.
+
+```rust
+#[derive(Clone)]
+pub struct OptionalTenant<T: Clone + Send + Sync + 'static>(pub Option<T>);
+```
+
+`OptionalTenant<T>` implements `Deref<Target = Option<T>>`, providing direct access to
+`Option` methods.
+
+**Important distinction:** `OptionalTenant` only suppresses the "no tenant found" case. If the
+resolver itself fails (e.g. a database error), the extractor still rejects with 500. This
+differs from `TenantContextLayer`, which silently swallows resolver errors (logging at WARN level)
+to avoid disrupting the request.
+
+```rust
+use modo_tenant::OptionalTenant;
+
+#[modo::handler(GET, "/")]
+async fn home(tenant: OptionalTenant<Workspace>) -> HandlerResult<String> {
+    match tenant.0 {
+        Some(ws) => Ok(format!("Welcome to {}", ws.display_name)),
+        None => Ok("Welcome".to_string()),
+    }
+}
+```
+
+Use `OptionalTenant<T>` on routes that serve both tenant-specific and public audiences (e.g.
+a landing page that is personalized when a tenant subdomain is detected).
+
+---
+
+## Integration Patterns
+
+### Tenant in Templates (`TenantContextLayer`)
+
+The `TenantContextLayer` (feature `"templates"`) is a Tower middleware layer that injects the
+resolved tenant into the request's `TemplateContext` under the key `"tenant"`. This makes tenant
+data available to all Jinja/MiniJinja templates rendered during the request without requiring
+the handler to pass it explicitly.
+
+```rust
+#[cfg(feature = "templates")]
+pub struct TenantContextLayer<T>
+where
+    T: Clone + Send + Sync + HasTenantId + serde::Serialize + 'static;
+```
+
+Behaviour:
+- If the tenant resolves successfully, it is serialized and inserted as `ctx["tenant"]`.
+- If resolution fails, the error is logged at WARN level and the request continues without
+  `"tenant"` in the context (the layer never returns an error response).
+- If no `TemplateContext` extension is present in the request, the layer is a no-op for context
+  injection but still passes the request through normally.
+
+**Registration:**
+
+```rust
+use modo_tenant::{TenantContextLayer, TenantResolverService};
+
+let tenant_svc = TenantResolverService::new(resolver);
+let tenant_layer = TenantContextLayer::new(tenant_svc.clone());
+
+// Apply as a global or module-level middleware layer
+app.layer(tenant_layer)
+```
+
+**In templates:**
+
+```jinja
+{% if tenant %}
+  <h1>{{ tenant.display_name }}</h1>
+{% else %}
+  <h1>Welcome</h1>
+{% endif %}
+```
+
+The tenant type must implement `serde::Serialize` — all public fields are available in templates
+by their Rust field names (or `#[serde(rename = "...")]` overrides).
+
+`TenantContextLayer` uses the same `resolve_and_cache` function as the extractors, so when a
+handler also uses `Tenant<T>` or `OptionalTenant<T>` in the same request, the resolver is still
+only called once.
+
+### Tenant-Scoped Database Queries
+
+`modo-tenant` does not automatically filter database queries by tenant. Every query that should
+be scoped to the current tenant must include an explicit WHERE clause. Retrieve the tenant from
+the `Tenant<T>` extractor and pass its ID to the query:
+
+```rust
+use modo_tenant::Tenant;
+use sea_orm::EntityTrait;
+
+#[modo::handler(GET, "/projects")]
+async fn list_projects(
+    db: Service<DatabaseConnection>,
+    tenant: Tenant<Workspace>,
+) -> JsonResult<Vec<ProjectResponse>> {
+    let projects = project::Entity::find()
+        .filter(project::Column::WorkspaceId.eq(tenant.tenant_id()))
+        .all(&*db)
+        .await?;
+
+    Ok(modo::Json(projects.into_iter().map(Into::into).collect()))
+}
+```
+
+For deeply nested resources where the tenant ID is not on the direct table, join through the
+parent chain:
+
+```rust
+// Comment belongs to Post belongs to Workspace
+comment::Entity::find()
+    .inner_join(post::Entity)
+    .filter(post::Column::WorkspaceId.eq(tenant.tenant_id()))
+    .filter(comment::Column::PostId.eq(post_id))
+    .all(&*db)
+    .await?
+```
+
+There is no row-level security or automatic tenant filter — forgetting the WHERE clause leaks
+cross-tenant data. Consider a helper function or repository layer that always takes a
+`&str` tenant ID to avoid accidental omission.
+
+### Multiple Tenant Types
+
+A single application can support multiple tenant types simultaneously by registering multiple
+`TenantResolverService` instances (one per tenant type) with the service registry. Each is keyed
+by its type parameter, so they do not conflict:
+
+```rust
+let workspace_svc = TenantResolverService::new(WorkspaceResolver::new(db.clone()));
+let account_svc = TenantResolverService::new(AccountResolver::new(db.clone()));
+
+app.service(workspace_svc)
+   .service(account_svc)
+```
+
+Handlers can then extract `Tenant<Workspace>` and `Tenant<Account>` independently on different
+route sets.
+
+### Middleware Stacking with Tenant Resolution
+
+`TenantContextLayer` is a Tower `Layer`, so stacking order follows the standard modo convention:
+Global (outermost) → Module → Handler (innermost). Apply `TenantContextLayer` at the global level
+so tenant data is available in templates regardless of which route is matched.
+
+```rust
+use modo_tenant::{TenantContextLayer, TenantResolverService};
+
+let tenant_svc = TenantResolverService::new(SubdomainResolver::new(
+    "myapp.com",
+    |slug| async move { db.find_workspace_by_slug(&slug).await },
+));
+
+// Register the service for extractor use
+app.service(tenant_svc.clone())
+   // Apply context layer globally so templates always have "tenant"
+   .layer(TenantContextLayer::new(tenant_svc))
+```
+
+When a route module also uses `Tenant<T>` extractors, caching ensures the resolver is only called
+once per request even though both the layer and the extractor participate in resolution.
+
+### Tenant Verification (Access Control)
+
+`TenantResolver::resolve` identifies the tenant from the request signal, but does not enforce
+ownership. After extracting a `Tenant<T>`, verify that the requested resource belongs to that
+tenant before returning it:
+
+```rust
+#[modo::handler(GET, "/projects/:project_id")]
+async fn get_project(
+    db: Service<DatabaseConnection>,
+    tenant: Tenant<Workspace>,
+    modo::axum::extract::Path(project_id): modo::axum::extract::Path<String>,
+) -> JsonResult<ProjectResponse> {
+    let project = project::Entity::find_by_id(&project_id)
+        .filter(project::Column::WorkspaceId.eq(tenant.tenant_id()))
+        .one(&*db)
+        .await?
+        .ok_or(modo::Error::from(modo::HttpError::NotFound))?;
+
+    Ok(modo::Json(project.into()))
+}
+```
+
+The combined `find_by_id` + `workspace_id` filter ensures the project both exists and belongs to
+the current tenant. A project in a different workspace returns 404 rather than leaking its
+existence.
+
+### Custom Resolver with Connection Pool
+
+When the resolver needs a database connection, capture the pool at construction time using a
+closure. The closure must be `Send + Sync + 'static`, so clone the pool before moving it in:
+
+```rust
+use sea_orm::DatabaseConnection;
+use modo_tenant::{SubdomainResolver, TenantResolverService};
+
+fn workspace_resolver(db: DatabaseConnection) -> TenantResolverService<Workspace> {
+    let resolver = SubdomainResolver::new("myapp.com", move |slug| {
+        let db = db.clone();  // DatabaseConnection is Arc-backed, cheap to clone
+        async move {
+            let row = workspace::Entity::find()
+                .filter(workspace::Column::Slug.eq(&slug))
+                .filter(workspace::Column::ActiveAt.is_not_null())
+                .one(&db)
+                .await
+                .map_err(|e| modo::Error::internal(e.to_string()))?;
+            Ok(row.map(Into::into))
+        }
+    });
+    TenantResolverService::new(resolver)
+}
+```
+
+`DatabaseConnection` from SeaORM is internally reference-counted, so cloning it inside the async
+block is inexpensive and safe across threads.
+
+---
+
+## Gotchas
+
+- **Missing service registration returns 500.** If `TenantResolverService<T>` is not registered
+  with `AppState`, both `Tenant<T>` and `OptionalTenant<T>` reject with an internal server error,
+  not a 404. Always register the service in `main`.
+
+- **`OptionalTenant` still fails on resolver errors.** Unlike `TenantContextLayer`, which swallows
+  resolver errors, `OptionalTenant` propagates them as 500. `Ok(None)` is the only case that
+  produces `None` inside the extractor.
+
+- **`TenantContextLayer` requires the `"templates"` feature.** The type is gated behind
+  `#[cfg(feature = "templates")]`. Add `modo-tenant = { features = ["templates"] }` to your
+  `Cargo.toml`. The `templates` feature activates `modo/templates` transitively.
+
+- **`PathPrefixResolver` calls lookup for every request.** The lookup closure is invoked for
+  every first path segment including `"assets"`, `"favicon.ico"`, `"api"`, etc. Return `Ok(None)`
+  immediately for non-tenant slugs to avoid spurious database queries.
+
+- **Subdomain resolver skips `www`.** `SubdomainResolver` explicitly returns `Ok(None)` for the
+  `www` subdomain and the bare domain. If you need custom handling for `www.myapp.com`, implement
+  `TenantResolver` directly.
+
+- **Header value is trimmed, not validated.** `HeaderResolver` trims whitespace but performs no
+  further sanitization. If the header value is user-controlled (e.g. forwarded from a proxy), the
+  lookup closure must validate it against your database before trusting it as a tenant identifier.
+
+- **Resolution caching is per-request.** The `ResolvedTenant<T>` cached in request extensions
+  lives only for the lifetime of a single request. There is no cross-request cache — each request
+  calls the resolver (or hits the per-request cache if multiple extractors are used).
+
+- **Resolver must be `Send + Sync + 'static`.** Database connection types such as SeaORM's
+  `DatabaseConnection` satisfy these bounds. If your resolver holds non-`Send` state, wrap it in
+  an appropriate synchronization primitive.
+
+- **No automatic tenant injection into jobs.** Background jobs (`modo_jobs`) run outside the HTTP
+  request lifecycle. Pass the tenant ID explicitly as part of the job payload if the job needs to
+  operate on behalf of a tenant.
+
+- **`TenantContextLayer` is a no-op without `TemplateContext`.** If no `TemplateContext` extension
+  is present in the request extensions, the layer does not panic or error — it simply skips
+  context injection and forwards the request as-is. The `TemplateEngine` service inserts
+  `TemplateContext` automatically; if you are using `TenantContextLayer` without a template engine
+  the tenant will never appear in templates.
+
+---
+
+## docs.rs Links
+
+| Type / Item                    | URL                                                                               |
+|--------------------------------|-----------------------------------------------------------------------------------|
+| `HasTenantId` trait            | https://docs.rs/modo-tenant/latest/modo_tenant/trait.HasTenantId.html             |
+| `TenantResolver` trait         | https://docs.rs/modo-tenant/latest/modo_tenant/trait.TenantResolver.html          |
+| `TenantResolverService<T>`     | https://docs.rs/modo-tenant/latest/modo_tenant/struct.TenantResolverService.html  |
+| `Tenant<T>` extractor          | https://docs.rs/modo-tenant/latest/modo_tenant/struct.Tenant.html                 |
+| `OptionalTenant<T>` extractor  | https://docs.rs/modo-tenant/latest/modo_tenant/struct.OptionalTenant.html         |
+| `TenantContextLayer`           | https://docs.rs/modo-tenant/latest/modo_tenant/struct.TenantContextLayer.html     |
+| `SubdomainResolver`            | https://docs.rs/modo-tenant/latest/modo_tenant/struct.SubdomainResolver.html      |
+| `HeaderResolver`               | https://docs.rs/modo-tenant/latest/modo_tenant/struct.HeaderResolver.html         |
+| `PathPrefixResolver`           | https://docs.rs/modo-tenant/latest/modo_tenant/struct.PathPrefixResolver.html     |

--- a/claude-plugin/skills/modo/references/testing.md
+++ b/claude-plugin/skills/modo/references/testing.md
@@ -1,0 +1,709 @@
+# Testing Reference
+
+This reference covers testing patterns across all modo crates. Every pattern shown here is derived
+from the actual test files in the repository.
+
+## Documentation
+
+- modo: https://docs.rs/modo
+- modo-db: https://docs.rs/modo-db
+- modo-session: https://docs.rs/modo-session
+- modo-auth: https://docs.rs/modo-auth
+- modo-jobs: https://docs.rs/modo-jobs
+- modo-upload: https://docs.rs/modo-upload
+- axum test utilities: https://docs.rs/axum
+- tower ServiceExt: https://docs.rs/tower/latest/tower/trait.ServiceExt.html
+
+---
+
+## Test Commands
+
+```bash
+# Run all workspace tests (no --all-features)
+just test
+# equivalent to:
+cargo test --workspace --all-targets
+
+# Run full CI check: fmt-check + lint + test
+just check
+
+# Lint (uses --all-features)
+just lint
+# equivalent to:
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+# Run feature-gated tests for a specific crate
+cargo test -p modo --features templates
+cargo test -p modo --features i18n
+cargo test -p modo --features sse
+cargo test -p modo --features csrf
+```
+
+### Critical difference: `just test` vs `just lint`
+
+`just test` runs `cargo test --workspace --all-targets` — **without** `--all-features`. This means
+any code guarded by a feature flag is excluded from the standard test run. `just lint` uses
+`--all-features`, so it covers feature-gated code during linting.
+
+Consequence: if you write tests for feature-gated code, you must run them explicitly:
+
+```bash
+# This WILL NOT run tests gated on #![cfg(feature = "templates")]
+just test
+
+# This WILL run them
+cargo test -p modo --features templates
+```
+
+Tests that exist inside `#![cfg(feature = "...")]` files (like `templates_e2e.rs`,
+`i18n_integration.rs`) are silently skipped by `just test`.
+
+---
+
+## Tower Middleware Testing with `.oneshot()`
+
+The standard pattern for testing Tower middleware and handlers is to build a bare
+`axum::Router`, attach middleware with `.layer()`, and drive it with `tower::ServiceExt::oneshot()`.
+No running server or bound TCP port is required.
+
+**Minimal example — testing a middleware that injects an extension:**
+
+```rust
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use modo::request_id::{RequestId, request_id_middleware};
+use tower::ServiceExt;
+
+fn build_test_router() -> Router {
+    Router::new()
+        .route(
+            "/echo",
+            get(|req_id: axum::Extension<RequestId>| async move { req_id.0.to_string() }),
+        )
+        .layer(axum::middleware::from_fn(request_id_middleware))
+}
+
+#[tokio::test]
+async fn test_generates_request_id() {
+    let app = build_test_router();
+
+    let response = app
+        .oneshot(Request::builder().uri("/echo").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let header = response
+        .headers()
+        .get("x-request-id")
+        .expect("x-request-id header missing");
+    let id = header.to_str().unwrap();
+    assert_eq!(id.len(), 26); // ULID is 26 chars
+    assert!(id.chars().all(|c| c.is_ascii_alphanumeric()));
+}
+```
+
+**Source:** `modo/tests/request_id.rs`
+
+### Key rules for `.oneshot()` tests
+
+- Import `tower::ServiceExt` — `oneshot()` is provided by that trait.
+- The router is consumed by `.oneshot()`. Each test call needs a fresh router instance
+  (or clone one before calling `oneshot`).
+- No `AppState` is needed when testing isolated middleware. Add state only when the handler
+  or middleware actually reads from it.
+- `axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap()` reads the full
+  response body as bytes.
+
+**Simple handler without state:**
+
+```rust
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use modo::health;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_liveness_200() {
+    let app = Router::new().route("/_live", get(health::liveness_handler));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/_live")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"ok");
+}
+```
+
+**Source:** `modo/tests/health.rs`
+
+---
+
+## Testing with AppState
+
+When a handler or middleware requires `AppState` (e.g. session middleware, auth middleware,
+or anything that reads `ServiceRegistry`), construct a minimal `AppState` directly and call
+`.with_state(state)` on the router.
+
+```rust
+use axum::Router;
+use axum::routing::get;
+use modo::app::{AppState, ServiceRegistry};
+use modo::config::ServerConfig;
+
+fn build_app(store: SessionStore) -> Router {
+    let services = ServiceRegistry::new()
+        .with(UserProviderService::new(TestProvider))
+        .with(store.clone());
+
+    let state = AppState {
+        services,
+        server_config: ServerConfig::default(),
+        cookie_key: axum_extra::extract::cookie::Key::generate(),
+    };
+
+    Router::new()
+        .route("/auth", get(auth_handler))
+        .route("/optional", get(optional_handler))
+        .layer(modo_session::layer(store))
+        .with_state(state)
+}
+
+#[tokio::test]
+async fn auth_valid_session_returns_user() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
+    let app = build_app(store.clone());
+
+    let cookie = create_session(&store, "user-1").await;
+    let resp = app
+        .oneshot(request_with_cookie("/auth", &cookie))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+    assert_eq!(&body[..], b"Alice");
+}
+```
+
+**Source:** `modo-auth/tests/integration.rs`
+
+### `AppState` struct fields
+
+```rust
+pub struct AppState {
+    pub services: ServiceRegistry,
+    pub server_config: ServerConfig,
+    pub cookie_key: axum_extra::extract::cookie::Key,
+}
+```
+
+Use `ServiceRegistry::new().with(svc)` to register services into the registry.
+Use `Key::generate()` in tests — no need for a stable key unless you are testing
+cookie signing round-trips across requests.
+
+---
+
+## Cookie Attribute Testing
+
+To test that response cookies carry specific attributes (domain, path, secure, HttpOnly,
+SameSite), read the raw `Set-Cookie` header from the response.
+
+The `CookieConfig` struct controls what attributes cookies carry:
+
+```rust
+pub struct CookieConfig {
+    pub domain: Option<String>,
+    pub path: String,
+    pub secure: bool,
+    pub http_only: bool,
+    pub same_site: SameSite,  // Strict | Lax | None
+    pub max_age: Option<u64>,
+}
+```
+
+**Pattern — assert that a Set-Cookie header contains expected attributes:**
+
+```rust
+let resp = app
+    .oneshot(Request::get("/?lang=es").body(Body::empty()).unwrap())
+    .await
+    .unwrap();
+
+let (parts, body) = resp.into_parts();
+let set_cookie = parts
+    .headers
+    .get("Set-Cookie")
+    .expect("should set cookie")
+    .to_str()
+    .unwrap()
+    .to_string();
+assert!(set_cookie.starts_with("lang=es"));
+```
+
+**Source:** `modo/tests/i18n_integration.rs`
+
+To test that a custom `CookieConfig` (e.g. a specific domain) is applied, create a
+`ServiceRegistry` that includes it and pass it through `AppState`. Then fire a request and assert
+the `Set-Cookie` header value.
+
+The `CookieConfig` default: `path = "/"`, `secure = true`, `http_only = true`,
+`same_site = Lax`, `domain = None`.
+
+---
+
+## In-Memory Database for Integration Tests
+
+`modo-session`, `modo-auth`, and `modo-jobs` tests all use `sqlite::memory:` to spin up a full
+schema without needing an external database. The pattern:
+
+1. Connect to `sqlite::memory:`.
+2. Locate the entity registration via `inventory::iter::<EntityRegistration>()`.
+3. Build the schema using SeaORM's `Schema` builder.
+4. Run any extra SQL (composite indexes, etc.) from `reg.extra_sql`.
+
+```rust
+use modo_db::sea_orm::{ConnectionTrait, Schema};
+use modo_db::{DatabaseConfig, DbPool};
+
+async fn setup_db() -> DbPool {
+    let config = DatabaseConfig {
+        url: "sqlite::memory:".to_string(),
+        max_connections: 1,
+        min_connections: 1,
+    };
+    let db = modo_db::connect(&config).await.expect("Failed to connect");
+
+    let schema = Schema::new(db.connection().get_database_backend());
+    let mut builder = schema.builder();
+    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_sessions")
+        .expect("modo_sessions entity not registered");
+    builder = (reg.register_fn)(builder);
+    builder
+        .sync(db.connection())
+        .await
+        .expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.connection()
+            .execute_unprepared(sql)
+            .await
+            .expect("Extra SQL failed");
+    }
+    db
+}
+```
+
+**Source:** `modo-session/tests/integration.rs`, `modo-auth/tests/integration.rs`
+
+For `modo-jobs` tests that work directly with the raw SeaORM `DatabaseConnection` (not `DbPool`):
+
+```rust
+use modo_db::sea_orm::{Database, Schema};
+
+async fn setup_db() -> modo_db::sea_orm::DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("Failed to connect");
+
+    let schema = Schema::new(db.get_database_backend());
+    let mut builder = schema.builder();
+    let reg = inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_jobs")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder.sync(&db).await.expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.execute_unprepared(sql).await.expect("Extra SQL failed");
+    }
+    db
+}
+```
+
+**Source:** `modo-jobs/tests/runner.rs`, `modo-jobs/tests/queue.rs`
+
+---
+
+## Inventory Force-Linking
+
+`inventory` registration from library crates may not link when running tests in a separate test
+binary. If `inventory::iter::<SomeType>()` returns an empty iterator in a test but works in
+production, the linker has discarded the registration.
+
+**Fix:** Force the registration to link by importing the entity module as a side effect:
+
+```rust
+use crate::entity::foo as _;
+```
+
+This is a Rust linker requirement — the symbol must be reachable from the test binary's
+dependency graph. The wildcard import `as _` keeps the symbol linked without introducing
+name conflicts.
+
+**In test files:** When using `inventory::iter::<EntityRegistration>()` to verify registrations,
+declare the entity types in the same test file (not in a separate library). The entity macro
+`#[modo_db::entity]` calls `inventory::submit!` at compile time, and the registration is
+included in the binary that defines the type. This is why `modo-db/tests/entity_macro.rs`
+defines all test entity structs in the test file itself rather than importing them.
+
+```rust
+// In the test file — entity defined here, so registration is present
+#[modo_db::entity(table = "test_users")]
+pub struct TestUser {
+    #[entity(primary_key)]
+    pub id: i32,
+    pub email: String,
+}
+
+#[test]
+fn test_basic_entity_registers() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let tables: Vec<&str> = registrations.iter().map(|r| r.table_name).collect();
+    assert!(tables.contains(&"test_users"));
+}
+```
+
+**Source:** `modo-db/tests/entity_macro.rs`
+
+---
+
+## Feature-Gated Tests
+
+Files that test optional features must declare the feature guard at the top:
+
+```rust
+#![cfg(feature = "templates")]
+// or
+#![cfg(feature = "i18n")]
+```
+
+These tests are excluded from `just test` (no `--all-features`). Run them explicitly:
+
+```bash
+cargo test -p modo --features templates
+cargo test -p modo --features i18n
+cargo test -p modo --features sse
+cargo test -p modo --features csrf
+```
+
+**Feature-gated test files in the modo crate:**
+
+| File | Feature required |
+|------|-----------------|
+| `tests/templates_e2e.rs` | `templates` |
+| `tests/templates_context_layer.rs` | `templates` |
+| `tests/templates_render_layer.rs` | `templates` |
+| `tests/templates_view_macro.rs` | `templates` |
+| `tests/templates_view_render_macro.rs` | `templates` |
+| `tests/templates_view_render_trait.rs` | `templates` |
+| `tests/templates_view_renderer.rs` | `templates` |
+| `tests/templates_view_response.rs` | `templates` |
+| `tests/templates_context_merge.rs` | `templates` |
+| `tests/i18n_integration.rs` | `i18n` |
+| `tests/i18n_template_integration.rs` | `i18n` + `templates` |
+| `tests/sse_broadcast.rs` | `sse` |
+| `tests/sse_channel.rs` | `sse` |
+| `tests/sse_config.rs` | `sse` |
+| `tests/sse_event.rs` | `sse` |
+| `tests/sse_last_event_id.rs` | `sse` |
+| `tests/sse_response.rs` | `sse` |
+| `tests/sse_stream_ext.rs` | `sse` |
+
+---
+
+## Testing Patterns by Crate
+
+### modo (core framework)
+
+Tests live in `modo/tests/`. Most use `Router::new().route(...).layer(mw).oneshot(request)`.
+
+**Extracting an `Extension<T>` in a test handler:**
+
+```rust
+get(|req_id: axum::Extension<RequestId>| async move { req_id.0.to_string() })
+```
+
+**Reading response body:**
+
+```rust
+let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+    .await
+    .unwrap();
+assert_eq!(&body[..], b"expected bytes");
+```
+
+**Checking JSON response shape:**
+
+```rust
+let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+    .await
+    .unwrap();
+let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+assert_eq!(json["status"], 404);
+assert_eq!(json["error"], "not_found");
+assert_eq!(json["message"], "Not found");
+```
+
+**Source:** `modo/tests/integration.rs`, `modo/tests/error_handling.rs`
+
+**Inventory-based route testing:** The integration test builds a minimal router by iterating
+`inventory::iter::<RouteRegistration>()` and filtering by path prefix. This avoids loading
+all registered routes and allows focused testing:
+
+```rust
+fn build_test_router() -> axum::Router {
+    let state = AppState {
+        services: Default::default(),
+        server_config: ServerConfig::default(),
+        cookie_key: axum_extra::extract::cookie::Key::generate(),
+    };
+
+    let mut router = axum::Router::new();
+    for reg in inventory::iter::<RouteRegistration> {
+        if reg.path.starts_with("/test") {
+            let method_router = (reg.handler)();
+            router = router.route(reg.path, method_router);
+        }
+    }
+    router
+        .fallback(|| async { HttpError::NotFound.into_response() })
+        .with_state(state)
+}
+```
+
+**Source:** `modo/tests/integration.rs`
+
+### modo-db
+
+Tests in `modo-db/tests/` cover the entity macro, migration macro, and pool types.
+
+**Trait bound assertions (compile-time tests):**
+
+```rust
+#[test]
+fn test_dbpool_is_send_sync() {
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+    assert_send::<DbPool>();
+    assert_sync::<DbPool>();
+}
+```
+
+This pattern verifies `Send + Sync` bounds without constructing a value. If the bound is not
+satisfied, the test fails to compile.
+
+**Source:** `modo-db/tests/pool.rs`
+
+**Entity registration verification:**
+
+```rust
+#[test]
+fn test_basic_entity_registers() {
+    let registrations: Vec<&EntityRegistration> = inventory::iter::<EntityRegistration>().collect();
+    let tables: Vec<&str> = registrations.iter().map(|r| r.table_name).collect();
+    assert!(
+        tables.contains(&"test_users"),
+        "test_users not registered. Found: {tables:?}"
+    );
+}
+```
+
+**Source:** `modo-db/tests/entity_macro.rs`
+
+### modo-session
+
+Tests use `sqlite::memory:` with the schema setup pattern above. Sessions are created via
+`SessionStore::create()` and tokens are passed through the `Cookie:` request header.
+
+The session token in a cookie header is: `{config.cookie_name}={token.as_hex()}`.
+
+```rust
+async fn create_session(store: &SessionStore, user_id: &str) -> String {
+    let meta = test_meta();
+    let (_session, token) = store.create(&meta, user_id, None).await.unwrap();
+    format!(
+        "{}={}",
+        SessionConfig::default().cookie_name,
+        token.as_hex()
+    )
+}
+
+fn request_with_cookie(uri: &str, cookie: &str) -> Request<axum::body::Body> {
+    Request::builder()
+        .uri(uri)
+        .header("cookie", cookie)
+        .header("user-agent", "Mozilla/5.0 ...")
+        .header("accept-language", "en-US")
+        .header("accept-encoding", "gzip")
+        .body(axum::body::Body::empty())
+        .unwrap()
+}
+```
+
+**Source:** `modo-auth/tests/integration.rs`
+
+### modo-auth
+
+Tests combine `modo-session` and a custom `UserProvider` implementation. Define a concrete user
+type, implement `UserProvider` for a test struct (using `match` on known IDs), wire everything
+into `AppState`, and drive requests through `.oneshot()`.
+
+```rust
+struct TestProvider;
+
+impl UserProvider for TestProvider {
+    type User = TestUser;
+
+    async fn find_by_id(&self, id: &str) -> Result<Option<Self::User>, modo::Error> {
+        match id {
+            "user-1" => Ok(Some(TestUser { name: "Alice".into() })),
+            "error-user" => Err(modo::Error::internal("db error")),
+            _ => Ok(None),
+        }
+    }
+}
+```
+
+**Source:** `modo-auth/tests/integration.rs`
+
+### modo-jobs
+
+Tests use `sqlite::memory:` and insert jobs directly via SeaORM `ActiveModel`. The runner
+functions (`claim_next`, `mark_completed`, `schedule_retry`, `handle_failure`) are called
+directly rather than through the full `JobRunner`.
+
+**Source:** `modo-jobs/tests/runner.rs`, `modo-jobs/tests/queue.rs`
+
+---
+
+## Template Engine in Tests
+
+The `modo/tests/common/mod.rs` helper creates a temporary directory, writes template files,
+and returns a configured `TemplateEngine`:
+
+```rust
+pub fn setup_engine(templates: &[(&str, &str)]) -> (TempDir, TemplateEngine) {
+    let dir = TempDir::new().unwrap();
+    for (name, content) in templates {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+    let config = TemplateConfig {
+        path: dir.path().to_string_lossy().to_string(),
+        ..Default::default()
+    };
+    let eng = engine(&config).unwrap();
+    (dir, eng)
+}
+```
+
+The `TempDir` guard must be kept alive for the duration of the test — dropping it deletes
+the directory. The end-to-end tests (`templates_e2e.rs`) use `std::env::temp_dir()` directly
+and call `fs::remove_dir_all` manually at the end.
+
+**Source:** `modo/tests/common/mod.rs`, `modo/tests/templates_e2e.rs`
+
+---
+
+## Validation Testing
+
+The `#[derive(modo::Validate)]` macro generates a `validate()` method. Tests call it directly,
+inspect the returned error shape, and assert field-level messages.
+
+```rust
+#[derive(serde::Deserialize, modo::Validate)]
+struct RequiredString {
+    #[validate(required)]
+    name: String,
+}
+
+#[test]
+fn required_string_empty_fails() {
+    let v = RequiredString { name: String::new() };
+    let err = v.validate().unwrap_err();
+    assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
+    assert_eq!(err.code(), "validation_error");
+    let msgs = err.details().get("name").unwrap().as_array().unwrap();
+    assert_eq!(msgs[0], "is required");
+}
+```
+
+Validation errors always have `status = 400`, `code = "validation_error"`,
+`message = "Validation failed"`. Field errors live in `details["field_name"]` as a JSON array.
+
+**Source:** `modo/tests/validation.rs`
+
+---
+
+## Gotchas
+
+**`just test` silently skips feature-gated tests.** Any test file starting with
+`#![cfg(feature = "...")]` is excluded from `just test`. This has caused situations where test
+coverage appears complete but feature code is untested. Always run feature-specific tests
+explicitly after writing feature-gated code.
+
+**`inventory` registrations may not link in test binaries.** When testing code that depends on
+`inventory::iter` returning items registered in a library crate, the linker may eliminate the
+registration if there is no direct reference to it. Force linking by importing the defining
+module with `use crate::entity::foo as _;` in the test file, or define the types in the test
+file directly.
+
+**`.oneshot()` consumes the router.** Each `oneshot` call moves the router. If you need
+multiple requests in one test, either clone the router before each call or rebuild it:
+
+```rust
+let app = build_test_router();
+let app2 = build_test_router(); // or app.clone() if AppState: Clone
+
+app.oneshot(req1).await.unwrap();
+app2.oneshot(req2).await.unwrap();
+```
+
+**SQLite in-memory databases are per-connection.** `sqlite::memory:` creates a fresh database
+each time a connection is opened. Each `setup_db()` call produces an independent, empty database.
+This is intentional for test isolation.
+
+**Session middleware requires `user-agent`, `accept-language`, and `accept-encoding` headers.**
+`SessionMeta::from_headers` reads these to populate session metadata. Omitting them in test
+requests will not cause a panic but the metadata fields will be empty strings. The auth
+integration tests include all three headers in helper functions.
+
+**`tokio::test` attribute is required for async tests.** All async test functions must use
+`#[tokio::test]`. The `tokio` dev-dependency in modo crates includes `features = ["full", "test-util"]`.
+
+---
+
+## Quick Reference
+
+| Task | Pattern |
+|------|---------|
+| Test middleware without state | `Router::new().route(...).layer(mw).oneshot(req)` |
+| Test handler with services | Build `ServiceRegistry`, create `AppState`, `.with_state(state)` |
+| Read response body | `axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap()` |
+| Assert JSON shape | `serde_json::from_slice::<serde_json::Value>(&body).unwrap()` |
+| In-memory DB setup | `DatabaseConfig { url: "sqlite::memory:".to_string(), .. }` |
+| Schema from entity registration | `inventory::iter::<EntityRegistration>().find(...)` |
+| Assert Set-Cookie header | `resp.headers().get("Set-Cookie").unwrap().to_str().unwrap()` |
+| Run feature-gated tests | `cargo test -p modo --features <feature>` |
+| Force inventory link | `use crate::entity::foo as _;` |
+| Assert trait bounds | `fn assert_send<T: Send>() {} assert_send::<MyType>();` |

--- a/claude-plugin/skills/modo/references/testing.md
+++ b/claude-plugin/skills/modo/references/testing.md
@@ -36,7 +36,6 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test -p modo --features templates
 cargo test -p modo --features i18n
 cargo test -p modo --features sse
-cargo test -p modo --features csrf
 ```
 
 ### Critical difference: `just test` vs `just lint`
@@ -399,7 +398,6 @@ These tests are excluded from `just test` (no `--all-features`). Run them explic
 cargo test -p modo --features templates
 cargo test -p modo --features i18n
 cargo test -p modo --features sse
-cargo test -p modo --features csrf
 ```
 
 **Feature-gated test files in the modo crate:**

--- a/claude-plugin/skills/modo/references/testing.md
+++ b/claude-plugin/skills/modo/references/testing.md
@@ -163,8 +163,8 @@ or anything that reads `ServiceRegistry`), construct a minimal `AppState` direct
 ```rust
 use axum::Router;
 use axum::routing::get;
-use modo::app::{AppState, ServiceRegistry};
-use modo::config::ServerConfig;
+use modo::{AppState, ServiceRegistry};
+use modo::ServerConfig;
 
 fn build_app(store: SessionStore) -> Router {
     let services = ServiceRegistry::new()

--- a/claude-plugin/skills/modo/references/upload.md
+++ b/claude-plugin/skills/modo/references/upload.md
@@ -1,0 +1,539 @@
+# File Upload Reference
+
+The `modo-upload` crate provides multipart form parsing, in-memory file buffering, per-field
+validation, and pluggable storage backends. The `#[derive(FromMultipart)]` macro (from
+`modo-upload-macros`) generates the `FromMultipart` implementation. The `MultipartForm<T>`
+extractor integrates with axum's request extraction pipeline and reads `UploadConfig` from the
+app's service registry.
+
+---
+
+## Documentation
+
+- modo-upload crate: https://docs.rs/modo-upload
+- modo-upload-macros crate: https://docs.rs/modo-upload-macros
+
+---
+
+## Multipart Parsing
+
+### `#[derive(FromMultipart)]`
+
+Apply the derive macro to any struct with named fields. The macro generates an implementation of
+the `FromMultipart` trait, which `MultipartForm<T>` calls automatically during request extraction.
+Only structs with named fields are supported — tuple structs and enums are a compile error.
+
+```rust
+use modo_upload::{FromMultipart, UploadedFile};
+
+#[derive(FromMultipart)]
+struct ProfileForm {
+    #[upload(max_size = "5mb", accept = "image/*")]
+    avatar: UploadedFile,
+
+    name: String,
+
+    #[upload(min_count = 1, max_count = 5)]
+    attachments: Vec<UploadedFile>,
+
+    #[serde(rename = "user_email")]
+    email: Option<String>,
+}
+```
+
+### Supported Field Types
+
+| Rust type              | Behaviour                                           |
+|------------------------|-----------------------------------------------------|
+| `UploadedFile`         | Required file field; errors if absent               |
+| `Option<UploadedFile>` | Optional file field                                 |
+| `Vec<UploadedFile>`    | Multiple files under the same field name            |
+| `BufferedUpload`       | Required streaming upload; at most one per struct   |
+| `String`               | Required text field                                 |
+| `Option<String>`       | Optional text field                                 |
+| any `T: FromStr`       | Required text field, parsed via `FromStr`           |
+
+### Field Name Override
+
+By default the Rust field name is used as the multipart field name. Use `#[serde(rename = "...")]`
+to override it:
+
+```rust
+#[derive(FromMultipart)]
+struct ContactForm {
+    #[serde(rename = "full_name")]
+    name: String,
+}
+```
+
+### `MultipartForm<T>` Extractor
+
+`MultipartForm<T>` is an axum extractor. It reads `UploadConfig` from the service registry to
+apply the global `max_file_size` limit. Auto-sanitization (`modo::sanitize::auto_sanitize`) runs
+on the parsed struct before it is returned. When `T` also implements `modo::validate::Validate`,
+call `.validate()` on the wrapper to run additional field-level rules.
+
+```rust
+use modo::JsonResult;
+use modo::extractors::service::Service;
+use modo_upload::{FileStorage, MultipartForm};
+
+use crate::types::ProfileForm;
+
+#[modo::handler(POST, "/profile")]
+async fn update_profile(
+    storage: Service<Box<dyn FileStorage>>,
+    form: MultipartForm<ProfileForm>,
+) -> JsonResult<serde_json::Value> {
+    form.validate()?;
+    let stored = storage.store("avatars", &form.avatar).await?;
+    Ok(modo::Json(serde_json::json!({
+        "name": form.name,
+        "avatar_path": stored.path,
+    })))
+}
+```
+
+`MultipartForm<T>` implements `Deref<Target = T>`, so fields are accessible directly via `form.field`.
+Use `.into_inner()` to consume the wrapper and take ownership of the inner `T`.
+
+### `UploadedFile`
+
+An uploaded file fully buffered in memory. Available accessors:
+
+| Method              | Return type      | Description                                  |
+|---------------------|------------------|----------------------------------------------|
+| `name()`            | `&str`           | Multipart field name                         |
+| `file_name()`       | `&str`           | Original filename from the client            |
+| `content_type()`    | `&str`           | MIME content type                            |
+| `data()`            | `&bytes::Bytes`  | Raw file bytes                               |
+| `size()`            | `usize`          | File size in bytes                           |
+| `extension()`       | `Option<String>` | File extension from the original name (lowercase, without dot) |
+| `is_empty()`        | `bool`           | Whether the file has zero bytes              |
+| `validate()`        | `UploadValidator`| Start a fluent validation chain              |
+
+### `BufferedUpload`
+
+A chunked upload buffered in memory as a `Vec<Bytes>`. Useful when you need streaming I/O after
+parsing, for example when writing directly to storage without a full-copy allocation. Only one
+`BufferedUpload` field is allowed per struct.
+
+| Method          | Return type               | Description                            |
+|-----------------|---------------------------|----------------------------------------|
+| `name()`        | `&str`                    | Multipart field name                   |
+| `file_name()`   | `&str`                    | Original filename                      |
+| `content_type()`| `&str`                    | MIME content type                      |
+| `size()`        | `usize`                   | Total bytes across all chunks          |
+| `chunk()`       | `Option<Result<Bytes, _>>`| Read next chunk (consumes sequentially)|
+| `into_reader()` | `Pin<Box<dyn AsyncRead>>` | Convert to a tokio `AsyncRead`         |
+| `to_bytes()`    | `bytes::Bytes`            | Collapse all chunks into one `Bytes`   |
+
+---
+
+## Field Validation
+
+### Declare-time validation via `#[upload(...)]`
+
+Validation attributes are evaluated at parse time, before the handler is called. A validation
+failure returns a structured error with per-field messages.
+
+| Attribute              | Applies to                    | Description                                   |
+|------------------------|-------------------------------|-----------------------------------------------|
+| `max_size = "<size>"`  | `UploadedFile`, `Vec<UploadedFile>` | Maximum file size. Accepts `"5mb"`, `"100kb"`, `"2gb"`, or plain bytes. Case-insensitive. |
+| `accept = "<pattern>"` | `UploadedFile`, `Vec<UploadedFile>` | MIME type pattern. Supports exact types (`"application/pdf"`) and wildcards (`"image/*"`, `"*/*"`). |
+| `min_count = <n>`      | `Vec<UploadedFile>`           | Minimum number of files.                      |
+| `max_count = <n>`      | `Vec<UploadedFile>`           | Maximum number of files.                      |
+
+```rust
+#[derive(FromMultipart)]
+struct DocumentForm {
+    // Exactly one PDF, max 10 MB
+    #[upload(max_size = "10mb", accept = "application/pdf")]
+    document: UploadedFile,
+
+    // One to three images
+    #[upload(min_count = 1, max_count = 3, accept = "image/*")]
+    photos: Vec<UploadedFile>,
+
+    // Optional thumbnail — only validated when present
+    #[upload(max_size = "500kb", accept = "image/*")]
+    thumbnail: Option<UploadedFile>,
+}
+```
+
+### Runtime validation via `UploadValidator`
+
+For validations that cannot be expressed at derive time, call `.validate()` on any `UploadedFile`
+to get a fluent `UploadValidator`:
+
+```rust
+file.validate()
+    .max_size(mb(5))    // uses the mb() helper
+    .accept("image/*")
+    .check()?;
+```
+
+The validator chains calls and collects all failures before returning a single structured error.
+Available methods:
+
+| Method             | Description                                          |
+|--------------------|------------------------------------------------------|
+| `.max_size(usize)` | Reject if file size exceeds the given byte count.    |
+| `.accept(&str)`    | Reject if MIME type does not match the pattern.      |
+| `.check()`         | Finalise. Returns `Ok(())` or a validation error.    |
+
+### Size helper functions
+
+Three free functions convert human-readable sizes to bytes:
+
+```rust
+use modo_upload::{kb, mb, gb};
+
+let limit = mb(5);   // 5 * 1024 * 1024
+let small = kb(100); // 100 * 1024
+let large = gb(1);   // 1 * 1024 * 1024 * 1024
+```
+
+### MIME matching rules
+
+MIME patterns follow these rules (implemented in `mime_matches`):
+
+- `"*/*"` matches any content type.
+- `"image/*"` matches any type whose main type is `image`.
+- `"image/png"` matches only `image/png`.
+- Parameters after `;` (e.g. `image/png; charset=utf-8`) are stripped before matching.
+- Matching is case-sensitive — `"Image/PNG"` does not match `"image/png"`.
+
+### Global size limit from config
+
+`MultipartForm<T>` reads `UploadConfig::max_file_size` from the service registry and passes it
+as the global `max_file_size` to every file field. Per-field `#[upload(max_size = ...)]` is
+checked after collection and takes precedence in the validation error message, but the global
+limit is enforced during streaming to prevent over-read.
+
+---
+
+## Storage Backends
+
+### `UploadConfig`
+
+Configure uploads in the app's YAML config, deserialized via `modo::config::load()`:
+
+```yaml
+upload:
+  backend: local       # "local" (default) or "s3"
+  path: ./uploads      # base directory for local storage
+  max_file_size: 10mb  # global default size limit
+
+  # Only relevant when backend = "s3" (requires opendal feature)
+  s3:
+    bucket: my-bucket
+    region: us-east-1
+    endpoint: ""        # leave empty for AWS; set for MinIO etc.
+    access_key_id: ""
+    secret_access_key: ""
+```
+
+In Rust, embed `UploadConfig` into your app's config struct:
+
+```rust
+use modo_upload::UploadConfig;
+
+#[derive(Default, Deserialize)]
+struct Config {
+    #[serde(flatten)]
+    core: modo::config::AppConfig,
+    #[serde(default)]
+    upload: UploadConfig,
+}
+```
+
+`UploadConfig` defaults: `backend = Local`, `path = "./uploads"`, `max_file_size = Some("10mb")`.
+
+### `StorageBackend` enum
+
+```rust
+pub enum StorageBackend {
+    Local,  // default
+    S3,     // requires opendal feature
+}
+```
+
+Serializes/deserializes as lowercase strings (`"local"`, `"s3"`).
+
+### `storage()` factory function
+
+Construct a `Box<dyn FileStorage>` from config, then register it as a service:
+
+```rust
+#[modo::main]
+async fn main(
+    app: modo::app::AppBuilder,
+    config: Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let storage = modo_upload::storage(&config.upload)?;
+    app.config(config.core).service(storage).run().await
+}
+```
+
+After registration, inject it into handlers via `Service<Box<dyn FileStorage>>`.
+
+### `FileStorage` trait
+
+```rust
+#[async_trait]
+pub trait FileStorage: Send + Sync + 'static {
+    async fn store(&self, prefix: &str, file: &UploadedFile)
+        -> Result<StoredFile, modo::Error>;
+
+    async fn store_stream(&self, prefix: &str, stream: &mut BufferedUpload)
+        -> Result<StoredFile, modo::Error>;
+
+    async fn delete(&self, path: &str) -> Result<(), modo::Error>;
+
+    async fn exists(&self, path: &str) -> Result<bool, modo::Error>;
+}
+```
+
+All methods take a `prefix` (e.g. `"avatars"`) and return a `StoredFile` with `path` and `size`
+fields. The path is relative within the storage root — store it in the database, not the full
+absolute path.
+
+### `StoredFile`
+
+```rust
+pub struct StoredFile {
+    pub path: String,  // relative path, e.g. "avatars/01hxk3q1a2b3.jpg"
+    pub size: u64,
+}
+```
+
+Filenames are ULID-based (`{ulid}.{ext}`), generated automatically. The original filename is
+never used in the stored path to avoid injection and collision issues.
+
+### Local filesystem storage (`LocalStorage`)
+
+Requires the `local` feature (enabled by default). Files are written to
+`<base_dir>/<prefix>/<ulid>.<ext>`. The directory is created automatically on the first store
+call.
+
+```rust
+use modo_upload::storage::local::LocalStorage;
+
+let storage = LocalStorage::new("./uploads");
+```
+
+Path traversal protection: `..` components and absolute paths in the prefix or generated path
+are rejected before any filesystem operation. The storage function factory builds a
+`LocalStorage` automatically when `backend = local`.
+
+### S3 / OpenDAL storage (`OpendalStorage`)
+
+Requires the `opendal` feature. Wraps any Apache OpenDAL `Operator`. The `storage()` factory
+builds the S3 operator from `S3Config` automatically:
+
+```rust
+use modo_upload::storage::opendal::OpendalStorage;
+use opendal::{Operator, services::S3};
+
+let op = Operator::new(
+    S3::default()
+        .bucket("my-bucket")
+        .region("us-east-1")
+        .access_key_id("key")
+        .secret_access_key("secret"),
+)?.finish();
+
+let storage = OpendalStorage::new(op);
+```
+
+For S3-compatible services (MinIO, Cloudflare R2, Tigris), set `endpoint` in `S3Config` or pass
+it to the builder via `.endpoint(url)`.
+
+Logical path safety: object-store keys are validated before every operation — leading `/`,
+`.`, and `..` segments are rejected to prevent path confusion.
+
+---
+
+## Integration Patterns
+
+### Full upload handler with validation
+
+The upload example shows the complete pattern combining `#[derive(FromMultipart)]`, `MultipartForm`,
+`Service<Box<dyn FileStorage>>`, and runtime validation:
+
+```rust
+use modo::JsonResult;
+use modo::extractors::service::Service;
+use modo_upload::{FileStorage, MultipartForm, UploadedFile, FromMultipart};
+
+#[derive(FromMultipart, modo::Sanitize, modo::Validate)]
+pub struct ProfileForm {
+    #[upload(max_size = "5mb", accept = "image/*")]
+    pub avatar: UploadedFile,
+
+    #[clean(trim)]
+    #[validate(required, min_length = 2)]
+    pub name: String,
+
+    #[clean(trim, normalize_email)]
+    #[validate(required, email)]
+    pub email: String,
+}
+
+#[modo::handler(POST, "/profile")]
+async fn update_profile(
+    storage: Service<Box<dyn FileStorage>>,
+    form: MultipartForm<ProfileForm>,
+) -> JsonResult<serde_json::Value> {
+    form.validate()?;
+    let stored = storage.store("avatars", &form.avatar).await?;
+    Ok(modo::Json(serde_json::json!({
+        "name": form.name,
+        "avatar_path": stored.path,
+    })))
+}
+```
+
+Key observations:
+- `storage` is extracted before `form` — extractor order in the function signature matches
+  extraction order.
+- `form.validate()?` calls the `modo::Validate` rules (e.g. `required`, `min_length`).
+  The `#[upload(...)]` rules are enforced before this, during multipart parsing.
+- `storage.store("avatars", &form.avatar)` returns `StoredFile` with the relative path.
+
+### Upload with authentication middleware
+
+When routes require authentication, attach auth middleware at the module or handler level.
+Middleware stacking order is outermost-first: Global → Module → Handler. Auth middleware runs
+_before_ `MultipartForm` extraction, which is correct — you never want to parse the body for an
+unauthenticated request.
+
+```rust
+// In your router setup
+let module = modo::Module::new()
+    .middleware(auth_required_middleware)   // runs first — rejects unauthed before body is read
+    .handler(update_profile);
+```
+
+Avoid placing auth middleware _after_ extractors are evaluated. Because axum resolves extractors
+in function parameter order, `MultipartForm` will buffer the entire body before middleware can
+reject the request if middleware is applied at the wrong layer.
+
+### Multiple file fields
+
+```rust
+#[derive(FromMultipart)]
+struct ReportForm {
+    title: String,
+
+    // Single required cover image
+    #[upload(max_size = "2mb", accept = "image/*")]
+    cover: UploadedFile,
+
+    // 1–10 attachments of any type
+    #[upload(min_count = 1, max_count = 10, max_size = "20mb")]
+    attachments: Vec<UploadedFile>,
+
+    // Optional supplemental document
+    #[upload(accept = "application/pdf")]
+    supplement: Option<UploadedFile>,
+}
+```
+
+### Storing a `BufferedUpload`
+
+Use `BufferedUpload` when you need to process the file as a stream after parsing, or pass it
+directly to `store_stream`:
+
+```rust
+#[derive(FromMultipart)]
+struct VideoForm {
+    title: String,
+    video: BufferedUpload,
+}
+
+#[modo::handler(POST, "/video")]
+async fn upload_video(
+    storage: Service<Box<dyn FileStorage>>,
+    form: MultipartForm<VideoForm>,
+) -> JsonResult<serde_json::Value> {
+    let mut form = form.into_inner();
+    let stored = storage.store_stream("videos", &mut form.video).await?;
+    Ok(modo::Json(serde_json::json!({ "path": stored.path })))
+}
+```
+
+### Delete and existence check
+
+```rust
+// Check before deleting to give a meaningful error
+if storage.exists(&old_path).await? {
+    storage.delete(&old_path).await?;
+}
+```
+
+---
+
+## Gotchas
+
+- **`MultipartForm` consumes the request body.** It must appear only once as an extractor. Do not
+  also use `axum::extract::Multipart` in the same handler.
+
+- **Extractor order matters for auth.** Place auth extractors or middleware before `MultipartForm`
+  in the parameter list (or at a higher middleware layer). If auth fails, the body should not be
+  buffered at all.
+
+- **Global size limit vs. per-field limit.** The global `UploadConfig::max_file_size` is enforced
+  during streaming (inside `UploadedFile::from_field` / `BufferedUpload::from_field`) to stop
+  over-read early. Per-field `#[upload(max_size = ...)]` is checked after collection and emits a
+  validation-style error keyed to the field name. Set the global limit conservatively and use
+  per-field limits for finer-grained messages.
+
+- **`BufferedUpload` limit: one per struct.** Having more than one `BufferedUpload` field on the
+  same struct is a compile error from the derive macro.
+
+- **MIME matching is case-sensitive.** Client-supplied content types like `Image/PNG` will not
+  match `image/*`. Normalise on the client side or accept the occasional false-negative.
+
+- **Filename uniqueness.** Stored filenames are ULID-based; original filenames are never used in
+  storage paths. Do not attempt to reconstruct the original filename from the stored path — store
+  it separately in the database if needed.
+
+- **`opendal` feature gate.** The `S3Config` struct and `OpendalStorage` type are only compiled
+  when the `opendal` feature is enabled. The `StorageBackend::S3` variant always exists in code,
+  but calling `storage()` with `S3` backend without the feature returns a runtime error.
+
+- **Local directory creation.** `LocalStorage` creates the target directory on the first write.
+  If the process does not have write permission to the parent, the first upload will fail at
+  runtime, not at startup.
+
+- **`service(storage)` registers `Box<dyn FileStorage>`.** Inject it exactly as
+  `Service<Box<dyn FileStorage>>` in handlers. Using `Service<LocalStorage>` or
+  `Service<OpendalStorage>` directly will fail to resolve.
+
+- **Auto-sanitization.** `MultipartForm` calls `modo::sanitize::auto_sanitize` on the parsed
+  struct automatically. Fields annotated with `#[clean(trim)]` are trimmed before `validate()`
+  runs, so you do not need to trim manually.
+
+---
+
+## docs.rs Links
+
+| Type / Item              | URL                                                            |
+|--------------------------|----------------------------------------------------------------|
+| `FromMultipart` trait    | https://docs.rs/modo-upload/latest/modo_upload/trait.FromMultipart.html |
+| `FromMultipart` derive   | https://docs.rs/modo-upload-macros/latest/modo_upload_macros/derive.FromMultipart.html |
+| `MultipartForm<T>`       | https://docs.rs/modo-upload/latest/modo_upload/struct.MultipartForm.html |
+| `UploadedFile`           | https://docs.rs/modo-upload/latest/modo_upload/struct.UploadedFile.html |
+| `BufferedUpload`         | https://docs.rs/modo-upload/latest/modo_upload/struct.BufferedUpload.html |
+| `FileStorage` trait      | https://docs.rs/modo-upload/latest/modo_upload/storage/trait.FileStorage.html |
+| `StoredFile`             | https://docs.rs/modo-upload/latest/modo_upload/storage/struct.StoredFile.html |
+| `StorageBackend`         | https://docs.rs/modo-upload/latest/modo_upload/enum.StorageBackend.html |
+| `UploadConfig`           | https://docs.rs/modo-upload/latest/modo_upload/struct.UploadConfig.html |
+| `S3Config`               | https://docs.rs/modo-upload/latest/modo_upload/struct.S3Config.html |
+| `LocalStorage`           | https://docs.rs/modo-upload/latest/modo_upload/storage/local/struct.LocalStorage.html |
+| `OpendalStorage`         | https://docs.rs/modo-upload/latest/modo_upload/storage/opendal/struct.OpendalStorage.html |
+| `UploadValidator`        | https://docs.rs/modo-upload/latest/modo_upload/struct.UploadValidator.html |
+| `storage()` function     | https://docs.rs/modo-upload/latest/modo_upload/storage/fn.storage.html |
+| `kb()`, `mb()`, `gb()`   | https://docs.rs/modo-upload/latest/modo_upload/fn.mb.html |

--- a/claude-plugin/skills/modo/references/upload.md
+++ b/claude-plugin/skills/modo/references/upload.md
@@ -75,7 +75,7 @@ call `.validate()` on the wrapper to run additional field-level rules.
 
 ```rust
 use modo::JsonResult;
-use modo::extractors::service::Service;
+use modo::Service;
 use modo_upload::{FileStorage, MultipartForm};
 
 use crate::types::ProfileForm;
@@ -364,7 +364,7 @@ The upload example shows the complete pattern combining `#[derive(FromMultipart)
 
 ```rust
 use modo::JsonResult;
-use modo::extractors::service::Service;
+use modo::Service;
 use modo_upload::{FileStorage, MultipartForm, UploadedFile, FromMultipart};
 
 #[derive(FromMultipart, modo::Sanitize, modo::Validate)]

--- a/docs/superpowers/plans/2026-03-13-modo-dev-skill.md
+++ b/docs/superpowers/plans/2026-03-13-modo-dev-skill.md
@@ -1,0 +1,732 @@
+# modo-dev Skill Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create an installable Claude Code plugin with a skill for building applications with the modo Rust web framework.
+
+**Architecture:** One plugin with a single skill (`modo-dev`). Lean SKILL.md (~800-1,000 words) with hard rules, macro cheat sheet, and topic index. Eleven reference files (2,000-4,000 words each) with patterns, code examples, integration sections, and gotchas — all derived from the actual crate source code.
+
+**Tech Stack:** Claude Code plugin system (plugin.json, marketplace.json, SKILL.md, markdown reference files)
+
+**Spec:** `docs/superpowers/specs/2026-03-13-modo-dev-skill-design.md`
+
+---
+
+## Reference File Structure Template
+
+Every reference file (Tasks 3-13) MUST follow this 6-part structure:
+
+1. **Documentation** — docs.rs links for the crate(s) covered
+2. **Core Concepts** — types, traits, macros with complete code examples
+3. **Patterns** — real-world usage patterns derived from examples/ or tests/
+4. **Integration Patterns** — cross-module interactions (from spec cross-reference table)
+5. **Gotchas** — pitfalls, footguns, non-obvious behavior
+6. **docs.rs Links** — quick-reference links to key types/traits
+
+Target word count: **2,000-4,000 words** per file. Verify with `wc -w` after writing.
+
+---
+
+## Chunk 1: Scaffolding
+
+### Task 1: Create plugin directory structure and manifests
+
+**Files:**
+- Create: `.claude-plugin/marketplace.json`
+- Create: `claude-plugin/.claude-plugin/plugin.json`
+- Create: `claude-plugin/skills/modo/references/` (empty directory)
+
+- [ ] **Step 1: Create marketplace.json at repo root**
+
+Create `.claude-plugin/marketplace.json`:
+
+```json
+{
+    "name": "modo",
+    "owner": {
+        "name": "Dmytro Momot"
+    },
+    "plugins": [
+        {
+            "name": "modo-dev",
+            "source": {
+                "source": "git-subdir",
+                "url": "https://github.com/dmitrymomot/modo.git",
+                "path": "claude-plugin"
+            },
+            "description": "Skills for building apps with the modo Rust web framework"
+        }
+    ]
+}
+```
+
+- [ ] **Step 2: Create plugin.json**
+
+Create `claude-plugin/.claude-plugin/plugin.json`:
+
+```json
+{
+    "name": "modo-dev",
+    "description": "Skills for building applications with the modo Rust web framework",
+    "version": "0.1.0",
+    "author": { "name": "Dmytro Momot" },
+    "repository": "https://github.com/dmitrymomot/modo",
+    "license": "Apache-2.0"
+}
+```
+
+- [ ] **Step 3: Create the skills directory structure**
+
+```bash
+mkdir -p claude-plugin/skills/modo/references
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude-plugin/ claude-plugin/
+git commit -m "chore: scaffold modo-dev Claude Code plugin structure"
+```
+
+---
+
+### Task 2: Write SKILL.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/SKILL.md`
+- Read (for macro verification): `modo-macros/src/lib.rs`, `modo-db-macros/src/lib.rs`, `modo-jobs-macros/src/lib.rs`, `modo-upload-macros/src/lib.rs`
+
+- [ ] **Step 1: Read all proc macro entry points to verify macro names and syntax**
+
+Read these files to confirm every macro in the cheat sheet is accurate:
+- `modo-macros/src/lib.rs` — handler, module, main, error_handler, view, template_function, template_filter, t, Sanitize, Validate
+- `modo-db-macros/src/lib.rs` — entity, migration
+- `modo-jobs-macros/src/lib.rs` — job
+- `modo-upload-macros/src/lib.rs` — FromMultipart
+
+For each macro, note the exact attribute syntax (named args vs positional).
+
+- [ ] **Step 2: Write SKILL.md**
+
+Create `claude-plugin/skills/modo/SKILL.md` with these sections (target ~800-1,000 words):
+
+1. **Frontmatter** — name: `modo-dev`, description with trigger phrases (as defined in spec)
+2. **Hard Rules** — requirement-gathering gate (use AskUserQuestion before writing code) + use built-in functionality first
+3. **Assumed Starting Point** — scaffolded by `modo-cli`
+4. **Macro Cheat Sheet** — compact table with 14 macros (verified from step 1)
+5. **Topic Index** — maps tasks to reference files
+6. **Common Multi-Module Workflows** — composite task reading sequences (from spec cross-references section)
+
+- [ ] **Step 3: Verify word count is in range**
+
+```bash
+wc -w claude-plugin/skills/modo/SKILL.md
+```
+
+Target: 800-1,000 words. Adjust if needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add claude-plugin/skills/modo/SKILL.md
+git commit -m "feat: add modo-dev skill with macro cheat sheet and topic index"
+```
+
+---
+
+## Chunk 2: Foundation Reference
+
+### Task 3: Write conventions.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/conventions.md`
+- Read: `modo/src/lib.rs`, `modo/src/error.rs`, `modo/src/app.rs` (middleware stacking), `CLAUDE.md`
+
+- [ ] **Step 1: Read source files for conventions**
+
+Read these files to extract conventions, error patterns, and gotchas:
+- `modo/src/lib.rs` — public re-exports (verify alphabetical sort rule)
+- `modo/src/error.rs` — `HandlerResult`, `JsonResult`, `ViewResult`, `Error`, `HttpError`, error_handler registration
+- `modo/src/app.rs` — middleware stacking order, `AppBuilder` API, service registration
+- `CLAUDE.md` — all conventions and gotchas listed there
+
+- [ ] **Step 2: Write conventions.md**
+
+Create the file with these sections:
+1. **Documentation** — link to `https://docs.rs/modo`
+2. **File Organization** — `mod.rs` rules, handlers/views in separate files
+3. **Error Handling** — `HandlerResult<T>`, `JsonResult<T>`, `ViewResult<T>`, `#[error_handler]`, API vs web error patterns
+4. **Core Patterns** — `modo::Json`, ULID session IDs, feature flag syntax
+5. **Middleware Stacking** — Global → Module → Handler order
+6. **Integration Patterns** — API vs web error handling (from cross-reference table)
+7. **Common Multi-Module Workflows** — composite task reference table (from spec)
+8. **Gotchas** — inventory linking, ExprTrait conflicts, HTMX 200-only, alphabetical re-exports
+
+Every pattern and type name must be verified against the source files read in step 1.
+
+- [ ] **Step 3: Verify all type names exist in source**
+
+Grep for each type/trait mentioned in the file to confirm it exists:
+```bash
+grep -r "HandlerResult\|JsonResult\|ViewResult\|HttpError" modo/src/
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/conventions.md
+git commit -m "docs: add conventions reference for modo-dev skill"
+```
+
+---
+
+## Chunk 3: Core Feature References
+
+### Task 4: Write handlers.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/handlers.md`
+- Read: `modo-macros/src/handler.rs`, `modo-macros/src/module.rs`, `modo-macros/src/main_macro.rs`, `modo/src/middleware/*.rs`, `modo/src/cors.rs`, `modo/src/middleware/security_headers.rs`, `modo/src/health.rs`, `modo/src/static_files.rs`, `modo/src/extractors/*.rs`, `modo/src/request_id.rs`, `examples/hello/`
+
+- [ ] **Step 1: Read handler and module macro source**
+
+Read the proc macro implementations to understand exact syntax, supported arguments, and generated code:
+- `modo-macros/src/handler.rs` — handler attribute syntax, METHOD + PATH args
+- `modo-macros/src/module.rs` — module attribute syntax, `prefix = "..."` named arg
+- `modo-macros/src/main_macro.rs` — main attribute, `static_assets` arg
+- `modo-macros/src/validate.rs` and `modo-macros/src/sanitize.rs` — derive macro behavior
+- `modo-macros/src/middleware.rs` — per-handler middleware macro (if applicable)
+
+- [ ] **Step 2: Read middleware and built-in features source**
+
+Read modo's middleware and feature modules:
+- `modo/src/middleware/rate_limit.rs` — `RateLimitConfig`, `RateLimitInfo`
+- `modo/src/middleware/security_headers.rs` — `SecurityHeadersConfig`
+- `modo/src/middleware/trailing_slash.rs` — trailing slash normalization
+- `modo/src/middleware/client_ip.rs` — `ClientIp` extractor
+- `modo/src/middleware/catch_panic.rs` — panic catching middleware
+- `modo/src/middleware/maintenance.rs` — maintenance mode
+- `modo/src/cors.rs` — `CorsConfig`
+- `modo/src/request_id.rs` — `RequestId` extractor
+- `modo/src/health.rs` — health check endpoint
+- `modo/src/static_files.rs` — static file serving
+- `modo/src/extractors/service.rs` — service extractor
+
+- [ ] **Step 3: Read hello example for handler patterns**
+
+Read `examples/hello/src/` for working handler examples.
+
+- [ ] **Step 4: Write handlers.md**
+
+Sections:
+1. **Documentation** — docs.rs links
+2. **Handler Registration** — `#[handler(GET, "/path")]` patterns with examples
+3. **Modules** — `#[module(prefix = "/api")]` grouping
+4. **Path Parameters** — partial extraction with `..`
+5. **Extractors** — Query, Json, Path, RequestId, ClientIp
+6. **Validation & Sanitization** — `#[derive(Validate)]`, `#[derive(Sanitize)]`
+7. **Middleware** — rate limiting, CORS, security headers, trailing slash, per-handler middleware
+8. **Static Files** — `static-fs` vs `static-embed`, `static_assets` in `#[main]`
+9. **Integration Patterns** — static files + templates (from cross-reference table)
+10. **Gotchas**
+
+- [ ] **Step 5: Verify all types/configs exist**
+
+```bash
+grep -r "RateLimitConfig\|SecurityHeadersConfig\|CorsConfig\|TrailingSlash\|ClientIp\|RateLimitInfo\|RequestId" modo/src/
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/handlers.md
+git commit -m "docs: add handlers reference for modo-dev skill"
+```
+
+---
+
+### Task 5: Write database.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/database.md`
+- Read: `modo-db/src/`, `modo-db-macros/src/`, `examples/todo-api/src/`
+
+- [ ] **Step 1: Read modo-db source in depth**
+
+Read all files in `modo-db/src/`:
+- Entity registration, `Db` extractor, `DbPool`
+- Migration runner, auto-migration
+- Pagination helpers (offset + cursor)
+- Group-scoped sync
+- Query helpers
+
+- [ ] **Step 2: Read entity macro source**
+
+Read `modo-db-macros/src/` to understand:
+- `#[entity(table = "...")]` — supported attributes, field types, generated code
+- `#[migration]` — SQL migration syntax
+
+- [ ] **Step 3: Read todo-api example**
+
+Read `examples/todo-api/src/` for real CRUD patterns with entities.
+
+- [ ] **Step 4: Write database.md**
+
+Sections:
+1. **Documentation** — docs.rs links
+2. **Entity Definition** — `#[entity]` macro, field types, attributes
+3. **Migrations** — auto-migration, `#[migration]` for versioned SQL
+4. **Db Extractor** — accessing the database in handlers
+5. **CRUD Patterns** — create, read, update, delete with code examples
+6. **Query Building** — SeaORM v2 query patterns
+7. **Pagination** — offset and cursor helpers
+8. **Group-Scoped Sync** — multiple databases
+9. **Integration Patterns** — multiple databases (from cross-reference table)
+10. **Gotchas** — SeaORM v2 only (not v1.x), `ExprTrait` conflicts
+
+- [ ] **Step 5: Verify word count and all types exist**
+
+```bash
+wc -w claude-plugin/skills/modo/references/database.md
+grep -r "Db\|DbPool\|entity\|migration\|CursorPagination\|OffsetPagination" modo-db/src/
+```
+
+Target: 2,000-4,000 words. Verify all referenced types/traits exist.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/database.md
+git commit -m "docs: add database reference for modo-dev skill"
+```
+
+---
+
+### Task 6: Write jobs.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/jobs.md`
+- Read: `modo-jobs/src/`, `modo-jobs-macros/src/`, `examples/jobs/src/`
+
+- [ ] **Step 1: Read modo-jobs source in depth**
+
+Read all files in `modo-jobs/src/`:
+- `JobQueue` extractor, `JobsBuilder`, `JobsHandle`
+- Job state machine, retry logic, exponential backoff
+- Cron scheduling (in-memory)
+- Graceful shutdown, drain timeout
+- Service injection into jobs
+
+- [ ] **Step 2: Read job macro source**
+
+Read `modo-jobs-macros/src/` for `#[job]` attribute syntax and supported arguments.
+
+- [ ] **Step 3: Read jobs example**
+
+Read `examples/jobs/src/` for working job definitions and cron patterns.
+
+- [ ] **Step 4: Write jobs.md**
+
+Sections:
+1. **Documentation** — docs.rs links
+2. **Job Definition** — `#[job]` macro with examples
+3. **Enqueuing Jobs** — `JobQueue` extractor
+4. **Cron Scheduling** — in-memory only, not persisted
+5. **Retry & Backoff** — configuration options
+6. **Graceful Shutdown** — drain timeout
+7. **Integration Patterns** — accessing services (Db, Mailer) in job handlers (from cross-reference table)
+8. **Gotchas** — cron not persisted, inventory registration in tests
+
+- [ ] **Step 5: Verify word count and all types exist**
+
+```bash
+wc -w claude-plugin/skills/modo/references/jobs.md
+grep -r "JobQueue\|JobsBuilder\|JobsHandle\|CronJob" modo-jobs/src/
+```
+
+Target: 2,000-4,000 words. Verify all referenced types/traits exist.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/jobs.md
+git commit -m "docs: add jobs reference for modo-dev skill"
+```
+
+---
+
+## Chunk 4: Supporting Feature References
+
+### Task 7: Write email.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/email.md`
+- Read: `modo-email/src/`
+
+- [ ] **Step 1: Read modo-email source in depth**
+
+Read all files in `modo-email/src/`:
+- `Mailer` service, `SendEmail`, `SendEmailPayload`
+- Template system (Markdown → HTML + plain text)
+- Transport implementations (SMTP via lettre, Resend via reqwest)
+- `EmailConfig`
+
+- [ ] **Step 2: Write email.md**
+
+Sections:
+1. **Documentation** — docs.rs link
+2. **Email Service Setup** — `Mailer` configuration, transport selection
+3. **Markdown Templates** — template structure, layouts, variables
+4. **Sending Email** — `SendEmailPayload` structure
+5. **Integration Patterns** — mailer registered on jobs builder (not app), enqueue `SendEmailPayload`, accessing Db from email job, template var syntax overlap with scaffold-time Jinja (from cross-reference table)
+6. **Gotchas** — mailer on jobs builder not app, raw blocks for var syntax overlap
+
+- [ ] **Step 3: Verify word count and all types exist**
+
+```bash
+wc -w claude-plugin/skills/modo/references/email.md
+grep -r "Mailer\|SendEmail\|SendEmailPayload\|EmailConfig" modo-email/src/
+```
+
+Target: 2,000-4,000 words. Verify all referenced types/traits exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/email.md
+git commit -m "docs: add email reference for modo-dev skill"
+```
+
+---
+
+### Task 8: Write auth-sessions.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/auth-sessions.md`
+- Read: `modo-auth/src/lib.rs`, `modo-auth/src/provider.rs`, `modo-auth/src/extractor.rs`, `modo-auth/src/password.rs`, `modo-auth/src/context_layer.rs`, `modo-auth/src/cache.rs`, `modo-session/src/lib.rs`, `modo-session/src/manager.rs`, `modo-session/src/store.rs`, `modo-session/src/config.rs`, `modo-session/src/middleware.rs`, `modo-session/src/cleanup.rs`, `modo-session/src/fingerprint.rs`, `modo-session/src/entity.rs`, `modo-session/src/types.rs`, `modo-session/src/device.rs`, `modo-session/src/meta.rs`, `examples/sse-chat/src/`
+
+- [ ] **Step 1: Read modo-auth source in depth**
+
+Read all files in `modo-auth/src/`:
+- `UserProvider` trait
+- `Auth<U>`, `OptionalAuth<U>` extractors
+- `PasswordHasher`, `PasswordConfig`, Argon2id
+- `UserContextLayer`
+
+- [ ] **Step 2: Read modo-session source in depth**
+
+Read all files in `modo-session/src/`:
+- `SessionManager` extractor, `SessionStore`, `SessionConfig`
+- `user_id_from_extensions`
+- Database-backed sessions, SHA-256 hashed tokens, ULID IDs
+- LRU eviction, sliding expiry
+- Cleanup job feature
+
+- [ ] **Step 3: Read sse-chat example for auth + session patterns**
+
+Read `examples/sse-chat/src/` for real auth flow examples.
+
+- [ ] **Step 4: Write auth-sessions.md**
+
+Sections:
+1. **Documentation** — docs.rs links for both crates
+2. **UserProvider Trait** — implementing for your entity
+3. **Authentication Extractors** — `Auth<U>`, `OptionalAuth<U>`
+4. **Password Hashing** — Argon2id, `PasswordHasher`, `PasswordConfig`
+5. **Session Management** — `SessionManager`, `SessionConfig`, ULID IDs
+6. **Session Security** — SHA-256 hashing, fingerprinting, LRU eviction
+7. **Integration Patterns** — auth user in templates (`UserContextLayer`), auth backed by entity (`UserProvider` querying `#[entity]`), session cleanup job (requires cleanup-job feature + modo-jobs) (from cross-reference table)
+8. **Gotchas** — `user_id_from_extensions` returns `Option<String>`, ULID not UUID
+
+- [ ] **Step 5: Verify word count and all types exist**
+
+```bash
+wc -w claude-plugin/skills/modo/references/auth-sessions.md
+grep -r "UserProvider\|Auth<\|OptionalAuth\|PasswordHasher\|SessionManager\|SessionConfig\|user_id_from_extensions" modo-auth/src/ modo-session/src/
+```
+
+Target: 2,000-4,000 words. Verify all referenced types/traits exist.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/auth-sessions.md
+git commit -m "docs: add auth-sessions reference for modo-dev skill"
+```
+
+---
+
+### Task 9: Write templates-htmx.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/templates-htmx.md`
+- Read: `modo/src/templates/`, `modo/src/sse/`, `modo/src/csrf/`, `modo/src/i18n/`, `modo-macros/src/view.rs`, `modo-macros/src/template_function.rs`, `modo-macros/src/template_filter.rs`, `examples/templates/`, `examples/sse-chat/`, `examples/sse-dashboard/`
+
+- [ ] **Step 1: Read template engine source**
+
+Read `modo/src/templates/` — template engine setup, auto-registration, context injection, HTML helpers.
+
+- [ ] **Step 2: Read SSE source**
+
+Read `modo/src/sse/` — `SseBroadcastManager`, `SseEvent`, `Sse` extractor, keep-alive.
+
+- [ ] **Step 3: Read CSRF source**
+
+Read `modo/src/csrf/` — double-submit cookie, `CsrfToken` extractor.
+
+- [ ] **Step 4: Read i18n source**
+
+Read `modo/src/i18n/` — `I18n` extractor, `t!()` macro usage, per-request language resolution.
+
+- [ ] **Step 5: Read view/template macros**
+
+Read `modo-macros/src/view.rs`, `modo-macros/src/template_function.rs`, `modo-macros/src/template_filter.rs` for exact syntax.
+
+- [ ] **Step 6: Read template and SSE examples**
+
+Read `examples/templates/src/`, `examples/sse-chat/src/`, `examples/sse-dashboard/src/`.
+
+- [ ] **Step 7: Write templates-htmx.md**
+
+Sections:
+1. **Documentation** — docs.rs link (modo with features)
+2. **Template Engine** — MiniJinja, auto-registration, `#[view]` macro
+3. **Template Functions & Filters** — `#[template_function]`, `#[template_filter]`
+4. **HTMX Rendering** — HX-Request detection, always 200, non-200 skips render
+5. **Server-Sent Events** — `SseBroadcastManager`, `SseEvent`, keyed channels
+6. **CSRF Protection** — double-submit cookie, `CsrfToken` extractor
+7. **Internationalization** — `I18n` extractor, `t!()` in Rust vs in templates
+8. **Integration Patterns** — i18n in templates, CSRF in HTMX forms, HTMX + non-200 status (from cross-reference table)
+9. **Gotchas** — auto-layer (no manual .layer()), HTMX 200-only rendering
+
+- [ ] **Step 8: Verify word count and all types exist**
+
+```bash
+wc -w claude-plugin/skills/modo/references/templates-htmx.md
+grep -r "SseBroadcastManager\|SseEvent\|CsrfToken\|I18n\|TemplateEngine" modo/src/
+```
+
+Target: 2,000-4,000 words. Verify all referenced types/traits exist.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/templates-htmx.md
+git commit -m "docs: add templates-htmx reference for modo-dev skill"
+```
+
+---
+
+## Chunk 5: Remaining Feature References
+
+### Task 10: Write upload.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/upload.md`
+- Read: `modo-upload/src/`, `modo-upload-macros/src/`, `examples/upload/src/`
+
+- [ ] **Step 1: Read modo-upload and macro source**
+
+Read all files in `modo-upload/src/` and `modo-upload-macros/src/`:
+- `FromMultipart` derive, `MultipartForm<T>` extractor
+- Per-field validation (size, MIME)
+- `FileStorage` trait, local + S3 (OpenDAL)
+- `UploadedFile`, `StorageBackend`
+
+- [ ] **Step 2: Read upload example**
+
+Read `examples/upload/src/`.
+
+- [ ] **Step 3: Write upload.md**
+
+Sections:
+1. **Documentation** — docs.rs links
+2. **Multipart Parsing** — `#[derive(FromMultipart)]`, `MultipartForm<T>`
+3. **Field Validation** — size limits, MIME type filtering
+4. **Storage Backends** — local filesystem, S3 via OpenDAL
+5. **Integration Patterns** — upload with auth (middleware order) (from cross-reference table)
+6. **Gotchas**
+
+- [ ] **Step 4: Verify word count and all types exist**
+
+```bash
+wc -w claude-plugin/skills/modo/references/upload.md
+grep -r "FromMultipart\|MultipartForm\|FileStorage\|UploadedFile\|StorageBackend" modo-upload/src/ modo-upload-macros/src/
+```
+
+Target: 2,000-4,000 words. Verify all referenced types/traits exist.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/upload.md
+git commit -m "docs: add upload reference for modo-dev skill"
+```
+
+---
+
+### Task 11: Write tenant.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/tenant.md`
+- Read: `modo-tenant/src/lib.rs`, `modo-tenant/src/resolver.rs`, `modo-tenant/src/extractor.rs`, `modo-tenant/src/context_layer.rs`, `modo-tenant/src/cache.rs`, `modo-tenant/src/resolvers/mod.rs`, `modo-tenant/src/resolvers/subdomain.rs`, `modo-tenant/src/resolvers/header.rs`, `modo-tenant/src/resolvers/path_prefix.rs`
+
+- [ ] **Step 1: Read modo-tenant source in depth**
+
+Read all files in `modo-tenant/src/`:
+- `TenantResolver` trait, resolution strategies (subdomain, header, path)
+- `Tenant`, `OptionalTenant` extractors
+- Type-erased service pattern (`TenantResolverDyn`, `Arc<dyn ...>`)
+- `TenantContextLayer`
+
+- [ ] **Step 2: Write tenant.md**
+
+Sections:
+1. **Documentation** — docs.rs link
+2. **Tenant Resolution** — `TenantResolver` trait, strategies
+3. **Extractors** — `Tenant`, `OptionalTenant`
+4. **Type-Erased Service** — `TenantResolverDyn` pattern
+5. **Integration Patterns** — tenant in templates (`TenantContextLayer`), tenant-scoped queries (manual WHERE) (from cross-reference table)
+6. **Gotchas**
+
+- [ ] **Step 3: Verify word count and all types exist**
+
+```bash
+wc -w claude-plugin/skills/modo/references/tenant.md
+grep -r "TenantResolver\|TenantResolverDyn\|Tenant\|OptionalTenant\|TenantContextLayer" modo-tenant/src/
+```
+
+Target: 2,000-4,000 words. Verify all referenced types/traits exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/tenant.md
+git commit -m "docs: add tenant reference for modo-dev skill"
+```
+
+---
+
+### Task 12: Write config.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/config.md`
+- Read: `modo/src/config.rs`, `modo/src/app.rs` (config wiring)
+
+- [ ] **Step 1: Read config source**
+
+Read `modo/src/config.rs` to understand:
+- YAML loading from `config/{MODO_ENV}.yaml`
+- Environment variable interpolation (`${VAR}`, `${VAR:-default}`)
+- Config struct sections (server, cookies, database, jobs, email, upload, tenant, auth, session)
+- Feature-gated fields
+
+Also read `modo/src/app.rs` for how config feeds into `AppBuilder`.
+
+- [ ] **Step 2: Write config.md**
+
+Sections:
+1. **Documentation** — docs.rs link
+2. **Config Loading** — YAML files, MODO_ENV, environment-based
+3. **Environment Interpolation** — `${VAR}` and `${VAR:-default}` syntax
+4. **Config Sections** — all config struct fields with descriptions
+5. **Feature-Gated Fields** — `#[cfg(feature = "...")]` pattern
+6. **Integration Patterns** — how config sections wire into AppBuilder for DB, jobs, email, session (from cross-reference table)
+7. **Gotchas** — feature flag syntax, Default and from_env() must match
+
+- [ ] **Step 3: Verify word count and all types exist**
+
+```bash
+wc -w claude-plugin/skills/modo/references/config.md
+grep -r "AppConfig\|ServerConfig\|CookieConfig\|MODO_ENV" modo/src/config.rs modo/src/app.rs
+```
+
+Target: 2,000-4,000 words. Verify all referenced types/config fields exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/config.md
+git commit -m "docs: add config reference for modo-dev skill"
+```
+
+---
+
+### Task 13: Write testing.md
+
+**Files:**
+- Create: `claude-plugin/skills/modo/references/testing.md`
+- Read: Test files across crates: `modo/tests/`, `modo-db/tests/`, `modo-session/tests/`, `modo-auth/tests/`, `modo-jobs/tests/`
+
+- [ ] **Step 1: Read test files across crates**
+
+Search for and read test files to extract testing patterns:
+- `modo/tests/` — middleware testing with `.oneshot()`, cookie testing
+- `modo-session/tests/` — session testing patterns
+- `modo-auth/tests/` — auth testing patterns
+- Any other crate `tests/` directories
+
+Look for patterns: Tower `.oneshot()`, custom `AppState`, `Extension<T>`, inventory force-linking.
+
+- [ ] **Step 2: Write testing.md**
+
+Sections:
+1. **Documentation** — docs.rs links for all crates
+2. **Tower Middleware Testing** — `Router::new().route(...).layer(mw).oneshot(request)` pattern, no AppState needed
+3. **Cookie Attribute Testing** — custom `CookieConfig` in `AppState`, assert `Set-Cookie` header
+4. **Inventory Force-Linking** — `use crate::entity::foo as _;` pattern for tests
+5. **Feature-Gated Testing** — `cargo test -p crate --features feat`
+6. **Test Commands** — `just test` (no --all-features), `just check` (fmt + lint + test)
+7. **Gotchas** — `just test` vs `just lint` feature flag difference
+
+- [ ] **Step 3: Verify word count**
+
+```bash
+wc -w claude-plugin/skills/modo/references/testing.md
+```
+
+Target: 2,000-4,000 words.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add claude-plugin/skills/modo/references/testing.md
+git commit -m "docs: add testing reference for modo-dev skill"
+```
+
+---
+
+## Chunk 6: Final Review
+
+### Task 14: Final review and integration commit
+
+- [ ] **Step 1: Verify all files exist**
+
+```bash
+find claude-plugin/ -type f | sort
+```
+
+Expected: 14 files (plugin.json, SKILL.md, 11 reference files + marketplace.json at root).
+
+- [ ] **Step 2: Verify SKILL.md topic index matches actual reference files**
+
+Check that every file referenced in the topic index exists and every reference file is referenced in the topic index.
+
+- [ ] **Step 3: Verify cross-references are present in each file**
+
+For each integration pattern in the spec's cross-reference ownership table, confirm the assigned reference file has an "Integration Patterns" section covering it.
+
+- [ ] **Step 4: Verify docs.rs links are present**
+
+Check each reference file starts with a Documentation section containing the correct docs.rs links per the spec mapping.
+
+- [ ] **Step 5: Spot-check code examples against source**
+
+For 3-5 reference files, pick a code example and grep the source to confirm the API exists as documented.
+
+- [ ] **Step 6: Final commit if any fixes were needed**
+
+```bash
+git add -A claude-plugin/
+git commit -m "docs: finalize modo-dev skill plugin reference files"
+```

--- a/docs/superpowers/specs/2026-03-13-modo-dev-skill-design.md
+++ b/docs/superpowers/specs/2026-03-13-modo-dev-skill-design.md
@@ -54,21 +54,21 @@ modo/                                   # existing repo root
 
 ```json
 {
-  "name": "modo",
-  "owner": {
-    "name": "Dmytro Momot"
-  },
-  "plugins": [
-    {
-      "name": "modo-dev",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/dmitrymomot/modo.git",
-        "path": "claude-plugin"
-      },
-      "description": "Skills for building apps with the modo Rust web framework"
-    }
-  ]
+    "name": "modo",
+    "owner": {
+        "name": "Dmytro Momot"
+    },
+    "plugins": [
+        {
+            "name": "modo-dev",
+            "source": {
+                "source": "git-subdir",
+                "url": "https://github.com/dmitrymomot/modo.git",
+                "path": "claude-plugin"
+            },
+            "description": "Skills for building apps with the modo Rust web framework"
+        }
+    ]
 }
 ```
 
@@ -76,12 +76,12 @@ modo/                                   # existing repo root
 
 ```json
 {
-  "name": "modo-dev",
-  "description": "Skills for building applications with the modo Rust web framework",
-  "version": "0.1.0",
-  "author": { "name": "Dmytro Momot" },
-  "repository": "https://github.com/dmitrymomot/modo",
-  "license": "Apache-2.0"
+    "name": "modo-dev",
+    "description": "Skills for building applications with the modo Rust web framework",
+    "version": "0.1.0",
+    "author": { "name": "Dmytro Momot" },
+    "repository": "https://github.com/dmitrymomot/modo",
+    "license": "Apache-2.0"
 }
 ```
 
@@ -93,14 +93,14 @@ modo/                                   # existing repo root
 
 ```yaml
 ---
-name: modo
+name: modo-dev
 description: >
-  This skill should be used when the user is building an application with the
-  modo Rust web framework, asks about modo handlers, modules, middleware,
-  database entities, migrations, jobs, email, sessions, authentication,
-  templates, HTMX, SSE, uploads, multi-tenancy, configuration, or testing
-  patterns. Also use when the user references modo macros like #[handler],
-  #[module], #[main], #[entity], #[job], #[view], or FromMultipart.
+    This skill should be used when the user is building an application with the
+    modo Rust web framework, asks about modo handlers, modules, middleware,
+    database entities, migrations, jobs, email, sessions, authentication,
+    templates, HTMX, SSE, uploads, multi-tenancy, configuration, or testing
+    patterns. Also use when the user references modo macros like #[handler],
+    #[module], #[main], #[entity], #[job], #[view], or FromMultipart.
 ---
 ```
 
@@ -121,40 +121,40 @@ Project scaffolded by `modo-cli` with all needed modules enabled. This skill foc
 
 Compact table:
 
-| Macro | Crate | Purpose |
-|-------|-------|---------|
-| `#[modo::handler(METHOD, PATH)]` | modo-macros | Route registration |
-| `#[modo::module(prefix = "/path")]` | modo-macros | Route prefix grouping |
-| `#[modo::main]` / `#[modo::main(static_assets = "path/")]` | modo-macros | App bootstrap (optional embedded static assets) |
-| `#[modo::error_handler]` | modo-macros | Custom error handling |
-| `#[modo::view]` | modo-macros | Template rendering |
-| `#[modo::template_function]` | modo-macros | Custom template function |
-| `#[modo::template_filter]` | modo-macros | Custom template filter |
-| `modo::t!(i18n, "key")` | modo-macros | i18n translation (function-like macro) |
-| `#[derive(Sanitize)]` | modo-macros | Input sanitization |
-| `#[derive(Validate)]` | modo-macros | Input validation |
-| `#[modo_db::entity]` | modo-db-macros | Entity + migration generation |
-| `#[modo_db::migration]` | modo-db-macros | Versioned SQL migration |
-| `#[modo_jobs::job]` | modo-jobs-macros | Job definition |
-| `#[derive(FromMultipart)]` | modo-upload-macros | Multipart form parsing |
+| Macro                                                      | Crate              | Purpose                                         |
+| ---------------------------------------------------------- | ------------------ | ----------------------------------------------- |
+| `#[modo::handler(METHOD, PATH)]`                           | modo-macros        | Route registration                              |
+| `#[modo::module(prefix = "/path")]`                        | modo-macros        | Route prefix grouping                           |
+| `#[modo::main]` / `#[modo::main(static_assets = "path/")]` | modo-macros        | App bootstrap (optional embedded static assets) |
+| `#[modo::error_handler]`                                   | modo-macros        | Custom error handling                           |
+| `#[modo::view]`                                            | modo-macros        | Template rendering                              |
+| `#[modo::template_function]`                               | modo-macros        | Custom template function                        |
+| `#[modo::template_filter]`                                 | modo-macros        | Custom template filter                          |
+| `modo::t!(i18n, "key")`                                    | modo-macros        | i18n translation (function-like macro)          |
+| `#[derive(Sanitize)]`                                      | modo-macros        | Input sanitization                              |
+| `#[derive(Validate)]`                                      | modo-macros        | Input validation                                |
+| `#[modo_db::entity]`                                       | modo-db-macros     | Entity + migration generation                   |
+| `#[modo_db::migration]`                                    | modo-db-macros     | Versioned SQL migration                         |
+| `#[modo_jobs::job]`                                        | modo-jobs-macros   | Job definition                                  |
+| `#[derive(FromMultipart)]`                                 | modo-upload-macros | Multipart form parsing                          |
 
 #### 4. Topic Index
 
 Maps tasks to reference files:
 
-| Task | Read |
-|------|------|
-| File organization, error patterns, custom error handlers, gotchas | `references/conventions.md` |
-| Handlers, routing, modules, middleware, rate limiting, CORS, security headers, static files | `references/handlers.md` |
-| Entities, migrations, queries, pagination | `references/database.md` |
-| Background jobs, cron scheduling | `references/jobs.md` |
-| Email templates, transports | `references/email.md` |
-| Authentication, sessions, password hashing | `references/auth-sessions.md` |
-| Templates, HTMX, SSE, CSRF, i18n | `references/templates-htmx.md` |
-| File uploads, multipart, storage backends | `references/upload.md` |
-| Multi-tenancy resolver patterns | `references/tenant.md` |
-| YAML config, env interpolation, feature flags | `references/config.md` |
-| Testing middleware, cookies, inventory | `references/testing.md` |
+| Task                                                                                        | Read                           |
+| ------------------------------------------------------------------------------------------- | ------------------------------ |
+| File organization, error patterns, custom error handlers, gotchas                           | `references/conventions.md`    |
+| Handlers, routing, modules, middleware, rate limiting, CORS, security headers, static files | `references/handlers.md`       |
+| Entities, migrations, queries, pagination                                                   | `references/database.md`       |
+| Background jobs, cron scheduling                                                            | `references/jobs.md`           |
+| Email templates, transports                                                                 | `references/email.md`          |
+| Authentication, sessions, password hashing                                                  | `references/auth-sessions.md`  |
+| Templates, HTMX, SSE, CSRF, i18n                                                            | `references/templates-htmx.md` |
+| File uploads, multipart, storage backends                                                   | `references/upload.md`         |
+| Multi-tenancy resolver patterns                                                             | `references/tenant.md`         |
+| YAML config, env interpolation, feature flags                                               | `references/config.md`         |
+| Testing middleware, cookies, inventory                                                      | `references/testing.md`        |
 
 ## Reference Files
 
@@ -164,23 +164,24 @@ Each reference file (2,000-4,000 words) follows this structure:
 2. **Built-in first** — leads with modo's built-in way to do things
 3. **Patterns + inline code examples** — extracted from actual crate source, examples, and tests
 4. **Common recipes** — hand-written walkthroughs connecting patterns together
-5. **Gotchas** — topic-specific pitfalls
+5. **Integration patterns** — cross-module interactions relevant to this topic (see Cross-References section below)
+6. **Gotchas** — topic-specific pitfalls
 
 ### Reference file → docs.rs mapping
 
-| File | docs.rs links |
-|------|---------------|
-| `conventions.md` | https://docs.rs/modo |
-| `handlers.md` | https://docs.rs/modo, https://docs.rs/modo-macros |
-| `database.md` | https://docs.rs/modo-db, https://docs.rs/modo-db-macros |
-| `jobs.md` | https://docs.rs/modo-jobs, https://docs.rs/modo-jobs-macros |
-| `email.md` | https://docs.rs/modo-email |
-| `auth-sessions.md` | https://docs.rs/modo-auth, https://docs.rs/modo-session |
-| `templates-htmx.md` | https://docs.rs/modo (features: templates, sse, csrf, i18n) |
-| `upload.md` | https://docs.rs/modo-upload, https://docs.rs/modo-upload-macros |
-| `tenant.md` | https://docs.rs/modo-tenant |
-| `config.md` | https://docs.rs/modo |
-| `testing.md` | All relevant crates |
+| File                | docs.rs links                                                   |
+| ------------------- | --------------------------------------------------------------- |
+| `conventions.md`    | https://docs.rs/modo                                            |
+| `handlers.md`       | https://docs.rs/modo, https://docs.rs/modo-macros               |
+| `database.md`       | https://docs.rs/modo-db, https://docs.rs/modo-db-macros         |
+| `jobs.md`           | https://docs.rs/modo-jobs, https://docs.rs/modo-jobs-macros     |
+| `email.md`          | https://docs.rs/modo-email                                      |
+| `auth-sessions.md`  | https://docs.rs/modo-auth, https://docs.rs/modo-session         |
+| `templates-htmx.md` | https://docs.rs/modo (features: templates, sse, csrf, i18n)     |
+| `upload.md`         | https://docs.rs/modo-upload, https://docs.rs/modo-upload-macros |
+| `tenant.md`         | https://docs.rs/modo-tenant                                     |
+| `config.md`         | https://docs.rs/modo                                            |
+| `testing.md`        | All relevant crates                                             |
 
 ### Reference file content summaries
 
@@ -206,6 +207,44 @@ Each reference file (2,000-4,000 words) follows this structure:
 
 **testing.md** — Tower middleware testing with `Router::new().route(...).layer(mw).oneshot(request)` (no AppState needed, handler reads `Extension<T>`), cookie attribute testing (create `AppState` with custom `CookieConfig`, fire request, assert `Set-Cookie` header), inventory force-linking with `use crate::entity::foo as _;`, feature-gated testing with `cargo test -p crate --features feat`.
 
+## Cross-References & Integration Patterns
+
+Many modo features interact with each other. Each reference file includes an **Integration Patterns** section covering the cross-module interactions relevant to its topic. This table defines which interactions go where.
+
+### Cross-reference ownership
+
+| Interaction | Documented in | What to cover |
+|---|---|---|
+| i18n in templates | `templates-htmx.md` | `t!()` in MiniJinja templates vs in Rust handlers — different syntax |
+| Auth user in templates | `auth-sessions.md` | `UserContextLayer` middleware must be in stack for `{{ user }}` to work in templates |
+| Tenant in templates | `tenant.md` | `TenantContextLayer` injects tenant into template context |
+| CSRF in HTMX forms | `templates-htmx.md` | CSRF token in forms + HTMX header interaction with double-submit cookie |
+| Email via jobs | `email.md` | Mailer on jobs builder not app, enqueue `SendEmailPayload`, accessing `Db` from job |
+| Auth backed by entity | `auth-sessions.md` | `UserProvider` implementation that queries a `#[entity]` — full example |
+| Session cleanup job | `auth-sessions.md` | Requires both `modo-session` `cleanup-job` feature AND `modo-jobs` wired up |
+| Tenant-scoped queries | `tenant.md` | Extract `Tenant` + manually filter `Db` queries — no built-in magic, manual `WHERE` |
+| Upload with auth | `upload.md` | Middleware order matters — auth middleware before multipart parsing |
+| Config wiring modules | `config.md` | How config sections feed into `AppBuilder` — DB, jobs, email, session all read from config |
+| Services in jobs | `jobs.md` | Accessing `Db`, `Mailer`, or other services inside `#[job]` handlers |
+| API vs web errors | `conventions.md` | `HandlerResult` for JSON APIs, `ViewResult` for templates, `#[error_handler]` customization |
+| Static files + templates | `handlers.md` | `static-fs` in dev vs `static-embed` in prod, referencing asset paths in templates |
+| Multiple databases | `database.md` | Group-scoped sync — separate entities into different DBs |
+| HTMX + non-200 status | `templates-htmx.md` | Non-200 skips render — strategies for showing errors in HTMX partial responses |
+
+### Common multi-module workflows
+
+`conventions.md` includes a quick-reference table for composite tasks:
+
+| Workflow | Reference files to read (in order) |
+|---|---|
+| Authenticated CRUD API | `conventions.md` → `database.md` → `handlers.md` → `auth-sessions.md` |
+| Web form with validation | `conventions.md` → `handlers.md` → `templates-htmx.md` |
+| Background email on user action | `handlers.md` → `jobs.md` → `email.md` |
+| File upload with auth | `auth-sessions.md` → `upload.md` → `handlers.md` |
+| Multi-tenant web app | `tenant.md` → `database.md` → `templates-htmx.md` |
+| HTMX live dashboard | `templates-htmx.md` → `auth-sessions.md` |
+| Full-stack feature (entity → API → job → email) | `conventions.md` → `database.md` → `handlers.md` → `jobs.md` → `email.md` |
+
 ## Scope Boundaries
 
 The skill helps with **building features on top of a scaffolded modo project**. It does NOT cover:
@@ -221,15 +260,15 @@ Reference files cover the **80% use-case patterns**, not exhaustive API surface.
 
 ## Example → Reference Mapping
 
-| Example | Primary reference |
-|---------|-------------------|
-| `hello` | `handlers.md` |
-| `todo-api` | `handlers.md`, `database.md` |
-| `jobs` | `jobs.md` |
-| `upload` | `upload.md` |
-| `templates` | `templates-htmx.md` |
-| `sse-chat` | `templates-htmx.md`, `auth-sessions.md` |
-| `sse-dashboard` | `templates-htmx.md` |
+| Example         | Primary reference                       |
+| --------------- | --------------------------------------- |
+| `hello`         | `handlers.md`                           |
+| `todo-api`      | `handlers.md`, `database.md`            |
+| `jobs`          | `jobs.md`                               |
+| `upload`        | `upload.md`                             |
+| `templates`     | `templates-htmx.md`                     |
+| `sse-chat`      | `templates-htmx.md`, `auth-sessions.md` |
+| `sse-dashboard` | `templates-htmx.md`                     |
 
 ## Implementation Approach
 
@@ -249,14 +288,14 @@ No guessing or hallucinating APIs. Every code example in a reference file must b
 2. Write `SKILL.md`
 3. Write `references/conventions.md` (foundational — other refs depend on it)
 4. Write remaining reference files one at a time, reading each crate in depth:
-   - `handlers.md` (modo + modo-macros)
-   - `database.md` (modo-db + modo-db-macros)
-   - `jobs.md` (modo-jobs + modo-jobs-macros)
-   - `email.md` (modo-email)
-   - `auth-sessions.md` (modo-auth + modo-session)
-   - `templates-htmx.md` (modo features: templates, sse, csrf, i18n)
-   - `upload.md` (modo-upload + modo-upload-macros)
-   - `tenant.md` (modo-tenant)
-   - `config.md` (modo config module)
-   - `testing.md` (patterns across crates)
+    - `handlers.md` (modo + modo-macros)
+    - `database.md` (modo-db + modo-db-macros)
+    - `jobs.md` (modo-jobs + modo-jobs-macros)
+    - `email.md` (modo-email)
+    - `auth-sessions.md` (modo-auth + modo-session)
+    - `templates-htmx.md` (modo features: templates, sse, csrf, i18n)
+    - `upload.md` (modo-upload + modo-upload-macros)
+    - `tenant.md` (modo-tenant)
+    - `config.md` (modo config module)
+    - `testing.md` (patterns across crates)
 5. Review all files for accuracy

--- a/docs/superpowers/specs/2026-03-13-modo-dev-skill-design.md
+++ b/docs/superpowers/specs/2026-03-13-modo-dev-skill-design.md
@@ -1,0 +1,262 @@
+# modo-dev Skill Plugin — Design Spec
+
+## Overview
+
+A Claude Code plugin that provides a skill for building applications with the modo Rust web framework. The skill guides Claude through requirement gathering, directs it to the right reference documentation, and enforces modo conventions and built-in functionality usage.
+
+**Target audience:** Developers building apps with modo (not framework development).
+**Assumed starting point:** Project scaffolded by `modo-cli` with required modules enabled.
+
+## Plugin Location & Installation
+
+The plugin lives in the modo repo at `claude-plugin/`. A marketplace entry at the repo root enables installation.
+
+### Installation flow
+
+```
+/plugin marketplace add dmitrymomot/modo
+/plugin install modo-dev@modo
+```
+
+### Repository structure
+
+```
+modo/                                   # existing repo root
+├── .claude-plugin/
+│   └── marketplace.json                # marketplace catalog
+├── claude-plugin/                      # plugin root
+│   ├── .claude-plugin/
+│   │   └── plugin.json
+│   └── skills/
+│       └── modo/
+│           ├── SKILL.md
+│           └── references/
+│               ├── conventions.md
+│               ├── handlers.md
+│               ├── database.md
+│               ├── jobs.md
+│               ├── email.md
+│               ├── auth-sessions.md
+│               ├── templates-htmx.md
+│               ├── upload.md
+│               ├── tenant.md
+│               ├── config.md
+│               └── testing.md
+├── Cargo.toml
+├── modo/
+├── modo-macros/
+└── ...
+```
+
+## Plugin Manifest
+
+### `.claude-plugin/marketplace.json` (repo root)
+
+```json
+{
+  "name": "modo",
+  "owner": {
+    "name": "Dmytro Momot"
+  },
+  "plugins": [
+    {
+      "name": "modo-dev",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/dmitrymomot/modo.git",
+        "path": "claude-plugin"
+      },
+      "description": "Skills for building apps with the modo Rust web framework"
+    }
+  ]
+}
+```
+
+### `claude-plugin/.claude-plugin/plugin.json`
+
+```json
+{
+  "name": "modo-dev",
+  "description": "Skills for building applications with the modo Rust web framework",
+  "version": "0.1.0",
+  "author": { "name": "Dmytro Momot" },
+  "repository": "https://github.com/dmitrymomot/modo",
+  "license": "Apache-2.0"
+}
+```
+
+## Skill Design
+
+### SKILL.md (~800-1,000 words)
+
+**Frontmatter:**
+
+```yaml
+---
+name: modo
+description: >
+  This skill should be used when the user is building an application with the
+  modo Rust web framework, asks about modo handlers, modules, middleware,
+  database entities, migrations, jobs, email, sessions, authentication,
+  templates, HTMX, SSE, uploads, multi-tenancy, configuration, or testing
+  patterns. Also use when the user references modo macros like #[handler],
+  #[module], #[main], #[entity], #[job], #[view], or FromMultipart.
+---
+```
+
+**Body structure (4 sections):**
+
+#### 1. Hard Rules
+
+Two non-negotiable rules at the top:
+
+- **Requirement-gathering gate:** Before writing any code, use AskUserQuestion to clarify what the user wants to build (endpoint, entity, job, auth flow, etc.), understand specifics (field types, relations, validation, modules involved, error handling), then describe the approach and wait for approval. Do not skip even for simple tasks.
+- **Use built-in functionality first:** Always prefer modo's built-in macros, extractors, middleware, config, and error types over manual implementations or external crates. Use `#[entity]` not manual SeaORM models. Use `HandlerResult` not custom error types. Use `modo::Json` not `axum::Json`. Use built-in validation/sanitization derives. Only reach for manual approaches when no built-in exists.
+
+#### 2. Assumed Starting Point
+
+Project scaffolded by `modo-cli` with all needed modules enabled. This skill focuses on building features on top of that structure.
+
+#### 3. Macro Cheat Sheet
+
+Compact table:
+
+| Macro | Crate | Purpose |
+|-------|-------|---------|
+| `#[modo::handler(METHOD, PATH)]` | modo-macros | Route registration |
+| `#[modo::module(prefix = "/path")]` | modo-macros | Route prefix grouping |
+| `#[modo::main]` / `#[modo::main(static_assets = "path/")]` | modo-macros | App bootstrap (optional embedded static assets) |
+| `#[modo::error_handler]` | modo-macros | Custom error handling |
+| `#[modo::view]` | modo-macros | Template rendering |
+| `#[modo::template_function]` | modo-macros | Custom template function |
+| `#[modo::template_filter]` | modo-macros | Custom template filter |
+| `modo::t!(i18n, "key")` | modo-macros | i18n translation (function-like macro) |
+| `#[derive(Sanitize)]` | modo-macros | Input sanitization |
+| `#[derive(Validate)]` | modo-macros | Input validation |
+| `#[modo_db::entity]` | modo-db-macros | Entity + migration generation |
+| `#[modo_db::migration]` | modo-db-macros | Versioned SQL migration |
+| `#[modo_jobs::job]` | modo-jobs-macros | Job definition |
+| `#[derive(FromMultipart)]` | modo-upload-macros | Multipart form parsing |
+
+#### 4. Topic Index
+
+Maps tasks to reference files:
+
+| Task | Read |
+|------|------|
+| File organization, error patterns, custom error handlers, gotchas | `references/conventions.md` |
+| Handlers, routing, modules, middleware, rate limiting, CORS, security headers, static files | `references/handlers.md` |
+| Entities, migrations, queries, pagination | `references/database.md` |
+| Background jobs, cron scheduling | `references/jobs.md` |
+| Email templates, transports | `references/email.md` |
+| Authentication, sessions, password hashing | `references/auth-sessions.md` |
+| Templates, HTMX, SSE, CSRF, i18n | `references/templates-htmx.md` |
+| File uploads, multipart, storage backends | `references/upload.md` |
+| Multi-tenancy resolver patterns | `references/tenant.md` |
+| YAML config, env interpolation, feature flags | `references/config.md` |
+| Testing middleware, cookies, inventory | `references/testing.md` |
+
+## Reference Files
+
+Each reference file (2,000-4,000 words) follows this structure:
+
+1. **Documentation header** — docs.rs links for relevant crates
+2. **Built-in first** — leads with modo's built-in way to do things
+3. **Patterns + inline code examples** — extracted from actual crate source, examples, and tests
+4. **Common recipes** — hand-written walkthroughs connecting patterns together
+5. **Gotchas** — topic-specific pitfalls
+
+### Reference file → docs.rs mapping
+
+| File | docs.rs links |
+|------|---------------|
+| `conventions.md` | https://docs.rs/modo |
+| `handlers.md` | https://docs.rs/modo, https://docs.rs/modo-macros |
+| `database.md` | https://docs.rs/modo-db, https://docs.rs/modo-db-macros |
+| `jobs.md` | https://docs.rs/modo-jobs, https://docs.rs/modo-jobs-macros |
+| `email.md` | https://docs.rs/modo-email |
+| `auth-sessions.md` | https://docs.rs/modo-auth, https://docs.rs/modo-session |
+| `templates-htmx.md` | https://docs.rs/modo (features: templates, sse, csrf, i18n) |
+| `upload.md` | https://docs.rs/modo-upload, https://docs.rs/modo-upload-macros |
+| `tenant.md` | https://docs.rs/modo-tenant |
+| `config.md` | https://docs.rs/modo |
+| `testing.md` | All relevant crates |
+
+### Reference file content summaries
+
+**conventions.md** — File organization rules (`mod.rs` only for imports/re-exports, handlers and views in separate files), middleware stacking order (Global → Module → Handler), error handling patterns (`HandlerResult<T>`, `JsonResult<T>`, `#[error_handler]` for custom error handling), `modo::Json` not `axum::Json`, ULID session IDs (no UUID), feature flag syntax (`dep:name`), gotchas (inventory linking in tests, `ExprTrait` conflicts with `Ord::max`/`Ord::min`, HTMX 200-only rendering, re-exports must be alphabetically sorted).
+
+**handlers.md** — `#[handler(GET, "/path")]` and `#[handler(POST, "/path")]` patterns, `#[module(prefix = "/path")]` for grouping, path params with partial extraction via `..`, extractors (Query, Json, Path), `#[derive(Validate)]` and `#[derive(Sanitize)]` for input processing, per-handler middleware, `HandlerResult<T>` and `JsonResult<T>` return types, `modo::Json` wrapper, built-in middleware (`RateLimitConfig`, `SecurityHeadersConfig`, `CorsConfig`, `TrailingSlash`, `ClientIp`, `RateLimitInfo`), static file serving (`static-fs` for dev, `static-embed` for prod), health check endpoints.
+
+**database.md** — `#[entity(table = "name")]` macro for model + migration generation, field types and attributes, `Db` extractor, CRUD patterns, query building, offset and cursor pagination helpers, `#[migration]` for versioned SQL, group-scoped database sync, SeaORM v2 RC specifics.
+
+**jobs.md** — `#[job(queue = "name")]` macro, `JobQueue` extractor for enqueuing, cron scheduling (in-memory only, not persisted), retry with exponential backoff, graceful shutdown with drain timeout, compile-time registration via `inventory`.
+
+**email.md** — `Mailer` service, Markdown templates with HTML rendering + plain-text fallback, SMTP (lettre) and Resend transports, template filesystem provider with layouts, integration pattern: mailer registered on jobs builder (`.service(email)`), app enqueues `SendEmailPayload`, job worker sends. Template var syntax overlap with scaffold-time Jinja vars — use raw blocks when both appear.
+
+**auth-sessions.md** — `UserProvider` trait for pluggable user repos, `Auth<U>` and `OptionalAuth<U>` extractors, Argon2id password hashing with `PasswordHasher`/`PasswordConfig`, `SessionManager` extractor, `SessionStore`, `SessionConfig`, `user_id_from_extensions(&parts.extensions)` for session user ID access, database-backed sessions with SHA-256 hashed tokens, ULID session IDs, LRU eviction for multi-device, sliding expiry, optional cleanup job via `cleanup-job` feature, `UserContextLayer` for template injection.
+
+**templates-htmx.md** — MiniJinja `#[view]` macro, auto-registered template layer (no manual `.layer()`), `#[template_function]` and `#[template_filter]`, HTMX rendering rules (render on `HX-Request`, always HTTP 200, non-200 skips render), SSE with `SseBroadcastManager` and `SseEvent` builder, CSRF double-submit cookie with `CsrfToken` extractor, i18n with `I18n` extractor and `#[t]` macro.
+
+**upload.md** — `#[derive(FromMultipart)]` for declarative multipart parsing, per-field validation (size limits, MIME type filtering), `FileStorage` trait, local filesystem (default) and S3-compatible via OpenDAL, `StorageBackend` enum in config, `UploadedFile` type, `MultipartForm<T>` extractor.
+
+**tenant.md** — `TenantResolver` trait for custom resolution, subdomain/header/path resolution strategies, `Tenant` and `OptionalTenant` extractors, type-erased service pattern with `Arc<dyn TenantResolverDyn<T>>`, `TenantContextLayer` for template injection.
+
+**config.md** — YAML config loaded from `config/{MODO_ENV}.yaml`, environment variable interpolation (`${VAR}` and `${VAR:-default}`), config struct with serde deserialization, nested sections (server, cookies, database, jobs, email, upload, tenant, auth, session), feature-gated fields with `#[cfg(feature = "...")]` in struct, `Default`, and `from_env()`.
+
+**testing.md** — Tower middleware testing with `Router::new().route(...).layer(mw).oneshot(request)` (no AppState needed, handler reads `Extension<T>`), cookie attribute testing (create `AppState` with custom `CookieConfig`, fire request, assert `Set-Cookie` header), inventory force-linking with `use crate::entity::foo as _;`, feature-gated testing with `cargo test -p crate --features feat`.
+
+## Scope Boundaries
+
+The skill helps with **building features on top of a scaffolded modo project**. It does NOT cover:
+
+- Framework development (modifying modo itself, writing new macros)
+- Project scaffolding (that's `modo-cli`)
+- Deployment, Docker, CI/CD
+- External crate selection beyond modo's ecosystem
+
+## Reference Depth
+
+Reference files cover the **80% use-case patterns**, not exhaustive API surface. docs.rs links are provided for full API details. Content summaries below are rough guides for topic coverage — not strict checklists. The implementer should use judgment on what patterns are most useful, based on what the actual source code reveals.
+
+## Example → Reference Mapping
+
+| Example | Primary reference |
+|---------|-------------------|
+| `hello` | `handlers.md` |
+| `todo-api` | `handlers.md`, `database.md` |
+| `jobs` | `jobs.md` |
+| `upload` | `upload.md` |
+| `templates` | `templates-htmx.md` |
+| `sse-chat` | `templates-htmx.md`, `auth-sessions.md` |
+| `sse-dashboard` | `templates-htmx.md` |
+
+## Implementation Approach
+
+Reference content will be derived from the actual crate source code, read one crate at a time in depth:
+
+1. Read the crate's `src/` files (public API, structs, traits, macros)
+2. Read the crate's examples and tests
+3. Read the crate's README
+4. Cross-reference with relevant examples in `examples/`
+5. Write the reference file with extracted patterns + hand-written narrative
+
+No guessing or hallucinating APIs. Every code example in a reference file must be verified against the actual source.
+
+## Build Sequence
+
+1. Create directory structure and manifests (`marketplace.json`, `plugin.json`)
+2. Write `SKILL.md`
+3. Write `references/conventions.md` (foundational — other refs depend on it)
+4. Write remaining reference files one at a time, reading each crate in depth:
+   - `handlers.md` (modo + modo-macros)
+   - `database.md` (modo-db + modo-db-macros)
+   - `jobs.md` (modo-jobs + modo-jobs-macros)
+   - `email.md` (modo-email)
+   - `auth-sessions.md` (modo-auth + modo-session)
+   - `templates-htmx.md` (modo features: templates, sse, csrf, i18n)
+   - `upload.md` (modo-upload + modo-upload-macros)
+   - `tenant.md` (modo-tenant)
+   - `config.md` (modo config module)
+   - `testing.md` (patterns across crates)
+5. Review all files for accuracy

--- a/examples/sse-chat/Cargo.toml
+++ b/examples/sse-chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sse-chat"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 publish = false
 

--- a/examples/sse-chat/src/chat.rs
+++ b/examples/sse-chat/src/chat.rs
@@ -3,6 +3,7 @@
 mod chat {
     use modo::handler;
 
+    use modo::extractors::Form;
     use modo::sse::{Sse, SseEvent, SseResponse, SseStreamExt};
     use modo::{Service, ViewRenderer};
     use modo_db::Db;
@@ -93,7 +94,7 @@ mod chat {
         view: ViewRenderer,
         Db(db): Db,
         Service(bc): Service<ChatBroadcaster>,
-        form: modo::extractors::Form<SendForm>,
+        form: Form<SendForm>,
     ) -> modo::ViewResult {
         let username = session
             .user_id()

--- a/examples/sse-chat/src/chat.rs
+++ b/examples/sse-chat/src/chat.rs
@@ -3,9 +3,8 @@
 mod chat {
     use modo::handler;
 
-    use modo::extractors::service::Service;
     use modo::sse::{Sse, SseEvent, SseResponse, SseStreamExt};
-    use modo::templates::ViewRenderer;
+    use modo::{Service, ViewRenderer};
     use modo_db::Db;
     use modo_session::SessionManager;
 

--- a/examples/sse-chat/src/handlers_auth.rs
+++ b/examples/sse-chat/src/handlers_auth.rs
@@ -1,4 +1,5 @@
 use modo::ViewRenderer;
+use modo::extractors::Form;
 use modo_session::SessionManager;
 
 use crate::types::ROOMS;
@@ -25,7 +26,7 @@ async fn login_page(session: SessionManager, view: ViewRenderer) -> modo::ViewRe
 async fn login_submit(
     session: SessionManager,
     view: ViewRenderer,
-    form: modo::extractors::Form<LoginForm>,
+    form: Form<LoginForm>,
 ) -> modo::ViewResult {
     let username = form.username.trim().to_string();
     if username.len() < 2 || username.len() > 30 {

--- a/examples/sse-chat/src/handlers_auth.rs
+++ b/examples/sse-chat/src/handlers_auth.rs
@@ -1,4 +1,4 @@
-use modo::templates::ViewRenderer;
+use modo::ViewRenderer;
 use modo_session::SessionManager;
 
 use crate::types::ROOMS;

--- a/examples/sse-dashboard/src/handlers.rs
+++ b/examples/sse-dashboard/src/handlers.rs
@@ -1,6 +1,5 @@
-use modo::extractors::service::Service;
 use modo::sse::{Sse, SseEvent, SseResponse, SseStreamExt};
-use modo::templates::ViewRenderer;
+use modo::{Service, ViewRenderer};
 
 use crate::types::{ServerStatus, StatusBroadcaster};
 

--- a/examples/todo-api/Cargo.toml
+++ b/examples/todo-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "todo-api"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 publish = false
 

--- a/examples/todo-api/src/handlers.rs
+++ b/examples/todo-api/src/handlers.rs
@@ -1,5 +1,6 @@
 use modo::HttpError;
 use modo::JsonResult;
+use modo::extractors::Json;
 use modo_db::Db;
 use serde_json::{Value, json};
 
@@ -19,10 +20,7 @@ async fn list_todos(Db(db): Db) -> JsonResult<Vec<TodoResponse>> {
 }
 
 #[modo::handler(POST, "/todos")]
-async fn create_todo(
-    Db(db): Db,
-    input: modo::validate::Json<CreateTodo>,
-) -> JsonResult<TodoResponse> {
+async fn create_todo(Db(db): Db, input: Json<CreateTodo>) -> JsonResult<TodoResponse> {
     input.validate()?;
     use modo_db::sea_orm::{ActiveModelTrait, Set};
     let model = todo::ActiveModel {

--- a/examples/upload/src/handlers.rs
+++ b/examples/upload/src/handlers.rs
@@ -1,5 +1,5 @@
 use modo::JsonResult;
-use modo::extractors::service::Service;
+use modo::Service;
 use modo_upload::{FileStorage, MultipartForm};
 
 use crate::types::ProfileForm;

--- a/modo-auth/Cargo.toml
+++ b/modo-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-auth"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/modo-auth/README.md
+++ b/modo-auth/README.md
@@ -93,7 +93,7 @@ async fn home(OptionalAuth(user): OptionalAuth<MyUser>) -> String {
 
 ```rust
 use modo_auth::{PasswordHasher, PasswordConfig};
-use modo::extractors::Service;
+use modo::Service;
 
 // Use default OWASP-recommended settings
 let hasher = PasswordHasher::default();

--- a/modo-auth/tests/integration.rs
+++ b/modo-auth/tests/integration.rs
@@ -1,8 +1,7 @@
 use axum::Router;
 use axum::routing::get;
 use http::Request;
-use modo::app::{AppState, ServiceRegistry};
-use modo::config::ServerConfig;
+use modo::{AppState, ServerConfig, ServiceRegistry};
 use modo_auth::{Auth, OptionalAuth, UserProvider, UserProviderService};
 use modo_db::sea_orm::{ConnectionTrait, Schema};
 use modo_db::{DatabaseConfig, DbPool};

--- a/modo-cli/Cargo.toml
+++ b/modo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-cli"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/modo-cli/Cargo.toml
+++ b/modo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-cli"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/modo-cli/Cargo.toml
+++ b/modo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-cli"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/modo-cli/templates/api/justfile.jinja
+++ b/modo-cli/templates/api/justfile.jinja
@@ -1,3 +1,5 @@
+set dotenv-load
+
 # Run dev server with auto-reload
 {%- if db_driver == "postgres" %}
 dev: docker-up

--- a/modo-cli/templates/api/src/config.rs.jinja
+++ b/modo-cli/templates/api/src/config.rs.jinja
@@ -1,4 +1,4 @@
-use modo::config::AppConfig;
+use modo::AppConfig;
 use modo_db::DatabaseConfig;
 use serde::Deserialize;
 

--- a/modo-cli/templates/minimal/justfile.jinja
+++ b/modo-cli/templates/minimal/justfile.jinja
@@ -1,3 +1,5 @@
+set dotenv-load
+
 # Run dev server with auto-reload
 dev:
 	cargo watch -x run

--- a/modo-cli/templates/minimal/src/config.rs.jinja
+++ b/modo-cli/templates/minimal/src/config.rs.jinja
@@ -1,4 +1,4 @@
-use modo::config::AppConfig;
+use modo::AppConfig;
 use serde::Deserialize;
 
 #[derive(Default, Deserialize)]

--- a/modo-cli/templates/shared/CLAUDE.md.jinja
+++ b/modo-cli/templates/shared/CLAUDE.md.jinja
@@ -14,3 +14,4 @@ Built with the [modo](https://github.com/dmitrymomot/modo) framework.
 ## Conventions
 
 - Handlers, views, and tasks go in separate files (e.g. `handlers/home.rs`, `views/home.rs`, `tasks/send_email.rs`); `mod.rs` contains only `mod` and `pub use` re-exports
+- Extractors: `use modo::extractors::{Json, Form};` — use short form in handler signatures

--- a/modo-cli/templates/web/justfile.jinja
+++ b/modo-cli/templates/web/justfile.jinja
@@ -1,3 +1,5 @@
+set dotenv-load
+
 # Run dev server with auto-reload
 dev: docker-up css
 	cargo watch -x run

--- a/modo-cli/templates/web/src/config.rs.jinja
+++ b/modo-cli/templates/web/src/config.rs.jinja
@@ -1,4 +1,4 @@
-use modo::config::AppConfig;
+use modo::AppConfig;
 use modo_db::DatabaseConfig;
 use modo_email::EmailConfig;
 use modo_jobs::JobsConfig;

--- a/modo-cli/templates/web/src/tasks/send_email.rs.jinja
+++ b/modo-cli/templates/web/src/tasks/send_email.rs.jinja
@@ -1,4 +1,4 @@
-use modo::extractors::Service;
+use modo::Service;
 use modo::HandlerResult;
 use modo_email::{Mailer, SendEmail, SendEmailPayload};
 

--- a/modo-cli/templates/worker/justfile.jinja
+++ b/modo-cli/templates/worker/justfile.jinja
@@ -1,3 +1,5 @@
+set dotenv-load
+
 # Run dev server with auto-reload
 {%- if db_driver == "postgres" %}
 dev: docker-up

--- a/modo-cli/templates/worker/src/config.rs.jinja
+++ b/modo-cli/templates/worker/src/config.rs.jinja
@@ -1,4 +1,4 @@
-use modo::config::AppConfig;
+use modo::AppConfig;
 use modo_db::DatabaseConfig;
 use modo_jobs::JobsConfig;
 use serde::Deserialize;

--- a/modo-macros/README.md
+++ b/modo-macros/README.md
@@ -150,7 +150,8 @@ struct CreateTodo {
 }
 
 // In a handler:
-async fn create(input: modo::validate::Json<CreateTodo>) -> modo::JsonResult<()> {
+use modo::extractors::Json;
+async fn create(input: Json<CreateTodo>) -> modo::JsonResult<()> {
     input.validate()?;
     Ok(modo::Json(()))
 }

--- a/modo-upload/Cargo.toml
+++ b/modo-upload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-upload"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/modo-upload/README.md
+++ b/modo-upload/README.md
@@ -62,7 +62,7 @@ Call `.validate()` when `T` also derives `modo::Validate`.
 
 ```rust
 use modo::JsonResult;
-use modo::extractors::service::Service;
+use modo::Service;
 use modo_upload::{FileStorage, MultipartForm};
 
 #[modo::handler(POST, "/profile")]

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/modo/README.md
+++ b/modo/README.md
@@ -80,7 +80,7 @@ async fn list_users() -> JsonResult<Vec<String>> {
 ### Registering services and extractors
 
 ```rust
-use modo::extractors::service::Service;
+use modo::Service;
 
 struct MyDatabase { /* ... */ }
 

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -37,21 +37,34 @@ pub(crate) mod static_files;
 pub mod templates;
 pub mod validate;
 
+pub use app::{AppBuilder, AppState, ServiceRegistry};
 pub use axum::Json;
-pub use config::{AppConfig, HttpConfig, RateLimitConfig, SecurityHeadersConfig, TrailingSlash};
+pub use config::{
+    AppConfig, HttpConfig, RateLimitConfig, SecurityHeadersConfig, ServerConfig, TrailingSlash,
+};
 pub use cookies::{CookieConfig, CookieManager, CookieOptions, SameSite};
 pub use cors::CorsConfig;
+#[cfg(feature = "csrf")]
+pub use csrf::{CsrfConfig, CsrfToken};
 #[cfg(feature = "templates")]
 pub use error::ViewResult;
 pub use error::{
     Error, ErrorContext, ErrorHandlerFn, ErrorHandlerRegistration, HandlerResult, HttpError,
     JsonResult,
 };
+pub use extractors::Service;
+#[cfg(feature = "i18n")]
+pub use i18n::{I18n, I18nConfig};
 pub use middleware::{ClientIp, RateLimitInfo};
 pub use request_id::RequestId;
+pub use router::Method;
+pub use sanitize::Sanitize;
 pub use shutdown::{GracefulShutdown, ShutdownPhase};
 #[cfg(feature = "templates")]
-pub use templates::{ViewRender, ViewRenderer, ViewResponse};
+pub use templates::{
+    TemplateConfig, TemplateContext, TemplateEngine, ViewRender, ViewRenderer, ViewResponse,
+};
+pub use validate::Validate;
 
 // Re-exports for macro-generated code
 pub use axum;

--- a/modo/tests/app_builder.rs
+++ b/modo/tests/app_builder.rs
@@ -1,5 +1,4 @@
-use modo::app::AppBuilder;
-use modo::config::ServerConfig;
+use modo::{AppBuilder, ServerConfig};
 
 #[test]
 fn test_default_server_config() {

--- a/modo/tests/error_handler_macro.rs
+++ b/modo/tests/error_handler_macro.rs
@@ -1,4 +1,4 @@
-use modo::error::{Error, ErrorContext, ErrorHandlerRegistration, HttpError};
+use modo::{Error, ErrorContext, ErrorHandlerRegistration, HttpError};
 
 #[modo::error_handler]
 fn custom_error_handler(err: Error, _ctx: &ErrorContext) -> axum::response::Response {

--- a/modo/tests/error_handling.rs
+++ b/modo/tests/error_handling.rs
@@ -1,6 +1,6 @@
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use modo::error::{Error, ErrorContext, HttpError};
+use modo::{Error, ErrorContext, HttpError};
 use serde_json::json;
 
 #[test]

--- a/modo/tests/handler_macro.rs
+++ b/modo/tests/handler_macro.rs
@@ -1,4 +1,5 @@
-use modo::router::{Method, RouteRegistration};
+use modo::Method;
+use modo::router::RouteRegistration;
 
 // -- Basic HTTP method handlers --
 

--- a/modo/tests/integration.rs
+++ b/modo/tests/integration.rs
@@ -1,9 +1,7 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use modo::app::AppState;
-use modo::config::ServerConfig;
-use modo::error::HttpError;
 use modo::router::RouteRegistration;
+use modo::{AppState, HttpError, ServerConfig};
 use tower::ServiceExt;
 
 #[modo::handler(GET, "/test")]

--- a/modo/tests/route_registration.rs
+++ b/modo/tests/route_registration.rs
@@ -2,7 +2,7 @@ use modo::router::RouteRegistration;
 
 inventory::submit! {
     RouteRegistration {
-        method: modo::router::Method::GET,
+        method: modo::Method::GET,
         path: "/test",
         handler: || modo::axum::routing::get(|| async { "test" }),
         middleware: vec![],

--- a/modo/tests/sanitization.rs
+++ b/modo/tests/sanitization.rs
@@ -1,5 +1,4 @@
-use modo::sanitize::Sanitize;
-use modo::validate::Validate;
+use modo::{Sanitize, Validate};
 
 // =============================================================================
 // Built-in rule tests

--- a/modo/tests/service_extractor.rs
+++ b/modo/tests/service_extractor.rs
@@ -1,4 +1,4 @@
-use modo::extractors::service::Service;
+use modo::Service;
 
 #[allow(dead_code)]
 struct MyService {

--- a/modo/tests/validation.rs
+++ b/modo/tests/validation.rs
@@ -1,4 +1,4 @@
-use modo::validate::Validate;
+use modo::Validate;
 
 // --- Helper for custom validation ---
 


### PR DESCRIPTION
## Summary

Introduces the modo-dev Claude Code skill plugin — a structured knowledge base that gives Claude accurate, project-specific context about the modo framework during development sessions.

### Changes

- Scaffold plugin structure under `claude-plugin/` with `plugin.json` and `marketplace.json`
- Add `SKILL.md` with macro cheat sheet, gotchas, and a topic index linking all references
- Add 11 reference files covering conventions, handlers, database, jobs, email, auth/sessions, templates/HTMX, upload, tenant, config, and testing

### Breaking Changes

None.