### PR TITLE
feat(modo-jobs): batch 7 — configurable reaper, catch_unwind, cron validation, queue depth limit

### DIFF
--- a/modo-jobs-macros/Cargo.toml
+++ b/modo-jobs-macros/Cargo.toml
@@ -10,6 +10,7 @@ description = "Procedural macros for modo-jobs"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full", "extra-traits"] }
-quote = "1"
+cron = "0.15"
 proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "extra-traits"] }

--- a/modo-jobs-macros/src/job.rs
+++ b/modo-jobs-macros/src/job.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{FnArg, Ident, ItemFn, Lit, LitStr, Pat, Result, Token, Type, parse2};
@@ -54,6 +56,12 @@ impl syn::parse::Parse for JobArgs {
                 args.timeout = val.value();
             } else if ident == "cron" {
                 let val: LitStr = input.parse()?;
+                if let Err(e) = cron::Schedule::from_str(&val.value()) {
+                    return Err(syn::Error::new_spanned(
+                        &val,
+                        format!("invalid cron expression: {e}"),
+                    ));
+                }
                 args.cron = Some(val.value());
             } else {
                 return Err(syn::Error::new_spanned(
@@ -334,5 +342,24 @@ fn extract_pat_ident(pat: &Pat) -> TokenStream {
             let fallback = format_ident!("__param");
             quote! { #fallback }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    #[test]
+    fn valid_cron_expression_parses() {
+        assert!(cron::Schedule::from_str("0 */5 * * * *").is_ok());
+        assert!(cron::Schedule::from_str("0 0 * * * *").is_ok());
+        assert!(cron::Schedule::from_str("0 0 0 * * *").is_ok());
+    }
+
+    #[test]
+    fn invalid_cron_expression_fails() {
+        assert!(cron::Schedule::from_str("not a cron").is_err());
+        assert!(cron::Schedule::from_str("").is_err());
+        assert!(cron::Schedule::from_str("* * *").is_err());
     }
 }

--- a/modo-jobs/Cargo.toml
+++ b/modo-jobs/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 cron = "0.15"
+futures-util = "0.3"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"

--- a/modo-jobs/src/config.rs
+++ b/modo-jobs/src/config.rs
@@ -117,16 +117,20 @@ mod tests {
 
     #[test]
     fn validate_rejects_zero_stale_reaper_interval() {
-        let mut config = JobsConfig::default();
-        config.stale_reaper_interval_secs = 0;
+        let config = JobsConfig {
+            stale_reaper_interval_secs: 0,
+            ..Default::default()
+        };
         let err = config.validate().unwrap_err();
         assert!(err.to_string().contains("stale_reaper_interval_secs"));
     }
 
     #[test]
     fn validate_accepts_nonzero_stale_reaper_interval() {
-        let mut config = JobsConfig::default();
-        config.stale_reaper_interval_secs = 30;
+        let config = JobsConfig {
+            stale_reaper_interval_secs: 30,
+            ..Default::default()
+        };
         assert!(config.validate().is_ok());
     }
 

--- a/modo-jobs/src/config.rs
+++ b/modo-jobs/src/config.rs
@@ -20,6 +20,9 @@ pub struct JobsConfig {
     pub cleanup: CleanupConfig,
     /// Optional maximum payload size in bytes. `None` means unlimited.
     pub max_payload_bytes: Option<usize>,
+    /// Optional maximum number of pending jobs per queue. `None` means unlimited.
+    /// When set and the queue is full, `enqueue()` returns a 503 error.
+    pub max_queue_depth: Option<usize>,
 }
 
 impl JobsConfig {
@@ -53,6 +56,9 @@ impl JobsConfig {
         if self.cleanup.interval_secs == 0 {
             return Err(Error::internal("cleanup.interval_secs must be > 0"));
         }
+        if self.max_queue_depth == Some(0) {
+            return Err(Error::internal("max_queue_depth must be > 0 if set"));
+        }
         Ok(())
     }
 }
@@ -70,6 +76,7 @@ impl Default for JobsConfig {
             }],
             cleanup: CleanupConfig::default(),
             max_payload_bytes: None,
+            max_queue_depth: None,
         }
     }
 }
@@ -141,5 +148,30 @@ mod tests {
         "#;
         let config: JobsConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(config.stale_reaper_interval_secs, 120);
+    }
+
+    #[test]
+    fn default_config_has_no_queue_depth_limit() {
+        let config = JobsConfig::default();
+        assert!(config.max_queue_depth.is_none());
+    }
+
+    #[test]
+    fn config_deserializes_max_queue_depth() {
+        let yaml = r#"
+            max_queue_depth: 1000
+        "#;
+        let config: JobsConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.max_queue_depth, Some(1000));
+    }
+
+    #[test]
+    fn validate_rejects_zero_max_queue_depth() {
+        let config = JobsConfig {
+            max_queue_depth: Some(0),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("max_queue_depth"));
     }
 }

--- a/modo-jobs/src/config.rs
+++ b/modo-jobs/src/config.rs
@@ -10,6 +10,8 @@ pub struct JobsConfig {
     pub poll_interval_secs: u64,
     /// Jobs running longer than this are considered stale and re-queued (seconds).
     pub stale_threshold_secs: u64,
+    /// How often the stale reaper checks for stale jobs (seconds).
+    pub stale_reaper_interval_secs: u64,
     /// Maximum time to wait for in-flight jobs during shutdown (seconds).
     pub drain_timeout_secs: u64,
     /// Per-queue concurrency configuration.
@@ -23,15 +25,19 @@ pub struct JobsConfig {
 impl JobsConfig {
     /// Validate the configuration, returning an error if any invariant is violated.
     ///
-    /// Checks that `poll_interval_secs`, `stale_threshold_secs`, and
-    /// `cleanup.interval_secs` are all greater than zero, that at least one queue
-    /// is configured, and that every queue has `concurrency > 0`.
+    /// Checks that `poll_interval_secs`, `stale_threshold_secs`,
+    /// `stale_reaper_interval_secs`, and `cleanup.interval_secs` are all greater
+    /// than zero, that at least one queue is configured, and that every queue has
+    /// `concurrency > 0`.
     pub fn validate(&self) -> Result<(), Error> {
         if self.poll_interval_secs == 0 {
             return Err(Error::internal("poll_interval_secs must be > 0"));
         }
         if self.stale_threshold_secs == 0 {
             return Err(Error::internal("stale_threshold_secs must be > 0"));
+        }
+        if self.stale_reaper_interval_secs == 0 {
+            return Err(Error::internal("stale_reaper_interval_secs must be > 0"));
         }
         if self.queues.is_empty() {
             return Err(Error::internal("at least one queue must be configured"));
@@ -56,6 +62,7 @@ impl Default for JobsConfig {
         Self {
             poll_interval_secs: 1,
             stale_threshold_secs: 600,
+            stale_reaper_interval_secs: 60,
             drain_timeout_secs: 30,
             queues: vec![QueueConfig {
                 name: "default".to_string(),
@@ -95,5 +102,40 @@ impl Default for CleanupConfig {
             retention_secs: 86400,
             statuses: vec![JobState::Completed, JobState::Dead, JobState::Cancelled],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_60s_stale_reaper_interval() {
+        let config = JobsConfig::default();
+        assert_eq!(config.stale_reaper_interval_secs, 60);
+    }
+
+    #[test]
+    fn validate_rejects_zero_stale_reaper_interval() {
+        let mut config = JobsConfig::default();
+        config.stale_reaper_interval_secs = 0;
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("stale_reaper_interval_secs"));
+    }
+
+    #[test]
+    fn validate_accepts_nonzero_stale_reaper_interval() {
+        let mut config = JobsConfig::default();
+        config.stale_reaper_interval_secs = 30;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn config_deserializes_stale_reaper_interval() {
+        let yaml = r#"
+            stale_reaper_interval_secs: 120
+        "#;
+        let config: JobsConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.stale_reaper_interval_secs, 120);
     }
 }

--- a/modo-jobs/src/queue.rs
+++ b/modo-jobs/src/queue.rs
@@ -2,7 +2,9 @@ use crate::entity::job;
 use crate::handler::JobRegistration;
 use crate::types::{JobId, JobState};
 use chrono::{DateTime, Utc};
-use modo_db::sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter};
+use modo_db::sea_orm::{
+    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter,
+};
 
 /// Handle for enqueuing and cancelling jobs.
 ///
@@ -19,17 +21,24 @@ use modo_db::sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, 
 pub struct JobQueue {
     pub(crate) db: modo_db::sea_orm::DatabaseConnection,
     pub(crate) max_payload_bytes: Option<usize>,
+    pub(crate) max_queue_depth: Option<usize>,
 }
 
 impl JobQueue {
     /// Create a new `JobQueue` wrapping the given database pool.
     ///
     /// `max_payload_bytes` sets an optional upper bound on serialized payload
-    /// size; `None` disables the check.
-    pub fn new(db: &modo_db::pool::DbPool, max_payload_bytes: Option<usize>) -> Self {
+    /// size; `None` disables the check.  `max_queue_depth` sets an optional
+    /// cap on pending jobs per queue; `None` means unlimited.
+    pub fn new(
+        db: &modo_db::pool::DbPool,
+        max_payload_bytes: Option<usize>,
+        max_queue_depth: Option<usize>,
+    ) -> Self {
         Self {
             db: db.connection().clone(),
             max_payload_bytes,
+            max_queue_depth,
         }
     }
 
@@ -74,6 +83,24 @@ impl JobQueue {
                 "job payload size ({} bytes) exceeds limit ({max} bytes)",
                 payload_json.len()
             )));
+        }
+
+        // Check queue depth limit (soft limit — the count-then-insert is not
+        // atomic, so concurrent enqueues may briefly exceed the cap).
+        if let Some(max_depth) = self.max_queue_depth {
+            let count = job::Entity::find()
+                .filter(job::Column::Queue.eq(reg.queue))
+                .filter(job::Column::State.eq(JobState::Pending.as_str()))
+                .count(&self.db)
+                .await
+                .map_err(|e| modo::Error::internal(format!("Failed to count queue depth: {e}")))?;
+
+            if count as usize >= max_depth {
+                return Err(modo::HttpError::ServiceUnavailable.with_message(format!(
+                    "Queue '{}' is full ({max_depth} pending jobs)",
+                    reg.queue
+                )));
+            }
         }
 
         self.insert_job(reg, payload_json, run_at).await
@@ -176,11 +203,45 @@ mod tests {
         let queue = JobQueue {
             db,
             max_payload_bytes: None,
+            max_queue_depth: None,
         };
 
         let fake_id = JobId::new();
         let err = queue.cancel(&fake_id).await.unwrap_err();
 
         assert_eq!(err.status_code(), modo::axum::http::StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn enqueue_respects_queue_depth_limit() {
+        let db = setup_db().await;
+        let queue = JobQueue {
+            db,
+            max_payload_bytes: None,
+            max_queue_depth: Some(2),
+        };
+
+        // At minimum, verify the queue construction doesn't panic
+        assert!(queue.max_queue_depth == Some(2));
+    }
+
+    #[tokio::test]
+    async fn queue_depth_none_means_unlimited() {
+        let db = setup_db().await;
+        let queue = JobQueue {
+            db,
+            max_payload_bytes: None,
+            max_queue_depth: None,
+        };
+        // No depth limit — enqueue should not fail due to depth
+        // (will fail due to missing job registration, which is fine)
+        let err = queue.enqueue("nonexistent", &()).await.unwrap_err();
+        // The error should be about missing registration, NOT about queue depth
+        assert!(
+            err.to_string().contains("No job registered")
+                || err.to_string().contains("no job registered"),
+            "Expected 'No job registered' error, got: {}",
+            err
+        );
     }
 }

--- a/modo-jobs/src/queue.rs
+++ b/modo-jobs/src/queue.rs
@@ -93,9 +93,9 @@ impl JobQueue {
                 .filter(job::Column::State.eq(JobState::Pending.as_str()))
                 .count(&self.db)
                 .await
-                .map_err(|e| modo::Error::internal(format!("Failed to count queue depth: {e}")))?;
+                .map_err(|e| modo::Error::internal(format!("failed to count queue depth: {e}")))?;
 
-            if count as usize >= max_depth {
+            if count >= max_depth as u64 {
                 return Err(modo::HttpError::ServiceUnavailable.with_message(format!(
                     "Queue '{}' is full ({max_depth} pending jobs)",
                     reg.queue
@@ -177,7 +177,28 @@ impl JobQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handler::{JobHandlerDyn, JobRegistration};
     use modo_db::sea_orm::{ConnectionTrait, Database, Schema};
+
+    // Dummy handler for queue depth tests
+    struct DummyHandler;
+    impl crate::handler::JobHandler for DummyHandler {
+        async fn run(&self, _ctx: crate::handler::JobContext) -> Result<(), modo::Error> {
+            Ok(())
+        }
+    }
+
+    inventory::submit! {
+        JobRegistration {
+            name: "__test_dummy",
+            queue: "default",
+            priority: 0,
+            max_attempts: 3,
+            timeout_secs: 30,
+            cron: None,
+            handler_factory: || Box::new(DummyHandler) as Box<dyn JobHandlerDyn>,
+        }
+    }
 
     async fn setup_db() -> modo_db::sea_orm::DatabaseConnection {
         let db = Database::connect("sqlite::memory:")
@@ -221,8 +242,16 @@ mod tests {
             max_queue_depth: Some(2),
         };
 
-        // At minimum, verify the queue construction doesn't panic
-        assert!(queue.max_queue_depth == Some(2));
+        // Fill the queue up to the limit
+        let _id1 = queue.enqueue("__test_dummy", &"a").await.unwrap();
+        let _id2 = queue.enqueue("__test_dummy", &"b").await.unwrap();
+
+        // Third enqueue should be rejected with 503
+        let err = queue.enqueue("__test_dummy", &"c").await.unwrap_err();
+        assert_eq!(
+            err.status_code(),
+            modo::axum::http::StatusCode::SERVICE_UNAVAILABLE,
+        );
     }
 
     #[tokio::test]

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -4,6 +4,7 @@ use crate::handler::{JobContext, JobHandlerDyn, JobRegistration};
 use crate::queue::JobQueue;
 use crate::types::{JobId, JobState};
 use chrono::{DateTime, Utc};
+use futures_util::FutureExt;
 use modo::app::ServiceRegistry;
 use modo_db::sea_orm::{
     ColumnTrait, DatabaseBackend, EntityTrait, ExprTrait, FromQueryResult, QueryFilter, Statement,
@@ -11,6 +12,7 @@ use modo_db::sea_orm::{
 };
 use std::collections::HashMap;
 use std::ops::Deref;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Notify, Semaphore};
@@ -386,14 +388,23 @@ async fn execute_job(
         payload_json: job.payload.clone(),
     };
 
-    let result =
-        tokio::time::timeout(Duration::from_secs(timeout_secs), handler.run_dyn(ctx)).await;
+    // Wrap the entire timeout+handler in catch_unwind to prevent panics
+    // from crashing the worker loop. Only catches unwinding panics
+    // (abort panics cannot be caught).
+    let panic_result = AssertUnwindSafe(tokio::time::timeout(
+        Duration::from_secs(timeout_secs),
+        handler.run_dyn(ctx),
+    ))
+    .catch_unwind()
+    .await;
 
-    match result {
-        Ok(Ok(())) => {
+    match panic_result {
+        Ok(Ok(Ok(()))) => {
+            // timeout Ok, handler Ok
             mark_completed(db, &job.id).await;
         }
-        Ok(Err(e)) => {
+        Ok(Ok(Err(e))) => {
+            // timeout Ok, handler Err
             error!(
                 job_id = %job.id, job_name = %job_name, queue = %queue,
                 attempt = job.attempts, max_attempts = job.max_attempts,
@@ -401,7 +412,8 @@ async fn execute_job(
             );
             handle_failure(db, &job, Some(&e.to_string())).await;
         }
-        Err(_) => {
+        Ok(Err(_)) => {
+            // timeout elapsed
             error!(
                 job_id = %job.id, job_name = %job_name, queue = %queue,
                 attempt = job.attempts, max_attempts = job.max_attempts,
@@ -413,6 +425,21 @@ async fn execute_job(
                 Some(&format!("Job timed out after {timeout_secs}s")),
             )
             .await;
+        }
+        Err(panic_payload) => {
+            // Handler panicked — extract the panic message
+            let panic_msg = panic_payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| panic_payload.downcast_ref::<&str>().map(|s| s.to_string()))
+                .unwrap_or_else(|| "unknown panic".to_string());
+
+            error!(
+                job_id = %job.id, job_name = %job_name, queue = %queue,
+                attempt = job.attempts, max_attempts = job.max_attempts,
+                panic = %panic_msg, "Job panicked"
+            );
+            handle_failure(db, &job, Some(&format!("Job panicked: {panic_msg}"))).await;
         }
     }
 }
@@ -600,5 +627,59 @@ async fn cleanup_loop(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn panic_payload_extraction_string() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("test panic".to_string());
+        let msg = payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_else(|| "unknown panic".to_string());
+        assert_eq!(msg, "test panic");
+    }
+
+    #[test]
+    fn panic_payload_extraction_str() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("test panic");
+        let msg = payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_else(|| "unknown panic".to_string());
+        assert_eq!(msg, "test panic");
+    }
+
+    #[test]
+    fn panic_payload_extraction_unknown() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        let msg = payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+            .unwrap_or_else(|| "unknown panic".to_string());
+        assert_eq!(msg, "unknown panic");
+    }
+
+    #[tokio::test]
+    async fn catch_unwind_catches_panic_in_future() {
+        use futures_util::FutureExt;
+        use std::panic::AssertUnwindSafe;
+
+        let result = AssertUnwindSafe(async { panic!("boom") })
+            .catch_unwind()
+            .await;
+
+        assert!(result.is_err());
+        let payload = result.unwrap_err();
+        let msg = payload
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        assert_eq!(msg, "boom");
     }
 }

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -178,7 +178,7 @@ async fn start_inner(
     }
 
     let cancel = CancellationToken::new();
-    let queue = JobQueue::new(db, config.max_payload_bytes);
+    let queue = JobQueue::new(db, config.max_payload_bytes, config.max_queue_depth);
     let worker_id = ulid::Ulid::new().to_string();
     let mut semaphores = Vec::new();
 

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -358,6 +358,19 @@ pub async fn claim_next(
     Ok(result)
 }
 
+/// Extract a human-readable message from a panic payload.
+///
+/// Handles `String` and `&str` payloads (the two types produced by
+/// `panic!()` and `panic!("{}", ...)`) and falls back to `"unknown panic"`
+/// for anything else.
+fn extract_panic_msg(payload: Box<dyn std::any::Any + Send>) -> String {
+    payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_else(|| "unknown panic".to_string())
+}
+
 async fn execute_job(
     db: &modo_db::sea_orm::DatabaseConnection,
     job: job::Model,
@@ -427,12 +440,7 @@ async fn execute_job(
             .await;
         }
         Err(panic_payload) => {
-            // Handler panicked — extract the panic message
-            let panic_msg = panic_payload
-                .downcast_ref::<String>()
-                .cloned()
-                .or_else(|| panic_payload.downcast_ref::<&str>().map(|s| s.to_string()))
-                .unwrap_or_else(|| "unknown panic".to_string());
+            let panic_msg = extract_panic_msg(panic_payload);
 
             error!(
                 job_id = %job.id, job_name = %job_name, queue = %queue,
@@ -635,34 +643,19 @@ mod tests {
     #[test]
     fn panic_payload_extraction_string() {
         let payload: Box<dyn std::any::Any + Send> = Box::new("test panic".to_string());
-        let msg = payload
-            .downcast_ref::<String>()
-            .cloned()
-            .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
-            .unwrap_or_else(|| "unknown panic".to_string());
-        assert_eq!(msg, "test panic");
+        assert_eq!(super::extract_panic_msg(payload), "test panic");
     }
 
     #[test]
     fn panic_payload_extraction_str() {
         let payload: Box<dyn std::any::Any + Send> = Box::new("test panic");
-        let msg = payload
-            .downcast_ref::<String>()
-            .cloned()
-            .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
-            .unwrap_or_else(|| "unknown panic".to_string());
-        assert_eq!(msg, "test panic");
+        assert_eq!(super::extract_panic_msg(payload), "test panic");
     }
 
     #[test]
     fn panic_payload_extraction_unknown() {
         let payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
-        let msg = payload
-            .downcast_ref::<String>()
-            .cloned()
-            .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
-            .unwrap_or_else(|| "unknown panic".to_string());
-        assert_eq!(msg, "unknown panic");
+        assert_eq!(super::extract_panic_msg(payload), "unknown panic");
     }
 
     #[tokio::test]

--- a/modo-jobs/src/runner.rs
+++ b/modo-jobs/src/runner.rs
@@ -206,9 +206,10 @@ async fn start_inner(
         let db = db.connection().clone();
         let cancel = cancel.clone();
         let threshold_secs = config.stale_threshold_secs;
+        let reaper_interval_secs = config.stale_reaper_interval_secs;
 
         tokio::spawn(async move {
-            reap_stale_loop(&db, cancel, threshold_secs).await;
+            reap_stale_loop(&db, cancel, threshold_secs, reaper_interval_secs).await;
         });
     }
 
@@ -520,8 +521,9 @@ async fn reap_stale_loop(
     db: &modo_db::sea_orm::DatabaseConnection,
     cancel: CancellationToken,
     threshold_secs: u64,
+    reaper_interval_secs: u64,
 ) {
-    let mut interval = tokio::time::interval(Duration::from_secs(60));
+    let mut interval = tokio::time::interval(Duration::from_secs(reaper_interval_secs));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {


### PR DESCRIPTION
## Summary

- **DES-20:** Make stale reaper interval configurable via `JobsConfig.stale_reaper_interval_secs` (default 60s)
- **DES-37:** Wrap job handler execution in `catch_unwind` so panics fail the job gracefully instead of crashing the worker loop
- **DES-09:** Validate cron expressions at compile time in the `#[job]` proc macro — invalid expressions now produce compile errors with accurate spans
- **DES-30:** Add optional `max_queue_depth` to `JobsConfig` with 503 backpressure when the queue is full

## Test plan

- [x] `cargo test -p modo-jobs` — 14 unit tests pass
- [x] `cargo test -p modo-jobs-macros` — 2 unit tests pass
- [x] `just check` — fmt, clippy, and full workspace tests pass