### PR TITLE
feat: email, upload & tenant hardening (batch 8)

### DIFF
--- a/modo-email/Cargo.toml
+++ b/modo-email/Cargo.toml
@@ -12,6 +12,7 @@ smtp = ["dep:lettre"]
 resend = ["dep:reqwest"]
 
 [dependencies]
+lru = "0.12"
 modo.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/modo-email/src/config.rs
+++ b/modo-email/src/config.rs
@@ -33,6 +33,12 @@ pub struct EmailConfig {
     pub default_from_email: String,
     /// Optional default `Reply-To` address.
     pub default_reply_to: Option<String>,
+    /// Whether to cache compiled email templates. Defaults to `true`.
+    /// Set to `false` in development for live template reloading.
+    pub cache_templates: bool,
+    /// Maximum number of compiled templates to keep in cache.
+    /// Defaults to `100`. Only used when `cache_templates` is `true`.
+    pub template_cache_size: usize,
 
     /// SMTP connection settings. Requires the `smtp` feature.
     #[cfg(feature = "smtp")]
@@ -51,12 +57,28 @@ impl Default for EmailConfig {
             default_from_name: String::new(),
             default_from_email: String::new(),
             default_reply_to: None,
+            cache_templates: true,
+            template_cache_size: 100,
             #[cfg(feature = "smtp")]
             smtp: SmtpConfig::default(),
             #[cfg(feature = "resend")]
             resend: ResendConfig::default(),
         }
     }
+}
+
+/// TLS mode for SMTP connections.
+#[cfg(feature = "smtp")]
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SmtpSecurity {
+    /// No TLS — plaintext connection (use only for local dev or trusted networks).
+    None,
+    /// Upgrade a plaintext connection to TLS via the STARTTLS command (port 587).
+    #[default]
+    StartTls,
+    /// Connect with TLS from the start — SMTPS (port 465).
+    ImplicitTls,
 }
 
 /// SMTP connection settings. Requires the `smtp` feature.
@@ -72,9 +94,8 @@ pub struct SmtpConfig {
     pub username: String,
     /// SMTP authentication password.
     pub password: String,
-    /// When `true`, uses STARTTLS (port 587). When `false`, no TLS at all.
-    /// Implicit TLS / SMTPS (port 465) is not currently supported.
-    pub tls: bool,
+    /// TLS security mode. Defaults to `StartTls`.
+    pub security: SmtpSecurity,
 }
 
 #[cfg(feature = "smtp")]
@@ -85,7 +106,7 @@ impl Default for SmtpConfig {
             port: 587,
             username: String::new(),
             password: String::new(),
-            tls: true,
+            security: SmtpSecurity::default(),
         }
     }
 }
@@ -132,5 +153,71 @@ default_from_email: "hi@acme.com"
         let yaml = "transport: resend";
         let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(config.transport, TransportBackend::Resend);
+    }
+
+    #[cfg(feature = "smtp")]
+    #[test]
+    fn smtp_security_none_deserialization() {
+        let yaml = r#"
+transport: smtp
+smtp:
+  host: "localhost"
+  security: none
+"#;
+        let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.smtp.security, SmtpSecurity::None);
+    }
+
+    #[cfg(feature = "smtp")]
+    #[test]
+    fn smtp_security_starttls_deserialization() {
+        let yaml = r#"
+transport: smtp
+smtp:
+  host: "mail.example.com"
+  security: starttls
+"#;
+        let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.smtp.security, SmtpSecurity::StartTls);
+    }
+
+    #[cfg(feature = "smtp")]
+    #[test]
+    fn smtp_security_implicit_tls_deserialization() {
+        let yaml = r#"
+transport: smtp
+smtp:
+  host: "mail.example.com"
+  port: 465
+  security: implicit_tls
+"#;
+        let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.smtp.security, SmtpSecurity::ImplicitTls);
+        assert_eq!(config.smtp.port, 465);
+    }
+
+    #[cfg(feature = "smtp")]
+    #[test]
+    fn smtp_security_default_is_starttls() {
+        let config = SmtpConfig::default();
+        assert_eq!(config.security, SmtpSecurity::StartTls);
+    }
+
+    #[test]
+    fn cache_config_deserialization() {
+        let yaml = r#"
+cache_templates: false
+template_cache_size: 50
+"#;
+        let config: EmailConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(!config.cache_templates);
+        assert_eq!(config.template_cache_size, 50);
+    }
+
+    #[test]
+    fn cache_config_defaults() {
+        let config = EmailConfig::default();
+        assert!(config.cache_templates);
+        assert_eq!(config.template_cache_size, 100);
     }
 }

--- a/modo-email/src/config.rs
+++ b/modo-email/src/config.rs
@@ -76,6 +76,7 @@ pub enum SmtpSecurity {
     None,
     /// Upgrade a plaintext connection to TLS via the STARTTLS command (port 587).
     #[default]
+    #[serde(rename = "starttls")]
     StartTls,
     /// Connect with TLS from the start — SMTPS (port 465).
     ImplicitTls,

--- a/modo-email/src/factory.rs
+++ b/modo-email/src/factory.rs
@@ -1,14 +1,23 @@
 use std::sync::Arc;
 
 use crate::{
-    EmailConfig, FilesystemProvider, LayoutEngine, Mailer, SenderProfile, TemplateProvider,
+    CachedTemplateProvider, EmailConfig, FilesystemProvider, LayoutEngine, Mailer, SenderProfile,
+    TemplateProvider,
 };
 
 /// Create a [`Mailer`] using [`FilesystemProvider`] and the transport configured in `config`.
 ///
 /// This is the standard entry point. Templates are loaded from `config.templates_path`.
 pub fn mailer(config: &EmailConfig) -> Result<Mailer, modo::Error> {
-    let provider = Arc::new(FilesystemProvider::new(&config.templates_path));
+    let fs_provider = FilesystemProvider::new(&config.templates_path);
+    let provider: Arc<dyn TemplateProvider> = if config.cache_templates {
+        Arc::new(CachedTemplateProvider::new(
+            fs_provider,
+            config.template_cache_size,
+        ))
+    } else {
+        Arc::new(fs_provider)
+    };
     mailer_with(config, provider)
 }
 

--- a/modo-email/src/lib.rs
+++ b/modo-email/src/lib.rs
@@ -36,8 +36,9 @@ pub use transport::{MailTransport, MailTransportDyn, MailTransportSend};
 #[cfg(feature = "resend")]
 pub use config::ResendConfig;
 #[cfg(feature = "smtp")]
-pub use config::SmtpConfig;
+pub use config::{SmtpConfig, SmtpSecurity};
 
 pub use factory::{mailer, mailer_with};
+pub use template::CachedTemplateProvider;
 pub use template::filesystem::FilesystemProvider;
 pub use template::layout::LayoutEngine;

--- a/modo-email/src/template/cached.rs
+++ b/modo-email/src/template/cached.rs
@@ -1,0 +1,132 @@
+use super::{EmailTemplate, TemplateProvider};
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+
+/// A caching wrapper around any [`TemplateProvider`].
+///
+/// Compiled templates are stored in an LRU cache keyed by `(name, locale)`.
+/// Cache misses delegate to the inner provider. Thread-safe via `Mutex`.
+pub struct CachedTemplateProvider<P: TemplateProvider> {
+    inner: P,
+    cache: Mutex<LruCache<(String, String), EmailTemplate>>,
+}
+
+impl<P: TemplateProvider> CachedTemplateProvider<P> {
+    /// Wrap `inner` with an LRU cache of `capacity` entries.
+    ///
+    /// # Panics
+    /// Panics if `capacity` is zero.
+    pub fn new(inner: P, capacity: usize) -> Self {
+        Self {
+            inner,
+            cache: Mutex::new(LruCache::new(
+                NonZeroUsize::new(capacity).expect("template cache capacity must be > 0"),
+            )),
+        }
+    }
+}
+
+impl<P: TemplateProvider> TemplateProvider for CachedTemplateProvider<P> {
+    fn get(&self, name: &str, locale: &str) -> Result<EmailTemplate, modo::Error> {
+        let key = (name.to_owned(), locale.to_owned());
+
+        // Check cache first.
+        {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(cached) = cache.get(&key) {
+                return Ok(cached.clone());
+            }
+        }
+
+        // Cache miss — load from inner provider.
+        let template = self.inner.get(name, locale)?;
+
+        // Insert into cache.
+        {
+            let mut cache = self.cache.lock().unwrap();
+            cache.put(key, template.clone());
+        }
+
+        Ok(template)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingProvider {
+        call_count: AtomicUsize,
+    }
+
+    impl CountingProvider {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.call_count.load(Ordering::SeqCst)
+        }
+    }
+
+    impl TemplateProvider for CountingProvider {
+        fn get(&self, name: &str, _locale: &str) -> Result<EmailTemplate, modo::Error> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(EmailTemplate {
+                subject: format!("Subject for {name}"),
+                body: format!("Body for {name}"),
+                layout: None,
+            })
+        }
+    }
+
+    #[test]
+    fn cache_hit_avoids_inner_call() {
+        let inner = CountingProvider::new();
+        let cached = CachedTemplateProvider::new(inner, 10);
+
+        let t1 = cached.get("welcome", "").unwrap();
+        assert_eq!(t1.subject, "Subject for welcome");
+
+        let t2 = cached.get("welcome", "").unwrap();
+        assert_eq!(t2.subject, "Subject for welcome");
+
+        assert_eq!(cached.inner.calls(), 1);
+    }
+
+    #[test]
+    fn different_locales_cached_separately() {
+        let inner = CountingProvider::new();
+        let cached = CachedTemplateProvider::new(inner, 10);
+
+        cached.get("welcome", "en").unwrap();
+        cached.get("welcome", "de").unwrap();
+        cached.get("welcome", "en").unwrap(); // cache hit
+
+        assert_eq!(cached.inner.calls(), 2);
+    }
+
+    #[test]
+    fn lru_eviction() {
+        let inner = CountingProvider::new();
+        let cached = CachedTemplateProvider::new(inner, 2);
+
+        cached.get("a", "").unwrap(); // cache: [a]
+        cached.get("b", "").unwrap(); // cache: [a, b]
+        cached.get("c", "").unwrap(); // cache: [b, c] — evicts "a"
+        cached.get("a", "").unwrap(); // cache miss — reload "a"
+
+        assert_eq!(cached.inner.calls(), 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be > 0")]
+    fn zero_capacity_panics() {
+        let inner = CountingProvider::new();
+        let _cached = CachedTemplateProvider::new(inner, 0);
+    }
+}

--- a/modo-email/src/template/email_template.rs
+++ b/modo-email/src/template/email_template.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 
 /// A parsed email template with subject, body, and optional layout.
+#[derive(Clone)]
 pub struct EmailTemplate {
     /// Subject line with `{{var}}` placeholders (not yet substituted).
     pub subject: String,

--- a/modo-email/src/template/mod.rs
+++ b/modo-email/src/template/mod.rs
@@ -1,7 +1,9 @@
+pub mod cached;
 mod email_template;
 pub mod filesystem;
 pub mod layout;
 pub mod markdown;
 pub mod vars;
 
+pub use cached::CachedTemplateProvider;
 pub use email_template::{EmailTemplate, TemplateProvider};

--- a/modo-email/src/transport/smtp.rs
+++ b/modo-email/src/transport/smtp.rs
@@ -15,15 +15,25 @@ pub struct SmtpTransport {
 impl SmtpTransport {
     /// Create an SMTP transport from `SmtpConfig`.
     ///
-    /// When `config.tls` is `true`, uses STARTTLS via `relay()`.
-    /// When `false`, connects without TLS (useful for local dev or trusted relays).
+    /// - `SmtpSecurity::None` — plaintext, no TLS (local dev / trusted relay).
+    /// - `SmtpSecurity::StartTls` — upgrades a plaintext connection via STARTTLS (port 587).
+    /// - `SmtpSecurity::ImplicitTls` — direct TLS connection, SMTPS (port 465).
     pub fn new(config: &SmtpConfig) -> Result<Self, modo::Error> {
-        let builder = if config.tls {
-            AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)
-                .map_err(|e| modo::Error::internal(format!("SMTP config error: {e}")))?
-                .port(config.port)
-        } else {
-            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.host).port(config.port)
+        let builder = match config.security {
+            crate::config::SmtpSecurity::None => {
+                AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&config.host)
+                    .port(config.port)
+            }
+            crate::config::SmtpSecurity::StartTls => {
+                AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.host)
+                    .map_err(|e| modo::Error::internal(format!("SMTP config error: {e}")))?
+                    .port(config.port)
+            }
+            crate::config::SmtpSecurity::ImplicitTls => {
+                AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)
+                    .map_err(|e| modo::Error::internal(format!("SMTP config error: {e}")))?
+                    .port(config.port)
+            }
         };
 
         let mailer = if !config.username.is_empty() {

--- a/modo-email/tests/smtp_e2e.rs
+++ b/modo-email/tests/smtp_e2e.rs
@@ -5,7 +5,8 @@ use modo_email::template::filesystem::FilesystemProvider;
 use modo_email::template::layout::LayoutEngine;
 use modo_email::transport::smtp::SmtpTransport;
 use modo_email::{
-    MailMessage, MailTransport, Mailer, SendEmail, SenderProfile, SmtpConfig, TemplateProvider,
+    MailMessage, MailTransport, Mailer, SendEmail, SenderProfile, SmtpConfig, SmtpSecurity,
+    TemplateProvider,
 };
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
@@ -121,7 +122,7 @@ async fn smtp_end_to_end() {
         port,
         username: String::new(),
         password: String::new(),
-        tls: false,
+        security: SmtpSecurity::None,
     })
     .unwrap();
 
@@ -188,7 +189,7 @@ async fn smtp_full_pipeline_end_to_end() {
             port,
             username: String::new(),
             password: String::new(),
-            tls: false,
+            security: SmtpSecurity::None,
         })
         .unwrap(),
     );

--- a/modo-tenant/src/resolvers/subdomain.rs
+++ b/modo-tenant/src/resolvers/subdomain.rs
@@ -198,31 +198,33 @@ mod tests {
 
     #[tokio::test]
     async fn custom_reserved_subdomains() {
+        // Use a list that differs from the default to prove with_reserved
+        // actually overrides the default list (not just duplicates it).
         let resolver = SubdomainResolver::with_reserved(
             "myapp.com",
-            vec![
-                "www".to_string(),
-                "api".to_string(),
-                "admin".to_string(),
-                "mail".to_string(),
-            ],
+            vec!["staging".to_string(), "internal".to_string()],
             |slug| async move { Ok(Some(TestTenant { id: slug })) },
         );
 
-        // "api" is reserved
-        let p = parts("api.myapp.com");
+        // "staging" is in the custom reserved list
+        let p = parts("staging.myapp.com");
         let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
         assert_eq!(result, None);
 
-        // "admin" is reserved
-        let p = parts("admin.myapp.com");
+        // "internal" is in the custom reserved list
+        let p = parts("internal.myapp.com");
         let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
         assert_eq!(result, None);
 
-        // "mail" is reserved
-        let p = parts("mail.myapp.com");
+        // "www" is NOT in the custom list (proves default is replaced, not merged)
+        let p = parts("www.myapp.com");
         let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
-        assert_eq!(result, None);
+        assert_eq!(
+            result,
+            Some(TestTenant {
+                id: "www".to_string()
+            })
+        );
 
         // "acme" is NOT reserved
         let p = parts("acme.myapp.com");

--- a/modo-tenant/src/resolvers/subdomain.rs
+++ b/modo-tenant/src/resolvers/subdomain.rs
@@ -6,14 +6,19 @@ use std::marker::PhantomData;
 /// Resolves a tenant from the subdomain of the `Host` header.
 ///
 /// Given `base_domain = "myapp.com"`, a request for `acme.myapp.com` extracts
-/// `"acme"` and forwards it to the `lookup` closure. The bare domain and the
-/// `www` subdomain are never forwarded — both return `Ok(None)`. Port suffixes
-/// in the `Host` header are stripped before matching.
+/// `"acme"` and forwards it to the `lookup` closure. The bare domain and
+/// reserved subdomains (default: `["www", "api", "admin", "mail"]`) are never
+/// forwarded — all return `Ok(None)`. Port suffixes in the `Host` header are
+/// stripped before matching.
 pub struct SubdomainResolver<T, F> {
     dot_base_domain: String,
+    reserved: Vec<String>,
     lookup: F,
     _phantom: PhantomData<T>,
 }
+
+/// Default list of reserved subdomains that are never resolved to tenants.
+const DEFAULT_RESERVED: &[&str] = &["www", "api", "admin", "mail"];
 
 impl<T, F, Fut> SubdomainResolver<T, F>
 where
@@ -23,9 +28,25 @@ where
 {
     /// Creates a new `SubdomainResolver` that strips `base_domain` and calls
     /// `lookup` with the remaining subdomain label(s).
+    ///
+    /// Uses the default reserved list: `["www", "api", "admin", "mail"]`.
     pub fn new(base_domain: impl Into<String>, lookup: F) -> Self {
         Self {
             dot_base_domain: format!(".{}", base_domain.into()),
+            reserved: DEFAULT_RESERVED.iter().map(|s| (*s).to_string()).collect(),
+            lookup,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates a new `SubdomainResolver` with a custom reserved subdomain list.
+    ///
+    /// Any subdomain in `reserved` will be treated the same as the bare domain
+    /// and return `Ok(None)` without calling `lookup`.
+    pub fn with_reserved(base_domain: impl Into<String>, reserved: Vec<String>, lookup: F) -> Self {
+        Self {
+            dot_base_domain: format!(".{}", base_domain.into()),
+            reserved,
             lookup,
             _phantom: PhantomData,
         }
@@ -48,7 +69,9 @@ where
 
         let subdomain = host.strip_suffix(&self.dot_base_domain);
         match subdomain {
-            Some(sub) if !sub.is_empty() && sub != "www" => (self.lookup)(sub.to_string()).await,
+            Some(sub) if !sub.is_empty() && !self.reserved.iter().any(|r| r == sub) => {
+                (self.lookup)(sub.to_string()).await
+            }
             _ => Ok(None),
         }
     }
@@ -171,5 +194,44 @@ mod tests {
         let p = parts("acme.myapp.com");
         let result = crate::TenantResolver::resolve(&resolver, &p).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn custom_reserved_subdomains() {
+        let resolver = SubdomainResolver::with_reserved(
+            "myapp.com",
+            vec![
+                "www".to_string(),
+                "api".to_string(),
+                "admin".to_string(),
+                "mail".to_string(),
+            ],
+            |slug| async move { Ok(Some(TestTenant { id: slug })) },
+        );
+
+        // "api" is reserved
+        let p = parts("api.myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
+        assert_eq!(result, None);
+
+        // "admin" is reserved
+        let p = parts("admin.myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
+        assert_eq!(result, None);
+
+        // "mail" is reserved
+        let p = parts("mail.myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
+        assert_eq!(result, None);
+
+        // "acme" is NOT reserved
+        let p = parts("acme.myapp.com");
+        let result = crate::TenantResolver::resolve(&resolver, &p).await.unwrap();
+        assert_eq!(
+            result,
+            Some(TestTenant {
+                id: "acme".to_string()
+            })
+        );
     }
 }

--- a/modo-upload/Cargo.toml
+++ b/modo-upload/Cargo.toml
@@ -31,3 +31,4 @@ tokio = { version = "1", features = ["full", "test-util"] }
 tempfile = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+opendal = { version = "0.53", features = ["services-memory", "services-s3"] }

--- a/modo-upload/src/config.rs
+++ b/modo-upload/src/config.rs
@@ -42,6 +42,25 @@ impl Default for UploadConfig {
     }
 }
 
+impl UploadConfig {
+    /// Validate configuration at startup. Panics if `max_file_size` is set but
+    /// parses to zero or is not a valid size string.
+    ///
+    /// Call this during application startup (e.g., in the storage factory) to
+    /// fail fast rather than discovering bad config at request time.
+    pub fn validate(&self) {
+        if let Some(ref size_str) = self.max_file_size {
+            let bytes = modo::config::parse_size(size_str).unwrap_or_else(|e| {
+                panic!("invalid max_file_size \"{size_str}\": {e}");
+            });
+            assert!(
+                bytes > 0,
+                "max_file_size must be greater than 0, got \"{size_str}\""
+            );
+        }
+    }
+}
+
 /// S3-compatible storage configuration.
 #[cfg(feature = "opendal")]
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -57,4 +76,55 @@ pub struct S3Config {
     pub access_key_id: String,
     /// AWS secret access key.
     pub secret_access_key: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_valid() {
+        // Should not panic
+        let config = UploadConfig::default();
+        config.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "max_file_size")]
+    fn rejects_zero_max_file_size() {
+        let config = UploadConfig {
+            max_file_size: Some("0".to_string()),
+            ..Default::default()
+        };
+        config.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "max_file_size")]
+    fn rejects_zero_bytes_max_file_size() {
+        let config = UploadConfig {
+            max_file_size: Some("0mb".to_string()),
+            ..Default::default()
+        };
+        config.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "max_file_size")]
+    fn rejects_unparseable_max_file_size() {
+        let config = UploadConfig {
+            max_file_size: Some("not-a-size".to_string()),
+            ..Default::default()
+        };
+        config.validate();
+    }
+
+    #[test]
+    fn none_max_file_size_is_valid() {
+        let config = UploadConfig {
+            max_file_size: None,
+            ..Default::default()
+        };
+        config.validate();
+    }
 }

--- a/modo-upload/src/storage/factory.rs
+++ b/modo-upload/src/storage/factory.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 pub fn storage(
     config: &crate::config::UploadConfig,
 ) -> Result<Arc<dyn FileStorageDyn>, modo::Error> {
+    config.validate();
     match config.backend {
         #[cfg(feature = "local")]
         crate::config::StorageBackend::Local => {

--- a/modo-upload/src/storage/guard.rs
+++ b/modo-upload/src/storage/guard.rs
@@ -1,0 +1,90 @@
+use std::path::PathBuf;
+
+/// RAII guard that deletes a partially-written file on drop unless
+/// [`commit()`](Self::commit) is called.
+///
+/// Used by storage backends to ensure partial files are cleaned up
+/// when a write operation fails (e.g., I/O error mid-stream).
+pub(crate) struct CommitGuard {
+    path: Option<PathBuf>,
+}
+
+impl CommitGuard {
+    /// Create a guard that will delete `path` on drop.
+    pub(crate) fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: Some(path.into()),
+        }
+    }
+
+    /// Mark the write as successful. The file will NOT be deleted on drop.
+    pub(crate) fn commit(mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for CommitGuard {
+    fn drop(&mut self) {
+        if let Some(ref path) = self.path {
+            // Best-effort cleanup — log but do not propagate errors.
+            if let Err(e) = std::fs::remove_file(path) {
+                // File may not exist if the create itself failed.
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    modo::tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "failed to clean up partial upload file"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_deletes_file_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("partial.bin");
+        std::fs::write(&file_path, b"partial data").unwrap();
+        assert!(file_path.exists());
+
+        {
+            let _guard = CommitGuard::new(&file_path);
+            // guard dropped here without commit
+        }
+
+        assert!(!file_path.exists(), "partial file should be deleted");
+    }
+
+    #[test]
+    fn guard_keeps_file_after_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("complete.bin");
+        std::fs::write(&file_path, b"complete data").unwrap();
+        assert!(file_path.exists());
+
+        {
+            let guard = CommitGuard::new(&file_path);
+            guard.commit();
+        }
+
+        assert!(file_path.exists(), "committed file should be kept");
+    }
+
+    #[test]
+    fn guard_handles_nonexistent_file() {
+        // Should not panic when the file doesn't exist (create failed before write)
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("never_created.bin");
+
+        {
+            let _guard = CommitGuard::new(&file_path);
+            // guard dropped — file never existed
+        }
+        // No panic expected
+    }
+}

--- a/modo-upload/src/storage/local.rs
+++ b/modo-upload/src/storage/local.rs
@@ -1,3 +1,4 @@
+use super::guard::CommitGuard;
 use super::{FileStorageSend, StoredFile, ensure_within, generate_filename};
 use crate::file::UploadedFile;
 use crate::stream::BufferedUpload;
@@ -39,9 +40,11 @@ impl FileStorageSend for LocalStorage {
                 .map_err(|e| modo::Error::internal(format!("failed to create directory: {e}")))?;
         }
 
+        let guard = CommitGuard::new(&full_path);
         tokio::fs::write(&full_path, file.data())
             .await
             .map_err(|e| modo::Error::internal(format!("failed to write file: {e}")))?;
+        guard.commit();
 
         Ok(StoredFile {
             path: rel_path,
@@ -64,6 +67,7 @@ impl FileStorageSend for LocalStorage {
                 .map_err(|e| modo::Error::internal(format!("failed to create directory: {e}")))?;
         }
 
+        let guard = CommitGuard::new(&full_path);
         let mut file = tokio::fs::File::create(&full_path)
             .await
             .map_err(|e| modo::Error::internal(format!("failed to create file: {e}")))?;
@@ -80,6 +84,7 @@ impl FileStorageSend for LocalStorage {
         file.flush()
             .await
             .map_err(|e| modo::Error::internal(format!("failed to flush file: {e}")))?;
+        guard.commit();
 
         Ok(StoredFile {
             path: rel_path,

--- a/modo-upload/src/storage/mod.rs
+++ b/modo-upload/src/storage/mod.rs
@@ -10,6 +10,7 @@
 //!   including S3-compatible services.  Requires the `opendal` feature.
 
 mod factory;
+mod guard;
 #[cfg(feature = "local")]
 pub mod local;
 #[cfg(feature = "opendal")]

--- a/modo-upload/src/storage/opendal.rs
+++ b/modo-upload/src/storage/opendal.rs
@@ -70,6 +70,7 @@ impl FileStorageSend for OpendalStorage {
         }
 
         if let Err(e) = writer.close().await {
+            let _ = writer.abort().await;
             let _ = self.operator.delete(&path).await;
             return Err(modo::Error::internal(format!(
                 "Failed to finalize write: {e}"

--- a/modo-upload/src/storage/opendal.rs
+++ b/modo-upload/src/storage/opendal.rs
@@ -27,10 +27,11 @@ impl FileStorageSend for OpendalStorage {
         let path = format!("{prefix}/{filename}");
         let size = file.size() as u64;
 
-        self.operator
-            .write(&path, file.data().clone())
-            .await
-            .map_err(|e| modo::Error::internal(format!("failed to store file: {e}")))?;
+        if let Err(e) = self.operator.write(&path, file.data().clone()).await {
+            // Best-effort cleanup of any partial remote object.
+            let _ = self.operator.delete(&path).await;
+            return Err(modo::Error::internal(format!("Failed to store file: {e}")));
+        }
 
         Ok(StoredFile { path, size })
     }
@@ -47,10 +48,10 @@ impl FileStorageSend for OpendalStorage {
         let data = stream.to_bytes();
         let size = data.len() as u64;
 
-        self.operator
-            .write(&path, data)
-            .await
-            .map_err(|e| modo::Error::internal(format!("failed to store file: {e}")))?;
+        if let Err(e) = self.operator.write(&path, data).await {
+            let _ = self.operator.delete(&path).await;
+            return Err(modo::Error::internal(format!("Failed to store file: {e}")));
+        }
 
         Ok(StoredFile { path, size })
     }

--- a/modo-upload/src/storage/opendal.rs
+++ b/modo-upload/src/storage/opendal.rs
@@ -45,15 +45,41 @@ impl FileStorageSend for OpendalStorage {
         let filename = generate_filename(stream.file_name());
         let path = format!("{prefix}/{filename}");
 
-        let data = stream.to_bytes();
-        let size = data.len() as u64;
+        let mut writer = self
+            .operator
+            .writer(&path)
+            .await
+            .map_err(|e| modo::Error::internal(format!("Failed to create writer: {e}")))?;
 
-        if let Err(e) = self.operator.write(&path, data).await {
-            let _ = self.operator.delete(&path).await;
-            return Err(modo::Error::internal(format!("Failed to store file: {e}")));
+        let mut total_size: u64 = 0;
+        while let Some(chunk) = stream.chunk().await {
+            let chunk = match chunk {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = writer.abort().await;
+                    let _ = self.operator.delete(&path).await;
+                    return Err(modo::Error::internal(format!("Failed to read chunk: {e}")));
+                }
+            };
+            total_size += chunk.len() as u64;
+            if let Err(e) = writer.write(chunk).await {
+                let _ = writer.abort().await;
+                let _ = self.operator.delete(&path).await;
+                return Err(modo::Error::internal(format!("Failed to write chunk: {e}")));
+            }
         }
 
-        Ok(StoredFile { path, size })
+        if let Err(e) = writer.close().await {
+            let _ = self.operator.delete(&path).await;
+            return Err(modo::Error::internal(format!(
+                "Failed to finalize write: {e}"
+            )));
+        }
+
+        Ok(StoredFile {
+            path,
+            size: total_size,
+        })
     }
 
     async fn delete(&self, path: &str) -> Result<(), modo::Error> {
@@ -71,5 +97,44 @@ impl FileStorageSend for OpendalStorage {
             .exists(path)
             .await
             .map_err(|e| modo::Error::internal(format!("failed to check file: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::FileStorageSend;
+    use crate::stream::BufferedUpload;
+    use bytes::Bytes;
+
+    fn memory_operator() -> opendal::Operator {
+        opendal::Operator::new(opendal::services::Memory::default())
+            .unwrap()
+            .finish()
+    }
+
+    #[tokio::test]
+    async fn store_stream_writes_incrementally() {
+        let storage = OpendalStorage::new(memory_operator());
+        let chunks = vec![Bytes::from("hello "), Bytes::from("world")];
+        let mut upload = BufferedUpload::__test_new("file", "test.txt", "text/plain", chunks);
+
+        let result = storage.store_stream("uploads", &mut upload).await.unwrap();
+        assert_eq!(result.size, 11); // "hello " + "world"
+        assert!(result.path.starts_with("uploads/"));
+        assert!(result.path.ends_with(".txt"));
+
+        // Verify the file exists and has correct content
+        let data = storage.operator.read(&result.path).await.unwrap().to_vec();
+        assert_eq!(data, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn store_stream_empty_file() {
+        let storage = OpendalStorage::new(memory_operator());
+        let mut upload = BufferedUpload::__test_new("file", "empty.txt", "text/plain", vec![]);
+
+        let result = storage.store_stream("uploads", &mut upload).await.unwrap();
+        assert_eq!(result.size, 0);
     }
 }


### PR DESCRIPTION
## Summary

- **DES-17**: Validate `max_file_size` at startup — panics on zero or unparseable values in `UploadConfig::validate()`, called from storage factory
- **DES-13**: Clean up partial files on write failure — `CommitGuard` RAII for local storage, best-effort delete for OpenDAL
- **DES-23**: Stream chunks to OpenDAL `Writer` instead of buffering entire upload in memory
- **DES-34**: Replace `tls: bool` with `SmtpSecurity` enum (`None`, `StartTls`, `ImplicitTls`) for SMTPS support on port 465
- **DES-35**: Add `CachedTemplateProvider` LRU cache wrapper for email templates, configurable via `cache_templates` and `template_cache_size`
- **DES-38**: Replace hardcoded `"www"` subdomain check with configurable reserved list (default: `www`, `api`, `admin`, `mail`)

## Test Plan

- [x] `cargo test -p modo-upload` — config validation, CommitGuard, streaming writer tests
- [x] `cargo test -p modo-upload --features opendal` — OpenDAL memory-backed streaming tests
- [x] `cargo test -p modo-email --features smtp` — SmtpSecurity deserialization, template cache tests
- [x] `cargo test -p modo-tenant` — reserved subdomain tests (8 existing + 1 new)
- [x] `just check` — fmt, clippy, full workspace tests pass