### PR TITLE
feat: add Sentry integration as second tracing target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Rust web framework for small monolithic apps. Single binary, compile-time magic,
 - modo-db `find_by_id` returns `Result<T, Error>` with auto-404 — no `.ok_or(NotFound)?` needed
 - modo-db `update(&mut self)` refreshes all fields from DB after write — no re-fetch needed
 - Tracing fields: always snake_case (`user_id`, `session_id`, `job_id`) — never dotted names (`panic.message`) which require string literal syntax and can break subscribers
+- Sentry integration: opt-in via `sentry` feature flag — add `features = ["sentry"]` to modo dependency; custom configs must impl `SentryConfigProvider` (delegate to `self.core.sentry_config()`)
 
 ## Gotchas
 
@@ -70,4 +71,5 @@ Rust web framework for small monolithic apps. Single binary, compile-time magic,
 - SeaORM `UpdateMany`: no `.set(col, val)` method — use `.col_expr(col, Expr::value(val))` instead
 - `just test` may fail in sandboxed environments (missing `/tmp` dir) — run with `TMPDIR` set or outside sandbox
 - `#[template_function]` / `#[template_filter]` name override: use `name = "alias"` syntax — bare string `("alias")` does NOT work
+- Sentry is behind `sentry` feature flag — `SentryConfig`, `SentryConfigProvider`, and `modo::sentry` module all require `#[cfg(feature = "sentry")]`; without the feature, tracing init falls back to stdout-only in the macro
 - Publish workflow (`.github/workflows/publish.yml`) uses single workspace version — compares root `Cargo.toml` version against crates.io, publishes all or none

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 license = "Apache-2.0"
 repository = "https://github.com/dmitrymomot/modo"
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ The `modo` core crate has these optional features (all off by default):
 | `i18n`         | Locale detection and internationalization          |
 | `sse`          | Server-Sent Events support                         |
 | `static-fs`    | Serve static files from a directory at runtime     |
+| `sentry`       | Sentry error tracking with request metadata        |
 | `static-embed` | Embed static files into the binary at compile time |
 
 </details>

--- a/claude-plugin/skills/modo/references/config.md
+++ b/claude-plugin/skills/modo/references/config.md
@@ -283,6 +283,26 @@ Type: `SseConfig` — requires feature `sse`
 
 ---
 
+### sentry
+
+Type: `SentryConfig` — requires feature `sentry`. Wrapped in `Option` — absent section means Sentry is disabled.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `dsn` | `String` | `""` | Sentry DSN. Empty string disables Sentry |
+| `environment` | `String` | `"development"` | Environment tag sent to Sentry |
+| `traces_sample_rate` | `f32` | `0.0` | Fraction of transactions to send (0.0–1.0) |
+
+Example YAML:
+```yaml
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: production
+  traces_sample_rate: 0.2
+```
+
+---
+
 ## Feature-Gated Fields
 
 Several sections in `AppConfig` and `ServerConfig` are guarded by feature flags. Fields that do not exist when the feature is disabled are simply absent from the struct.
@@ -297,6 +317,9 @@ pub i18n: crate::i18n::I18nConfig,
 
 #[cfg(feature = "csrf")]
 pub csrf: crate::csrf::CsrfConfig,
+
+#[cfg(feature = "sentry")]
+pub sentry: Option<crate::sentry::SentryConfig>,
 
 #[cfg(feature = "sse")]
 pub sse: crate::sse::SseConfig,
@@ -443,6 +466,7 @@ server:
 | `TemplateConfig` | `modo::templates::TemplateConfig` | https://docs.rs/modo |
 | `I18nConfig` | `modo::i18n::I18nConfig` | https://docs.rs/modo |
 | `CsrfConfig` | `modo::csrf::CsrfConfig` | https://docs.rs/modo |
+| `SentryConfig` | `modo::sentry::SentryConfig` | https://docs.rs/modo |
 | `SseConfig` | `modo::sse::SseConfig` | https://docs.rs/modo |
 | `StaticConfig` | `modo::static_files::StaticConfig` | https://docs.rs/modo |
 | `parse_size` | `modo::config::parse_size` | https://docs.rs/modo |

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 [dependencies]
 modo.workspace = true
 serde = { version = "1", features = ["derive"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry"))'] }

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -7,6 +7,3 @@ publish = false
 [dependencies]
 modo.workspace = true
 serde = { version = "1", features = ["derive"] }
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry"))'] }

--- a/examples/jobs/Cargo.toml
+++ b/examples/jobs/Cargo.toml
@@ -12,3 +12,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 chrono = "0.4"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry"))'] }

--- a/examples/jobs/Cargo.toml
+++ b/examples/jobs/Cargo.toml
@@ -13,5 +13,5 @@ serde_json = "1"
 tracing = "0.1"
 chrono = "0.4"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry"))'] }
+[features]
+sentry = ["modo/sentry"]

--- a/examples/jobs/src/config.rs
+++ b/examples/jobs/src/config.rs
@@ -11,6 +11,7 @@ pub(crate) struct Config {
     pub(crate) jobs: modo_jobs::JobsConfig,
 }
 
+#[cfg(feature = "sentry")]
 impl modo::SentryConfigProvider for Config {
     fn sentry_config(&self) -> Option<&modo::SentryConfig> {
         self.core.sentry_config()

--- a/examples/jobs/src/config.rs
+++ b/examples/jobs/src/config.rs
@@ -10,3 +10,9 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) jobs: modo_jobs::JobsConfig,
 }
+
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/examples/sse-chat/Cargo.toml
+++ b/examples/sse-chat/Cargo.toml
@@ -12,5 +12,8 @@ chrono = "0.4"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 
+[features]
+sentry = ["modo/sentry"]
+
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("csrf", "sentry", "sse", "static-embed", "templates"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("csrf", "sse", "static-embed", "templates"))'] }

--- a/examples/sse-chat/Cargo.toml
+++ b/examples/sse-chat/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse", "csrf", "static-embed"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("csrf", "sentry", "sse", "static-embed", "templates"))'] }

--- a/examples/sse-chat/src/config.rs
+++ b/examples/sse-chat/src/config.rs
@@ -9,6 +9,7 @@ pub(crate) struct Config {
     pub(crate) database: DatabaseConfig,
 }
 
+#[cfg(feature = "sentry")]
 impl modo::SentryConfigProvider for Config {
     fn sentry_config(&self) -> Option<&modo::SentryConfig> {
         self.core.sentry_config()

--- a/examples/sse-chat/src/config.rs
+++ b/examples/sse-chat/src/config.rs
@@ -8,3 +8,9 @@ pub(crate) struct Config {
     pub(crate) core: AppConfig,
     pub(crate) database: DatabaseConfig,
 }
+
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/examples/sse-dashboard/Cargo.toml
+++ b/examples/sse-dashboard/Cargo.toml
@@ -11,5 +11,8 @@ rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 
+[features]
+sentry = ["modo/sentry"]
+
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry", "sse", "static-embed", "templates"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sse", "static-embed", "templates"))'] }

--- a/examples/sse-dashboard/Cargo.toml
+++ b/examples/sse-dashboard/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates", "sse", "static-embed"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry", "sse", "static-embed", "templates"))'] }

--- a/examples/sse-dashboard/src/config.rs
+++ b/examples/sse-dashboard/src/config.rs
@@ -7,6 +7,7 @@ pub(crate) struct Config {
     pub(crate) core: AppConfig,
 }
 
+#[cfg(feature = "sentry")]
 impl modo::SentryConfigProvider for Config {
     fn sentry_config(&self) -> Option<&modo::SentryConfig> {
         self.core.sentry_config()

--- a/examples/sse-dashboard/src/config.rs
+++ b/examples/sse-dashboard/src/config.rs
@@ -6,3 +6,9 @@ pub(crate) struct Config {
     #[serde(flatten)]
     pub(crate) core: AppConfig,
 }
+
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/examples/templates/Cargo.toml
+++ b/examples/templates/Cargo.toml
@@ -9,4 +9,4 @@ modo = { workspace = true, features = ["templates"] }
 chrono = "0.4"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry", "templates"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates"))'] }

--- a/examples/templates/Cargo.toml
+++ b/examples/templates/Cargo.toml
@@ -9,4 +9,4 @@ modo = { workspace = true, features = ["templates"] }
 chrono = "0.4"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("templates"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry", "templates"))'] }

--- a/examples/todo-api/Cargo.toml
+++ b/examples/todo-api/Cargo.toml
@@ -10,5 +10,5 @@ modo-db = { workspace = true, features = ["sqlite"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry"))'] }
+[features]
+sentry = ["modo/sentry"]

--- a/examples/todo-api/Cargo.toml
+++ b/examples/todo-api/Cargo.toml
@@ -9,3 +9,6 @@ modo.workspace = true
 modo-db = { workspace = true, features = ["sqlite"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry"))'] }

--- a/examples/todo-api/src/config.rs
+++ b/examples/todo-api/src/config.rs
@@ -9,6 +9,7 @@ pub(crate) struct Config {
     pub(crate) database: DatabaseConfig,
 }
 
+#[cfg(feature = "sentry")]
 impl modo::SentryConfigProvider for Config {
     fn sentry_config(&self) -> Option<&modo::SentryConfig> {
         self.core.sentry_config()

--- a/examples/todo-api/src/config.rs
+++ b/examples/todo-api/src/config.rs
@@ -8,3 +8,9 @@ pub(crate) struct Config {
     pub(crate) core: AppConfig,
     pub(crate) database: DatabaseConfig,
 }
+
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/examples/upload/Cargo.toml
+++ b/examples/upload/Cargo.toml
@@ -9,3 +9,6 @@ modo.workspace = true
 modo-upload.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry"))'] }

--- a/examples/upload/Cargo.toml
+++ b/examples/upload/Cargo.toml
@@ -10,5 +10,5 @@ modo-upload.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("sentry"))'] }
+[features]
+sentry = ["modo/sentry"]

--- a/examples/upload/src/config.rs
+++ b/examples/upload/src/config.rs
@@ -9,3 +9,9 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) upload: UploadConfig,
 }
+
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/examples/upload/src/config.rs
+++ b/examples/upload/src/config.rs
@@ -10,6 +10,7 @@ pub(crate) struct Config {
     pub(crate) upload: UploadConfig,
 }
 
+#[cfg(feature = "sentry")]
 impl modo::SentryConfigProvider for Config {
     fn sentry_config(&self) -> Option<&modo::SentryConfig> {
         self.core.sentry_config()

--- a/modo-cli/templates/api/src/config.rs.jinja
+++ b/modo-cli/templates/api/src/config.rs.jinja
@@ -8,3 +8,10 @@ pub(crate) struct Config {
     pub(crate) core: AppConfig,
     pub(crate) database: DatabaseConfig,
 }
+
+#[cfg(feature = "sentry")]
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/modo-cli/templates/minimal/src/config.rs.jinja
+++ b/modo-cli/templates/minimal/src/config.rs.jinja
@@ -6,3 +6,10 @@ pub(crate) struct Config {
     #[serde(flatten)]
     pub(crate) core: AppConfig,
 }
+
+#[cfg(feature = "sentry")]
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/modo-cli/templates/web/config/production.yaml.jinja
+++ b/modo-cli/templates/web/config/production.yaml.jinja
@@ -45,3 +45,7 @@ upload:
     endpoint: ${STORAGE_ENDPOINT}
     access_key_id: ${STORAGE_ACCESS_KEY_ID}
     secret_access_key: ${STORAGE_SECRET_ACCESS_KEY}
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: production
+  traces_sample_rate: 0.2

--- a/modo-cli/templates/web/src/config.rs.jinja
+++ b/modo-cli/templates/web/src/config.rs.jinja
@@ -23,3 +23,10 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) upload: UploadConfig,
 }
+
+#[cfg(feature = "sentry")]
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/modo-cli/templates/worker/config/production.yaml.jinja
+++ b/modo-cli/templates/worker/config/production.yaml.jinja
@@ -16,3 +16,7 @@ jobs:
   queues:
     - name: default
       concurrency: 4
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: production
+  traces_sample_rate: 0.2

--- a/modo-cli/templates/worker/src/config.rs.jinja
+++ b/modo-cli/templates/worker/src/config.rs.jinja
@@ -14,3 +14,10 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) jobs: JobsConfig,
 }
+
+#[cfg(feature = "sentry")]
+impl modo::SentryConfigProvider for Config {
+    fn sentry_config(&self) -> Option<&modo::SentryConfig> {
+        self.core.sentry_config()
+    }
+}

--- a/modo-macros/Cargo.toml
+++ b/modo-macros/Cargo.toml
@@ -16,4 +16,5 @@ proc-macro2 = "1"
 
 [features]
 default = []
+sentry = []
 static-embed = []

--- a/modo-macros/src/main_macro.rs
+++ b/modo-macros/src/main_macro.rs
@@ -127,9 +127,19 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                         async move {
                             let #config_ident: #config_ty = modo::__internal::load_or_default()?;
 
+                            #[cfg(feature = "sentry")]
                             let _sentry_guard = modo::__internal::init_tracing(
                                 modo::__internal::SentryConfigProvider::sentry_config(&#config_ident)
                             );
+
+                            #[cfg(not(feature = "sentry"))]
+                            {
+                                let __env_filter = modo::__internal::tracing_subscriber::EnvFilter::try_from_default_env()
+                                    .unwrap_or_else(|_| modo::__internal::tracing_subscriber::EnvFilter::new("info,sqlx::query=warn"));
+                                modo::__internal::tracing_subscriber::fmt()
+                                    .with_env_filter(__env_filter)
+                                    .init();
+                            }
 
                             let #app_ident = modo::__internal::AppBuilder::new();
 

--- a/modo-macros/src/main_macro.rs
+++ b/modo-macros/src/main_macro.rs
@@ -93,6 +93,28 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
         ));
     }
 
+    let sentry_init_tokens;
+    #[cfg(feature = "sentry")]
+    {
+        sentry_init_tokens = quote! {
+            let _sentry_guard = modo::__internal::init_tracing(
+                modo::__internal::SentryConfigProvider::sentry_config(&#config_ident)
+            );
+        };
+    }
+    #[cfg(not(feature = "sentry"))]
+    {
+        sentry_init_tokens = quote! {
+            {
+                let __env_filter = modo::__internal::tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| modo::__internal::tracing_subscriber::EnvFilter::new("info,sqlx::query=warn"));
+                modo::__internal::tracing_subscriber::fmt()
+                    .with_env_filter(__env_filter)
+                    .init();
+            }
+        };
+    }
+
     let static_embed_tokens;
     #[cfg(feature = "static-embed")]
     {
@@ -127,19 +149,7 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                         async move {
                             let #config_ident: #config_ty = modo::__internal::load_or_default()?;
 
-                            #[cfg(feature = "sentry")]
-                            let _sentry_guard = modo::__internal::init_tracing(
-                                modo::__internal::SentryConfigProvider::sentry_config(&#config_ident)
-                            );
-
-                            #[cfg(not(feature = "sentry"))]
-                            {
-                                let __env_filter = modo::__internal::tracing_subscriber::EnvFilter::try_from_default_env()
-                                    .unwrap_or_else(|_| modo::__internal::tracing_subscriber::EnvFilter::new("info,sqlx::query=warn"));
-                                modo::__internal::tracing_subscriber::fmt()
-                                    .with_env_filter(__env_filter)
-                                    .init();
-                            }
+                            #sentry_init_tokens
 
                             let #app_ident = modo::__internal::AppBuilder::new();
 

--- a/modo-macros/src/main_macro.rs
+++ b/modo-macros/src/main_macro.rs
@@ -123,26 +123,25 @@ pub fn expand(attr: TokenStream, item: TokenStream) -> Result<TokenStream> {
                 .build()
                 .expect("failed to build tokio runtime")
                 .block_on(async {
-                    let stdout_filter = modo::__internal::tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| modo::__internal::tracing_subscriber::EnvFilter::new("info,sqlx::query=warn"));
-
-                    modo::__internal::tracing_subscriber::fmt()
-                        .with_env_filter(stdout_filter)
-                        .init();
-
-                    let #app_ident = modo::__internal::AppBuilder::new();
-
-                    #static_embed_tokens
-
                     let __modo_result: std::result::Result<(), Box<dyn std::error::Error>> = {
                         async move {
                             let #config_ident: #config_ty = modo::__internal::load_or_default()?;
+
+                            let _sentry_guard = modo::__internal::init_tracing(
+                                modo::__internal::SentryConfigProvider::sentry_config(&#config_ident)
+                            );
+
+                            let #app_ident = modo::__internal::AppBuilder::new();
+
+                            #static_embed_tokens
+
                             #(#stmts)*
                         }
                     }.await;
 
                     if let Err(e) = __modo_result {
                         modo::__internal::tracing::error!("Application error: {e}");
+                        eprintln!("Application error: {e}");
                         std::process::exit(1);
                     }
                 });

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -35,7 +35,7 @@ anyhow = "1"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
-sentry = { version = "0.37", features = ["tracing", "tower", "tower-http"] }
+sentry = { version = "0.37", features = ["tracing", "tower", "tower-http"], optional = true }
 
 # Config
 dotenvy = "0.15"
@@ -73,6 +73,7 @@ csrf = ["dep:rand", "dep:hmac", "dep:sha2", "dep:subtle", "dep:form_urlencoded",
 i18n = ["dep:futures-util", "dep:http"]
 sse = ["dep:futures-util"]
 static-fs = ["tower-http/fs"]
+sentry = ["dep:sentry"]
 static-embed = ["dep:rust-embed", "dep:mime_guess", "modo-macros/static-embed"]
 
 [dev-dependencies]

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -73,7 +73,7 @@ csrf = ["dep:rand", "dep:hmac", "dep:sha2", "dep:subtle", "dep:form_urlencoded",
 i18n = ["dep:futures-util", "dep:http"]
 sse = ["dep:futures-util"]
 static-fs = ["tower-http/fs"]
-sentry = ["dep:sentry"]
+sentry = ["dep:sentry", "modo-macros/sentry"]
 static-embed = ["dep:rust-embed", "dep:mime_guess", "modo-macros/static-embed"]
 
 [dev-dependencies]

--- a/modo/Cargo.toml
+++ b/modo/Cargo.toml
@@ -35,6 +35,7 @@ anyhow = "1"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+sentry = { version = "0.37", features = ["tracing", "tower", "tower-http"] }
 
 # Config
 dotenvy = "0.15"

--- a/modo/README.md
+++ b/modo/README.md
@@ -13,6 +13,7 @@ Ergonomic Rust web framework for small monolithic apps. Single binary, compile-t
 | `i18n`         | Translation store, `I18n` extractor, `#[t]` macro                                                                     |
 | `sse`          | Server-Sent Events (`SseEvent`, `SseBroadcastManager`, `Sse` extractor)                                               |
 | `static-fs`    | Filesystem static file serving (development)                                                                           |
+| `sentry`       | Sentry error tracking (`SentryConfig`, `SentryConfigProvider`, request_id tagging)                                     |
 | `static-embed` | Embedded static files via `rust-embed` (production)                                                                    |
 
 ## Usage
@@ -228,3 +229,5 @@ cookies:
 | `SseBroadcastManager` | `sse`       | Keyed fan-out broadcast channels                           |
 | `SseResponse`         | `sse`       | Handler return type wrapping an SSE stream                 |
 | `Sse`                 | `sse`       | Extractor that applies keep-alive config to SSE responses  |
+| `SentryConfig`        | `sentry`    | Sentry DSN, environment, and traces_sample_rate config     |
+| `SentryConfigProvider` | `sentry`   | Trait for extracting Sentry config from custom configs     |

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -343,6 +343,12 @@ impl AppBuilder {
 
         server_config.environment = crate::config::detect_env();
 
+        let sentry_active = app_config
+            .sentry
+            .as_ref()
+            .is_some_and(|s| !s.dsn.is_empty())
+            && sentry::Hub::current().client().is_some();
+
         let http_config = &server_config.http;
 
         let cookie_key = if server_config.secret_key.is_empty() {
@@ -565,6 +571,7 @@ impl AppBuilder {
         // =====================================================================
         // Middleware stack (applied bottom-up; last .layer() call = outermost)
         // Stack order: CORS > Maintenance > Catch Panic > Request ID >
+        //   Sentry Hub > Sentry Request ID Tag > Sentry HTTP >
         //   Sensitive Headers > Tracing > Client IP > Timeout > Trailing Slash >
         //   Compression > Body Limit > Security Headers > Error Handler >
         //   Rate Limiter > Context Layer > Request ID Injector > User Layers > Render Layer >
@@ -710,6 +717,17 @@ impl AppBuilder {
                 sensitive.clone(),
             ));
             router = router.layer(SetSensitiveResponseHeadersLayer::from_shared(sensitive));
+        }
+
+        // --- Sentry request context (if active) ---
+        if sentry_active {
+            router = router.layer(sentry::integrations::tower::SentryHttpLayer::with_transaction());
+            router = router.layer(axum::middleware::from_fn(
+                crate::sentry::sentry_request_id_middleware,
+            ));
+            router = router.layer(sentry::integrations::tower::NewSentryLayer::<
+                axum::http::Request<axum::body::Body>,
+            >::new_from_top());
         }
 
         // --- Request ID (always on) ---

--- a/modo/src/app.rs
+++ b/modo/src/app.rs
@@ -343,6 +343,7 @@ impl AppBuilder {
 
         server_config.environment = crate::config::detect_env();
 
+        #[cfg(feature = "sentry")]
         let sentry_active = app_config
             .sentry
             .as_ref()
@@ -720,6 +721,7 @@ impl AppBuilder {
         }
 
         // --- Sentry request context (if active) ---
+        #[cfg(feature = "sentry")]
         if sentry_active {
             router = router.layer(sentry::integrations::tower::SentryHttpLayer::with_transaction());
             router = router.layer(axum::middleware::from_fn(

--- a/modo/src/config.rs
+++ b/modo/src/config.rs
@@ -281,6 +281,7 @@ impl ServerConfig {
 pub struct AppConfig {
     pub server: ServerConfig,
     pub cookies: crate::cookies::CookieConfig,
+    pub sentry: Option<crate::sentry::SentryConfig>,
     #[cfg(feature = "templates")]
     pub templates: crate::templates::TemplateConfig,
     #[cfg(feature = "i18n")]
@@ -290,6 +291,12 @@ pub struct AppConfig {
     #[cfg(feature = "sse")]
     #[serde(default)]
     pub sse: crate::sse::SseConfig,
+}
+
+impl crate::sentry::SentryConfigProvider for AppConfig {
+    fn sentry_config(&self) -> Option<&crate::sentry::SentryConfig> {
+        self.sentry.as_ref()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/modo/src/config.rs
+++ b/modo/src/config.rs
@@ -281,6 +281,7 @@ impl ServerConfig {
 pub struct AppConfig {
     pub server: ServerConfig,
     pub cookies: crate::cookies::CookieConfig,
+    #[cfg(feature = "sentry")]
     pub sentry: Option<crate::sentry::SentryConfig>,
     #[cfg(feature = "templates")]
     pub templates: crate::templates::TemplateConfig,
@@ -293,6 +294,7 @@ pub struct AppConfig {
     pub sse: crate::sse::SseConfig,
 }
 
+#[cfg(feature = "sentry")]
 impl crate::sentry::SentryConfigProvider for AppConfig {
     fn sentry_config(&self) -> Option<&crate::sentry::SentryConfig> {
         self.sentry.as_ref()

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -28,6 +28,7 @@ pub mod middleware;
 pub mod request_id;
 pub mod router;
 pub mod sanitize;
+#[cfg(feature = "sentry")]
 pub mod sentry;
 pub mod shutdown;
 #[cfg(feature = "sse")]
@@ -61,6 +62,7 @@ pub use middleware::{ClientIp, OptionalRateLimitInfo, RateLimitInfo};
 pub use request_id::RequestId;
 pub use router::Method;
 pub use sanitize::Sanitize;
+#[cfg(feature = "sentry")]
 pub use sentry::{SentryConfig, SentryConfigProvider};
 pub use shutdown::{GracefulShutdown, ShutdownPhase};
 #[cfg(feature = "templates")]
@@ -111,6 +113,7 @@ pub mod __internal {
     // -- main macro --
     pub use crate::app::AppBuilder;
     pub use crate::config::load_or_default;
+    #[cfg(feature = "sentry")]
     pub use crate::sentry::{SentryConfigProvider, init_tracing};
 
     // -- view macro (template-gated) --

--- a/modo/src/lib.rs
+++ b/modo/src/lib.rs
@@ -28,6 +28,7 @@ pub mod middleware;
 pub mod request_id;
 pub mod router;
 pub mod sanitize;
+pub mod sentry;
 pub mod shutdown;
 #[cfg(feature = "sse")]
 pub mod sse;
@@ -60,6 +61,7 @@ pub use middleware::{ClientIp, OptionalRateLimitInfo, RateLimitInfo};
 pub use request_id::RequestId;
 pub use router::Method;
 pub use sanitize::Sanitize;
+pub use sentry::{SentryConfig, SentryConfigProvider};
 pub use shutdown::{GracefulShutdown, ShutdownPhase};
 #[cfg(feature = "templates")]
 pub use templates::{
@@ -109,6 +111,7 @@ pub mod __internal {
     // -- main macro --
     pub use crate::app::AppBuilder;
     pub use crate::config::load_or_default;
+    pub use crate::sentry::{SentryConfigProvider, init_tracing};
 
     // -- view macro (template-gated) --
     #[cfg(feature = "templates")]

--- a/modo/src/sentry.rs
+++ b/modo/src/sentry.rs
@@ -47,7 +47,11 @@ pub trait SentryConfigProvider {
 pub fn init_tracing(sentry_cfg: Option<&SentryConfig>) -> Option<sentry::ClientInitGuard> {
     let guard = sentry_cfg.filter(|s| !s.dsn.is_empty()).map(|cfg| {
         sentry::init(sentry::ClientOptions {
-            dsn: cfg.dsn.parse().ok(),
+            dsn: cfg
+                .dsn
+                .parse()
+                .map_err(|e| tracing::warn!("Invalid Sentry DSN {:?}: {e}", cfg.dsn))
+                .ok(),
             release: sentry::release_name!(),
             environment: Some(cfg.environment.clone().into()),
             traces_sample_rate: cfg.traces_sample_rate,

--- a/modo/src/sentry.rs
+++ b/modo/src/sentry.rs
@@ -1,0 +1,85 @@
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use serde::Deserialize;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Sentry error-tracking configuration.
+///
+/// Deserialized from the `sentry` key in YAML config.
+/// Sentry is enabled when `dsn` is non-empty.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SentryConfig {
+    /// Sentry DSN. Empty string disables Sentry.
+    pub dsn: String,
+    /// Environment tag sent to Sentry (e.g. "production", "development").
+    pub environment: String,
+    /// Fraction of transactions to send for performance monitoring (0.0–1.0).
+    pub traces_sample_rate: f32,
+}
+
+impl Default for SentryConfig {
+    fn default() -> Self {
+        Self {
+            dsn: String::new(),
+            environment: "development".to_string(),
+            traces_sample_rate: 0.0,
+        }
+    }
+}
+
+/// Trait for extracting Sentry config from any application config type.
+///
+/// `AppConfig` implements this automatically. Custom config types must
+/// implement this trait — the default returns `None` (Sentry disabled).
+pub trait SentryConfigProvider {
+    fn sentry_config(&self) -> Option<&SentryConfig> {
+        None
+    }
+}
+
+/// Initialize the tracing subscriber with stdout (always) and Sentry (if configured).
+///
+/// Returns the Sentry `ClientInitGuard` which must be held alive for the
+/// lifetime of the application. Dropping it flushes and disables Sentry.
+pub fn init_tracing(sentry_cfg: Option<&SentryConfig>) -> Option<sentry::ClientInitGuard> {
+    let guard = sentry_cfg.filter(|s| !s.dsn.is_empty()).map(|cfg| {
+        sentry::init(sentry::ClientOptions {
+            dsn: cfg.dsn.parse().ok(),
+            release: sentry::release_name!(),
+            environment: Some(cfg.environment.clone().into()),
+            traces_sample_rate: cfg.traces_sample_rate,
+            ..Default::default()
+        })
+    });
+
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,sqlx::query=warn"));
+
+    if guard.is_some() {
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(tracing_subscriber::fmt::layer())
+            .with(sentry::integrations::tracing::layer())
+            .init();
+    } else {
+        tracing_subscriber::fmt().with_env_filter(env_filter).init();
+    }
+
+    guard
+}
+
+/// Middleware that tags the current Sentry scope with the request ID.
+pub async fn sentry_request_id_middleware(
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    if let Some(rid) = request.extensions().get::<crate::request_id::RequestId>() {
+        sentry::configure_scope(|scope| {
+            scope.set_tag("request_id", rid.as_str());
+        });
+    }
+    next.run(request).await
+}

--- a/modo/tests/sentry_config.rs
+++ b/modo/tests/sentry_config.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sentry")]
+
 use modo::sentry::SentryConfig;
 
 #[test]
@@ -36,4 +38,11 @@ fn sentry_empty_dsn() {
     let cfg: modo::AppConfig = serde_yaml_ng::from_str(yaml).unwrap();
     let sentry = cfg.sentry.unwrap();
     assert!(sentry.dsn.is_empty());
+}
+
+#[test]
+fn sentry_invalid_dsn_does_not_panic() {
+    let yaml = "sentry:\n  dsn: \"not-a-valid-dsn\"\n";
+    let cfg: modo::AppConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(cfg.sentry.unwrap().dsn, "not-a-valid-dsn");
 }

--- a/modo/tests/sentry_config.rs
+++ b/modo/tests/sentry_config.rs
@@ -1,0 +1,39 @@
+use modo::sentry::SentryConfig;
+
+#[test]
+fn sentry_config_defaults() {
+    let cfg = SentryConfig::default();
+    assert!(cfg.dsn.is_empty());
+    assert_eq!(cfg.environment, "development");
+    assert_eq!(cfg.traces_sample_rate, 0.0);
+}
+
+#[test]
+fn sentry_config_from_yaml() {
+    let yaml = r#"
+sentry:
+  dsn: "https://key@sentry.io/123"
+  environment: "production"
+  traces_sample_rate: 0.5
+"#;
+    let cfg: modo::AppConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    let sentry = cfg.sentry.unwrap();
+    assert_eq!(sentry.dsn, "https://key@sentry.io/123");
+    assert_eq!(sentry.environment, "production");
+    assert_eq!(sentry.traces_sample_rate, 0.5);
+}
+
+#[test]
+fn sentry_absent_is_none() {
+    let yaml = "server:\n  port: 3000\n";
+    let cfg: modo::AppConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    assert!(cfg.sentry.is_none());
+}
+
+#[test]
+fn sentry_empty_dsn() {
+    let yaml = "sentry:\n  dsn: \"\"\n";
+    let cfg: modo::AppConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    let sentry = cfg.sentry.unwrap();
+    assert!(sentry.dsn.is_empty());
+}


### PR DESCRIPTION
## Summary

- Add `sentry 0.37` dependency with tracing, tower, and tower-http features
- Create `SentryConfig` / `SentryConfigProvider` trait for opt-in Sentry activation via YAML config (`sentry.dsn`)
- Restructure `#[modo::main]` macro to load config before tracing init, enabling Sentry layer setup from config
- Add Sentry Tower middleware layers (Hub isolation, HTTP metadata capture, request_id tagging) to the middleware stack
- Implement `SentryConfigProvider` for all example custom config types
- Bump workspace version to 0.3.3

## Test Plan

- [x] `cargo test -p modo sentry` — 4 config deserialization tests pass
- [x] `cargo build -p hello` — validates macro expansion end-to-end
- [x] `cargo check --workspace` — all examples compile with SentryConfigProvider
- [x] `just check` (fmt + lint + test) — full CI check passes
- [ ] Manual: run example with `sentry.dsn` set to a test DSN, trigger an error, verify event appears in Sentry with `request_id` tag