### PR TITLE
fix(modo-db): apply SQLite PRAGMAs per-connection via after_connect hook

### DIFF
--- a/claude-plugin/skills/modo/references/config.md
+++ b/claude-plugin/skills/modo/references/config.md
@@ -79,7 +79,8 @@ server:
   secret_key: ${SECRET_KEY:-dev-only-insecure-key}
 
 database:
-  url: ${DATABASE_URL:-sqlite://app.db?mode=rwc}
+  sqlite:
+    path: ${DATABASE_URL:-data/app.db}
 ```
 
 This pattern makes development configs work without a `.env` file while production uses real secrets from the environment.

--- a/claude-plugin/skills/modo/references/database.md
+++ b/claude-plugin/skills/modo/references/database.md
@@ -18,7 +18,7 @@ versioned migrations, pagination helpers, and group-scoped sync for multi-databa
 
 | Feature | Effect |
 |---------|--------|
-| `sqlite` *(default)* | Enables SQLite via `sqlx-sqlite`. Applies WAL mode, busy_timeout, synchronous=NORMAL, and foreign key pragmas on connect. |
+| `sqlite` *(default)* | Enables SQLite via `sqlx-sqlite`. Configurable PRAGMAs (WAL mode, busy_timeout, synchronous, foreign_keys, cache_size, mmap_size, etc.) applied per-connection. |
 | `postgres` | Enables PostgreSQL via `sqlx-postgres`. |
 
 ---
@@ -28,7 +28,8 @@ versioned migrations, pagination helpers, and group-scoped sync for multi-databa
 ### Configuration
 
 `DatabaseConfig` is deserialized from YAML (via `modo::config::load()`). The backend is
-auto-detected from the URL scheme.
+selected by setting either the `sqlite` or `postgres` sub-config. If neither is set,
+defaults to SQLite with `path: "data/main.db"`.
 
 ```rust
 use modo_db::DatabaseConfig;
@@ -46,33 +47,62 @@ pub struct Config {
 
 | Field | Type | Default |
 |-------|------|---------|
-| `url` | `String` | `"sqlite://data/main.db?mode=rwc"` |
+| `sqlite` | `Option<SqliteDbConfig>` | `Some(SqliteDbConfig::default())` |
+| `postgres` | `Option<PostgresDbConfig>` | `None` |
 | `max_connections` | `u32` | `5` |
 | `min_connections` | `u32` | `1` |
 | `acquire_timeout_secs` | `u64` | `30` |
 | `idle_timeout_secs` | `u64` | `600` |
 | `max_lifetime_secs` | `u64` | `1800` |
 
-Example YAML:
+`SqliteDbConfig` fields:
+
+| Field | Type | Default |
+|-------|------|---------|
+| `path` | `String` | `"data/main.db"` |
+| `pragmas` | `SqliteConfig` | WAL, busy_timeout=5000, synchronous=NORMAL, foreign_keys=true, cache_size=-2000 |
+
+`PostgresDbConfig` fields:
+
+| Field | Type | Default |
+|-------|------|---------|
+| `url` | `String` | (required) |
+
+Example YAML (SQLite):
 
 ```yaml
 database:
-  url: "sqlite://data/main.db?mode=rwc"
+  sqlite:
+    path: "data/main.db"
   max_connections: 5
   min_connections: 1
-  acquire_timeout_secs: 30
-  idle_timeout_secs: 600
-  max_lifetime_secs: 1800
+```
+
+Example YAML (SQLite with custom PRAGMAs):
+
+```yaml
+database:
+  sqlite:
+    path: "data/main.db"
+    pragmas:
+      journal_mode: WAL
+      busy_timeout: 10000
+      synchronous: FULL
+      foreign_keys: true
+      cache_size: -4000
+      mmap_size: 268435456
+  max_connections: 5
+  min_connections: 1
 ```
 
 For PostgreSQL:
 
 ```yaml
 database:
-  url: "postgres://user:pass@localhost/myapp"
+  postgres:
+    url: "postgres://user:pass@localhost/myapp"
   max_connections: 10
   min_connections: 2
-  acquire_timeout_secs: 30
 ```
 
 ### Connecting and registering
@@ -1244,6 +1274,9 @@ am.update(&*db).await.map_err(modo_db::db_err_to_error)?;
 | Type | Path |
 |------|------|
 | `DatabaseConfig` | `modo_db::DatabaseConfig` |
+| `SqliteDbConfig` | `modo_db::SqliteDbConfig` |
+| `PostgresDbConfig` | `modo_db::PostgresDbConfig` |
+| `SqliteConfig` | `modo_db::SqliteConfig` |
 | `DbPool` | `modo_db::DbPool` |
 | `Db` | `modo_db::Db` |
 | `Record` | `modo_db::Record` |

--- a/examples/sse-chat/config/development.yaml
+++ b/examples/sse-chat/config/development.yaml
@@ -12,6 +12,7 @@ templates:
 cookie:
     secure: false
 database:
-    url: ${DATABASE_URL:-sqlite://chat.db?mode=rwc}
+    sqlite:
+        path: ${DATABASE_URL:-data/chat.db}
     max_connections: 5
     min_connections: 1

--- a/examples/todo-api/config/development.yaml
+++ b/examples/todo-api/config/development.yaml
@@ -2,6 +2,7 @@ server:
   port: 3001
   secret_key: ${SECRET_KEY:-todo-api-dev-secret-key-change-in-production}
 database:
-  url: ${DATABASE_URL:-sqlite://todos.db?mode=rwc}
+  sqlite:
+    path: ${DATABASE_URL:-data/todos.db}
   max_connections: 5
   min_connections: 1

--- a/modo-auth/tests/integration.rs
+++ b/modo-auth/tests/integration.rs
@@ -8,7 +8,7 @@ use http::Request;
 use modo::{AppState, ServerConfig, ServiceRegistry};
 use modo_auth::{Auth, OptionalAuth, UserProvider, UserProviderService};
 use modo_db::sea_orm::{ConnectionTrait, Schema};
-use modo_db::{DatabaseConfig, DbPool};
+use modo_db::{DatabaseConfig, DbPool, SqliteDbConfig};
 use modo_session::{SessionConfig, SessionMeta, SessionStore};
 use tower::ServiceExt;
 
@@ -39,7 +39,10 @@ impl UserProvider for TestProvider {
 
 async fn setup_db() -> DbPool {
     let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
+        sqlite: Some(SqliteDbConfig {
+            path: ":memory:".to_string(),
+            ..Default::default()
+        }),
         max_connections: 1,
         min_connections: 1,
         ..Default::default()

--- a/modo-cli/templates/api/.env.jinja
+++ b/modo-cli/templates/api/.env.jinja
@@ -1,6 +1,6 @@
 SECRET_KEY={{ project_name }}-dev-secret-change-in-production
 {%- if db_driver == "sqlite" %}
-DATABASE_URL=sqlite://data/main.db?mode=rwc
+DATABASE_URL=data/main.db
 {%- else %}
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ project_name }}
 {%- endif %}

--- a/modo-cli/templates/api/config/development.yaml.jinja
+++ b/modo-cli/templates/api/config/development.yaml.jinja
@@ -4,9 +4,11 @@ server:
   show_banner: true
 database:
 {%- if db_driver == "sqlite" %}
-  url: ${DATABASE_URL:-sqlite://data/main.db?mode=rwc}
+  sqlite:
+    path: ${DATABASE_URL:-data/main.db}
 {%- else %}
-  url: ${DATABASE_URL:-postgres://postgres:postgres@localhost:5432/{{ project_name }}}
+  postgres:
+    url: ${DATABASE_URL:-postgres://postgres:postgres@localhost:5432/{{ project_name }}}
 {%- endif %}
   max_connections: 5
   min_connections: 1

--- a/modo-cli/templates/api/config/production.yaml.jinja
+++ b/modo-cli/templates/api/config/production.yaml.jinja
@@ -3,6 +3,12 @@ server:
   secret_key: ${SECRET_KEY}
   show_banner: false
 database:
-  url: ${DATABASE_URL}
+{%- if db_driver == "sqlite" %}
+  sqlite:
+    path: ${DATABASE_URL}
+{%- else %}
+  postgres:
+    url: ${DATABASE_URL}
+{%- endif %}
   max_connections: 20
   min_connections: 5

--- a/modo-cli/templates/web/.env.jinja
+++ b/modo-cli/templates/web/.env.jinja
@@ -1,7 +1,7 @@
 SECRET_KEY={{ project_name }}-dev-secret-change-in-production
 {%- if db_driver == "sqlite" %}
-DATABASE_URL=sqlite://data/main.db?mode=rwc
-JOBS_DATABASE_URL=sqlite://data/jobs.db?mode=rwc
+DATABASE_URL=data/main.db
+JOBS_DATABASE_URL=data/jobs.db
 {%- else %}
 DATABASE_URL=postgres://{{ project_name }}:{{ project_name }}@localhost:5432/{{ project_name }}_development
 {%- endif %}

--- a/modo-cli/templates/web/config/development.yaml.jinja
+++ b/modo-cli/templates/web/config/development.yaml.jinja
@@ -10,15 +10,18 @@ templates:
   path: templates/app
 database:
 {%- if db_driver == "sqlite" %}
-  url: ${DATABASE_URL:-sqlite://data/main.db?mode=rwc}
+  sqlite:
+    path: ${DATABASE_URL:-data/main.db}
 {%- else %}
-  url: ${DATABASE_URL:-postgres://{{ project_name }}:{{ project_name }}@localhost:5432/{{ project_name }}_development}
+  postgres:
+    url: ${DATABASE_URL:-postgres://{{ project_name }}:{{ project_name }}@localhost:5432/{{ project_name }}_development}
 {%- endif %}
   max_connections: 5
   min_connections: 1
 {%- if db_driver == "sqlite" %}
 jobs_database:
-  url: ${JOBS_DATABASE_URL:-sqlite://data/jobs.db?mode=rwc}
+  sqlite:
+    path: ${JOBS_DATABASE_URL:-data/jobs.db}
   max_connections: 5
   min_connections: 1
 {%- endif %}

--- a/modo-cli/templates/web/config/production.yaml.jinja
+++ b/modo-cli/templates/web/config/production.yaml.jinja
@@ -7,12 +7,19 @@ server:
 templates:
   path: templates/app
 database:
-  url: ${DATABASE_URL}
+{%- if db_driver == "sqlite" %}
+  sqlite:
+    path: ${DATABASE_URL}
+{%- else %}
+  postgres:
+    url: ${DATABASE_URL}
+{%- endif %}
   max_connections: 20
   min_connections: 5
 {%- if db_driver == "sqlite" %}
 jobs_database:
-  url: ${JOBS_DATABASE_URL}
+  sqlite:
+    path: ${JOBS_DATABASE_URL}
   max_connections: 10
   min_connections: 2
 {%- endif %}

--- a/modo-cli/templates/worker/.env.jinja
+++ b/modo-cli/templates/worker/.env.jinja
@@ -1,7 +1,7 @@
 SECRET_KEY={{ project_name }}-dev-secret-change-in-production
 {%- if db_driver == "sqlite" %}
-DATABASE_URL=sqlite://data/main.db?mode=rwc
-JOBS_DATABASE_URL=sqlite://data/jobs.db?mode=rwc
+DATABASE_URL=data/main.db
+JOBS_DATABASE_URL=data/jobs.db
 {%- else %}
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/{{ project_name }}
 {%- endif %}

--- a/modo-cli/templates/worker/config/development.yaml.jinja
+++ b/modo-cli/templates/worker/config/development.yaml.jinja
@@ -4,15 +4,18 @@ server:
   show_banner: true
 database:
 {%- if db_driver == "sqlite" %}
-  url: ${DATABASE_URL:-sqlite://data/main.db?mode=rwc}
+  sqlite:
+    path: ${DATABASE_URL:-data/main.db}
 {%- else %}
-  url: ${DATABASE_URL:-postgres://postgres:postgres@localhost:5432/{{ project_name }}}
+  postgres:
+    url: ${DATABASE_URL:-postgres://postgres:postgres@localhost:5432/{{ project_name }}}
 {%- endif %}
   max_connections: 5
   min_connections: 1
 {%- if db_driver == "sqlite" %}
 jobs_database:
-  url: ${JOBS_DATABASE_URL:-sqlite://data/jobs.db?mode=rwc}
+  sqlite:
+    path: ${JOBS_DATABASE_URL:-data/jobs.db}
   max_connections: 5
   min_connections: 1
 {%- endif %}

--- a/modo-cli/templates/worker/config/production.yaml.jinja
+++ b/modo-cli/templates/worker/config/production.yaml.jinja
@@ -3,12 +3,19 @@ server:
   secret_key: ${SECRET_KEY}
   show_banner: false
 database:
-  url: ${DATABASE_URL}
+{%- if db_driver == "sqlite" %}
+  sqlite:
+    path: ${DATABASE_URL}
+{%- else %}
+  postgres:
+    url: ${DATABASE_URL}
+{%- endif %}
   max_connections: 20
   min_connections: 5
 {%- if db_driver == "sqlite" %}
 jobs_database:
-  url: ${JOBS_DATABASE_URL}
+  sqlite:
+    path: ${JOBS_DATABASE_URL}
   max_connections: 10
   min_connections: 2
 {%- endif %}

--- a/modo-db/Cargo.toml
+++ b/modo-db/Cargo.toml
@@ -8,7 +8,7 @@ description = "Database layer for modo using SeaORM"
 
 [features]
 default = ["sqlite"]
-sqlite = ["sea-orm/sqlx-sqlite"]
+sqlite = ["sea-orm/sqlx-sqlite", "dep:sqlx"]
 postgres = ["sea-orm/sqlx-postgres"]
 
 [dependencies]
@@ -25,6 +25,7 @@ inventory.workspace = true
 serde = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.9"
+sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-native-tls"], optional = true }
 tracing = "0.1"
 thiserror = "2"
 

--- a/modo-db/README.md
+++ b/modo-db/README.md
@@ -6,14 +6,14 @@ Database integration for the modo framework. Provides SeaORM-backed connection p
 
 ## Features
 
-- `sqlite` _(default)_ — enables SQLite via `sqlx-sqlite`. WAL mode, busy-timeout, and foreign keys are applied automatically.
+- `sqlite` _(default)_ — enables SQLite via `sqlx-sqlite`. WAL mode, busy-timeout, foreign keys, and other PRAGMAs are configurable per-connection.
 - `postgres` — enables PostgreSQL via `sqlx-postgres`.
 
 ## Usage
 
 ### Configuration
 
-`DatabaseConfig` is deserialized from your app's YAML config. The backend is auto-detected from the URL scheme.
+`DatabaseConfig` is deserialized from your app's YAML config. The backend is selected by setting either `sqlite` or `postgres` sub-config. If neither is set, defaults to SQLite with `path: "data/main.db"`.
 
 ```rust,ignore
 use modo::AppConfig;
@@ -28,16 +28,43 @@ struct Config {
 }
 ```
 
-Example `config.yaml`:
+Example `config.yaml` (SQLite):
 
 ```yaml
 database:
-    url: "sqlite://data/main.db?mode=rwc"
+    sqlite:
+        path: "data/main.db"
     max_connections: 5
     min_connections: 1
 ```
 
-Defaults: `sqlite://data/main.db?mode=rwc`, `max_connections: 5`, `min_connections: 1`.
+Example `config.yaml` (Postgres):
+
+```yaml
+database:
+    postgres:
+        url: "postgres://user:pass@localhost/myapp"
+    max_connections: 10
+    min_connections: 2
+```
+
+SQLite PRAGMAs (WAL mode, busy_timeout, synchronous, foreign_keys, cache_size, etc.) are applied per-connection and can be overridden via the `sqlite.pragmas` section:
+
+```yaml
+database:
+    sqlite:
+        path: "data/main.db"
+        pragmas:
+            journal_mode: WAL
+            busy_timeout: 5000
+            synchronous: NORMAL
+            foreign_keys: true
+            cache_size: -2000
+    max_connections: 5
+    min_connections: 1
+```
+
+Defaults: SQLite with `path: "data/main.db"`, `max_connections: 5`, `min_connections: 1`.
 
 ### Connecting and migrating
 
@@ -530,7 +557,7 @@ let short_id = modo_db::generate_short_id(); // 13-char Base36, time-sortable
 
 | Type                                  | Purpose                                                                           |
 | ------------------------------------- | --------------------------------------------------------------------------------- |
-| `DatabaseConfig`                      | Connection URL + pool size, deserialised from YAML                                |
+| `DatabaseConfig`                      | Backend selection (`sqlite`/`postgres`) + pool size, deserialised from YAML       |
 | `DbPool`                              | Newtype over `sea_orm::DatabaseConnection`; implements `GracefulShutdown`         |
 | `Db`                                  | Axum extractor that pulls `DbPool` from app state                                 |
 | `Record`                              | Trait providing `find_all`, `query`, `update_many`, `delete_many`; implemented for every entity struct |

--- a/modo-db/src/config.rs
+++ b/modo-db/src/config.rs
@@ -1,35 +1,183 @@
 use serde::Deserialize;
+use std::fmt;
 
 /// Database configuration, deserialized from YAML via `modo::config::load()`.
 ///
-/// Backend is auto-detected from the URL scheme (`sqlite://` or `postgres://`).
-/// Irrelevant fields are silently ignored for the active backend.
+/// Backend is selected by setting either `sqlite` or `postgres` sub-config.
+/// If neither is set, defaults to SQLite with `path: "data/main.db"`.
+/// Setting both is an error (detected at connect time).
 #[derive(Debug, Clone, Deserialize)]
-#[serde(default)]
 pub struct DatabaseConfig {
-    /// Connection URL (e.g., `sqlite://data.db?mode=rwc` or `postgres://localhost/myapp`).
-    pub url: String,
     /// Maximum number of connections in the pool.
+    #[serde(default = "default_max_connections")]
     pub max_connections: u32,
     /// Minimum number of connections in the pool.
+    #[serde(default = "default_min_connections")]
     pub min_connections: u32,
-    /// Seconds to wait for a connection from the pool before timing out (default: 30).
+    /// Seconds to wait for a connection from the pool before timing out.
+    #[serde(default = "default_acquire_timeout")]
     pub acquire_timeout_secs: u64,
-    /// Seconds a connection may sit idle in the pool before being closed (default: 600).
+    /// Seconds a connection may sit idle in the pool before being closed.
+    #[serde(default = "default_idle_timeout")]
     pub idle_timeout_secs: u64,
-    /// Maximum lifetime of a connection in seconds before it is closed and replaced (default: 1800).
+    /// Maximum lifetime of a connection in seconds before it is closed and replaced.
+    #[serde(default = "default_max_lifetime")]
     pub max_lifetime_secs: u64,
+    /// SQLite-specific config. Presence selects SQLite backend.
+    pub sqlite: Option<SqliteDbConfig>,
+    /// Postgres-specific config. Presence selects Postgres backend.
+    pub postgres: Option<PostgresDbConfig>,
+    /// Legacy connection URL — used by `connect.rs` until it is rewritten.
+    /// Will be removed in the next breaking change.
+    #[serde(default = "default_url")]
+    pub url: String,
+}
+
+fn default_max_connections() -> u32 {
+    5
+}
+fn default_min_connections() -> u32 {
+    1
+}
+fn default_acquire_timeout() -> u64 {
+    30
+}
+fn default_idle_timeout() -> u64 {
+    600
+}
+fn default_max_lifetime() -> u64 {
+    1800
+}
+fn default_url() -> String {
+    "sqlite://data/main.db?mode=rwc".to_string()
 }
 
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
-            url: "sqlite://data/main.db?mode=rwc".to_string(),
-            max_connections: 5,
-            min_connections: 1,
-            acquire_timeout_secs: 30,
-            idle_timeout_secs: 600,
-            max_lifetime_secs: 1800,
+            max_connections: default_max_connections(),
+            min_connections: default_min_connections(),
+            acquire_timeout_secs: default_acquire_timeout(),
+            idle_timeout_secs: default_idle_timeout(),
+            max_lifetime_secs: default_max_lifetime(),
+            sqlite: Some(SqliteDbConfig::default()),
+            postgres: None,
+            url: default_url(),
+        }
+    }
+}
+
+/// SQLite-specific config. Presence of this section selects SQLite backend.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SqliteDbConfig {
+    /// Path to the SQLite database file (e.g., "data/main.db" or ":memory:").
+    pub path: String,
+    /// PRAGMA tuning settings applied per-connection.
+    pub pragmas: SqliteConfig,
+}
+
+impl Default for SqliteDbConfig {
+    fn default() -> Self {
+        Self {
+            path: "data/main.db".to_string(),
+            pragmas: SqliteConfig::default(),
+        }
+    }
+}
+
+/// Postgres-specific config. Presence of this section selects Postgres backend.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PostgresDbConfig {
+    /// Full Postgres connection URL.
+    pub url: String,
+}
+
+/// SQLite PRAGMA configuration applied to every connection in the pool.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SqliteConfig {
+    pub journal_mode: JournalMode,
+    pub busy_timeout: u32,
+    pub synchronous: SynchronousMode,
+    pub foreign_keys: bool,
+    pub cache_size: i32,
+    pub mmap_size: Option<i64>,
+    pub temp_store: Option<TempStore>,
+    pub wal_autocheckpoint: Option<u32>,
+}
+
+impl Default for SqliteConfig {
+    fn default() -> Self {
+        Self {
+            journal_mode: JournalMode::Wal,
+            busy_timeout: 5000,
+            synchronous: SynchronousMode::Normal,
+            foreign_keys: true,
+            cache_size: -2000,
+            mmap_size: None,
+            temp_store: None,
+            wal_autocheckpoint: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum JournalMode {
+    #[default]
+    Wal,
+    Delete,
+    Truncate,
+    Persist,
+    Off,
+}
+
+impl fmt::Display for JournalMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JournalMode::Wal => write!(f, "WAL"),
+            JournalMode::Delete => write!(f, "DELETE"),
+            JournalMode::Truncate => write!(f, "TRUNCATE"),
+            JournalMode::Persist => write!(f, "PERSIST"),
+            JournalMode::Off => write!(f, "OFF"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum SynchronousMode {
+    Full,
+    #[default]
+    Normal,
+    Off,
+}
+
+impl fmt::Display for SynchronousMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SynchronousMode::Full => write!(f, "FULL"),
+            SynchronousMode::Normal => write!(f, "NORMAL"),
+            SynchronousMode::Off => write!(f, "OFF"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TempStore {
+    Default,
+    File,
+    Memory,
+}
+
+impl fmt::Display for TempStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TempStore::Default => write!(f, "DEFAULT"),
+            TempStore::File => write!(f, "FILE"),
+            TempStore::Memory => write!(f, "MEMORY"),
         }
     }
 }
@@ -49,11 +197,13 @@ mod tests {
     #[test]
     fn partial_yaml_deserialization() {
         let yaml = r#"
-url: "postgres://localhost/test"
+postgres:
+    url: "postgres://localhost/test"
 acquire_timeout_secs: 10
 "#;
         let config: DatabaseConfig = serde_yaml_ng::from_str(yaml).unwrap();
-        assert_eq!(config.url, "postgres://localhost/test");
+        let pg = config.postgres.unwrap();
+        assert_eq!(pg.url, "postgres://localhost/test");
         assert_eq!(config.acquire_timeout_secs, 10);
         // defaults for omitted fields
         assert_eq!(config.idle_timeout_secs, 600);

--- a/modo-db/src/config.rs
+++ b/modo-db/src/config.rs
@@ -27,10 +27,6 @@ pub struct DatabaseConfig {
     pub sqlite: Option<SqliteDbConfig>,
     /// Postgres-specific config. Presence selects Postgres backend.
     pub postgres: Option<PostgresDbConfig>,
-    /// Legacy connection URL — used by `connect.rs` until it is rewritten.
-    /// Will be removed in the next breaking change.
-    #[serde(default = "default_url")]
-    pub url: String,
 }
 
 fn default_max_connections() -> u32 {
@@ -48,10 +44,6 @@ fn default_idle_timeout() -> u64 {
 fn default_max_lifetime() -> u64 {
     1800
 }
-fn default_url() -> String {
-    "sqlite://data/main.db?mode=rwc".to_string()
-}
-
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
@@ -62,7 +54,6 @@ impl Default for DatabaseConfig {
             max_lifetime_secs: default_max_lifetime(),
             sqlite: Some(SqliteDbConfig::default()),
             postgres: None,
-            url: default_url(),
         }
     }
 }

--- a/modo-db/src/config.rs
+++ b/modo-db/src/config.rs
@@ -7,6 +7,7 @@ use std::fmt;
 /// If neither is set, defaults to SQLite with `path: "data/main.db"`.
 /// Setting both is an error (detected at connect time).
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DatabaseConfig {
     /// Maximum number of connections in the pool.
     #[serde(default = "default_max_connections")]
@@ -121,6 +122,7 @@ pub enum JournalMode {
     Delete,
     Truncate,
     Persist,
+    Memory,
     Off,
 }
 
@@ -131,6 +133,7 @@ impl fmt::Display for JournalMode {
             JournalMode::Delete => write!(f, "DELETE"),
             JournalMode::Truncate => write!(f, "TRUNCATE"),
             JournalMode::Persist => write!(f, "PERSIST"),
+            JournalMode::Memory => write!(f, "MEMORY"),
             JournalMode::Off => write!(f, "OFF"),
         }
     }

--- a/modo-db/src/connect.rs
+++ b/modo-db/src/connect.rs
@@ -1,15 +1,98 @@
 use crate::config::DatabaseConfig;
 use crate::pool::DbPool;
-use sea_orm::{ConnectOptions, Database};
 use std::time::Duration;
 use tracing::info;
 
 /// Connect to the database using the provided configuration.
 ///
-/// Auto-detects the backend from the URL scheme and applies
-/// backend-specific settings (SQLite pragmas, Postgres pool tuning).
+/// Backend is selected from the config:
+/// - `sqlite` set → SQLite (builds sqlx pool with per-connection PRAGMAs)
+/// - `postgres` set → Postgres (uses SeaORM ConnectOptions)
+/// - Neither set → defaults to SQLite with `SqliteDbConfig::default()`
+/// - Both set → returns an error
 pub async fn connect(config: &DatabaseConfig) -> Result<DbPool, modo::Error> {
-    let mut opts = ConnectOptions::new(&config.url);
+    match (&config.sqlite, &config.postgres) {
+        (Some(_), Some(_)) => {
+            return Err(modo::Error::internal(
+                "both `sqlite` and `postgres` are set in database config — pick one",
+            ));
+        }
+        (Some(sqlite), None) => connect_sqlite(sqlite, config).await,
+        (None, Some(pg)) => connect_postgres(pg, config).await,
+        (None, None) => {
+            // Default to SQLite when neither is configured
+            let sqlite = crate::config::SqliteDbConfig::default();
+            connect_sqlite(&sqlite, config).await
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+async fn connect_sqlite(
+    sqlite: &crate::config::SqliteDbConfig,
+    config: &DatabaseConfig,
+) -> Result<DbPool, modo::Error> {
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use std::str::FromStr;
+
+    // Build the connection URL
+    let url = if sqlite.path == ":memory:" {
+        "sqlite::memory:".to_string()
+    } else {
+        // Ensure parent directory exists
+        if let Some(parent) = std::path::Path::new(&sqlite.path).parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    modo::Error::internal(format!(
+                        "failed to create database directory {}: {e}",
+                        parent.display()
+                    ))
+                })?;
+            }
+        }
+        format!("sqlite://{}?mode=rwc", sqlite.path)
+    };
+
+    let connect_options = SqliteConnectOptions::from_str(&url)
+        .map_err(|e| modo::Error::internal(format!("invalid SQLite URL: {e}")))?;
+
+    let pragmas = sqlite.pragmas.clone();
+    let pool = SqlitePoolOptions::new()
+        .max_connections(config.max_connections)
+        .min_connections(config.min_connections)
+        .acquire_timeout(Duration::from_secs(config.acquire_timeout_secs))
+        .idle_timeout(Duration::from_secs(config.idle_timeout_secs))
+        .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
+        .after_connect(move |conn, _meta| {
+            let pragmas = pragmas.clone();
+            Box::pin(async move { apply_sqlite_pragmas(conn, &pragmas).await })
+        })
+        .connect_with(connect_options)
+        .await
+        .map_err(|e| modo::Error::internal(format!("SQLite connection failed: {e}")))?;
+
+    let db_conn = sea_orm::SqlxSqliteConnector::from_sqlx_sqlite_pool(pool);
+    info!(path = %sqlite.path, "SQLite database connected");
+    Ok(DbPool(db_conn))
+}
+
+#[cfg(not(feature = "sqlite"))]
+async fn connect_sqlite(
+    _sqlite: &crate::config::SqliteDbConfig,
+    _config: &DatabaseConfig,
+) -> Result<DbPool, modo::Error> {
+    Err(modo::Error::internal(
+        "SQLite config provided but `sqlite` feature is not enabled",
+    ))
+}
+
+async fn connect_postgres(
+    pg: &crate::config::PostgresDbConfig,
+    config: &DatabaseConfig,
+) -> Result<DbPool, modo::Error> {
+    use sea_orm::{ConnectOptions, Database};
+
+    let mut opts = ConnectOptions::new(&pg.url);
     opts.max_connections(config.max_connections)
         .min_connections(config.min_connections)
         .acquire_timeout(Duration::from_secs(config.acquire_timeout_secs))
@@ -18,41 +101,50 @@ pub async fn connect(config: &DatabaseConfig) -> Result<DbPool, modo::Error> {
 
     let conn = Database::connect(opts)
         .await
-        .map_err(|e| modo::Error::internal(format!("database connection failed: {e}")))?;
+        .map_err(|e| modo::Error::internal(format!("Postgres connection failed: {e}")))?;
 
-    // Apply backend-specific settings
-    if conn.get_database_backend() == sea_orm::DatabaseBackend::Sqlite {
-        apply_sqlite_pragmas(&conn).await?;
-    }
-
-    info!(url = %redact_url(&config.url), "Database connected");
+    info!(url = %redact_url(&pg.url), "Postgres database connected");
     Ok(DbPool(conn))
 }
 
 #[cfg(feature = "sqlite")]
-async fn apply_sqlite_pragmas(conn: &sea_orm::DatabaseConnection) -> Result<(), modo::Error> {
-    use sea_orm::ConnectionTrait;
+async fn apply_sqlite_pragmas(
+    conn: &mut sqlx::sqlite::SqliteConnection,
+    config: &crate::config::SqliteConfig,
+) -> Result<(), sqlx::Error> {
+    use sqlx::Executor;
 
-    conn.execute_unprepared("PRAGMA journal_mode=WAL")
-        .await
-        .map_err(|e| modo::Error::internal(format!("failed to set WAL mode: {e}")))?;
-    conn.execute_unprepared("PRAGMA busy_timeout=5000")
-        .await
-        .map_err(|e| modo::Error::internal(format!("failed to set busy_timeout: {e}")))?;
-    conn.execute_unprepared("PRAGMA synchronous=NORMAL")
-        .await
-        .map_err(|e| modo::Error::internal(format!("failed to set synchronous: {e}")))?;
-    conn.execute_unprepared("PRAGMA foreign_keys=ON")
-        .await
-        .map_err(|e| modo::Error::internal(format!("failed to enable foreign_keys: {e}")))?;
+    conn.execute(format!("PRAGMA journal_mode={}", config.journal_mode).as_str())
+        .await?;
+    conn.execute(format!("PRAGMA busy_timeout={}", config.busy_timeout).as_str())
+        .await?;
+    conn.execute(format!("PRAGMA synchronous={}", config.synchronous).as_str())
+        .await?;
+    conn.execute(
+        format!(
+            "PRAGMA foreign_keys={}",
+            if config.foreign_keys { "ON" } else { "OFF" }
+        )
+        .as_str(),
+    )
+    .await?;
+    conn.execute(format!("PRAGMA cache_size={}", config.cache_size).as_str())
+        .await?;
+
+    if let Some(mmap_size) = config.mmap_size {
+        conn.execute(format!("PRAGMA mmap_size={mmap_size}").as_str())
+            .await?;
+    }
+    if let Some(ref temp_store) = config.temp_store {
+        conn.execute(format!("PRAGMA temp_store={temp_store}").as_str())
+            .await?;
+    }
+    if let Some(wal_autocheckpoint) = config.wal_autocheckpoint {
+        conn.execute(format!("PRAGMA wal_autocheckpoint={wal_autocheckpoint}").as_str())
+            .await?;
+    }
+
     Ok(())
-}
-
-#[cfg(not(feature = "sqlite"))]
-async fn apply_sqlite_pragmas(_conn: &sea_orm::DatabaseConnection) -> Result<(), modo::Error> {
-    Err(modo::Error::internal(
-        "SQLite URL provided but `sqlite` feature is not enabled",
-    ))
 }
 
 /// Redact credentials from database URL for logging.

--- a/modo-db/src/connect.rs
+++ b/modo-db/src/connect.rs
@@ -18,7 +18,7 @@ pub async fn connect(config: &DatabaseConfig) -> Result<DbPool, modo::Error> {
         (Some(sqlite), None) => connect_sqlite(sqlite, config).await,
         (None, Some(pg)) => connect_postgres(pg, config).await,
         (None, None) => {
-            // Default to SQLite when neither is configured
+            tracing::debug!("no sqlite or postgres config set, defaulting to SQLite");
             let sqlite = crate::config::SqliteDbConfig::default();
             connect_sqlite(&sqlite, config).await
         }
@@ -33,7 +33,9 @@ async fn connect_sqlite(
     use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
     use std::str::FromStr;
 
-    // Build the connection URL
+    // Build the connection URL.
+    // Note: for :memory: databases, SQLite silently ignores journal_mode=WAL
+    // (reverts to "memory" mode). The PRAGMA executes without error but has no effect.
     let url = if sqlite.path == ":memory:" {
         "sqlite::memory:".to_string()
     } else {
@@ -84,6 +86,7 @@ async fn connect_sqlite(
     ))
 }
 
+#[cfg(feature = "postgres")]
 async fn connect_postgres(
     pg: &crate::config::PostgresDbConfig,
     config: &DatabaseConfig,
@@ -103,6 +106,16 @@ async fn connect_postgres(
 
     info!(url = %redact_url(&pg.url), "Postgres database connected");
     Ok(DbPool(conn))
+}
+
+#[cfg(not(feature = "postgres"))]
+async fn connect_postgres(
+    _pg: &crate::config::PostgresDbConfig,
+    _config: &DatabaseConfig,
+) -> Result<DbPool, modo::Error> {
+    Err(modo::Error::internal(
+        "Postgres config provided but `postgres` feature is not enabled",
+    ))
 }
 
 #[cfg(feature = "sqlite")]
@@ -146,6 +159,7 @@ async fn apply_sqlite_pragmas(
 }
 
 /// Redact credentials from database URL for logging.
+#[cfg(feature = "postgres")]
 fn redact_url(url: &str) -> String {
     if let Some(scheme_end) = url.find("://") {
         let authority_start = scheme_end + 3;

--- a/modo-db/src/connect.rs
+++ b/modo-db/src/connect.rs
@@ -12,11 +12,9 @@ use tracing::info;
 /// - Both set → returns an error
 pub async fn connect(config: &DatabaseConfig) -> Result<DbPool, modo::Error> {
     match (&config.sqlite, &config.postgres) {
-        (Some(_), Some(_)) => {
-            return Err(modo::Error::internal(
-                "both `sqlite` and `postgres` are set in database config — pick one",
-            ));
-        }
+        (Some(_), Some(_)) => Err(modo::Error::internal(
+            "both `sqlite` and `postgres` are set in database config — pick one",
+        )),
         (Some(sqlite), None) => connect_sqlite(sqlite, config).await,
         (None, Some(pg)) => connect_postgres(pg, config).await,
         (None, None) => {
@@ -40,15 +38,15 @@ async fn connect_sqlite(
         "sqlite::memory:".to_string()
     } else {
         // Ensure parent directory exists
-        if let Some(parent) = std::path::Path::new(&sqlite.path).parent() {
-            if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent).map_err(|e| {
-                    modo::Error::internal(format!(
-                        "failed to create database directory {}: {e}",
-                        parent.display()
-                    ))
-                })?;
-            }
+        if let Some(parent) = std::path::Path::new(&sqlite.path).parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                modo::Error::internal(format!(
+                    "failed to create database directory {}: {e}",
+                    parent.display()
+                ))
+            })?;
         }
         format!("sqlite://{}?mode=rwc", sqlite.path)
     };

--- a/modo-db/src/lib.rs
+++ b/modo-db/src/lib.rs
@@ -56,7 +56,10 @@ mod record;
 pub mod sync;
 
 // Public API
-pub use config::DatabaseConfig;
+pub use config::{
+    DatabaseConfig, JournalMode, PostgresDbConfig, SqliteConfig, SqliteDbConfig, SynchronousMode,
+    TempStore,
+};
 pub use connect::connect;
 pub use entity::EntityRegistration;
 #[doc(hidden)]

--- a/modo-db/tests/config.rs
+++ b/modo-db/tests/config.rs
@@ -1,33 +1,44 @@
-use modo_db::DatabaseConfig;
+use modo_db::config::{DatabaseConfig, JournalMode, SynchronousMode};
 
 #[test]
-fn test_default_config() {
+fn sqlite_sub_config_deserialization() {
+    let yaml = r#"
+sqlite:
+    path: "data/test.db"
+    pragmas:
+        busy_timeout: 3000
+        cache_size: -8000
+        journal_mode: DELETE
+        synchronous: FULL
+"#;
+    let config: DatabaseConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    let sqlite = config.sqlite.unwrap();
+    assert_eq!(sqlite.path, "data/test.db");
+    assert_eq!(sqlite.pragmas.busy_timeout, 3000);
+    assert_eq!(sqlite.pragmas.cache_size, -8000);
+    assert!(matches!(sqlite.pragmas.journal_mode, JournalMode::Delete));
+    assert!(matches!(sqlite.pragmas.synchronous, SynchronousMode::Full));
+}
+
+#[test]
+fn postgres_sub_config_deserialization() {
+    let yaml = r#"
+postgres:
+    url: "postgres://localhost/test"
+"#;
+    let config: DatabaseConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    let pg = config.postgres.unwrap();
+    assert_eq!(pg.url, "postgres://localhost/test");
+    assert!(config.sqlite.is_none());
+}
+
+#[test]
+fn default_config_has_sqlite() {
     let config = DatabaseConfig::default();
-    assert_eq!(config.url, "sqlite://data/main.db?mode=rwc");
-    assert_eq!(config.max_connections, 5);
-    assert_eq!(config.min_connections, 1);
-}
-
-#[test]
-fn test_config_deserialize() {
-    let yaml = r#"
-url: "postgres://localhost/myapp"
-max_connections: 10
-min_connections: 2
-"#;
-    let config: DatabaseConfig = serde_yaml_ng::from_str(yaml).unwrap();
-    assert_eq!(config.url, "postgres://localhost/myapp");
-    assert_eq!(config.max_connections, 10);
-    assert_eq!(config.min_connections, 2);
-}
-
-#[test]
-fn test_config_deserialize_defaults() {
-    let yaml = r#"
-url: "sqlite://test.db"
-"#;
-    let config: DatabaseConfig = serde_yaml_ng::from_str(yaml).unwrap();
-    assert_eq!(config.url, "sqlite://test.db");
-    assert_eq!(config.max_connections, 5);
-    assert_eq!(config.min_connections, 1);
+    assert!(config.sqlite.is_some());
+    assert!(config.postgres.is_none());
+    let sqlite = config.sqlite.unwrap();
+    assert_eq!(sqlite.path, "data/main.db");
+    assert_eq!(sqlite.pragmas.busy_timeout, 5000);
+    assert!(matches!(sqlite.pragmas.journal_mode, JournalMode::Wal));
 }

--- a/modo-db/tests/connect.rs
+++ b/modo-db/tests/connect.rs
@@ -30,8 +30,8 @@ async fn test_pragmas_applied_on_all_connections() {
     };
     let db = modo_db::connect(&config).await.unwrap();
 
-    // Query PRAGMA on multiple connections by running concurrent queries.
-    // Each should return the configured value, not the default.
+    // Query PRAGMA value — all connections are pre-warmed via after_connect,
+    // so any connection from the pool should return the configured value.
     use sea_orm::ConnectionTrait;
     for _ in 0..3 {
         let result = db

--- a/modo-db/tests/connect.rs
+++ b/modo-db/tests/connect.rs
@@ -1,9 +1,12 @@
-use modo_db::DatabaseConfig;
+use modo_db::config::{DatabaseConfig, SqliteConfig, SqliteDbConfig};
 
 #[tokio::test]
 async fn test_connect_sqlite_in_memory() {
     let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
+        sqlite: Some(SqliteDbConfig {
+            path: ":memory:".to_string(),
+            ..Default::default()
+        }),
         ..Default::default()
     };
     let db = modo_db::connect(&config).await.unwrap();
@@ -12,9 +15,46 @@ async fn test_connect_sqlite_in_memory() {
 }
 
 #[tokio::test]
+async fn test_pragmas_applied_on_all_connections() {
+    let config = DatabaseConfig {
+        max_connections: 3,
+        min_connections: 3,
+        sqlite: Some(SqliteDbConfig {
+            path: ":memory:".to_string(),
+            pragmas: SqliteConfig {
+                busy_timeout: 7777,
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let db = modo_db::connect(&config).await.unwrap();
+
+    // Query PRAGMA on multiple connections by running concurrent queries.
+    // Each should return the configured value, not the default.
+    use sea_orm::ConnectionTrait;
+    for _ in 0..3 {
+        let result = db
+            .query_one_raw(sea_orm::Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "PRAGMA busy_timeout".to_string(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        let timeout: i32 = result.try_get_by_index(0).unwrap();
+        assert_eq!(timeout, 7777);
+    }
+}
+
+#[tokio::test]
 async fn test_sync_and_migrate_empty() {
     let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
+        sqlite: Some(SqliteDbConfig {
+            path: ":memory:".to_string(),
+            ..Default::default()
+        }),
         ..Default::default()
     };
     let db = modo_db::connect(&config).await.unwrap();
@@ -29,17 +69,18 @@ async fn test_sync_and_migrate_empty() {
 #[tokio::test]
 async fn test_sync_and_migrate_group() {
     let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
+        sqlite: Some(SqliteDbConfig {
+            path: ":memory:".to_string(),
+            ..Default::default()
+        }),
         ..Default::default()
     };
     let db = modo_db::connect(&config).await.unwrap();
-    // Syncing a group that has no entities should succeed without error
     modo_db::sync_and_migrate_group(&db, "nonexistent")
         .await
         .unwrap();
 
     use sea_orm::ConnectionTrait;
-    // _modo_migrations table should still be bootstrapped
     db.execute_unprepared("SELECT * FROM _modo_migrations")
         .await
         .unwrap();

--- a/modo-db/tests/connect.rs
+++ b/modo-db/tests/connect.rs
@@ -25,7 +25,6 @@ async fn test_pragmas_applied_on_all_connections() {
                 busy_timeout: 7777,
                 ..Default::default()
             },
-            ..Default::default()
         }),
         ..Default::default()
     };

--- a/modo-session/tests/common/mod.rs
+++ b/modo-session/tests/common/mod.rs
@@ -1,9 +1,12 @@
 use modo_db::sea_orm::{ConnectionTrait, Schema};
-use modo_db::{DatabaseConfig, DbPool};
+use modo_db::{DatabaseConfig, DbPool, SqliteDbConfig};
 
 pub async fn setup_db() -> DbPool {
     let config = DatabaseConfig {
-        url: "sqlite::memory:".to_string(),
+        sqlite: Some(SqliteDbConfig {
+            path: ":memory:".to_string(),
+            ..Default::default()
+        }),
         max_connections: 1,
         min_connections: 1,
         ..Default::default()


### PR DESCRIPTION
## Summary

- **Bug fix:** SQLite PRAGMAs (`busy_timeout`, `foreign_keys`, `journal_mode`, `synchronous`) are now applied to every connection in the pool via sqlx's `after_connect` hook, fixing the bug where only one connection received PRAGMAs
- **Config redesign:** Replaced `DatabaseConfig.url` with `sqlite`/`postgres` sub-configs (`SqliteDbConfig`, `PostgresDbConfig`), adding a new `SqliteConfig` struct with enum-typed PRAGMA fields for type-safe configuration
- **Downstream updates:** Updated all example YAML configs, CLI scaffold templates, modo-session/modo-auth tests, and documentation to use the new config shape

## Test plan

- [x] `cargo test -p modo-db` — all 92 tests pass including new PRAGMA verification test
- [x] `cargo test -p modo-session` — passes with updated config
- [x] `cargo test -p modo-auth` — passes with updated config
- [x] `just lint` — zero warnings
- [x] `just test` — full workspace passes