### PR TITLE
docs(references): sync skill reference docs with latest crate changes

### DIFF
--- a/claude-plugin/skills/modo/references/config.md
+++ b/claude-plugin/skills/modo/references/config.md
@@ -118,6 +118,7 @@ Controls the HTTP server, middleware stack, and health check endpoints.
 | `log_level` | `String` | `"info"` | Log level filter: `trace`, `debug`, `info`, `warn`, `error` |
 | `trusted_proxies` | `Vec<String>` | `[]` | CIDR ranges for trusted proxy IP extraction (e.g. `["10.0.0.0/8"]`) |
 | `shutdown_timeout_secs` | `u64` | `30` | Graceful shutdown timeout in seconds |
+| `hook_timeout_secs` | `u64` | `5` | Per-hook timeout in seconds during graceful shutdown. Each `on_shutdown` callback is capped to this duration. |
 | `cors` | `Option<CorsYamlConfig>` | `None` | CORS policy. Absent = no CORS middleware applied |
 | `liveness_path` | `String` | `"/_live"` | Path for the liveness health check endpoint |
 | `readiness_path` | `String` | `"/_ready"` | Path for the readiness health check endpoint |

--- a/claude-plugin/skills/modo/references/database.md
+++ b/claude-plugin/skills/modo/references/database.md
@@ -49,6 +49,9 @@ pub struct Config {
 | `url` | `String` | `"sqlite://data/main.db?mode=rwc"` |
 | `max_connections` | `u32` | `5` |
 | `min_connections` | `u32` | `1` |
+| `acquire_timeout_secs` | `u64` | `30` |
+| `idle_timeout_secs` | `u64` | `600` |
+| `max_lifetime_secs` | `u64` | `1800` |
 
 Example YAML:
 
@@ -57,6 +60,9 @@ database:
   url: "sqlite://data/main.db?mode=rwc"
   max_connections: 5
   min_connections: 1
+  acquire_timeout_secs: 30
+  idle_timeout_secs: 600
+  max_lifetime_secs: 1800
 ```
 
 For PostgreSQL:
@@ -66,6 +72,7 @@ database:
   url: "postgres://user:pass@localhost/myapp"
   max_connections: 10
   min_connections: 2
+  acquire_timeout_secs: 30
 ```
 
 ### Connecting and registering
@@ -402,6 +409,43 @@ let page: CursorResult<Todo> = Todo::query()
     )
     .await?;
 ```
+
+### Joined Queries
+
+`EntityQuery` supports loading related records in a single query via `find_also_related` and
+`find_with_related`, which return `JoinedQuery` and `JoinedManyQuery` respectively.
+
+**One-to-one / belongs-to join (`find_also_related`):**
+
+```rust
+// Load each todo with its optional author
+let results: Vec<(Todo, Option<User>)> = Todo::query()
+    .filter(todo::Column::Completed.eq(false))
+    .find_also_related::<User, user::Entity>()
+    .all(&*db)
+    .await?;
+```
+
+`JoinedQuery` supports the same chainable methods: `.filter()`, `.order_by_asc()`,
+`.order_by_desc()`, `.limit()`, `.offset()`, `.all()`, `.one()`, and `.into_select()`
+(which returns a `SelectTwo<E, F>` for raw SeaORM usage).
+
+**One-to-many join (`find_with_related`):**
+
+```rust
+// Load each user with all their posts
+let results: Vec<(User, Vec<Post>)> = User::query()
+    .find_with_related::<Post, post::Entity>()
+    .all(&*db)
+    .await?;
+```
+
+`JoinedManyQuery` supports `.filter()`, `.order_by_asc()`, `.order_by_desc()`, `.limit()`,
+`.offset()`, `.all()`, and `.into_select()` (which returns a `SelectTwoMany<E, F>`).
+
+Both require the source entity to implement `sea_orm::Related<F>` for the target entity,
+which is generated automatically by `#[entity(belongs_to)]`, `#[entity(has_many)]`, and
+`#[entity(has_one)]` field annotations.
 
 ### Escape hatch to raw SeaORM
 
@@ -1207,6 +1251,8 @@ am.update(&*db).await.map_err(modo_db::db_err_to_error)?;
 | `EntityQuery<T, E>` | `modo_db::EntityQuery` |
 | `EntityUpdateMany<E>` | `modo_db::EntityUpdateMany` |
 | `EntityDeleteMany<E>` | `modo_db::EntityDeleteMany` |
+| `JoinedQuery<T, U, E, F>` | `modo_db::JoinedQuery` |
+| `JoinedManyQuery<T, U, E, F>` | `modo_db::JoinedManyQuery` |
 | `EntityRegistration` | `modo_db::EntityRegistration` |
 | `MigrationRegistration` | `modo_db::MigrationRegistration` |
 | `PageParams` | `modo_db::PageParams` |

--- a/claude-plugin/skills/modo/references/email.md
+++ b/claude-plugin/skills/modo/references/email.md
@@ -40,6 +40,8 @@ pub struct Config {
 | `default_from_name` | `String` | `""` | Display name for the `From` header. |
 | `default_from_email` | `String` | `""` | Email address for the `From` header. |
 | `default_reply_to` | `Option<String>` | `None` | Optional default `Reply-To` address. |
+| `cache_templates` | `bool` | `true` | Cache compiled templates. Set `false` in dev for live reloading. |
+| `template_cache_size` | `usize` | `100` | Max cached templates (LRU eviction). Only used when `cache_templates` is `true`. |
 | `smtp` | `SmtpConfig` | see below | SMTP settings (requires `smtp` feature). |
 | `resend` | `ResendConfig` | see below | Resend API settings (requires `resend` feature). |
 
@@ -61,12 +63,14 @@ email:
   default_from_name: "My App"
   default_from_email: "noreply@myapp.com"
   default_reply_to: "support@myapp.com"
+  cache_templates: true
+  template_cache_size: 100
   smtp:
     host: smtp.mailgun.org
     port: 587
     username: postmaster@myapp.com
     password: secret
-    tls: true
+    security: starttls
 ```
 
 ### SmtpConfig (requires `smtp` feature)
@@ -77,10 +81,15 @@ email:
 | `port` | `u16` | `587` | SMTP server port. |
 | `username` | `String` | `""` | SMTP authentication username. |
 | `password` | `String` | `""` | SMTP authentication password. |
-| `tls` | `bool` | `true` | When `true`, uses STARTTLS. When `false`, no TLS. |
+| `security` | `SmtpSecurity` | `starttls` | TLS security mode. |
 
-STARTTLS (port 587) is the only supported TLS mode. Implicit TLS / SMTPS (port 465)
-is not currently supported. For local development without TLS, set `tls: false`.
+`SmtpSecurity` is an enum serialized as snake_case strings:
+
+| Variant | YAML value | Description |
+|---------|------------|-------------|
+| `None` | `none` | Plaintext — no TLS (local dev or trusted networks only). |
+| `StartTls` | `starttls` | Upgrade to TLS via STARTTLS command (port 587, default). |
+| `ImplicitTls` | `implicit_tls` | Connect with TLS from the start — SMTPS (port 465). |
 
 ### ResendConfig (requires `resend` feature)
 
@@ -548,8 +557,9 @@ tool are unaffected.
 The mailer must be on the jobs builder for job handlers to resolve it via
 `Service<Mailer>`.
 
-**SMTPS (port 465) not supported.** Only STARTTLS (port 587) is available when
-`tls: true`. Connecting to port 465 with `tls: true` will fail at connection time.
+**SMTPS (port 465) requires `implicit_tls`.** Set `security: implicit_tls` and
+`port: 465` for SMTPS connections. Using `security: starttls` with port 465
+will fail at connection time.
 
 **`brand_color` is validated.** Only `#RGB` and `#RRGGBB` hex strings are accepted.
 Any other value (e.g. `"red"`, `"#zzzzzz"`, or a CSS injection attempt) silently
@@ -588,6 +598,7 @@ at startup.
 |------|---------|-------------|
 | `EmailConfig` | https://docs.rs/modo-email/latest/modo_email/struct.EmailConfig.html | Top-level email configuration. |
 | `SmtpConfig` | https://docs.rs/modo-email/latest/modo_email/struct.SmtpConfig.html | SMTP connection settings (`smtp` feature). |
+| `SmtpSecurity` | https://docs.rs/modo-email/latest/modo_email/enum.SmtpSecurity.html | TLS mode: `None`, `StartTls`, `ImplicitTls` (`smtp` feature). |
 | `ResendConfig` | https://docs.rs/modo-email/latest/modo_email/struct.ResendConfig.html | Resend API key config (`resend` feature). |
 | `TransportBackend` | https://docs.rs/modo-email/latest/modo_email/enum.TransportBackend.html | `Smtp` or `Resend` transport selector. |
 | `Mailer` | https://docs.rs/modo-email/latest/modo_email/struct.Mailer.html | High-level email service (clone-safe). |

--- a/claude-plugin/skills/modo/references/jobs.md
+++ b/claude-plugin/skills/modo/references/jobs.md
@@ -187,10 +187,12 @@ pub struct Config {
 |-------|------|---------|-------------|
 | `poll_interval_secs` | `u64` | `1` | How often each queue polls for new jobs. |
 | `stale_threshold_secs` | `u64` | `600` | Jobs locked longer than this are re-queued. |
+| `stale_reaper_interval_secs` | `u64` | `60` | How often the stale reaper checks for stale jobs. |
 | `drain_timeout_secs` | `u64` | `30` | Max time to wait for in-flight jobs at shutdown. |
 | `queues` | `Vec<QueueConfig>` | `[{name: "default", concurrency: 4}]` | Per-queue configuration. |
 | `cleanup` | `CleanupConfig` | see below | Automatic cleanup of finished jobs. |
 | `max_payload_bytes` | `Option<usize>` | `None` (unlimited) | Optional cap on serialized payload size. |
+| `max_queue_depth` | `Option<usize>` | `None` (unlimited) | Optional cap on pending jobs per queue. When set, `enqueue()` returns 503 if the queue is full. |
 
 ### QueueConfig fields
 
@@ -213,6 +215,7 @@ Example YAML:
 jobs:
   poll_interval_secs: 1
   stale_threshold_secs: 600
+  stale_reaper_interval_secs: 60
   drain_timeout_secs: 30
   queues:
     - name: default
@@ -482,7 +485,7 @@ error when the serialized payload exceeds that limit. The default is `None` (unl
 
 **Stale job reaping.** Jobs locked longer than `stale_threshold_secs` (default 600 s) are
 reset to `Pending` and their attempt counter is decremented. This handles crashed workers.
-The reaper runs every 60 seconds.
+The reaper runs every `stale_reaper_interval_secs` seconds (default 60).
 
 **Cron timeout panics on invalid expressions.** A malformed cron expression causes a `panic!`
 at startup rather than returning an error. Verify expressions before deploying.

--- a/claude-plugin/skills/modo/references/upload.md
+++ b/claude-plugin/skills/modo/references/upload.md
@@ -76,13 +76,13 @@ call `.validate()` on the wrapper to run additional field-level rules.
 ```rust
 use modo::JsonResult;
 use modo::Service;
-use modo_upload::{FileStorage, MultipartForm};
+use modo_upload::{FileStorageDyn, MultipartForm};
 
 use crate::types::ProfileForm;
 
 #[modo::handler(POST, "/profile")]
 async fn update_profile(
-    storage: Service<Arc<dyn FileStorage>>,
+    storage: Service<Arc<dyn FileStorageDyn>>,
     form: MultipartForm<ProfileForm>,
 ) -> JsonResult<serde_json::Value> {
     form.validate()?;
@@ -263,7 +263,7 @@ Serializes/deserializes as lowercase strings (`"local"`, `"s3"`).
 
 ### `storage()` factory function
 
-Construct a `Arc<dyn FileStorage>` from config, then register it as a service:
+Construct an `Arc<dyn FileStorageDyn>` from config, then register it as a service:
 
 ```rust
 #[modo::main]
@@ -276,13 +276,19 @@ async fn main(
 }
 ```
 
-After registration, inject it into handlers via `Service<Arc<dyn FileStorage>>`.
+After registration, inject it into handlers via `Service<Arc<dyn FileStorageDyn>>`.
 
 ### `FileStorage` trait
 
+`FileStorage` defines the storage interface. The crate uses `trait_variant` to generate three
+related traits:
+
+- `FileStorage` — the base async trait (not object-safe due to async methods).
+- `FileStorageSend` — variant with `Send` bound on futures.
+- `FileStorageDyn` — object-safe companion for use as `Arc<dyn FileStorageDyn>`.
+
 ```rust
-#[async_trait]
-pub trait FileStorage: Send + Sync + 'static {
+pub trait FileStorage: Sync + 'static {
     async fn store(&self, prefix: &str, file: &UploadedFile)
         -> Result<StoredFile, modo::Error>;
 
@@ -294,6 +300,10 @@ pub trait FileStorage: Send + Sync + 'static {
     async fn exists(&self, path: &str) -> Result<bool, modo::Error>;
 }
 ```
+
+A blanket impl provides `FileStorageDyn` for all `T: FileStorageSend`. The `storage()` factory
+returns `Arc<dyn FileStorageDyn>`, which is the type to register as a service and inject in
+handlers.
 
 All methods take a `prefix` (e.g. `"avatars"`) and return a `StoredFile` with `path` and `size`
 fields. The path is relative within the storage root — store it in the database, not the full
@@ -360,12 +370,12 @@ Logical path safety: object-store keys are validated before every operation — 
 ### Full upload handler with validation
 
 The upload example shows the complete pattern combining `#[derive(FromMultipart)]`, `MultipartForm`,
-`Service<Arc<dyn FileStorage>>`, and runtime validation:
+`Service<Arc<dyn FileStorageDyn>>`, and runtime validation:
 
 ```rust
 use modo::JsonResult;
 use modo::Service;
-use modo_upload::{FileStorage, MultipartForm, UploadedFile, FromMultipart};
+use modo_upload::{FileStorageDyn, MultipartForm, UploadedFile, FromMultipart};
 
 #[derive(FromMultipart, modo::Sanitize, modo::Validate)]
 pub struct ProfileForm {
@@ -383,7 +393,7 @@ pub struct ProfileForm {
 
 #[modo::handler(POST, "/profile")]
 async fn update_profile(
-    storage: Service<Arc<dyn FileStorage>>,
+    storage: Service<Arc<dyn FileStorageDyn>>,
     form: MultipartForm<ProfileForm>,
 ) -> JsonResult<serde_json::Value> {
     form.validate()?;
@@ -455,7 +465,7 @@ struct VideoForm {
 
 #[modo::handler(POST, "/video")]
 async fn upload_video(
-    storage: Service<Arc<dyn FileStorage>>,
+    storage: Service<Arc<dyn FileStorageDyn>>,
     form: MultipartForm<VideoForm>,
 ) -> JsonResult<serde_json::Value> {
     let mut form = form.into_inner();
@@ -508,8 +518,8 @@ if storage.exists(&old_path).await? {
   If the process does not have write permission to the parent, the first upload will fail at
   runtime, not at startup.
 
-- **`service(storage)` registers `Arc<dyn FileStorage>`.** Inject it exactly as
-  `Service<Arc<dyn FileStorage>>` in handlers. Using `Service<LocalStorage>` or
+- **`service(storage)` registers `Arc<dyn FileStorageDyn>`.** Inject it exactly as
+  `Service<Arc<dyn FileStorageDyn>>` in handlers. Using `Service<LocalStorage>` or
   `Service<OpendalStorage>` directly will fail to resolve.
 
 - **Auto-sanitization.** `MultipartForm` calls `modo::sanitize::auto_sanitize` on the parsed
@@ -527,8 +537,9 @@ if storage.exists(&old_path).await? {
 | `MultipartForm<T>`       | https://docs.rs/modo-upload/latest/modo_upload/struct.MultipartForm.html |
 | `UploadedFile`           | https://docs.rs/modo-upload/latest/modo_upload/struct.UploadedFile.html |
 | `BufferedUpload`         | https://docs.rs/modo-upload/latest/modo_upload/struct.BufferedUpload.html |
-| `FileStorage` trait      | https://docs.rs/modo-upload/latest/modo_upload/storage/trait.FileStorage.html |
-| `StoredFile`             | https://docs.rs/modo-upload/latest/modo_upload/storage/struct.StoredFile.html |
+| `FileStorage` trait      | https://docs.rs/modo-upload/latest/modo_upload/trait.FileStorage.html |
+| `FileStorageDyn` trait   | https://docs.rs/modo-upload/latest/modo_upload/trait.FileStorageDyn.html |
+| `StoredFile`             | https://docs.rs/modo-upload/latest/modo_upload/struct.StoredFile.html |
 | `StorageBackend`         | https://docs.rs/modo-upload/latest/modo_upload/enum.StorageBackend.html |
 | `UploadConfig`           | https://docs.rs/modo-upload/latest/modo_upload/struct.UploadConfig.html |
 | `S3Config`               | https://docs.rs/modo-upload/latest/modo_upload/struct.S3Config.html |


### PR DESCRIPTION
## Summary

Synchronizes the Claude plugin skill reference docs under `claude-plugin/skills/modo/references/` with API and config changes from recent crate updates.

### Changes

- **config.md**: add `hook_timeout_secs` field to the server config table (per-hook graceful-shutdown timeout)
- **database.md**: add `acquire_timeout_secs`, `idle_timeout_secs`, and `max_lifetime_secs` connection pool fields; add a new *Joined Queries* section documenting `JoinedQuery` / `JoinedManyQuery` and their chainable builder methods; add both types to the API-reference table
- **email.md**: replace the `tls: bool` field with the new `SmtpSecurity` enum (`none` / `starttls` / `implicit_tls`); add `cache_templates` and `template_cache_size` config fields; add `SmtpSecurity` to the API-reference table; update the SMTPS gotcha note to reflect implicit TLS support
- **jobs.md**: add `stale_reaper_interval_secs` and `max_queue_depth` config fields; update the stale-reaper gotcha to reference the now-configurable interval
- **upload.md**: replace every `Arc<dyn FileStorage>` reference with `Arc<dyn FileStorageDyn>`; document the `FileStorage` / `FileStorageSend` / `FileStorageDyn` trait trio and the blanket impl; fix docs.rs paths for `FileStorage`, `FileStorageDyn`, and `StoredFile`