### PR TITLE
test: add batch 9 testing infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
 
   test-postgres:
     name: Test (Postgres)
-    needs: changes
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,5 +89,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: extractions/setup-just@v2
       - name: Run tests with postgres feature
-        run: cargo test --workspace --all-targets --features postgres
+        run: just test-pg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -61,3 +62,31 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: extractions/setup-just@v2
       - run: just test
+
+  test-postgres:
+    name: Test (Postgres)
+    needs: changes
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: modo
+          POSTGRES_PASSWORD: modo_test
+          POSTGRES_DB: modo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U modo"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://modo:modo_test@localhost:5432/modo_test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests with postgres feature
+        run: cargo test --workspace --all-targets --features postgres

--- a/justfile
+++ b/justfile
@@ -18,6 +18,10 @@ lint:
 test:
     cargo test --workspace --all-targets
 
+# Run all tests with postgres feature (requires running Postgres)
+test-pg:
+    cargo test --workspace --all-targets --features postgres
+
 # Run all checks (fmt + lint + test) — use in CI or pre-push
 check: fmt-check lint test
 

--- a/modo-db-macros/Cargo.toml
+++ b/modo-db-macros/Cargo.toml
@@ -13,3 +13,7 @@ proc-macro = true
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
+
+[dev-dependencies]
+trybuild = "1"
+modo-db = { workspace = true }

--- a/modo-db-macros/tests/ui.rs
+++ b/modo-db-macros/tests/ui.rs
@@ -1,5 +1,4 @@
 #[test]
-#[ignore]
 fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");

--- a/modo-db-macros/tests/ui.rs
+++ b/modo-db-macros/tests/ui.rs
@@ -1,0 +1,6 @@
+#[test]
+#[ignore]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/modo-db-macros/tests/ui/missing_table_attr.rs
+++ b/modo-db-macros/tests/ui/missing_table_attr.rs
@@ -1,0 +1,9 @@
+use modo_db::entity;
+
+#[entity]
+pub struct BadEntity {
+    pub id: String,
+    pub name: String,
+}
+
+fn main() {}

--- a/modo-db-macros/tests/ui/missing_table_attr.stderr
+++ b/modo-db-macros/tests/ui/missing_table_attr.stderr
@@ -1,0 +1,7 @@
+error: unexpected end of input, missing `table` argument
+ --> tests/ui/missing_table_attr.rs:3:1
+  |
+3 | #[entity]
+  | ^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `entity` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/modo-db/tests/concurrent_writes.rs
+++ b/modo-db/tests/concurrent_writes.rs
@@ -1,0 +1,96 @@
+use modo_db::Record;
+use modo_db::sea_orm::{ConnectionTrait, Database, DatabaseConnection};
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::task::JoinSet;
+
+// Force inventory registration
+#[allow(unused_imports)]
+use stress_item as _;
+
+#[modo_db::entity(table = "stress_items")]
+#[entity(timestamps)]
+pub struct StressItem {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub label: String,
+    #[entity(default_value = 0)]
+    pub counter: i32,
+}
+
+async fn setup_db() -> DatabaseConnection {
+    let db = Database::connect("sqlite::memory:").await.unwrap();
+    db.execute_unprepared(
+        "CREATE TABLE IF NOT EXISTS stress_items (
+            id TEXT PRIMARY KEY,
+            label TEXT NOT NULL,
+            counter INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )",
+    )
+    .await
+    .unwrap();
+    db
+}
+
+#[tokio::test]
+async fn concurrent_inserts_no_corruption() {
+    let db = Arc::new(setup_db().await);
+
+    let mut set = JoinSet::new();
+
+    for task_num in 0..20 {
+        let db = db.clone();
+        set.spawn(async move {
+            let mut ids = Vec::new();
+            for i in 0..10 {
+                let item = StressItem {
+                    label: format!("task{task_num}_item{i}"),
+                    ..Default::default()
+                };
+                let inserted = item.insert(&*db).await.unwrap();
+                ids.push(inserted.id.clone());
+            }
+            ids
+        });
+    }
+
+    let mut all_ids = Vec::new();
+    while let Some(result) = set.join_next().await {
+        let ids = result.expect("Task panicked");
+        all_ids.extend(ids);
+    }
+
+    // All 200 inserts should have completed
+    assert_eq!(
+        all_ids.len(),
+        200,
+        "Expected 200 inserts, got {}",
+        all_ids.len()
+    );
+
+    // All IDs should be unique (ULIDs should never collide)
+    let unique_ids: HashSet<&String> = all_ids.iter().collect();
+    assert_eq!(
+        unique_ids.len(),
+        200,
+        "Expected 200 unique IDs, got {}",
+        unique_ids.len()
+    );
+
+    // Verify via find_all that all rows are in the database
+    let all_rows = StressItem::find_all(&*db).await.unwrap();
+    assert_eq!(
+        all_rows.len(),
+        200,
+        "find_all should return 200 rows, got {}",
+        all_rows.len()
+    );
+
+    // Verify all returned IDs match our inserts
+    let db_ids: HashSet<String> = all_rows.into_iter().map(|r| r.id).collect();
+    for id in &all_ids {
+        assert!(db_ids.contains(id), "DB should contain inserted ID {id}");
+    }
+}

--- a/modo-db/tests/pagination.rs
+++ b/modo-db/tests/pagination.rs
@@ -129,6 +129,7 @@ async fn offset_beyond_last_page() {
 async fn offset_per_page_clamped_to_100() {
     let db = setup_db().await;
 
+    // No rows needed — clamping is metadata-only (happens before the query).
     let params = PageParams {
         page: 1,
         per_page: 999,

--- a/modo-db/tests/pagination.rs
+++ b/modo-db/tests/pagination.rs
@@ -1,0 +1,290 @@
+use modo_db::sea_orm::{ConnectionTrait, Database, DatabaseConnection, EntityTrait};
+use modo_db::{CursorParams, CursorResult, PageParams, PageResult, paginate, paginate_cursor};
+
+// Force inventory registration of the test entity
+#[allow(unused_imports)]
+use pag_item as _;
+
+// -- Test entity definition ---------------------------------------------------
+
+#[modo_db::entity(table = "pag_items")]
+#[entity(timestamps)]
+pub struct PagItem {
+    #[entity(primary_key, auto = "ulid")]
+    pub id: String,
+    pub title: String,
+    #[entity(default_value = 0)]
+    pub position: i32,
+}
+
+// -- Setup helpers ------------------------------------------------------------
+
+async fn setup_db() -> DatabaseConnection {
+    let db = Database::connect("sqlite::memory:").await.unwrap();
+    db.execute_unprepared(
+        "CREATE TABLE IF NOT EXISTS pag_items (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            position INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )",
+    )
+    .await
+    .unwrap();
+    db
+}
+
+async fn seed(db: &DatabaseConnection, count: usize) -> Vec<PagItem> {
+    let mut items = Vec::new();
+    for i in 0..count {
+        let item = PagItem {
+            title: format!("item-{i:03}"),
+            position: i as i32,
+            ..Default::default()
+        };
+        let inserted = item.insert(db).await.unwrap();
+        items.push(inserted);
+        // Small delay to ensure ULIDs are ordered
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+    }
+    items
+}
+
+// -- Offset pagination tests --------------------------------------------------
+
+#[tokio::test]
+async fn offset_first_page() {
+    let db = setup_db().await;
+    seed(&db, 25).await;
+
+    let params = PageParams {
+        page: 1,
+        per_page: 10,
+    };
+    let result: PageResult<pag_item::Model> = paginate(pag_item::Entity::find(), &db, &params)
+        .await
+        .unwrap();
+
+    assert_eq!(result.data.len(), 10);
+    assert!(result.has_next, "first page of 25 items should have next");
+    assert!(!result.has_prev, "first page should not have prev");
+}
+
+#[tokio::test]
+async fn offset_middle_page() {
+    let db = setup_db().await;
+    seed(&db, 25).await;
+
+    let params = PageParams {
+        page: 2,
+        per_page: 10,
+    };
+    let result: PageResult<pag_item::Model> = paginate(pag_item::Entity::find(), &db, &params)
+        .await
+        .unwrap();
+
+    assert_eq!(result.data.len(), 10);
+    assert!(result.has_next, "middle page should have next");
+    assert!(result.has_prev, "middle page should have prev");
+}
+
+#[tokio::test]
+async fn offset_last_page() {
+    let db = setup_db().await;
+    seed(&db, 25).await;
+
+    let params = PageParams {
+        page: 3,
+        per_page: 10,
+    };
+    let result: PageResult<pag_item::Model> = paginate(pag_item::Entity::find(), &db, &params)
+        .await
+        .unwrap();
+
+    assert_eq!(result.data.len(), 5);
+    assert!(!result.has_next, "last page should not have next");
+    assert!(result.has_prev, "last page should have prev");
+}
+
+#[tokio::test]
+async fn offset_beyond_last_page() {
+    let db = setup_db().await;
+    seed(&db, 5).await;
+
+    let params = PageParams {
+        page: 10,
+        per_page: 10,
+    };
+    let result: PageResult<pag_item::Model> = paginate(pag_item::Entity::find(), &db, &params)
+        .await
+        .unwrap();
+
+    assert!(result.data.is_empty(), "page beyond last should be empty");
+    assert!(!result.has_next, "page beyond last should not have next");
+    assert!(result.has_prev, "page beyond last should have prev");
+}
+
+#[tokio::test]
+async fn offset_per_page_clamped_to_100() {
+    let db = setup_db().await;
+
+    let params = PageParams {
+        page: 1,
+        per_page: 999,
+    };
+    let result: PageResult<pag_item::Model> = paginate(pag_item::Entity::find(), &db, &params)
+        .await
+        .unwrap();
+
+    assert_eq!(result.per_page, 100, "per_page should be clamped to 100");
+}
+
+#[tokio::test]
+async fn offset_page_zero_treated_as_one() {
+    let db = setup_db().await;
+    seed(&db, 5).await;
+
+    let params = PageParams {
+        page: 0,
+        per_page: 10,
+    };
+    let result: PageResult<pag_item::Model> = paginate(pag_item::Entity::find(), &db, &params)
+        .await
+        .unwrap();
+
+    assert_eq!(result.page, 1, "page 0 should be treated as page 1");
+    assert_eq!(result.data.len(), 5);
+    assert!(!result.has_prev, "page 1 should not have prev");
+}
+
+// -- Cursor pagination tests --------------------------------------------------
+
+#[tokio::test]
+async fn cursor_first_page() {
+    let db = setup_db().await;
+    seed(&db, 15).await;
+
+    let params = CursorParams::<String> {
+        per_page: Some(5),
+        ..Default::default()
+    };
+    let result: CursorResult<pag_item::Model> = paginate_cursor(
+        pag_item::Entity::find(),
+        pag_item::Column::Id,
+        |m: &pag_item::Model| m.id.clone(),
+        &db,
+        &params,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.data.len(), 5);
+    assert!(
+        result.has_next,
+        "first cursor page of 15 items should have next"
+    );
+    assert!(!result.has_prev, "first cursor page should not have prev");
+    assert!(
+        result.next_cursor.is_some(),
+        "first cursor page should provide next_cursor"
+    );
+}
+
+#[tokio::test]
+async fn cursor_forward_navigation() {
+    let db = setup_db().await;
+    seed(&db, 15).await;
+
+    // First page
+    let params1 = CursorParams::<String> {
+        per_page: Some(5),
+        ..Default::default()
+    };
+    let page1: CursorResult<pag_item::Model> = paginate_cursor(
+        pag_item::Entity::find(),
+        pag_item::Column::Id,
+        |m: &pag_item::Model| m.id.clone(),
+        &db,
+        &params1,
+    )
+    .await
+    .unwrap();
+
+    let next_cursor = page1.next_cursor.expect("page1 should have next_cursor");
+
+    // Second page using next_cursor
+    let params2 = CursorParams::<String> {
+        per_page: Some(5),
+        after: Some(next_cursor),
+        ..Default::default()
+    };
+    let page2: CursorResult<pag_item::Model> = paginate_cursor(
+        pag_item::Entity::find(),
+        pag_item::Column::Id,
+        |m: &pag_item::Model| m.id.clone(),
+        &db,
+        &params2,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(page2.data.len(), 5);
+
+    // Ensure no overlap between page1 and page2
+    let page1_ids: Vec<&str> = page1.data.iter().map(|m| m.id.as_str()).collect();
+    let page2_ids: Vec<&str> = page2.data.iter().map(|m| m.id.as_str()).collect();
+    for id in &page2_ids {
+        assert!(
+            !page1_ids.contains(id),
+            "page2 should not overlap with page1, but found {id} in both"
+        );
+    }
+}
+
+#[tokio::test]
+async fn cursor_last_page_no_next() {
+    let db = setup_db().await;
+    seed(&db, 7).await;
+
+    // First page: 5 items
+    let params1 = CursorParams::<String> {
+        per_page: Some(5),
+        ..Default::default()
+    };
+    let page1: CursorResult<pag_item::Model> = paginate_cursor(
+        pag_item::Entity::find(),
+        pag_item::Column::Id,
+        |m: &pag_item::Model| m.id.clone(),
+        &db,
+        &params1,
+    )
+    .await
+    .unwrap();
+
+    let next_cursor = page1.next_cursor.expect("page1 should have next_cursor");
+
+    // Second (last) page: 2 items
+    let params2 = CursorParams::<String> {
+        per_page: Some(5),
+        after: Some(next_cursor),
+        ..Default::default()
+    };
+    let page2: CursorResult<pag_item::Model> = paginate_cursor(
+        pag_item::Entity::find(),
+        pag_item::Column::Id,
+        |m: &pag_item::Model| m.id.clone(),
+        &db,
+        &params2,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        page2.data.len(),
+        2,
+        "last page should have 2 remaining items"
+    );
+    assert!(!page2.has_next, "last page should not have next");
+    assert!(page2.has_prev, "last page should have prev");
+}

--- a/modo-jobs-macros/Cargo.toml
+++ b/modo-jobs-macros/Cargo.toml
@@ -14,3 +14,8 @@ cron = "0.15"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
+
+[dev-dependencies]
+trybuild = "1"
+modo-jobs = { workspace = true }
+modo = { workspace = true }

--- a/modo-jobs-macros/tests/ui.rs
+++ b/modo-jobs-macros/tests/ui.rs
@@ -1,5 +1,4 @@
 #[test]
-#[ignore]
 fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");

--- a/modo-jobs-macros/tests/ui.rs
+++ b/modo-jobs-macros/tests/ui.rs
@@ -1,0 +1,6 @@
+#[test]
+#[ignore]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/modo-jobs-macros/tests/ui/not_async.rs
+++ b/modo-jobs-macros/tests/ui/not_async.rs
@@ -1,0 +1,8 @@
+use modo_jobs::job;
+
+#[job(queue = "default")]
+fn sync_job() -> Result<(), modo::Error> {
+    Ok(())
+}
+
+fn main() {}

--- a/modo-jobs-macros/tests/ui/not_async.stderr
+++ b/modo-jobs-macros/tests/ui/not_async.stderr
@@ -1,0 +1,5 @@
+error: #[job] handlers must be async functions
+ --> tests/ui/not_async.rs:4:1
+  |
+4 | fn sync_job() -> Result<(), modo::Error> {
+  | ^^

--- a/modo-jobs/tests/cleanup_loop.rs
+++ b/modo-jobs/tests/cleanup_loop.rs
@@ -1,0 +1,123 @@
+mod common;
+
+use common::setup_db;
+use modo_db::sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter};
+use modo_jobs::entity::job as jobs_entity;
+use modo_jobs::{JobId, JobState};
+
+async fn insert_job_with_state(
+    db: &modo_db::sea_orm::DatabaseConnection,
+    id: &JobId,
+    state: JobState,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) {
+    let now = chrono::Utc::now();
+    let model = jobs_entity::ActiveModel {
+        id: ActiveValue::Set(id.as_str().to_string()),
+        name: ActiveValue::Set("test_job".to_string()),
+        queue: ActiveValue::Set("default".to_string()),
+        payload: ActiveValue::Set("{}".to_string()),
+        state: ActiveValue::Set(state.as_str().to_string()),
+        priority: ActiveValue::Set(0),
+        attempts: ActiveValue::Set(1),
+        max_attempts: ActiveValue::Set(3),
+        run_at: ActiveValue::Set(now),
+        timeout_secs: ActiveValue::Set(300),
+        locked_by: ActiveValue::Set(None),
+        locked_at: ActiveValue::Set(None),
+        last_error: ActiveValue::Set(None),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(updated_at),
+    };
+    model.insert(db).await.expect("Insert failed");
+}
+
+#[tokio::test]
+async fn cleanup_deletes_old_terminal_jobs() {
+    let db = setup_db().await;
+    let now = chrono::Utc::now();
+    let two_days_ago = now - chrono::Duration::days(2);
+    let one_hour_ago = now - chrono::Duration::hours(1);
+
+    // Old terminal jobs (should be deleted)
+    let old_completed_id = JobId::new();
+    insert_job_with_state(&db, &old_completed_id, JobState::Completed, two_days_ago).await;
+
+    let old_dead_id = JobId::new();
+    insert_job_with_state(&db, &old_dead_id, JobState::Dead, two_days_ago).await;
+
+    let old_cancelled_id = JobId::new();
+    insert_job_with_state(&db, &old_cancelled_id, JobState::Cancelled, two_days_ago).await;
+
+    // Recent completed job (should survive - within retention)
+    let recent_completed_id = JobId::new();
+    insert_job_with_state(&db, &recent_completed_id, JobState::Completed, one_hour_ago).await;
+
+    // Old pending job (should survive - not a terminal state)
+    let old_pending_id = JobId::new();
+    insert_job_with_state(&db, &old_pending_id, JobState::Pending, two_days_ago).await;
+
+    // Simulate cleanup: retention = 86400 seconds (1 day)
+    let retention_secs: i64 = 86400;
+    let cutoff = now - chrono::Duration::seconds(retention_secs);
+
+    let terminal_states: Vec<String> = vec![
+        JobState::Completed.as_str().to_string(),
+        JobState::Dead.as_str().to_string(),
+        JobState::Cancelled.as_str().to_string(),
+    ];
+
+    let result = jobs_entity::Entity::delete_many()
+        .filter(jobs_entity::Column::State.is_in(&terminal_states))
+        .filter(jobs_entity::Column::UpdatedAt.lt(cutoff))
+        .exec(&db)
+        .await
+        .expect("Cleanup delete failed");
+
+    assert_eq!(
+        result.rows_affected, 3,
+        "Should have deleted 3 old terminal jobs"
+    );
+
+    // Verify old terminal jobs are gone
+    let old_completed = jobs_entity::Entity::find_by_id(old_completed_id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed");
+    assert!(
+        old_completed.is_none(),
+        "Old completed job should be deleted"
+    );
+
+    let old_dead = jobs_entity::Entity::find_by_id(old_dead_id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed");
+    assert!(old_dead.is_none(), "Old dead job should be deleted");
+
+    let old_cancelled = jobs_entity::Entity::find_by_id(old_cancelled_id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed");
+    assert!(
+        old_cancelled.is_none(),
+        "Old cancelled job should be deleted"
+    );
+
+    // Verify recent completed job survives
+    let recent_completed = jobs_entity::Entity::find_by_id(recent_completed_id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed");
+    assert!(
+        recent_completed.is_some(),
+        "Recent completed job should survive"
+    );
+
+    // Verify old pending job survives
+    let old_pending = jobs_entity::Entity::find_by_id(old_pending_id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed");
+    assert!(old_pending.is_some(), "Old pending job should survive");
+}

--- a/modo-jobs/tests/concurrent_claims.rs
+++ b/modo-jobs/tests/concurrent_claims.rs
@@ -1,0 +1,91 @@
+mod common;
+
+use common::setup_db;
+use modo_db::sea_orm::{ActiveModelTrait, ActiveValue};
+use modo_jobs::entity::job as jobs_entity;
+use modo_jobs::runner;
+use modo_jobs::{JobId, JobState};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+async fn insert_pending_job(db: &modo_db::sea_orm::DatabaseConnection, id: &JobId) {
+    let now = chrono::Utc::now();
+    let model = jobs_entity::ActiveModel {
+        id: ActiveValue::Set(id.as_str().to_string()),
+        name: ActiveValue::Set("test_job".to_string()),
+        queue: ActiveValue::Set("default".to_string()),
+        payload: ActiveValue::Set("{}".to_string()),
+        state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
+        priority: ActiveValue::Set(0),
+        attempts: ActiveValue::Set(0),
+        max_attempts: ActiveValue::Set(3),
+        run_at: ActiveValue::Set(now),
+        timeout_secs: ActiveValue::Set(300),
+        locked_by: ActiveValue::Set(None),
+        locked_at: ActiveValue::Set(None),
+        last_error: ActiveValue::Set(None),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+    };
+    model.insert(db).await.expect("Insert failed");
+}
+
+#[tokio::test]
+async fn no_double_claims_under_concurrency() {
+    let db = setup_db().await;
+
+    // Insert 10 pending jobs
+    let mut job_ids: HashSet<String> = HashSet::new();
+    for _ in 0..10 {
+        let id = JobId::new();
+        job_ids.insert(id.as_str().to_string());
+        insert_pending_job(&db, &id).await;
+    }
+
+    // Spawn 20 workers (2x the number of jobs) each trying to claim
+    let db = Arc::new(db);
+    let mut handles = Vec::new();
+
+    for worker_num in 0..20 {
+        let db = db.clone();
+        let worker_id = format!("worker-{worker_num}");
+        handles.push(tokio::spawn(async move {
+            runner::claim_next(&*db, "default", &worker_id)
+                .await
+                .expect("Claim failed")
+                .map(|job| job.id)
+        }));
+    }
+
+    // Collect all claimed job IDs
+    let mut claimed_ids: Vec<String> = Vec::new();
+    for handle in handles {
+        if let Some(id) = handle.await.expect("Task panicked") {
+            claimed_ids.push(id);
+        }
+    }
+
+    // Verify: exactly 10 jobs claimed (all jobs were claimed)
+    assert_eq!(
+        claimed_ids.len(),
+        10,
+        "Should have claimed exactly 10 jobs, got {}",
+        claimed_ids.len()
+    );
+
+    // Verify: no duplicates
+    let claimed_set: HashSet<String> = claimed_ids.iter().cloned().collect();
+    assert_eq!(
+        claimed_set.len(),
+        claimed_ids.len(),
+        "No duplicate claims should occur"
+    );
+
+    // Verify: all claimed IDs are from the original set
+    for claimed_id in &claimed_set {
+        assert!(
+            job_ids.contains(claimed_id),
+            "Claimed ID {claimed_id} should be from the original job set"
+        );
+    }
+}

--- a/modo-jobs/tests/concurrent_claims.rs
+++ b/modo-jobs/tests/concurrent_claims.rs
@@ -50,7 +50,7 @@ async fn no_double_claims_under_concurrency() {
         let db = db.clone();
         let worker_id = format!("worker-{worker_num}");
         handles.push(tokio::spawn(async move {
-            runner::claim_next(&*db, "default", &worker_id)
+            runner::claim_next(&db, "default", &worker_id)
                 .await
                 .expect("Claim failed")
                 .map(|job| job.id)

--- a/modo-jobs/tests/concurrent_stress.rs
+++ b/modo-jobs/tests/concurrent_stress.rs
@@ -1,0 +1,116 @@
+mod common;
+
+use chrono::Utc;
+use common::setup_db;
+use modo_db::sea_orm::{ActiveModelTrait, ActiveValue};
+use modo_jobs::entity::job as jobs_entity;
+use modo_jobs::runner;
+use modo_jobs::{JobId, JobState};
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::task::JoinSet;
+
+async fn insert_job(db: &modo_db::sea_orm::DatabaseConnection, id: &JobId) {
+    let now = Utc::now();
+    let model = jobs_entity::ActiveModel {
+        id: ActiveValue::Set(id.as_str().to_string()),
+        name: ActiveValue::Set("stress_job".to_string()),
+        queue: ActiveValue::Set("default".to_string()),
+        payload: ActiveValue::Set("{}".to_string()),
+        state: ActiveValue::Set(JobState::Pending.as_str().to_string()),
+        priority: ActiveValue::Set(0),
+        attempts: ActiveValue::Set(0),
+        max_attempts: ActiveValue::Set(3),
+        run_at: ActiveValue::Set(now),
+        timeout_secs: ActiveValue::Set(300),
+        locked_by: ActiveValue::Set(None),
+        locked_at: ActiveValue::Set(None),
+        last_error: ActiveValue::Set(None),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+    };
+    model.insert(db).await.expect("Insert failed");
+}
+
+#[tokio::test]
+async fn concurrent_inserts_and_claims() {
+    let db = Arc::new(setup_db().await);
+
+    // Phase 1: 50 concurrent inserts
+    let mut insert_set = JoinSet::new();
+    let mut expected_ids = HashSet::new();
+
+    for _ in 0..50 {
+        let id = JobId::new();
+        expected_ids.insert(id.as_str().to_string());
+        let db = db.clone();
+        insert_set.spawn(async move {
+            insert_job(&*db, &id).await;
+        });
+    }
+
+    // Wait for all inserts to complete
+    while let Some(result) = insert_set.join_next().await {
+        result.expect("Insert task panicked");
+    }
+
+    // Phase 2: 10 workers claiming until queue is empty
+    let claimed_ids = Arc::new(Mutex::new(Vec::new()));
+    let mut claim_set = JoinSet::new();
+
+    for worker_num in 0..10 {
+        let db = db.clone();
+        let claimed_ids = claimed_ids.clone();
+        let worker_id = format!("worker-{worker_num}");
+
+        claim_set.spawn(async move {
+            loop {
+                let result = runner::claim_next(&*db, "default", &worker_id)
+                    .await
+                    .expect("Claim failed");
+
+                match result {
+                    Some(job) => {
+                        let mut ids = claimed_ids.lock().await;
+                        ids.push(job.id);
+                    }
+                    None => break, // No more jobs
+                }
+            }
+        });
+    }
+
+    // Wait for all workers to finish
+    while let Some(result) = claim_set.join_next().await {
+        result.expect("Claim task panicked");
+    }
+
+    let claimed = claimed_ids.lock().await;
+
+    // Verify: total claimed == 50
+    assert_eq!(
+        claimed.len(),
+        50,
+        "Expected 50 claimed jobs, got {}",
+        claimed.len()
+    );
+
+    // Verify: no duplicate claims
+    let claimed_set: HashSet<String> = claimed.iter().cloned().collect();
+    assert_eq!(
+        claimed_set.len(),
+        claimed.len(),
+        "No duplicate claims should occur; unique={}, total={}",
+        claimed_set.len(),
+        claimed.len()
+    );
+
+    // Verify: all claimed IDs come from the original set
+    for id in claimed_set.iter() {
+        assert!(
+            expected_ids.contains(id),
+            "Claimed ID {id} should be from the original job set"
+        );
+    }
+}

--- a/modo-jobs/tests/concurrent_stress.rs
+++ b/modo-jobs/tests/concurrent_stress.rs
@@ -46,7 +46,7 @@ async fn concurrent_inserts_and_claims() {
         expected_ids.insert(id.as_str().to_string());
         let db = db.clone();
         insert_set.spawn(async move {
-            insert_job(&*db, &id).await;
+            insert_job(&db, &id).await;
         });
     }
 
@@ -66,7 +66,7 @@ async fn concurrent_inserts_and_claims() {
 
         claim_set.spawn(async move {
             loop {
-                let result = runner::claim_next(&*db, "default", &worker_id)
+                let result = runner::claim_next(&db, "default", &worker_id)
                     .await
                     .expect("Claim failed");
 

--- a/modo-jobs/tests/cron_system.rs
+++ b/modo-jobs/tests/cron_system.rs
@@ -13,7 +13,7 @@ fn cron_expression_parses_and_schedules() {
     let now = Utc::now();
     let diff = (next_time - now).num_seconds();
     assert!(
-        diff >= 0 && diff <= 60,
+        (0..=60).contains(&diff),
         "Next fire time should be within 60s, got {diff}s"
     );
 }
@@ -30,7 +30,7 @@ fn cron_every_second_expression() {
     for (i, time) in upcoming.iter().enumerate() {
         let diff = (*time - now).num_seconds();
         assert!(
-            diff >= 0 && diff <= 5,
+            (0..=5).contains(&diff),
             "Fire time {i} should be within 5s of now, got {diff}s"
         );
     }

--- a/modo-jobs/tests/cron_system.rs
+++ b/modo-jobs/tests/cron_system.rs
@@ -1,3 +1,9 @@
+//! Dependency smoke tests for cron scheduling infrastructure.
+//!
+//! These tests validate the upstream `cron` and `tokio_util` crates that
+//! modo-jobs relies on for cron scheduling — they don't exercise modo-jobs
+//! APIs directly, but guard against regressions in key dependency behaviour.
+
 use chrono::Utc;
 use cron::Schedule;
 use std::str::FromStr;

--- a/modo-jobs/tests/cron_system.rs
+++ b/modo-jobs/tests/cron_system.rs
@@ -1,0 +1,106 @@
+use chrono::Utc;
+use cron::Schedule;
+use std::str::FromStr;
+
+#[test]
+fn cron_expression_parses_and_schedules() {
+    // "0 * * * * *" = every minute (at second 0)
+    let schedule = Schedule::from_str("0 * * * * *").expect("Failed to parse cron expression");
+    let next = schedule.upcoming(Utc).next();
+    assert!(next.is_some(), "Should have a next fire time");
+
+    let next_time = next.unwrap();
+    let now = Utc::now();
+    let diff = (next_time - now).num_seconds();
+    assert!(
+        diff >= 0 && diff <= 60,
+        "Next fire time should be within 60s, got {diff}s"
+    );
+}
+
+#[test]
+fn cron_every_second_expression() {
+    // "* * * * * *" = every second
+    let schedule = Schedule::from_str("* * * * * *").expect("Failed to parse cron expression");
+    let now = Utc::now();
+    let upcoming: Vec<_> = schedule.upcoming(Utc).take(5).collect();
+
+    assert_eq!(upcoming.len(), 5, "Should have 5 upcoming fire times");
+
+    for (i, time) in upcoming.iter().enumerate() {
+        let diff = (*time - now).num_seconds();
+        assert!(
+            diff >= 0 && diff <= 5,
+            "Fire time {i} should be within 5s of now, got {diff}s"
+        );
+    }
+}
+
+#[tokio::test]
+async fn cron_loop_respects_cancellation() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use tokio_util::sync::CancellationToken;
+
+    let cancel = CancellationToken::new();
+    let tick_count = Arc::new(AtomicU32::new(0));
+    let tick_count_clone = tick_count.clone();
+    let cancel_clone = cancel.clone();
+
+    let handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(50));
+        loop {
+            tokio::select! {
+                _ = cancel_clone.cancelled() => {
+                    break;
+                }
+                _ = interval.tick() => {
+                    tick_count_clone.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        }
+    });
+
+    // Let it tick a few times
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let count_before_cancel = tick_count.load(Ordering::SeqCst);
+    assert!(
+        count_before_cancel >= 2,
+        "Should have ticked at least twice before cancel, got {count_before_cancel}"
+    );
+
+    // Cancel and wait for the task to fully exit
+    cancel.cancel();
+    handle.await.expect("Task panicked");
+
+    // Record count after the task has exited
+    let count_at_exit = tick_count.load(Ordering::SeqCst);
+
+    // After a further delay, verify no more ticks occur
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let count_after_wait = tick_count.load(Ordering::SeqCst);
+    assert_eq!(
+        count_at_exit, count_after_wait,
+        "No more ticks should occur after cancellation (at_exit={count_at_exit}, after_wait={count_after_wait})"
+    );
+}
+
+#[test]
+fn cron_schedule_exhaustion() {
+    // "0 0 * * * *" = every hour (at minute 0, second 0)
+    let schedule = Schedule::from_str("0 0 * * * *").expect("Failed to parse cron expression");
+
+    // An hourly schedule should always have upcoming times
+    let upcoming: Vec<_> = schedule.upcoming(Utc).take(10).collect();
+    assert_eq!(
+        upcoming.len(),
+        10,
+        "Hourly schedule should always have upcoming fire times"
+    );
+
+    // Verify each subsequent time is about 1 hour apart
+    for window in upcoming.windows(2) {
+        let diff = (window[1] - window[0]).num_seconds();
+        assert_eq!(diff, 3600, "Each pair should be 1 hour apart, got {diff}s");
+    }
+}

--- a/modo-jobs/tests/stale_reaper.rs
+++ b/modo-jobs/tests/stale_reaper.rs
@@ -1,0 +1,129 @@
+mod common;
+
+use common::setup_db;
+use modo_db::sea_orm::sea_query::Expr;
+use modo_db::sea_orm::{
+    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, ExprTrait, QueryFilter,
+};
+use modo_jobs::entity::job as jobs_entity;
+use modo_jobs::{JobId, JobState};
+
+async fn insert_running_job(
+    db: &modo_db::sea_orm::DatabaseConnection,
+    id: &JobId,
+    locked_at: chrono::DateTime<chrono::Utc>,
+    attempts: i32,
+) {
+    let now = chrono::Utc::now();
+    let model = jobs_entity::ActiveModel {
+        id: ActiveValue::Set(id.as_str().to_string()),
+        name: ActiveValue::Set("test_job".to_string()),
+        queue: ActiveValue::Set("default".to_string()),
+        payload: ActiveValue::Set("{}".to_string()),
+        state: ActiveValue::Set(JobState::Running.as_str().to_string()),
+        priority: ActiveValue::Set(0),
+        attempts: ActiveValue::Set(attempts),
+        max_attempts: ActiveValue::Set(5),
+        run_at: ActiveValue::Set(now),
+        timeout_secs: ActiveValue::Set(300),
+        locked_by: ActiveValue::Set(Some("worker-1".to_string())),
+        locked_at: ActiveValue::Set(Some(locked_at)),
+        last_error: ActiveValue::Set(None),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+    };
+    model.insert(db).await.expect("Insert failed");
+}
+
+#[tokio::test]
+async fn reaper_requeues_stale_running_job() {
+    let db = setup_db().await;
+    let now = chrono::Utc::now();
+
+    // Stale job: locked 20 minutes ago (threshold is 10 min = 600s)
+    let stale_id = JobId::new();
+    let stale_locked_at = now - chrono::Duration::minutes(20);
+    insert_running_job(&db, &stale_id, stale_locked_at, 3).await;
+
+    // Fresh job: locked 2 minutes ago (well within threshold)
+    let fresh_id = JobId::new();
+    let fresh_locked_at = now - chrono::Duration::minutes(2);
+    insert_running_job(&db, &fresh_id, fresh_locked_at, 2).await;
+
+    // Simulate reaper: threshold = 10 minutes (600 seconds)
+    let threshold_secs: i64 = 600;
+    let cutoff = now - chrono::Duration::seconds(threshold_secs);
+
+    let update = jobs_entity::Entity::update_many()
+        .filter(jobs_entity::Column::State.eq(JobState::Running.as_str()))
+        .filter(jobs_entity::Column::LockedAt.lt(cutoff))
+        .col_expr(
+            jobs_entity::Column::State,
+            Expr::value(JobState::Pending.as_str()),
+        )
+        .col_expr(
+            jobs_entity::Column::Attempts,
+            Expr::col(jobs_entity::Column::Attempts).sub(1),
+        )
+        .col_expr(
+            jobs_entity::Column::LockedBy,
+            Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            jobs_entity::Column::LockedAt,
+            Expr::value(Option::<chrono::DateTime<chrono::Utc>>::None),
+        )
+        .col_expr(jobs_entity::Column::UpdatedAt, Expr::value(now));
+
+    let result = update.exec(&db).await.expect("Reaper update failed");
+    assert_eq!(
+        result.rows_affected, 1,
+        "Should have reaped exactly 1 stale job"
+    );
+
+    // Verify stale job is now pending with decremented attempts and cleared lock
+    let stale_job = jobs_entity::Entity::find_by_id(stale_id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed")
+        .expect("Stale job not found");
+
+    assert_eq!(stale_job.state, "pending", "Stale job should be pending");
+    assert_eq!(
+        stale_job.attempts, 2,
+        "Stale job attempts should be decremented from 3 to 2"
+    );
+    assert!(
+        stale_job.locked_by.is_none(),
+        "Stale job locked_by should be cleared"
+    );
+    assert!(
+        stale_job.locked_at.is_none(),
+        "Stale job locked_at should be cleared"
+    );
+
+    // Verify fresh job is unchanged
+    let fresh_job = jobs_entity::Entity::find_by_id(fresh_id.as_str())
+        .one(&db)
+        .await
+        .expect("Query failed")
+        .expect("Fresh job not found");
+
+    assert_eq!(
+        fresh_job.state, "running",
+        "Fresh job should still be running"
+    );
+    assert_eq!(
+        fresh_job.attempts, 2,
+        "Fresh job attempts should be unchanged"
+    );
+    assert_eq!(
+        fresh_job.locked_by.as_deref(),
+        Some("worker-1"),
+        "Fresh job locked_by should be unchanged"
+    );
+    assert!(
+        fresh_job.locked_at.is_some(),
+        "Fresh job locked_at should still be set"
+    );
+}

--- a/modo-session/tests/common/mod.rs
+++ b/modo-session/tests/common/mod.rs
@@ -1,0 +1,29 @@
+use modo_db::sea_orm::{ConnectionTrait, Schema};
+use modo_db::{DatabaseConfig, DbPool};
+
+pub async fn setup_db() -> DbPool {
+    let config = DatabaseConfig {
+        url: "sqlite::memory:".to_string(),
+        max_connections: 1,
+        min_connections: 1,
+        ..Default::default()
+    };
+    let db = modo_db::connect(&config).await.expect("Failed to connect");
+    let schema = Schema::new(db.connection().get_database_backend());
+    let mut builder = schema.builder();
+    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_sessions")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder
+        .sync(db.connection())
+        .await
+        .expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.connection()
+            .execute_unprepared(sql)
+            .await
+            .expect("Extra SQL failed");
+    }
+    db
+}

--- a/modo-session/tests/concurrent_sessions.rs
+++ b/modo-session/tests/concurrent_sessions.rs
@@ -1,0 +1,112 @@
+// Force the linker to include modo_session entity registration.
+#[allow(unused_imports)]
+use modo_session::entity::session as _;
+
+use modo_db::sea_orm::{ConnectionTrait, Schema};
+use modo_db::{DatabaseConfig, DbPool};
+use modo_session::{SessionConfig, SessionMeta, SessionStore};
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::task::JoinSet;
+
+async fn setup_db() -> DbPool {
+    let config = DatabaseConfig {
+        url: "sqlite::memory:".to_string(),
+        max_connections: 1,
+        min_connections: 1,
+        ..Default::default()
+    };
+    let db = modo_db::connect(&config).await.expect("Failed to connect");
+
+    let schema = Schema::new(db.connection().get_database_backend());
+    let mut builder = schema.builder();
+    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_sessions")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder
+        .sync(db.connection())
+        .await
+        .expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.connection()
+            .execute_unprepared(sql)
+            .await
+            .expect("Extra SQL failed");
+    }
+    db
+}
+
+fn test_meta(user_num: usize) -> SessionMeta {
+    SessionMeta::from_headers(
+        format!("127.0.0.{user_num}"),
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0",
+        "en-US",
+        "gzip",
+    )
+}
+
+#[tokio::test]
+async fn concurrent_session_creation() {
+    let db = setup_db().await;
+    let mut config = SessionConfig::default();
+    config.max_sessions_per_user = 100; // High limit for stress test
+    let store = Arc::new(SessionStore::new(&db, config, Default::default()));
+
+    let mut set = JoinSet::new();
+
+    // 5 users x 10 sessions each = 50 sessions
+    for user_num in 0..5_usize {
+        for session_num in 0..10_usize {
+            let store = store.clone();
+            let meta = test_meta(user_num);
+            let user_id = format!("user_{user_num}");
+            set.spawn(async move {
+                let (session, token) =
+                    store
+                        .create(&meta, &user_id, None)
+                        .await
+                        .unwrap_or_else(|e| {
+                            panic!("Failed to create session for {user_id} #{session_num}: {e}")
+                        });
+
+                // Read back by token to verify it was persisted correctly
+                let found = store.read_by_token(&token).await.unwrap_or_else(|e| {
+                    panic!("Failed to read session by token for {user_id}: {e}")
+                });
+                assert!(
+                    found.is_some(),
+                    "Session for {user_id} #{session_num} should be found by token"
+                );
+                let found = found.unwrap();
+                assert_eq!(found.id, session.id);
+                assert_eq!(found.user_id, user_id);
+
+                session.id.to_string()
+            });
+        }
+    }
+
+    let mut all_ids: Vec<String> = Vec::new();
+    while let Some(result) = set.join_next().await {
+        let session_id = result.expect("Task panicked");
+        all_ids.push(session_id);
+    }
+
+    // Verify total count
+    assert_eq!(
+        all_ids.len(),
+        50,
+        "Expected 50 sessions, got {}",
+        all_ids.len()
+    );
+
+    // Verify all session IDs are unique
+    let unique_ids: HashSet<&String> = all_ids.iter().collect();
+    assert_eq!(
+        unique_ids.len(),
+        50,
+        "Expected 50 unique session IDs, got {}",
+        unique_ids.len()
+    );
+}

--- a/modo-session/tests/concurrent_sessions.rs
+++ b/modo-session/tests/concurrent_sessions.rs
@@ -1,41 +1,16 @@
+//! TEST-12: Concurrent session creation stress test.
+
 // Force the linker to include modo_session entity registration.
 #[allow(unused_imports)]
 use modo_session::entity::session as _;
 
-use modo_db::sea_orm::{ConnectionTrait, Schema};
-use modo_db::{DatabaseConfig, DbPool};
+mod common;
+
+use common::setup_db;
 use modo_session::{SessionConfig, SessionMeta, SessionStore};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::task::JoinSet;
-
-async fn setup_db() -> DbPool {
-    let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
-        max_connections: 1,
-        min_connections: 1,
-        ..Default::default()
-    };
-    let db = modo_db::connect(&config).await.expect("Failed to connect");
-
-    let schema = Schema::new(db.connection().get_database_backend());
-    let mut builder = schema.builder();
-    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
-        .find(|r| r.table_name == "modo_sessions")
-        .unwrap();
-    builder = (reg.register_fn)(builder);
-    builder
-        .sync(db.connection())
-        .await
-        .expect("Schema sync failed");
-    for sql in reg.extra_sql {
-        db.connection()
-            .execute_unprepared(sql)
-            .await
-            .expect("Extra SQL failed");
-    }
-    db
-}
 
 fn test_meta(user_num: usize) -> SessionMeta {
     SessionMeta::from_headers(

--- a/modo-session/tests/concurrent_sessions.rs
+++ b/modo-session/tests/concurrent_sessions.rs
@@ -49,8 +49,10 @@ fn test_meta(user_num: usize) -> SessionMeta {
 #[tokio::test]
 async fn concurrent_session_creation() {
     let db = setup_db().await;
-    let mut config = SessionConfig::default();
-    config.max_sessions_per_user = 100; // High limit for stress test
+    let config = SessionConfig {
+        max_sessions_per_user: 100, // High limit for stress test
+        ..Default::default()
+    };
     let store = Arc::new(SessionStore::new(&db, config, Default::default()));
 
     let mut set = JoinSet::new();

--- a/modo-session/tests/cross_user_revocation.rs
+++ b/modo-session/tests/cross_user_revocation.rs
@@ -8,36 +8,10 @@
 #[allow(unused_imports)]
 use modo_session::entity::session as _;
 
-use modo_db::sea_orm::{ConnectionTrait, Schema};
-use modo_db::{DatabaseConfig, DbPool};
-use modo_session::{SessionConfig, SessionMeta, SessionStore};
+mod common;
 
-async fn setup_db() -> DbPool {
-    let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
-        max_connections: 1,
-        min_connections: 1,
-        ..Default::default()
-    };
-    let db = modo_db::connect(&config).await.expect("Failed to connect");
-    let schema = Schema::new(db.connection().get_database_backend());
-    let mut builder = schema.builder();
-    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
-        .find(|r| r.table_name == "modo_sessions")
-        .unwrap();
-    builder = (reg.register_fn)(builder);
-    builder
-        .sync(db.connection())
-        .await
-        .expect("Schema sync failed");
-    for sql in reg.extra_sql {
-        db.connection()
-            .execute_unprepared(sql)
-            .await
-            .expect("Extra SQL failed");
-    }
-    db
-}
+use common::setup_db;
+use modo_session::{SessionConfig, SessionMeta, SessionStore};
 
 fn test_meta() -> SessionMeta {
     SessionMeta::from_headers(

--- a/modo-session/tests/cross_user_revocation.rs
+++ b/modo-session/tests/cross_user_revocation.rs
@@ -1,0 +1,112 @@
+//! TEST-09: Cross-user session revocation.
+//!
+//! Validates that an admin can revoke all sessions belonging to a specific user
+//! without affecting other users, and that individual sessions can be revoked
+//! by ID.
+
+// Force the linker to include modo_session entity registration.
+#[allow(unused_imports)]
+use modo_session::entity::session as _;
+
+use modo_db::sea_orm::{ConnectionTrait, Schema};
+use modo_db::{DatabaseConfig, DbPool};
+use modo_session::{SessionConfig, SessionMeta, SessionStore};
+
+async fn setup_db() -> DbPool {
+    let config = DatabaseConfig {
+        url: "sqlite::memory:".to_string(),
+        max_connections: 1,
+        min_connections: 1,
+        ..Default::default()
+    };
+    let db = modo_db::connect(&config).await.expect("Failed to connect");
+    let schema = Schema::new(db.connection().get_database_backend());
+    let mut builder = schema.builder();
+    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_sessions")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder
+        .sync(db.connection())
+        .await
+        .expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.connection()
+            .execute_unprepared(sql)
+            .await
+            .expect("Extra SQL failed");
+    }
+    db
+}
+
+fn test_meta() -> SessionMeta {
+    SessionMeta::from_headers(
+        "127.0.0.1".to_string(),
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0",
+        "en-US",
+        "gzip",
+    )
+}
+
+/// Admin revokes all sessions for user A; user A's tokens become invalid
+/// while the admin's own session survives.
+#[tokio::test]
+async fn admin_revokes_all_user_sessions() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
+    let meta = test_meta();
+
+    // User A creates 2 sessions.
+    let (_sa1, ta1) = store.create(&meta, "user-a", None).await.unwrap();
+    let (_sa2, ta2) = store.create(&meta, "user-a", None).await.unwrap();
+
+    // Admin creates 1 session.
+    let (_sadmin, tadmin) = store.create(&meta, "admin", None).await.unwrap();
+
+    // Admin revokes all of user A's sessions.
+    store.destroy_all_for_user("user-a").await.unwrap();
+
+    // Both of user A's tokens are now invalid.
+    assert!(
+        store.read_by_token(&ta1).await.unwrap().is_none(),
+        "user-a session 1 should be revoked"
+    );
+    assert!(
+        store.read_by_token(&ta2).await.unwrap().is_none(),
+        "user-a session 2 should be revoked"
+    );
+
+    // Admin's session is unaffected.
+    assert!(
+        store.read_by_token(&tadmin).await.unwrap().is_some(),
+        "admin session should still be valid"
+    );
+}
+
+/// Destroying a specific session by ID leaves other sessions for the same
+/// user intact.
+#[tokio::test]
+async fn revoke_specific_session_by_id() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
+    let meta = test_meta();
+
+    // User creates 2 sessions.
+    let (s1, t1) = store.create(&meta, "user-a", None).await.unwrap();
+    let (_s2, t2) = store.create(&meta, "user-a", None).await.unwrap();
+
+    // Destroy only the first session.
+    store.destroy(&s1.id).await.unwrap();
+
+    // First session is gone.
+    assert!(
+        store.read_by_token(&t1).await.unwrap().is_none(),
+        "first session should be destroyed"
+    );
+
+    // Second session remains.
+    assert!(
+        store.read_by_token(&t2).await.unwrap().is_some(),
+        "second session should still be valid"
+    );
+}

--- a/modo-session/tests/fingerprint_mismatch.rs
+++ b/modo-session/tests/fingerprint_mismatch.rs
@@ -1,0 +1,121 @@
+//! TEST-08: Fingerprint mismatch detection.
+//!
+//! Validates that session fingerprint comparison works correctly:
+//! - Mismatched fingerprints (different User-Agent) are detected and the session
+//!   is destroyed (simulating middleware behaviour when `validate_fingerprint` is true).
+//! - Matching fingerprints leave the session intact.
+
+// Force the linker to include modo_session entity registration.
+#[allow(unused_imports)]
+use modo_session::entity::session as _;
+
+use modo_db::sea_orm::{ConnectionTrait, Schema};
+use modo_db::{DatabaseConfig, DbPool};
+use modo_session::{SessionConfig, SessionMeta, SessionStore};
+
+async fn setup_db() -> DbPool {
+    let config = DatabaseConfig {
+        url: "sqlite::memory:".to_string(),
+        max_connections: 1,
+        min_connections: 1,
+        ..Default::default()
+    };
+    let db = modo_db::connect(&config).await.expect("Failed to connect");
+    let schema = Schema::new(db.connection().get_database_backend());
+    let mut builder = schema.builder();
+    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
+        .find(|r| r.table_name == "modo_sessions")
+        .unwrap();
+    builder = (reg.register_fn)(builder);
+    builder
+        .sync(db.connection())
+        .await
+        .expect("Schema sync failed");
+    for sql in reg.extra_sql {
+        db.connection()
+            .execute_unprepared(sql)
+            .await
+            .expect("Extra SQL failed");
+    }
+    db
+}
+
+fn chrome_meta() -> SessionMeta {
+    SessionMeta::from_headers(
+        "127.0.0.1".to_string(),
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0",
+        "en-US",
+        "gzip",
+    )
+}
+
+fn firefox_meta() -> SessionMeta {
+    SessionMeta::from_headers(
+        "127.0.0.1".to_string(),
+        "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+        "en-US",
+        "gzip",
+    )
+}
+
+/// When a session is replayed with a different User-Agent the fingerprints
+/// differ. The middleware would destroy such a session; here we simulate
+/// that flow at the store level.
+#[tokio::test]
+async fn fingerprint_mismatch_destroys_session() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
+
+    // Create a session with Chrome UA.
+    let chrome = chrome_meta();
+    let (session, token) = store.create(&chrome, "user-a", None).await.unwrap();
+
+    // Session exists.
+    let found = store.read_by_token(&token).await.unwrap();
+    assert!(found.is_some(), "session should exist after creation");
+
+    // Simulate a replayed request with Firefox UA.
+    let firefox = firefox_meta();
+
+    // Fingerprints must differ.
+    assert_ne!(
+        session.fingerprint, firefox.fingerprint,
+        "Chrome and Firefox fingerprints should differ"
+    );
+
+    // Middleware would destroy the session on mismatch; simulate that.
+    store.destroy(&session.id).await.unwrap();
+
+    // Session is gone.
+    let found = store.read_by_token(&token).await.unwrap();
+    assert!(
+        found.is_none(),
+        "session should be destroyed after fingerprint mismatch"
+    );
+}
+
+/// When a session is loaded back with the same headers, fingerprints match
+/// and the session remains accessible.
+#[tokio::test]
+async fn fingerprint_match_preserves_session() {
+    let db = setup_db().await;
+    let store = SessionStore::new(&db, SessionConfig::default(), Default::default());
+
+    let meta = chrome_meta();
+    let (session, token) = store.create(&meta, "user-a", None).await.unwrap();
+
+    // Re-derive fingerprint from the same headers.
+    let same_meta = chrome_meta();
+    assert_eq!(
+        session.fingerprint, same_meta.fingerprint,
+        "identical headers should produce the same fingerprint"
+    );
+
+    // Session is still accessible.
+    let found = store.read_by_token(&token).await.unwrap();
+    assert!(
+        found.is_some(),
+        "session should survive when fingerprint matches"
+    );
+    assert_eq!(found.unwrap().id, session.id);
+}

--- a/modo-session/tests/fingerprint_mismatch.rs
+++ b/modo-session/tests/fingerprint_mismatch.rs
@@ -9,36 +9,10 @@
 #[allow(unused_imports)]
 use modo_session::entity::session as _;
 
-use modo_db::sea_orm::{ConnectionTrait, Schema};
-use modo_db::{DatabaseConfig, DbPool};
-use modo_session::{SessionConfig, SessionMeta, SessionStore};
+mod common;
 
-async fn setup_db() -> DbPool {
-    let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
-        max_connections: 1,
-        min_connections: 1,
-        ..Default::default()
-    };
-    let db = modo_db::connect(&config).await.expect("Failed to connect");
-    let schema = Schema::new(db.connection().get_database_backend());
-    let mut builder = schema.builder();
-    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
-        .find(|r| r.table_name == "modo_sessions")
-        .unwrap();
-    builder = (reg.register_fn)(builder);
-    builder
-        .sync(db.connection())
-        .await
-        .expect("Schema sync failed");
-    for sql in reg.extra_sql {
-        db.connection()
-            .execute_unprepared(sql)
-            .await
-            .expect("Extra SQL failed");
-    }
-    db
-}
+use common::setup_db;
+use modo_session::{SessionConfig, SessionMeta, SessionStore};
 
 fn chrome_meta() -> SessionMeta {
     SessionMeta::from_headers(

--- a/modo-session/tests/integration.rs
+++ b/modo-session/tests/integration.rs
@@ -2,37 +2,10 @@
 #[allow(unused_imports)]
 use modo_session::entity::session as _;
 
-use modo_db::sea_orm::{ConnectionTrait, Schema};
-use modo_db::{DatabaseConfig, DbPool};
+mod common;
+
+use common::setup_db;
 use modo_session::{SessionConfig, SessionMeta, SessionStore};
-
-async fn setup_db() -> DbPool {
-    let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
-        max_connections: 1,
-        min_connections: 1,
-        ..Default::default()
-    };
-    let db = modo_db::connect(&config).await.expect("Failed to connect");
-
-    let schema = Schema::new(db.connection().get_database_backend());
-    let mut builder = schema.builder();
-    let reg = modo_db::inventory::iter::<modo_db::EntityRegistration>()
-        .find(|r| r.table_name == "modo_sessions")
-        .unwrap();
-    builder = (reg.register_fn)(builder);
-    builder
-        .sync(db.connection())
-        .await
-        .expect("Schema sync failed");
-    for sql in reg.extra_sql {
-        db.connection()
-            .execute_unprepared(sql)
-            .await
-            .expect("Extra SQL failed");
-    }
-    db
-}
 
 fn test_meta() -> SessionMeta {
     SessionMeta::from_headers(

--- a/modo-session/tests/max_sessions_zero.rs
+++ b/modo-session/tests/max_sessions_zero.rs
@@ -1,0 +1,23 @@
+//! TEST-10: Validates DES-24 — `max_sessions_per_user = 0` must be rejected.
+//!
+//! The `SessionConfig` type uses a custom serde deserializer that rejects zero
+//! for `max_sessions_per_user` (setting it to 0 would lock out all users).
+//! These integration-level tests verify the guard from outside the crate.
+
+#[test]
+fn zero_max_sessions_rejected_on_deserialization() {
+    let yaml = "max_sessions_per_user: 0";
+    let err = serde_yaml_ng::from_str::<modo_session::SessionConfig>(yaml).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("max_sessions_per_user must be > 0"),
+        "unexpected error: {err}",
+    );
+}
+
+#[test]
+fn nonzero_max_sessions_accepted_on_deserialization() {
+    let yaml = "max_sessions_per_user: 1";
+    let config: modo_session::SessionConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(config.max_sessions_per_user, 1);
+}

--- a/modo-upload-macros/Cargo.toml
+++ b/modo-upload-macros/Cargo.toml
@@ -13,3 +13,7 @@ proc-macro = true
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
+
+[dev-dependencies]
+trybuild = "1"
+modo-upload = { workspace = true }

--- a/modo-upload-macros/tests/ui.rs
+++ b/modo-upload-macros/tests/ui.rs
@@ -1,5 +1,4 @@
 #[test]
-#[ignore]
 fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");

--- a/modo-upload-macros/tests/ui.rs
+++ b/modo-upload-macros/tests/ui.rs
@@ -1,0 +1,6 @@
+#[test]
+#[ignore]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/modo-upload-macros/tests/ui/non_struct.rs
+++ b/modo-upload-macros/tests/ui/non_struct.rs
@@ -1,0 +1,9 @@
+use modo_upload::FromMultipart;
+
+#[derive(FromMultipart)]
+enum BadForm {
+    A,
+    B,
+}
+
+fn main() {}

--- a/modo-upload-macros/tests/ui/non_struct.stderr
+++ b/modo-upload-macros/tests/ui/non_struct.stderr
@@ -1,0 +1,8 @@
+error: FromMultipart can only be derived for structs
+ --> tests/ui/non_struct.rs:4:1
+  |
+4 | / enum BadForm {
+5 | |     A,
+6 | |     B,
+7 | | }
+  | |_^

--- a/modo-upload/Cargo.toml
+++ b/modo-upload/Cargo.toml
@@ -27,7 +27,9 @@ ulid = "1"
 opendal = { version = "0.53", optional = true, features = ["services-s3"] }
 
 [dev-dependencies]
+axum-extra = { version = "0.10", features = ["cookie-signed"] }
 tokio = { version = "1", features = ["full", "test-util"] }
+tower = { version = "0.5", features = ["util"] }
 tempfile = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/modo-upload/tests/max_payload.rs
+++ b/modo-upload/tests/max_payload.rs
@@ -1,0 +1,90 @@
+//! Integration test for max_file_size enforcement in MultipartForm extractor.
+//!
+//! The `MultipartForm<T>` extractor reads `UploadConfig` from
+//! `AppState.services.get::<UploadConfig>()` and passes `max_file_size` to
+//! `FromMultipart::from_multipart()`. When a file exceeds the global
+//! max_file_size, it returns 413 PAYLOAD_TOO_LARGE. When within the limit,
+//! it returns 200 OK.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use modo::app::{AppState, ServiceRegistry};
+use modo::config::ServerConfig;
+use modo_upload::{FromMultipart, MultipartForm, UploadConfig, UploadedFile};
+use tower::ServiceExt;
+
+#[derive(FromMultipart)]
+struct TestUpload {
+    #[allow(dead_code)]
+    file: UploadedFile,
+}
+
+async fn upload_handler(form: MultipartForm<TestUpload>) -> &'static str {
+    let _ = form.into_inner();
+    "ok"
+}
+
+fn app_state_with_max_file_size(max_size: &str) -> AppState {
+    let config = UploadConfig {
+        max_file_size: Some(max_size.to_string()),
+        ..Default::default()
+    };
+    let services = ServiceRegistry::new().with(config);
+    AppState {
+        services,
+        server_config: ServerConfig::default(),
+        cookie_key: axum_extra::extract::cookie::Key::generate(),
+    }
+}
+
+fn multipart_request(file_content: &[u8]) -> Request<Body> {
+    let boundary = "----TestBoundary";
+    let mut body = format!(
+        "--{boundary}\r\n\
+         Content-Disposition: form-data; name=\"file\"; filename=\"test.bin\"\r\n\
+         Content-Type: application/octet-stream\r\n\r\n"
+    )
+    .into_bytes();
+    body.extend_from_slice(file_content);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+    Request::builder()
+        .method("POST")
+        .uri("/upload")
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(Body::from(body))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn rejects_file_exceeding_max_file_size() {
+    let state = app_state_with_max_file_size("100b");
+    let app = Router::new()
+        .route("/upload", post(upload_handler))
+        .with_state(state);
+
+    // Send 200 bytes, limit is 100 bytes
+    let request = multipart_request(&[0u8; 200]);
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn accepts_file_within_max_file_size() {
+    let state = app_state_with_max_file_size("1kb");
+    let app = Router::new()
+        .route("/upload", post(upload_handler))
+        .with_state(state);
+
+    // Send 100 bytes, limit is 1024 bytes
+    let request = multipart_request(&[0u8; 100]);
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/modo/tests/middleware_stacking.rs
+++ b/modo/tests/middleware_stacking.rs
@@ -1,0 +1,140 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Extension, Router};
+use std::sync::{Arc, Mutex};
+use tower::ServiceExt;
+
+#[derive(Clone, Default)]
+struct ExecutionLog(Arc<Mutex<Vec<String>>>);
+
+impl ExecutionLog {
+    fn push(&self, label: &str) {
+        self.0.lock().unwrap().push(label.to_string());
+    }
+
+    fn entries(&self) -> Vec<String> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+async fn handler(Extension(log): Extension<ExecutionLog>) -> impl IntoResponse {
+    log.push("handler");
+    "ok"
+}
+
+async fn global_middleware(
+    Extension(log): Extension<ExecutionLog>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    log.push("global_mw_before");
+    let response = next.run(request).await;
+    log.push("global_mw_after");
+    response
+}
+
+async fn module_middleware(
+    Extension(log): Extension<ExecutionLog>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    log.push("module_mw_before");
+    let response = next.run(request).await;
+    log.push("module_mw_after");
+    response
+}
+
+async fn handler_middleware(
+    Extension(log): Extension<ExecutionLog>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    log.push("handler_mw_before");
+    let response = next.run(request).await;
+    log.push("handler_mw_after");
+    response
+}
+
+#[tokio::test]
+async fn middleware_executes_in_correct_order() {
+    let log = ExecutionLog::default();
+
+    let app = Router::new()
+        .route("/test", get(handler))
+        .layer(axum::middleware::from_fn(handler_middleware)) // innermost
+        .layer(axum::middleware::from_fn(module_middleware)) // middle
+        .layer(axum::middleware::from_fn(global_middleware)) // outermost
+        .layer(Extension(log.clone()));
+
+    let response = app
+        .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"ok");
+
+    let entries = log.entries();
+    assert_eq!(
+        entries,
+        vec![
+            "global_mw_before",
+            "module_mw_before",
+            "handler_mw_before",
+            "handler",
+            "handler_mw_after",
+            "module_mw_after",
+            "global_mw_after",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn nested_module_middleware_order() {
+    let log = ExecutionLog::default();
+
+    let module_router = Router::new()
+        .route("/endpoint", get(handler))
+        .layer(axum::middleware::from_fn(module_middleware));
+
+    let app = Router::new()
+        .nest("/api", module_router)
+        .layer(axum::middleware::from_fn(global_middleware))
+        .layer(Extension(log.clone()));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/endpoint")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"ok");
+
+    let entries = log.entries();
+    assert_eq!(
+        entries,
+        vec![
+            "global_mw_before",
+            "module_mw_before",
+            "handler",
+            "module_mw_after",
+            "global_mw_after",
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

- **13 test items** across modo-db, modo-jobs, modo-session, modo-upload, and modo core crate validating features from Batches 5-8
- **Postgres CI job** (manual-trigger only via `workflow_dispatch` to save CI minutes) with PostgreSQL 18 service container
- **Trybuild compile-fail tests** for all 3 macro crates (modo-db-macros, modo-jobs-macros, modo-upload-macros)

### New test files

| File | Test ID | Crate |
|---|---|---|
| `modo-session/tests/fingerprint_mismatch.rs` | TEST-08 | modo-session |
| `modo-session/tests/cross_user_revocation.rs` | TEST-09 | modo-session |
| `modo-session/tests/max_sessions_zero.rs` | TEST-10 | modo-session |
| `modo-jobs/tests/cron_system.rs` | TEST-02 | modo-jobs |
| `modo-jobs/tests/stale_reaper.rs` | TEST-03 | modo-jobs |
| `modo-jobs/tests/cleanup_loop.rs` | TEST-04 | modo-jobs |
| `modo-jobs/tests/concurrent_claims.rs` | TEST-05 | modo-jobs |
| `modo-db/tests/pagination.rs` | TEST-01 | modo-db |
| `modo-upload/tests/max_payload.rs` | TEST-07 | modo-upload |
| `modo/tests/middleware_stacking.rs` | TEST-13 | modo |
| `modo-db/tests/concurrent_writes.rs` | TEST-12 | modo-db |
| `modo-session/tests/concurrent_sessions.rs` | TEST-12 | modo-session |
| `modo-jobs/tests/concurrent_stress.rs` | TEST-12 | modo-jobs |
| `modo-db-macros/tests/ui{.rs,/missing_table_attr.rs}` | TEST-11 | modo-db-macros |
| `modo-jobs-macros/tests/ui{.rs,/not_async.rs}` | TEST-11 | modo-jobs-macros |
| `modo-upload-macros/tests/ui{.rs,/non_struct.rs}` | TEST-11 | modo-upload-macros |

### Modified files

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Add `test-postgres` job (manual trigger only) |
| `modo-db-macros/Cargo.toml` | Add `trybuild` dev-dependency |
| `modo-jobs-macros/Cargo.toml` | Add `trybuild` dev-dependency |
| `modo-upload-macros/Cargo.toml` | Add `trybuild` dev-dependency |
| `modo-upload/Cargo.toml` | Add `tower`, `axum-extra` dev-dependencies |

## Test plan

- [x] `just check` passes (fmt + lint + test)
- [x] All 13 new test items pass individually
- [x] Trybuild compile-fail tests pass
- [x] No regressions in existing tests