### PR TITLE
docs: update READMEs and add inline doc comments across crates

### DIFF
--- a/modo-auth/src/provider.rs
+++ b/modo-auth/src/provider.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 /// Implement this on your own type (e.g., a repository struct that holds a DB pool)
 /// and register it via `app.service(UserProviderService::new(your_impl))`.
 pub trait UserProvider: Send + Sync + 'static {
+    /// The user type returned by this provider.
     type User: Clone + Send + Sync + 'static;
 
     /// Look up a user by their ID (as stored in the session).

--- a/modo-cli/README.md
+++ b/modo-cli/README.md
@@ -74,11 +74,25 @@ The CLI prints the recommended next steps. For a `web` project:
 
 ```
 cd my-app
-just assets-download     # download HTMX, Alpine.js (first time only)
+just assets-download     # download HTMX, Alpine.js, Tailwind Elements (first time only)
 just dev                 # start Docker services, build CSS, run dev server
 ```
 
-For other templates:
+For `api` or `worker` projects with SQLite:
+
+```
+cd my-service
+just dev
+```
+
+For `api` or `worker` projects with PostgreSQL, `just dev` also starts the Docker Compose services (Postgres):
+
+```
+cd my-api
+just dev
+```
+
+For `minimal` projects:
 
 ```
 cd my-service

--- a/modo-cli/README.md
+++ b/modo-cli/README.md
@@ -78,26 +78,15 @@ just assets-download     # download HTMX, Alpine.js, Tailwind Elements (first ti
 just dev                 # start Docker services, build CSS, run dev server
 ```
 
-For `api` or `worker` projects with SQLite:
+For other templates (`api`, `worker`, `minimal`):
 
 ```
 cd my-service
 just dev
 ```
 
-For `api` or `worker` projects with PostgreSQL, `just dev` also starts the Docker Compose services (Postgres):
-
-```
-cd my-api
-just dev
-```
-
-For `minimal` projects:
-
-```
-cd my-service
-just dev
-```
+When Docker Compose services are configured (Postgres via `--postgres`, RustFS via `--s3`,
+or Mailpit in `web` templates), `just dev` starts them automatically.
 
 ## Project name rules
 

--- a/modo-cli/src/scaffold.rs
+++ b/modo-cli/src/scaffold.rs
@@ -36,6 +36,11 @@ pub fn scaffold(
     Ok(())
 }
 
+/// Recursively writes all files in `dir` into `target_dir`, rooted at `prefix`.
+///
+/// Renders `.jinja` files through MiniJinja and strips the `.jinja` extension.
+/// Skips a `.jinja` file when it renders to empty output AND its source contains
+/// a `{% if %}` block (so unconditionally empty stubs are still written).
 fn write_dir(
     env: &Environment,
     dir: &Dir<'static>,

--- a/modo-db-macros/README.md
+++ b/modo-db-macros/README.md
@@ -1,7 +1,5 @@
 # modo-db-macros
 
-[![docs.rs](https://img.shields.io/docsrs/modo-db-macros)](https://docs.rs/modo-db-macros)
-
 Procedural macros powering the `modo-db` entity and migration system.
 
 This crate is an implementation detail of `modo-db`. Consume these macros through the
@@ -28,7 +26,7 @@ Place these as a second `#[entity(...)]` attribute on the struct itself.
 
 | Option                              | Effect                                                                                    |
 | ----------------------------------- | ----------------------------------------------------------------------------------------- |
-| `timestamps`                        | Injects `created_at` and `updated_at: DateTime<Utc>` columns; set automatically via `Record::apply_auto_fields` on every insert and update. |
+| `timestamps`                        | Injects `created_at` and `updated_at: DateTime<Utc>` columns; set automatically on every insert and update. |
 | `soft_delete`                       | Injects `deleted_at: Option<DateTime<Utc>>`. The `delete` method becomes a soft-delete (sets `deleted_at`). Extra methods generated: `with_deleted`, `only_deleted`, `restore`, `force_delete`, `force_delete_by_id`, `delete_many` (bulk soft-delete), `force_delete_many` (bulk hard-delete). `find_all` and `query` exclude soft-deleted rows automatically. |
 | `framework`                         | Marks the entity as framework-internal (hidden from user schema).                         |
 | `index(columns = ["col1", "col2"])` | Creates a composite index. Add `unique` inside for a unique index.                        |
@@ -44,6 +42,7 @@ Place these as `#[entity(...)]` on individual struct fields.
 | `auto = "ulid"\|"short_id"`    | Generates a ULID or short ID before insert. Only valid on `primary_key` fields.  |
 | `unique`                       | Adds a unique constraint.                                                        |
 | `indexed`                      | Creates a single-column index.                                                   |
+| `nullable`                     | Accepted but has no effect. `Option<T>` already implies nullable in SeaORM.      |
 | `column_type = "<type>"`       | Overrides the inferred SeaORM column type string.                                |
 | `default_value = <literal>`    | Sets a column default value.                                                     |
 | `default_expr = "<expr>"`      | Sets a default SQL expression.                                                   |
@@ -51,10 +50,10 @@ Place these as `#[entity(...)]` on individual struct fields.
 | `to_column = "<Column>"`       | Overrides the target column for a `belongs_to` FK (default: `"Id"`).            |
 | `on_delete = "<action>"`       | FK action on delete: `Cascade`, `SetNull`, `Restrict`, `NoAction`, `SetDefault`. |
 | `on_update = "<action>"`       | FK action on update. Same values as `on_delete`.                                 |
-| `has_many`                     | Declares a `HasMany` relation (field excluded from the model columns).           |
+| `has_many`                     | Declares a `HasMany` relation (field excluded from the model columns). Requires `target = "<Entity>"`. |
 | `has_one`                      | Declares a `HasOne` relation (field excluded from the model columns).            |
 | `via = "<JoinEntity>"`         | Many-to-many via a join entity. Used with `has_many` or `has_one`.               |
-| `target = "<Entity>"`          | Overrides the inferred target entity name for `has_many` / `has_one` when the field name does not match the entity name. |
+| `target = "<Entity>"`          | Overrides the inferred target entity name for `has_many` / `has_one` when the field name does not match the entity name. Required for `has_many`. |
 | `renamed_from = "<old>"`       | Records a rename hint as a column comment.                                       |
 
 #### What the macro emits
@@ -62,7 +61,7 @@ Place these as `#[entity(...)]` on individual struct fields.
 For a struct named `Foo`, the macro emits:
 
 - The original `Foo` struct with `#[derive(Clone, Debug, serde::Serialize)]`
-- `impl Default for Foo` — auto-generates IDs (ULID/NanoID), sets timestamps to `Utc::now()`,
+- `impl Default for Foo` — auto-generates IDs (ULID/short_id), sets timestamps to `Utc::now()`,
   uses type defaults for all other fields (`String::new()`, `false`, `0`, `None`, etc.)
 - `impl From<foo::Model> for Foo` — converts a SeaORM model to the domain struct
 - `pub mod foo { ... }` containing:
@@ -125,8 +124,8 @@ pub struct User {
     pub id: String,
     #[entity(unique)]
     pub email: String,
-    // Relation field — excluded from model columns
-    #[entity(has_many)]
+    // Relation field — excluded from model columns; target is required for has_many
+    #[entity(has_many, target = "Post")]
     pub posts: (),
 }
 
@@ -159,8 +158,7 @@ The optional `group` parameter (defaults to `"default"`) assigns the migration t
 Migrations in a group run only when `modo_db::sync_and_migrate_group` is called with the
 matching group name.
 
-The annotated function must be `async fn(db: &sea_orm::DatabaseConnection) -> Result<(), modo::Error>`.
-The `db` parameter implements `ConnectionTrait`, so the full SeaORM typed API is available:
+The annotated function must be `async fn(db: &sea_orm::DatabaseConnection) -> Result<(), modo::Error>`:
 
 ```rust,ignore
 #[modo_db::migration(version = 1, description = "seed default roles")]

--- a/modo-db-macros/README.md
+++ b/modo-db-macros/README.md
@@ -1,5 +1,7 @@
 # modo-db-macros
 
+[![docs.rs](https://img.shields.io/docsrs/modo-db-macros)](https://docs.rs/modo-db-macros)
+
 Procedural macros powering the `modo-db` entity and migration system.
 
 This crate is an implementation detail of `modo-db`. Consume these macros through the
@@ -158,7 +160,8 @@ The optional `group` parameter (defaults to `"default"`) assigns the migration t
 Migrations in a group run only when `modo_db::sync_and_migrate_group` is called with the
 matching group name.
 
-The annotated function must be `async fn(db: &sea_orm::DatabaseConnection) -> Result<(), modo::Error>`:
+The annotated function must be `async fn(db: &sea_orm::DatabaseConnection) -> Result<(), modo::Error>`.
+The `db` parameter implements `ConnectionTrait`, so the full SeaORM typed API is available:
 
 ```rust,ignore
 #[modo_db::migration(version = 1, description = "seed default roles")]

--- a/modo-db-macros/src/lib.rs
+++ b/modo-db-macros/src/lib.rs
@@ -21,8 +21,7 @@ mod migration;
 /// # Struct-level options (applied as a second `#[entity(...)]` attribute)
 ///
 /// - `timestamps` — injects `created_at` and `updated_at` columns of type
-///   `DateTime<Utc>`; both are set automatically via `Record::apply_auto_fields`
-///   on every insert and update.
+///   `DateTime<Utc>`; both are set automatically on every insert and update.
 /// - `soft_delete` — injects a `deleted_at: Option<DateTime<Utc>>` column. The
 ///   `delete` method becomes a soft-delete (sets `deleted_at`). Extra methods
 ///   generated on the struct: `with_deleted`, `only_deleted`, `restore`,
@@ -53,11 +52,12 @@ mod migration;
 ///   `Restrict`, `NoAction`, `SetDefault`.
 /// - `on_update = "<action>"` — FK action on update. Same values as `on_delete`.
 /// - `has_many` — declares a `HasMany` relation (field is excluded from the model).
+///   **Requires** `target = "<Entity>"`.
 /// - `has_one` — declares a `HasOne` relation (field is excluded from the model).
 /// - `via = "<JoinEntity>"` — used with `has_many` / `has_one` for many-to-many
 ///   relations through a join entity.
-/// - `target = "<Entity>"` — overrides the inferred target entity name for `has_many`
-///   / `has_one` relations when the field name does not match the entity name.
+/// - `target = "<Entity>"` — required for `has_many`; overrides the inferred target
+///   entity name for `has_one` when the field name does not match the entity name.
 /// - `renamed_from = "<old_name>"` — records a rename hint as a column comment.
 ///
 /// # Example

--- a/modo-db/README.md
+++ b/modo-db/README.md
@@ -92,7 +92,8 @@ The macro creates:
 
 - Your struct `Todo` with `Clone, Debug, Serialize, Default, From<todo::Model>`
 - A submodule `todo` containing `Model`, `ActiveModel`, `Entity`, `Column`, and `Relation`
-- An `impl Record for Todo` with CRUD operations and query builders
+- Inherent CRUD methods (`insert`, `update`, `delete`, `find_by_id`, `delete_by_id`) on the struct
+- An `impl Record for Todo` with query builder methods (`find_all`, `query`, `update_many`, `delete_many`)
 
 Because `Default` is generated, you can use struct-update syntax to set only the fields you care about:
 
@@ -132,7 +133,7 @@ let todo = Todo {
 
 ### CRUD operations
 
-The `Record` trait is implemented for every entity struct. All CRUD methods are inherent methods on your struct, so you call them directly without importing extra traits.
+All CRUD methods are inherent methods generated on your struct. The `Record` trait methods (`find_all`, `query`, `update_many`, `delete_many`) require `use modo_db::Record` in scope.
 
 #### Insert
 
@@ -331,7 +332,7 @@ impl User {
 
     pub fn before_delete(&self) -> Result<(), modo::Error> {
         if self.email.ends_with("@example.com") {
-            return Err(modo::Error::bad_request("cannot delete example accounts"));
+            return Err(modo::HttpError::BadRequest.with_message("cannot delete example accounts"));
         }
         Ok(())
     }
@@ -439,7 +440,7 @@ let n = Item::force_delete_many()
 
 ### Partial updates
 
-When you need to update only specific fields without fetching the full record first, use `into_active_model` and the raw SeaORM API:
+To update only specific fields using the raw SeaORM active model API, use `into_active_model` to obtain a PK-only active model and set only the fields you need:
 
 ```rust,ignore
 use sea_orm::{ActiveModelTrait, Set};
@@ -532,7 +533,7 @@ let short_id = modo_db::generate_short_id(); // 13-char Base36, time-sortable
 | `DatabaseConfig`                      | Connection URL + pool size, deserialised from YAML                                |
 | `DbPool`                              | Newtype over `sea_orm::DatabaseConnection`; implements `GracefulShutdown`         |
 | `Db`                                  | Axum extractor that pulls `DbPool` from app state                                 |
-| `Record`                              | Trait implemented by every entity struct; provides CRUD and query builder methods |
+| `Record`                              | Trait providing `find_all`, `query`, `update_many`, `delete_many`; implemented for every entity struct |
 | `DefaultHooks`                        | Blanket trait providing no-op `before_save`, `after_save`, `before_delete`        |
 | `EntityQuery<T, E>`                   | Chainable query builder with automatic domain-type conversion                     |
 | `EntityUpdateMany<E>`                 | Chainable bulk UPDATE builder                                                     |

--- a/modo-db/src/query.rs
+++ b/modo-db/src/query.rs
@@ -17,17 +17,18 @@ use crate::pagination::{
 /// A chainable query builder that wraps SeaORM's `Select<E>` and
 /// auto-converts results to the domain type `T` via `From<E::Model>`.
 ///
-/// Construct one from `E::find()` or `E::find_by_id(pk)` and then chain
-/// filter/order/limit/offset calls before executing with a terminal method.
+/// The primary entry point is the `Record::query()` method generated on every
+/// entity struct. `EntityQuery::new` is available for advanced cases where you
+/// need to wrap a raw `Select<E>`.
 ///
 /// # Example
 ///
 /// ```rust,ignore
-/// let todos: Vec<Todo> = EntityQuery::new(TodoEntity::find())
-///     .filter(todo::Column::Done.eq(false))
+/// let todos: Vec<Todo> = Todo::query()
+///     .filter(todo::Column::Completed.eq(false))
 ///     .order_by_asc(todo::Column::CreatedAt)
 ///     .limit(10)
-///     .all(&db)
+///     .all(&*db)
 ///     .await?;
 /// ```
 pub struct EntityQuery<T, E: EntityTrait> {
@@ -348,13 +349,17 @@ where
 /// A chainable wrapper around SeaORM's `UpdateMany<E>` that returns
 /// `rows_affected` on execution.
 ///
+/// Typically obtained via `Record::update_many()` on an entity struct.
+///
 /// # Example
 ///
 /// ```rust,ignore
-/// let affected = EntityUpdateMany::new(TodoEntity::update_many())
-///     .filter(todo::Column::Done.eq(false))
-///     .col_expr(todo::Column::Done, Expr::value(true))
-///     .exec(&db)
+/// use sea_orm::sea_query::Expr;
+///
+/// let affected = Todo::update_many()
+///     .filter(todo::Column::Completed.eq(false))
+///     .col_expr(todo::Column::Completed, Expr::value(true))
+///     .exec(&*db)
 ///     .await?;
 /// ```
 pub struct EntityUpdateMany<E: EntityTrait> {
@@ -402,12 +407,16 @@ impl<E: EntityTrait> EntityUpdateMany<E> {
 /// A chainable wrapper around SeaORM's `DeleteMany<E>` that returns
 /// `rows_affected` on execution.
 ///
+/// Typically obtained via `Record::delete_many()` on an entity struct.
+/// For soft-delete entities, `delete_many()` performs a soft delete (UPDATE SET
+/// `deleted_at`). Use `force_delete_many()` to permanently remove rows.
+///
 /// # Example
 ///
 /// ```rust,ignore
-/// let deleted = EntityDeleteMany::new(TodoEntity::delete_many())
-///     .filter(todo::Column::Done.eq(true))
-///     .exec(&db)
+/// let deleted = Todo::delete_many()
+///     .filter(todo::Column::Completed.eq(true))
+///     .exec(&*db)
 ///     .await?;
 /// ```
 pub struct EntityDeleteMany<E: EntityTrait> {

--- a/modo-db/src/sync.rs
+++ b/modo-db/src/sync.rs
@@ -6,12 +6,11 @@ use tracing::info;
 
 /// Synchronize database schema from all registered entities, then run all pending migrations.
 ///
-/// 1. Bootstrap `_modo_migrations` table (must exist before schema sync)
-/// 2. Collect all `EntityRegistration` entries from `inventory`
-/// 3. Register framework entities first, then user entities
-/// 4. Run `SchemaBuilder::sync()` (addition-only, topo-sorted by SeaORM)
-/// 5. Execute extra SQL (composite indices, partial unique indices)
-/// 6. Run pending migrations (version-ordered, tracked in `_modo_migrations`)
+/// 1. Bootstrap `_modo_migrations` table (must exist before schema sync).
+/// 2. Collect all `EntityRegistration` entries from `inventory` (framework entities first,
+///    then user entities), and run `SchemaBuilder::sync()` (addition-only).
+/// 3. Execute extra SQL registered with each entity (composite indices, partial unique indices).
+/// 4. Run pending migrations in ascending `version` order, tracked in `_modo_migrations`.
 pub async fn sync_and_migrate(db: &DbPool) -> Result<(), modo::Error> {
     do_sync(db, None).await
 }

--- a/modo-email/README.md
+++ b/modo-email/README.md
@@ -50,10 +50,10 @@ email:
         port: 587
         username: "user"
         password: "pass"
-        tls: true
+        security: starttls  # none | starttls | implicit_tls
 ```
 
-All fields have defaults (`templates_path` defaults to `"emails"`, `smtp.port` to `587`, `smtp.tls` to `true`). Only specify what you need to override.
+All fields have defaults (`templates_path` defaults to `"emails"`, `smtp.host` to `"localhost"`, `smtp.port` to `587`, `smtp.security` to `starttls`). Only specify what you need to override.
 
 ### Send a Templated Email
 
@@ -352,25 +352,27 @@ email:
 
 ### `EmailConfig`
 
-| Field                | Type              | Default    | Description                                 |
-| -------------------- | ----------------- | ---------- | ------------------------------------------- |
-| `transport`          | `smtp` / `resend` | `smtp`     | Which transport backend to use              |
-| `templates_path`     | `String`          | `"emails"` | Directory containing `.md` templates        |
-| `default_from_name`  | `String`          | `""`       | Default sender display name                 |
-| `default_from_email` | `String`          | `""`       | Default sender email address                |
-| `default_reply_to`   | `Option<String>`  | `None`     | Default reply-to address                    |
-| `smtp`               | `SmtpConfig`      | see below  | SMTP settings (requires `smtp` feature)     |
-| `resend`             | `ResendConfig`    | see below  | Resend settings (requires `resend` feature) |
+| Field                 | Type              | Default    | Description                                              |
+| --------------------- | ----------------- | ---------- | -------------------------------------------------------- |
+| `transport`           | `smtp` / `resend` | `smtp`     | Which transport backend to use                           |
+| `templates_path`      | `String`          | `"emails"` | Directory containing `.md` templates                     |
+| `default_from_name`   | `String`          | `""`       | Default sender display name                              |
+| `default_from_email`  | `String`          | `""`       | Default sender email address                             |
+| `default_reply_to`    | `Option<String>`  | `None`     | Default reply-to address                                 |
+| `cache_templates`     | `bool`            | `true`     | Cache compiled templates; set to `false` for hot-reload  |
+| `template_cache_size` | `usize`           | `100`      | Maximum number of templates kept in the LRU cache        |
+| `smtp`                | `SmtpConfig`      | see below  | SMTP settings (requires `smtp` feature)                  |
+| `resend`              | `ResendConfig`    | see below  | Resend settings (requires `resend` feature)              |
 
 ### `SmtpConfig`
 
-| Field      | Type     | Default       | Description                |
-| ---------- | -------- | ------------- | -------------------------- |
-| `host`     | `String` | `"localhost"` | SMTP server hostname       |
-| `port`     | `u16`    | `587`         | SMTP server port           |
-| `username` | `String` | `""`          | SMTP auth username         |
-| `password` | `String` | `""`          | SMTP auth password         |
-| `tls`      | `bool`   | `true`        | Enable STARTTLS (port 587) |
+| Field      | Type           | Default       | Description                                                              |
+| ---------- | -------------- | ------------- | ------------------------------------------------------------------------ |
+| `host`     | `String`       | `"localhost"` | SMTP server hostname                                                     |
+| `port`     | `u16`          | `587`         | SMTP server port                                                         |
+| `username` | `String`       | `""`          | SMTP auth username (skipped if empty)                                    |
+| `password` | `String`       | `""`          | SMTP auth password                                                       |
+| `security` | `SmtpSecurity` | `starttls`    | TLS mode: `none`, `starttls` (port 587), or `implicit_tls` (port 465)   |
 
 ### `ResendConfig`
 

--- a/modo-jobs-macros/README.md
+++ b/modo-jobs-macros/README.md
@@ -41,9 +41,9 @@ async fn send_email(payload: EmailPayload) -> HandlerResult<()> {
 For a function `send_email`, the macro emits:
 
 - `SendEmailJob` — a unit struct implementing `modo_jobs::JobHandler`
-- `SendEmailJob::JOB_NAME: &'static str` — the snake_case function name (`"send_email"`)
-- `SendEmailJob::enqueue(&queue, &payload) -> Result<JobId, Error>` — enqueue for immediate execution
-- `SendEmailJob::enqueue_at(&queue, &payload, run_at) -> Result<JobId, Error>` — schedule for a future time
+- `SendEmailJob::JOB_NAME: &str` — the snake_case function name (`"send_email"`)
+- `SendEmailJob::enqueue(&queue, &payload) -> Result<JobId, modo::Error>` — enqueue for immediate execution
+- `SendEmailJob::enqueue_at(&queue, &payload, run_at) -> Result<JobId, modo::Error>` — schedule for a future time
 - An `inventory` registration for automatic discovery at startup
 
 Cron jobs omit `enqueue` and `enqueue_at`.
@@ -62,7 +62,8 @@ Cron jobs omit `enqueue` and `enqueue_at`.
 
 - Must be `async`.
 - At most one plain parameter is the **payload** (deserialized from JSON via `serde`).
-- Use `Service<T>` to inject a registered service and `Db` to inject the database pool.
+- Use `Service<T>` to inject a registered service.
+- Use `Db(db): Db` to inject the database pool.
 - Return type must be `Result<(), modo::Error>` or a compatible alias such as `HandlerResult<()>`.
 
 ### Enqueueing from an HTTP Handler
@@ -141,6 +142,29 @@ async fn main(
 `JobsHandle` implements `modo::GracefulShutdown` and drains in-flight jobs on
 shutdown. `JobQueue` is available as an axum extractor once `JobsHandle` is
 registered as a managed service.
+
+## Configuration
+
+`modo_jobs::JobsConfig` (used in `config.jobs`) controls queue behaviour:
+
+```yaml
+jobs:
+  poll_interval_secs: 1         # how often each queue polls for new jobs
+  stale_threshold_secs: 600     # jobs locked longer than this are re-queued
+  stale_reaper_interval_secs: 60
+  drain_timeout_secs: 30        # graceful-shutdown drain window
+  max_payload_bytes: ~          # null = unlimited
+  max_queue_depth: ~            # null = unlimited; 503 when exceeded
+  queues:
+    - name: default
+      concurrency: 4
+    - name: emails
+      concurrency: 2
+  cleanup:
+    interval_secs: 3600
+    retention_secs: 86400
+    statuses: [completed, dead, cancelled]
+```
 
 ## Key Types (from `modo-jobs`)
 

--- a/modo-jobs-macros/src/lib.rs
+++ b/modo-jobs-macros/src/lib.rs
@@ -11,7 +11,7 @@ mod job;
 ///
 /// The macro generates:
 /// - A unit struct `<FnName>Job` (PascalCase) that implements `JobHandler`.
-/// - A `pub const JOB_NAME: &'static str` on the struct holding the snake_case function name.
+/// - A `pub const JOB_NAME: &str` on the struct holding the snake_case function name.
 /// - `enqueue` and `enqueue_at` async methods on the struct (omitted for cron jobs).
 /// - An `inventory` registration so the job is discovered automatically at startup.
 ///
@@ -30,7 +30,7 @@ mod job;
 /// - The function must be `async`.
 /// - At most one plain parameter is treated as the **payload** (deserialized from JSON).
 /// - Use `Service<T>` as the parameter type to inject a registered service.
-/// - Use `Db` as the parameter type to inject the database pool.
+/// - Use `Db(db): Db` as the parameter pattern to inject the database pool.
 /// - Return type must be `Result<(), modo::Error>` (or any compatible alias, e.g. `HandlerResult<()>`).
 ///
 /// # Examples
@@ -59,7 +59,7 @@ mod job;
 /// ```
 ///
 /// The generated `SendWelcomeJob::enqueue` and `SendWelcomeJob::enqueue_at`
-/// methods accept a `&JobQueue` and optional payload, returning `Result<JobId, Error>`:
+/// methods accept a `&JobQueue` and optional payload, returning `Result<JobId, modo::Error>`:
 ///
 /// ```rust,ignore
 /// let job_id = SendWelcomeJob::enqueue(&queue, &payload).await?;

--- a/modo-jobs/README.md
+++ b/modo-jobs/README.md
@@ -167,10 +167,12 @@ Only jobs in the `Pending` state can be cancelled.
 `JobsConfig` can be deserialized from YAML:
 
 ```yaml
-poll_interval_secs: 1       # how often each queue polls (default: 1)
-stale_threshold_secs: 600   # re-queue jobs locked longer than this (default: 600)
-drain_timeout_secs: 30      # max wait during shutdown (default: 30)
-max_payload_bytes: null     # payload size limit, null = unlimited (default: null)
+poll_interval_secs: 1          # how often each queue polls (default: 1)
+stale_threshold_secs: 600      # re-queue jobs locked longer than this (default: 600)
+stale_reaper_interval_secs: 60 # how often the stale reaper runs (default: 60)
+drain_timeout_secs: 30         # max wait during shutdown (default: 30)
+max_payload_bytes: null        # payload size limit, null = unlimited (default: null)
+max_queue_depth: null          # max pending jobs per queue, null = unlimited (default: null)
 
 queues:
   - name: default
@@ -185,6 +187,10 @@ cleanup:
 ```
 
 Queue names in YAML must match the `queue` attribute used in `#[job(queue = "...")]`.
+
+When `max_queue_depth` is set and a queue is full, `enqueue()` returns a 503
+error. The depth check is a soft limit — concurrent enqueues may briefly exceed
+the cap because the count and insert are not atomic.
 
 ## Key Types
 

--- a/modo-macros/README.md
+++ b/modo-macros/README.md
@@ -119,6 +119,10 @@ mod admin {
 All `#[handler]` attributes inside the module are automatically associated with
 the module's prefix and middleware at compile time via `inventory`.
 
+Bare `mod foo;` declarations inside the module body are allowed. Inline nested
+`mod foo { ... }` blocks are not supported and produce a compile error, because
+their handlers would not receive the outer prefix.
+
 ### Custom error handler
 
 ```rust
@@ -156,6 +160,7 @@ Available `#[clean(...)]` rules: `trim`, `lowercase`, `uppercase`,
 `custom = "path::to::fn"`.
 
 Sanitization runs automatically inside `JsonReq` and `FormReq` extractors.
+Generic structs are not supported.
 
 ### Input validation
 

--- a/modo-macros/src/lib.rs
+++ b/modo-macros/src/lib.rs
@@ -86,6 +86,10 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// All `#[handler]` attributes inside the module are automatically rewritten to
 /// include the module association so they are grouped correctly at startup.
 /// The module is registered via `inventory` and collected by `AppBuilder`.
+///
+/// Bare `mod foo;` declarations inside the module body are allowed. Inline
+/// nested `mod foo { ... }` blocks are not supported and will produce a compile
+/// error, because their handlers would not receive the outer module's prefix.
 #[proc_macro_attribute]
 pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
     module::expand(attr.into(), item.into())
@@ -103,6 +107,8 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// every `modo::Error` that propagates out of a route and can inspect the
 /// request context (method, URI, headers) to produce a suitable response.
 /// Call `err.default_response()` to delegate back to the built-in JSON rendering.
+///
+/// This attribute takes no arguments.
 #[proc_macro_attribute]
 pub fn error_handler(attr: TokenStream, item: TokenStream) -> TokenStream {
     error_handler::expand(attr.into(), item.into())
@@ -128,6 +134,8 @@ pub fn error_handler(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// The macro also registers a `SanitizerRegistration` entry via `inventory`
 /// so extractors (`JsonReq`, `FormReq`) can invoke `Sanitize::sanitize` automatically.
+///
+/// Generic structs are not supported; the derive will produce a compile error.
 #[proc_macro_derive(Sanitize, attributes(clean))]
 pub fn derive_sanitize(input: TokenStream) -> TokenStream {
     sanitize::expand(input.into())
@@ -198,6 +206,8 @@ pub fn t(input: TokenStream) -> TokenStream {
 /// context and rendering the named template. When the optional `htmx` path is
 /// provided, HTMX requests (`HX-Request` header present) render the partial
 /// instead of the full-page template.
+///
+/// Can only be applied to structs.
 ///
 /// Requires the `templates` feature on `modo`.
 #[proc_macro_attribute]

--- a/modo-session/README.md
+++ b/modo-session/README.md
@@ -22,7 +22,7 @@ Create a `SessionStore`, register it as a service, and install the middleware la
 Both steps are required: the service makes the store available to background jobs;
 the layer handles cookie reading and writing per request.
 
-```rust
+```rust,no_run
 use modo_session::{SessionConfig, SessionStore, layer};
 
 let session_store = SessionStore::new(
@@ -41,7 +41,7 @@ app.config(config.core)
 
 ### Authentication
 
-```rust
+```rust,no_run
 use modo_session::SessionManager;
 
 #[modo::handler(POST, "/login")]
@@ -62,7 +62,7 @@ async fn login_with_data(session: SessionManager) -> modo::HandlerResult<()> {
 
 ### Logout
 
-```rust
+```rust,no_run
 #[modo::handler(POST, "/logout")]
 async fn logout(session: SessionManager) -> modo::HandlerResult<()> {
     session.logout().await?;           // destroy current session
@@ -74,7 +74,7 @@ async fn logout(session: SessionManager) -> modo::HandlerResult<()> {
 
 ### Reading session state
 
-```rust
+```rust,no_run
 #[modo::handler(GET, "/me")]
 async fn me(session: SessionManager) -> modo::HandlerResult<String> {
     let user_id = session.user_id().await
@@ -85,7 +85,7 @@ async fn me(session: SessionManager) -> modo::HandlerResult<String> {
 
 ### Session data (key/value store)
 
-```rust
+```rust,no_run
 #[modo::handler(POST, "/set-flag")]
 async fn set_flag(session: SessionManager) -> modo::HandlerResult<()> {
     session.set("onboarded", &true).await?;
@@ -105,7 +105,7 @@ When you need the current user ID inside a Tower layer (not a handler), use the
 non-blocking helper. It reads from request extensions injected by the session
 middleware:
 
-```rust
+```rust,no_run
 use modo_session::user_id_from_extensions;
 
 // Inside a FromRequestParts or tower::Service impl:
@@ -135,8 +135,9 @@ Requires `modo-jobs` and a running job runner.
 modo-session = { version = "0.2", features = ["cleanup-job"] }
 ```
 
-The job is auto-registered via `inventory` — no explicit startup call is needed,
-but `SessionStore` must be registered as a service with `app.service(session_store)`.
+The job is registered automatically by the `modo-jobs` macro — no explicit startup
+call is needed, but `SessionStore` must be registered as a service with
+`app.service(session_store)` so the job runner can inject it.
 
 ## Key Types
 
@@ -144,7 +145,7 @@ but `SessionStore` must be registered as a service with `app.service(session_sto
 | ------------------------- | ------------------------------------------------------------------------ |
 | `SessionConfig`           | Tunable parameters: TTL, cookie name, fingerprint, proxies.              |
 | `SessionStore`            | Low-level DB store; register as a managed service for background jobs.   |
-| `SessionManager`          | Axum extractor for request-scoped session operations.                    |
+| `SessionManager`          | Per-request axum extractor for session operations.                       |
 | `SessionData`             | Full session record (ID, user, device info, JSON payload, timestamps).   |
 | `SessionId`               | Opaque ULID-based session identifier.                                    |
 | `SessionToken`            | 32-byte random token; serialises as hex; `Debug`/`Display` are redacted. |

--- a/modo-session/src/cleanup.rs
+++ b/modo-session/src/cleanup.rs
@@ -1,7 +1,9 @@
 //! Background job that periodically removes expired sessions from the database.
 //!
 //! Enabled by the `cleanup-job` feature.  The job is auto-registered via
-//! `modo-jobs` and runs every 15 minutes.
+//! `modo-jobs` and runs every 15 minutes.  `SessionStore` must be registered
+//! as a managed service (`.service(session_store)`) so the job runner can
+//! inject it.
 
 use crate::store::SessionStore;
 use modo::extractor::service::Service;
@@ -10,6 +12,7 @@ use modo::extractor::service::Service;
 ///
 /// Runs every 15 minutes (cron: `0 */15 * * * *`), with a 2-minute timeout.
 /// Requires the `cleanup-job` feature and a running `modo-jobs` job runner.
+/// `SessionStore` must be registered as a managed service.
 #[modo_jobs::job(cron = "0 */15 * * * *", timeout = "2m")]
 async fn cleanup_expired_sessions(
     Service(store): Service<SessionStore>,

--- a/modo-session/src/manager.rs
+++ b/modo-session/src/manager.rs
@@ -14,6 +14,10 @@ use std::sync::Arc;
 /// [`crate::layer`] for the extractor to work; if the middleware is missing the
 /// extractor returns an internal error.
 ///
+/// Each request receives its own `SessionManager` instance backed by its own
+/// per-request state.  There is no cross-request sharing; operations on one
+/// request's `SessionManager` cannot affect another request's session state.
+///
 /// Changes made through `SessionManager` (authentication, logout, token
 /// rotation, data writes) are applied to the HTTP response cookie automatically
 /// by the middleware after the handler returns.
@@ -36,16 +40,20 @@ impl<S: Send + Sync> FromRequestParts<S> for SessionManager {
 }
 
 impl SessionManager {
-    /// Create a session for the given user.
-    /// Destroys any existing session first (fixation prevention).
+    /// Create a new session for `user_id`.
+    ///
+    /// Any existing session is destroyed before the new one is created to
+    /// prevent session-fixation attacks.  The session cookie is set on the
+    /// response automatically.
     pub async fn authenticate(&self, user_id: &str) -> Result<(), Error> {
         self.authenticate_with(user_id, serde_json::json!({})).await
     }
 
-    /// Create a session with custom data attached.
+    /// Create a new session for `user_id` with custom JSON data attached.
     ///
     /// Any existing session is destroyed before the new one is created to
-    /// prevent session-fixation attacks.
+    /// prevent session-fixation attacks.  The session cookie is set on the
+    /// response automatically.
     pub async fn authenticate_with(
         &self,
         user_id: &str,
@@ -76,7 +84,10 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Destroy the current session. Cookie is removed automatically.
+    /// Destroy the current session.
+    ///
+    /// The session cookie is cleared on the response automatically.
+    /// If there is no active session this is a no-op.
     pub async fn logout(&self) -> Result<(), Error> {
         {
             let current = self.state.current_session.lock().await;
@@ -89,7 +100,10 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Destroy ALL sessions for the current user.
+    /// Destroy ALL sessions for the currently authenticated user.
+    ///
+    /// The session cookie is cleared on the response automatically.
+    /// If there is no active session this is a no-op.
     pub async fn logout_all(&self) -> Result<(), Error> {
         {
             let current = self.state.current_session.lock().await;
@@ -106,6 +120,8 @@ impl SessionManager {
     }
 
     /// Destroy all sessions for the current user except the current one.
+    ///
+    /// Returns `Unauthorized` if the request is not authenticated.
     pub async fn logout_other(&self) -> Result<(), Error> {
         let current = self.state.current_session.lock().await;
         let session = current
@@ -117,8 +133,12 @@ impl SessionManager {
             .await
     }
 
-    /// Destroy a specific session by ID (for "manage my devices" UI).
-    /// Only works on sessions owned by the current user.
+    /// Destroy a specific session by ID.
+    ///
+    /// Only sessions owned by the currently authenticated user can be revoked.
+    /// Returns `Unauthorized` if the request is not authenticated, or
+    /// `NotFound` if the target session does not exist or belongs to a
+    /// different user.
     pub async fn revoke(&self, id: &SessionId) -> Result<(), Error> {
         let current = self.state.current_session.lock().await;
         let session = current
@@ -139,7 +159,10 @@ impl SessionManager {
         self.state.store.destroy(id).await
     }
 
-    /// Regenerate the session token without changing the session ID.
+    /// Regenerate the session token without changing the session ID or data.
+    ///
+    /// The new token is set on the response cookie automatically.
+    /// Returns `Unauthorized` if the request is not authenticated.
     pub async fn rotate(&self) -> Result<(), Error> {
         let session_id = {
             let current = self.state.current_session.lock().await;
@@ -162,12 +185,14 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Access the current session data (if authenticated).
+    /// Return the full session record for the current request, or `None` if
+    /// the request is not authenticated.
     pub async fn current(&self) -> Option<SessionData> {
         self.state.current_session.lock().await.clone()
     }
 
-    /// Get the current user ID.
+    /// Return the authenticated user ID, or `None` if the request is not
+    /// authenticated.
     pub async fn user_id(&self) -> Option<String> {
         self.state
             .current_session
@@ -177,12 +202,16 @@ impl SessionManager {
             .map(|s| s.user_id.clone())
     }
 
-    /// Check if a session is active.
+    /// Return `true` if the current request has an active, authenticated
+    /// session.
     pub async fn is_authenticated(&self) -> bool {
         self.state.current_session.lock().await.is_some()
     }
 
-    /// List all active sessions for the authenticated user.
+    /// Return all active (non-expired) sessions for the authenticated user,
+    /// ordered by most-recently-active first.
+    ///
+    /// Returns `Unauthorized` if the request is not authenticated.
     pub async fn list_my_sessions(&self) -> Result<Vec<SessionData>, Error> {
         let user_id = {
             let current = self.state.current_session.lock().await;
@@ -194,7 +223,11 @@ impl SessionManager {
         self.state.store.list_for_user(&user_id).await
     }
 
-    /// Get a typed value from the session data by key.
+    /// Read a typed value from the session's JSON data by key.
+    ///
+    /// Returns `Ok(None)` if the key is absent or if the request is not
+    /// authenticated.  Returns `Ok(None)` (with a tracing warning) if the
+    /// stored value cannot be deserialised into `T`.
     pub async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>, Error> {
         let current = self.state.current_session.lock().await;
         let session = match current.as_ref() {
@@ -213,7 +246,9 @@ impl SessionManager {
         }
     }
 
-    /// Set a single key in the session data (immediate DB write).
+    /// Set a key in the session's JSON data and persist the change immediately.
+    ///
+    /// Returns `Unauthorized` if the request is not authenticated.
     pub async fn set<T: Serialize>(&self, key: &str, value: &T) -> Result<(), Error> {
         let mut current = self.state.current_session.lock().await;
         let session = current
@@ -236,7 +271,10 @@ impl SessionManager {
             .await
     }
 
-    /// Remove a key from the session data (immediate DB write).
+    /// Remove a key from the session's JSON data and persist the change
+    /// immediately.
+    ///
+    /// Returns `Unauthorized` if the request is not authenticated.
     pub async fn remove_key(&self, key: &str) -> Result<(), Error> {
         let mut current = self.state.current_session.lock().await;
         let session = current

--- a/modo-tenant/README.md
+++ b/modo-tenant/README.md
@@ -63,12 +63,14 @@ use modo_tenant::TenantResolverService;
 async fn main(
     app: modo::app::AppBuilder,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let resolver = TenantResolverService::new(DbTenantResolver { /* … */ });
+    let resolver = TenantResolverService::new(DbTenantResolver { /* ... */ });
     app.service(resolver).run().await
 }
 ```
 
 ### Extract in handlers
+
+`Tenant<T>` implements `Deref<Target = T>`, so tenant fields are accessible directly. `OptionalTenant<T>` implements `Deref<Target = Option<T>>`.
 
 ```rust
 use modo_tenant::{Tenant, OptionalTenant};
@@ -78,7 +80,8 @@ async fn dashboard(tenant: Tenant<MyTenant>) {
     println!("tenant: {}", tenant.name);
 }
 
-// Optional — never rejects; inner value is None when no tenant matches.
+// Optional — never rejects on missing tenant; inner value is None when no
+// tenant matches. Returns HTTP 500 if the resolver fails or is not registered.
 async fn home(tenant: OptionalTenant<MyTenant>) {
     if let Some(t) = &*tenant {
         println!("tenant: {}", t.name);
@@ -100,7 +103,10 @@ let resolver = SubdomainResolver::new("myapp.com", |slug| async move {
 let svc = TenantResolverService::new(resolver);
 ```
 
-`acme.myapp.com` → slug `"acme"`. The bare domain and `www` subdomain return `None`. Port suffixes are stripped automatically.
+`acme.myapp.com` → slug `"acme"`. The bare domain and reserved subdomains
+(`"www"`, `"api"`, `"admin"`, `"mail"`) return `None`. Port suffixes are
+stripped automatically. Use `SubdomainResolver::with_reserved` to override
+the reserved list.
 
 #### HTTP header
 
@@ -145,13 +151,13 @@ use modo_tenant::{TenantContextLayer, TenantResolverService};
 async fn main(
     app: modo::app::AppBuilder,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let svc = TenantResolverService::new(DbTenantResolver { /* … */ });
+    let svc = TenantResolverService::new(DbTenantResolver { /* ... */ });
     let layer = TenantContextLayer::new(svc);
     app.layer(layer).run().await
 }
 ```
 
-Inside templates the tenant is accessible as `{{ tenant.name }}`. Resolution errors are logged at `WARN` level and the request continues without a tenant in context.
+Inside templates the tenant is accessible as `{{ tenant.name }}`. Resolution errors are logged at `WARN` level and the request continues without a tenant in context (fail-open). If your application requires tenant context for security-sensitive rendering, use the `Tenant<T>` extractor instead — it returns HTTP 500 on resolver errors.
 
 ## Key Types
 
@@ -160,7 +166,7 @@ Inside templates the tenant is accessible as `{{ tenant.name }}`. Resolution err
 | `HasTenantId` | Trait a tenant type must implement to expose its unique ID. |
 | `TenantResolver` | Trait for pluggable tenant resolution strategies. |
 | `TenantResolverService<T>` | Type-erased, cheaply cloneable wrapper registered via `AppBuilder::service()`. |
-| `Tenant<T>` | Extractor that requires a tenant; returns HTTP 404 when absent. |
+| `Tenant<T>` | Extractor that requires a tenant; returns HTTP 404 when absent, HTTP 500 on resolver error. |
 | `OptionalTenant<T>` | Extractor that yields `Option<T>`; never rejects on missing tenant. |
 | `SubdomainResolver<T, F>` | Resolves tenant from the subdomain of the `Host` header. |
 | `HeaderResolver<T, F>` | Resolves tenant from a named HTTP header. |

--- a/modo-tenant/src/extractor.rs
+++ b/modo-tenant/src/extractor.rs
@@ -8,7 +8,14 @@ use modo::{Error, HttpError};
 use std::ops::Deref;
 use std::sync::Arc;
 
-/// Extractor that requires a resolved tenant. Returns 404 if not found.
+/// Extractor that requires a resolved tenant.
+///
+/// Returns HTTP 404 when the resolver finds no matching tenant, and HTTP 500
+/// when the resolver returns an error or when [`TenantResolverService<T>`] is
+/// not registered.
+///
+/// Implements `Deref<Target = T>`, so fields of the inner tenant type are
+/// accessible directly. The raw value is also available via `.0`.
 #[derive(Clone)]
 pub struct Tenant<T: Clone + Send + Sync + 'static>(pub T);
 
@@ -79,12 +86,15 @@ where
     }
 }
 
-/// Extractor that optionally resolves a tenant. Never rejects due to missing tenant.
+/// Extractor that optionally resolves a tenant. Returns `None` when no tenant matches.
 ///
-/// Note: unlike `TenantContextLayer` (which silently swallows resolver errors),
-/// this extractor will reject with an error if the resolver itself fails (e.g.
-/// misconfigured service). It only returns `None` when the resolver succeeds
-/// but finds no matching tenant.
+/// Unlike [`Tenant<T>`], this extractor never rejects due to a missing tenant.
+/// It does reject with HTTP 500 when the resolver itself returns an error or
+/// when [`TenantResolverService<T>`] is not registered. Use this when tenant
+/// context is optional (e.g. public landing pages that also serve tenants).
+///
+/// Implements `Deref<Target = Option<T>>`, so `.is_some()`, `.as_ref()`, etc.
+/// are available directly. The raw value is also accessible via `.0`.
 #[derive(Clone)]
 pub struct OptionalTenant<T: Clone + Send + Sync + 'static>(pub Option<T>);
 

--- a/modo-tenant/src/resolver.rs
+++ b/modo-tenant/src/resolver.rs
@@ -83,7 +83,10 @@ impl<T: Clone + Send + Sync + 'static> TenantResolverService<T> {
         }
     }
 
-    /// Delegates to the underlying resolver and returns the resolved tenant.
+    /// Delegates to the underlying resolver.
+    ///
+    /// Returns `Ok(Some(T))` when a tenant is found, `Ok(None)` when no tenant
+    /// matches, and `Err` on resolution failure.
     pub async fn resolve(&self, parts: &Parts) -> Result<Option<T>, modo::Error> {
         self.inner.resolve(parts).await
     }

--- a/modo-upload-macros/README.md
+++ b/modo-upload-macros/README.md
@@ -87,7 +87,7 @@ In a modo handler, use `MultipartForm<T>` from `modo_upload` to extract and vali
 ```rust
 use std::sync::Arc;
 use modo::{Json, JsonResult, Service};
-use modo_upload::{FileStorage, FromMultipart, MultipartForm, UploadedFile};
+use modo_upload::{FileStorageDyn, FromMultipart, MultipartForm, UploadedFile};
 
 #[derive(FromMultipart)]
 struct ProfileForm {
@@ -98,7 +98,7 @@ struct ProfileForm {
 
 #[modo::handler(POST, "/profile")]
 async fn update_profile(
-    storage: Service<Arc<dyn FileStorage>>,
+    storage: Service<Arc<dyn FileStorageDyn>>,
     form: MultipartForm<ProfileForm>,
 ) -> JsonResult<serde_json::Value> {
     let stored = storage.store("avatars", &form.avatar).await?;
@@ -134,7 +134,7 @@ Overrides the multipart field name. By default the Rust field name is used.
 | `UploadedFile`         | yes      | Single file; validation error if missing         |
 | `Option<UploadedFile>` | no       | Optional single file                             |
 | `Vec<UploadedFile>`    | no       | Zero or more files under the same multipart name |
-| `BufferedUpload`       | yes      | Buffered upload; at most one field per struct    |
+| `BufferedUpload`       | yes      | Buffered upload; only one field allowed per struct |
 | `String`               | yes      | Required text field                              |
 | `Option<String>`       | no       | Optional text field                              |
 | `T: FromStr`           | yes      | Required text field parsed via `FromStr`         |

--- a/modo-upload-macros/src/lib.rs
+++ b/modo-upload-macros/src/lib.rs
@@ -13,8 +13,8 @@ mod from_multipart;
 /// |-------------------------|------------------------------------------------|
 /// | `UploadedFile`          | Required file field; errors if absent          |
 /// | `Option<UploadedFile>`  | Optional file field                            |
-/// | `Vec<UploadedFile>`     | Multiple files under the same field name       |
-/// | `BufferedUpload`        | Required buffered upload; at most one per struct |
+/// | `Vec<UploadedFile>`     | Zero or more files under the same field name   |
+/// | `BufferedUpload`        | Required buffered upload (only one per struct) |
 /// | `String`                | Required text field                            |
 /// | `Option<String>`        | Optional text field                            |
 /// | any `T: FromStr`        | Required text field, parsed via `FromStr`      |

--- a/modo-upload/README.md
+++ b/modo-upload/README.md
@@ -63,11 +63,11 @@ Call `.validate()` when `T` also derives `modo::Validate`.
 ```rust
 use std::sync::Arc;
 use modo::{Json, JsonResult, Service};
-use modo_upload::{FileStorage, MultipartForm};
+use modo_upload::{FileStorageDyn, MultipartForm};
 
 #[modo::handler(POST, "/profile")]
 async fn update_profile(
-    storage: Service<Arc<dyn FileStorage>>,
+    storage: Service<Arc<dyn FileStorageDyn>>,
     form: MultipartForm<ProfileForm>,
 ) -> JsonResult<serde_json::Value> {
     form.validate()?;
@@ -82,7 +82,7 @@ async fn update_profile(
 ### Register the storage backend
 
 Build the storage backend from `UploadConfig` and register it as a service so
-extractors can resolve it via `Service<Arc<dyn FileStorage>>`.
+extractors can resolve it via `Service<Arc<dyn FileStorageDyn>>`.
 
 ```rust
 use modo_upload::{UploadConfig, storage};
@@ -154,15 +154,16 @@ upload:
 
 ## Key Types
 
-| Type                             | Description                                                      |
-| -------------------------------- | ---------------------------------------------------------------- |
-| `FromMultipart` (trait + derive) | Parse `multipart/form-data` into a struct                        |
-| `MultipartForm<T>`               | Axum extractor; wraps a `FromMultipart` type                     |
-| `UploadedFile`                   | In-memory file with name, content-type, and bytes                |
-| `BufferedUpload`                 | Chunked in-memory file; provides `AsyncRead` via `into_reader()` |
-| `FileStorage`                    | Trait for storing, deleting, and querying files                  |
-| `StoredFile`                     | Result of a store operation: `path` and `size`                   |
-| `UploadConfig`                   | Deserialized upload configuration                                |
-| `StorageBackend`                 | Enum: `Local` or `S3`                                            |
-| `storage()`                      | Factory function: `&UploadConfig` → `Arc<dyn FileStorage>`       |
-| `kb` / `mb` / `gb`               | Size helper functions (return `usize` bytes)                     |
+| Type                             | Description                                                              |
+| -------------------------------- | ------------------------------------------------------------------------ |
+| `FromMultipart` (trait + derive) | Parse `multipart/form-data` into a struct                                |
+| `MultipartForm<T>`               | Axum extractor; wraps a `FromMultipart` type                             |
+| `UploadedFile`                   | In-memory file with name, content-type, and bytes                        |
+| `BufferedUpload`                 | In-memory file; provides a chunked reader via `into_reader()`            |
+| `FileStorage`                    | Async trait for storing, deleting, and querying files                    |
+| `FileStorageDyn`                 | Object-safe companion; use `Arc<dyn FileStorageDyn>` in handlers         |
+| `StoredFile`                     | Result of a store operation: `path` and `size`                           |
+| `UploadConfig`                   | Deserialized upload configuration                                        |
+| `StorageBackend`                 | Enum: `Local` or `S3`                                                    |
+| `storage()`                      | Factory function: `&UploadConfig` → `Arc<dyn FileStorageDyn>`            |
+| `kb` / `mb` / `gb`               | Size helper functions (return `usize` bytes)                             |

--- a/modo-upload/src/file.rs
+++ b/modo-upload/src/file.rs
@@ -31,11 +31,12 @@ impl FieldMeta {
     }
 }
 
-/// An uploaded file fully buffered in memory.
+/// An uploaded file fully buffered in memory as a single contiguous buffer.
 ///
 /// `UploadedFile` holds all bytes in a single [`bytes::Bytes`] buffer after the
-/// multipart field has been drained.  For large files that should be streamed
-/// rather than fully buffered, use [`BufferedUpload`](crate::BufferedUpload) instead.
+/// multipart field has been drained.  Use [`BufferedUpload`](crate::BufferedUpload)
+/// instead when you need to write to storage via a chunked reader API
+/// (e.g. [`BufferedUpload::into_reader`](crate::BufferedUpload::into_reader)).
 pub struct UploadedFile {
     name: String,
     file_name: String,

--- a/modo-upload/src/storage/local.rs
+++ b/modo-upload/src/storage/local.rs
@@ -20,7 +20,7 @@ impl LocalStorage {
     /// Create a new `LocalStorage` rooted at `base_dir`.
     ///
     /// The directory does not need to exist at construction time; it is
-    /// created on the first [`store`](FileStorageDyn::store) call.
+    /// created on the first [`store`](crate::FileStorageDyn::store) call.
     pub fn new(base_dir: impl Into<PathBuf>) -> Self {
         Self {
             base_dir: base_dir.into(),

--- a/modo/README.md
+++ b/modo/README.md
@@ -168,8 +168,9 @@ server:
     secret_key: "${SECRET_KEY}"
     log_level: "info"
     shutdown_timeout_secs: 30
+    hook_timeout_secs: 5
     http:
-        timeout: 30 # request timeout in seconds
+        timeout: 30 # request timeout in seconds; omit to disable
         body_limit: "2mb"
         compression: false
         catch_panic: true
@@ -205,6 +206,8 @@ cookies:
 | `CookieManager`    | Plain, signed, and encrypted cookie read/write extractor          |
 | `JsonReq<T>`       | JSON request extractor with auto-sanitization                     |
 | `FormReq<T>`       | Form request extractor with auto-sanitization                     |
+| `PathReq<T>`       | Path parameter extractor (re-export of `axum::extract::Path`)     |
+| `QueryReq<T>`      | Query string extractor (re-export of `axum::extract::Query`)      |
 | `RequestId`        | ULID request ID injected by middleware and propagated via headers |
 | `ClientIp`         | Resolved client IP (supports trusted proxies and Cloudflare)      |
 | `RateLimitInfo`    | Rate limit header info available as a request extractor           |

--- a/modo/src/cookies/config.rs
+++ b/modo/src/cookies/config.rs
@@ -1,11 +1,17 @@
 use serde::Deserialize;
 
+/// Controls the `SameSite` cookie attribute.
+///
+/// Defaults to `Lax`. Serialized as `"strict"`, `"lax"`, or `"none"` in YAML.
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SameSite {
+    /// Cookie is only sent for same-site requests (most restrictive).
     Strict,
+    /// Cookie is sent for same-site requests and top-level navigations (default).
     #[default]
     Lax,
+    /// Cookie is sent for all requests, including cross-site. Requires `Secure`.
     None,
 }
 
@@ -19,15 +25,24 @@ impl From<SameSite> for cookie::SameSite {
     }
 }
 
+/// Global cookie defaults, deserialized from the `cookies` key in YAML config.
+///
+/// All cookies set via [`CookieManager`](super::CookieManager) inherit these
+/// defaults unless overridden with [`CookieOptions`].
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct CookieConfig {
+    /// Optional `Domain` attribute. `None` means the cookie is host-only.
     pub domain: Option<String>,
+    /// `Path` attribute. Default: `"/"`.
     pub path: String,
+    /// Whether to set the `Secure` attribute. Default: `true`.
     pub secure: bool,
+    /// Whether to set the `HttpOnly` attribute. Default: `true`.
     pub http_only: bool,
+    /// `SameSite` attribute. Default: `Lax`.
     pub same_site: SameSite,
-    /// Max age in seconds.
+    /// Max age in seconds. `None` means a session cookie (no `Max-Age`).
     pub max_age: Option<u64>,
 }
 
@@ -44,7 +59,10 @@ impl Default for CookieConfig {
     }
 }
 
-/// Per-cookie options that inherit from global CookieConfig.
+/// Per-cookie options that override global [`CookieConfig`] defaults.
+///
+/// Construct via [`CookieOptions::from_config`] and chain builder methods
+/// to customize individual cookies.
 #[derive(Debug, Clone)]
 pub struct CookieOptions {
     pub path: String,
@@ -56,6 +74,7 @@ pub struct CookieOptions {
 }
 
 impl CookieOptions {
+    /// Create options pre-populated with values from a [`CookieConfig`].
     pub fn from_config(config: &CookieConfig) -> Self {
         Self {
             path: config.path.clone(),
@@ -67,36 +86,43 @@ impl CookieOptions {
         }
     }
 
+    /// Override the `Path` attribute.
     pub fn path(mut self, path: impl Into<String>) -> Self {
         self.path = path.into();
         self
     }
 
+    /// Override the `Domain` attribute.
     pub fn domain(mut self, domain: impl Into<String>) -> Self {
         self.domain = Some(domain.into());
         self
     }
 
+    /// Override the `Secure` attribute.
     pub fn secure(mut self, secure: bool) -> Self {
         self.secure = secure;
         self
     }
 
+    /// Override the `HttpOnly` attribute.
     pub fn http_only(mut self, http_only: bool) -> Self {
         self.http_only = http_only;
         self
     }
 
+    /// Override the `SameSite` attribute.
     pub fn same_site(mut self, same_site: SameSite) -> Self {
         self.same_site = same_site;
         self
     }
 
+    /// Set `Max-Age` to `secs` seconds.
     pub fn max_age(mut self, secs: u64) -> Self {
         self.max_age = Some(secs);
         self
     }
 
+    /// Remove `Max-Age`, making the cookie a session cookie.
     pub fn session(mut self) -> Self {
         self.max_age = None;
         self

--- a/modo/src/cookies/manager.rs
+++ b/modo/src/cookies/manager.rs
@@ -8,8 +8,11 @@ use cookie::time::Duration;
 
 /// High-level cookie extractor with plain, signed, and encrypted cookie support.
 ///
-/// Uses global `CookieConfig` for defaults. Each setter accepts optional
-/// `CookieOptions` overrides.
+/// Uses the global [`CookieConfig`] for attribute defaults. Override per-cookie
+/// attributes with [`CookieOptions`] via the `_with` variants.
+///
+/// Return a `CookieManager` from a handler (or include it in a response tuple)
+/// to flush all pending `Set-Cookie` headers to the client.
 pub struct CookieManager {
     config: CookieConfig,
     jar: axum_extra::extract::CookieJar,
@@ -56,40 +59,48 @@ where
 impl CookieManager {
     // --- Plain cookies ---
 
+    /// Read a plain (unsigned, unencrypted) cookie by name.
     pub fn get(&self, name: &str) -> Option<String> {
         self.jar.get(name).map(|c| c.value().to_string())
     }
 
+    /// Set a plain cookie using global config defaults.
     pub fn set(&mut self, name: &str, value: &str) {
         let opts = CookieOptions::from_config(&self.config);
         self.set_with(name, value, opts);
     }
 
+    /// Set a plain cookie with explicit [`CookieOptions`].
     pub fn set_with(&mut self, name: &str, value: &str, opts: CookieOptions) {
         let cookie = build_cookie(name, value, &opts);
         self.jar = self.jar.clone().add(cookie);
     }
 
+    /// Remove a plain cookie by name.
     pub fn remove(&mut self, name: &str) {
         self.jar = self.jar.clone().remove(Cookie::from(name.to_string()));
     }
 
     // --- Signed cookies (HMAC, tamper-proof but readable) ---
 
+    /// Read and verify an HMAC-signed cookie. Returns `None` if missing or tampered.
     pub fn get_signed(&self, name: &str) -> Option<String> {
         self.signed_jar.get(name).map(|c| c.value().to_string())
     }
 
+    /// Set a signed cookie using global config defaults.
     pub fn set_signed(&mut self, name: &str, value: &str) {
         let opts = CookieOptions::from_config(&self.config);
         self.set_signed_with(name, value, opts);
     }
 
+    /// Set a signed cookie with explicit [`CookieOptions`].
     pub fn set_signed_with(&mut self, name: &str, value: &str, opts: CookieOptions) {
         let cookie = build_cookie(name, value, &opts);
         self.signed_jar = self.signed_jar.clone().add(cookie);
     }
 
+    /// Remove a signed cookie by name.
     pub fn remove_signed(&mut self, name: &str) {
         self.signed_jar = self
             .signed_jar
@@ -99,20 +110,24 @@ impl CookieManager {
 
     // --- Encrypted cookies (requires secret) ---
 
+    /// Read and decrypt an encrypted cookie. Returns `None` if missing or decryption fails.
     pub fn get_encrypted(&self, name: &str) -> Option<String> {
         self.private_jar.get(name).map(|c| c.value().to_string())
     }
 
+    /// Set an encrypted cookie using global config defaults.
     pub fn set_encrypted(&mut self, name: &str, value: &str) {
         let opts = CookieOptions::from_config(&self.config);
         self.set_encrypted_with(name, value, opts);
     }
 
+    /// Set an encrypted cookie with explicit [`CookieOptions`].
     pub fn set_encrypted_with(&mut self, name: &str, value: &str, opts: CookieOptions) {
         let cookie = build_cookie(name, value, &opts);
         self.private_jar = self.private_jar.clone().add(cookie);
     }
 
+    /// Remove an encrypted cookie by name.
     pub fn remove_encrypted(&mut self, name: &str) {
         self.private_jar = self
             .private_jar
@@ -122,10 +137,13 @@ impl CookieManager {
 
     // --- JSON convenience ---
 
+    /// Read a plain cookie and deserialize its value as JSON.
+    /// Returns `None` if the cookie is missing or deserialization fails.
     pub fn get_json<T: serde::de::DeserializeOwned>(&self, name: &str) -> Option<T> {
         deserialize_cookie_json(self.get(name), name)
     }
 
+    /// Serialize `value` as JSON and set it as a plain cookie.
     pub fn set_json<T: serde::Serialize>(
         &mut self,
         name: &str,
@@ -136,10 +154,13 @@ impl CookieManager {
         Ok(())
     }
 
+    /// Read a signed cookie and deserialize its value as JSON.
+    /// Returns `None` if the cookie is missing, tampered, or deserialization fails.
     pub fn get_signed_json<T: serde::de::DeserializeOwned>(&self, name: &str) -> Option<T> {
         deserialize_cookie_json(self.get_signed(name), name)
     }
 
+    /// Serialize `value` as JSON and set it as a signed cookie.
     pub fn set_signed_json<T: serde::Serialize>(
         &mut self,
         name: &str,
@@ -150,10 +171,13 @@ impl CookieManager {
         Ok(())
     }
 
+    /// Read an encrypted cookie and deserialize its value as JSON.
+    /// Returns `None` if the cookie is missing, decryption fails, or deserialization fails.
     pub fn get_encrypted_json<T: serde::de::DeserializeOwned>(&self, name: &str) -> Option<T> {
         deserialize_cookie_json(self.get_encrypted(name), name)
     }
 
+    /// Serialize `value` as JSON and set it as an encrypted cookie.
     pub fn set_encrypted_json<T: serde::Serialize>(
         &mut self,
         name: &str,

--- a/modo/src/extractor/mod.rs
+++ b/modo/src/extractor/mod.rs
@@ -1,6 +1,12 @@
 pub mod service;
+
+/// Re-export of [`crate::request_id::RequestId`] for ergonomic import via `modo::extractor`.
 pub use crate::request_id::RequestId;
+/// Re-export of form and JSON request extractors with auto-sanitization.
 pub use crate::validate::{FormReq, JsonReq};
+/// Path parameter extractor — use in handler signatures as `PathReq<(String,)>`.
 pub use axum::extract::Path as PathReq;
+/// Query string extractor — use in handler signatures as `QueryReq<MyParams>`.
 pub use axum::extract::Query as QueryReq;
+/// Service registry extractor — retrieves a registered service by type.
 pub use service::Service;

--- a/modo/src/logging.rs
+++ b/modo/src/logging.rs
@@ -7,12 +7,15 @@ use tower_http::trace::{
 };
 use tracing::{Level, Span};
 
+/// Tower-HTTP `MakeSpan` implementation that attaches `method`, `uri`, `version`,
+/// and `request_id` fields to every HTTP request span.
 #[derive(Clone, Debug)]
 pub struct ModoMakeSpan {
     level: Level,
 }
 
 impl ModoMakeSpan {
+    /// Create a new span factory at the given tracing level.
     pub fn new(level: Level) -> Self {
         Self { level }
     }
@@ -49,6 +52,8 @@ impl<B> MakeSpan<B> for ModoMakeSpan {
     }
 }
 
+/// Parse a log-level string (`"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`) into a
+/// [`tracing::Level`]. Returns `INFO` for unknown values.
 pub fn parse_level(s: &str) -> Level {
     match s.to_lowercase().as_str() {
         "trace" => Level::TRACE,
@@ -60,6 +65,7 @@ pub fn parse_level(s: &str) -> Level {
     }
 }
 
+/// Build a [`TraceLayer`] configured with [`ModoMakeSpan`] at the given level.
 pub fn trace_layer(
     level: Level,
 ) -> TraceLayer<


### PR DESCRIPTION
## Summary

Synchronizes all crate READMEs with current API reality and adds comprehensive inline doc comments to source files across the workspace.

### Changes

- **READMEs:** correct API examples (`FileStorage` → `FileStorageDyn`, `tls` → `security` with `SmtpSecurity` enum, `has_many` now requires `target`), document new config fields (`stale_reaper_interval_secs`, `max_queue_depth` in `JobsConfig`; `cache_templates`, `template_cache_size` in `EmailConfig`; `hook_timeout_secs` in server config), expand `SubdomainResolver` reserved subdomain list, add `PathReq`/`QueryReq` to the modo key-types table, and fix code block attributes (`no_run`) in modo-session README.
- **Source doc comments:** add missing `///` comments to `SessionManager` methods (per-request isolation, error conditions, cookie flush behaviour), `CookieConfig`/`CookieOptions`/`CookieManager`, extractor re-exports, `ModoMakeSpan`, `parse_level`, `trace_layer`, `Tenant`/`OptionalTenant` extractors, `TenantResolverService::resolve`, `LocalStorage::new`, `UploadedFile`, `EntityQuery`/`EntityUpdateMany`/`EntityDeleteMany`, `scaffold::write_dir`, and proc-macro entry points (`#[module]`, `#[error_handler]`, `Sanitize`, `#[view]`).

### Breaking Changes

None — all changes are documentation only; no public API signatures were modified.