### PR TITLE
feat: add modo-sqlite and modo-sqlite-macros crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [
   "modo-upload",
   "modo-upload-macros",
   "modo-cli",
+  "modo-sqlite",
+  "modo-sqlite-macros",
   "examples/*",
 ]
 
@@ -35,5 +37,7 @@ modo-auth = { path = "modo-auth", version = "0.3" }
 modo-tenant = { path = "modo-tenant", version = "0.3" }
 modo-upload = { path = "modo-upload", version = "0.3" }
 modo-upload-macros = { path = "modo-upload-macros", version = "0.3" }
+modo-sqlite = { path = "modo-sqlite", version = "0.3" }
+modo-sqlite-macros = { path = "modo-sqlite-macros", version = "0.3" }
 inventory = "0.3"
 serde_yaml_ng = "0.10"

--- a/modo-sqlite-macros/Cargo.toml
+++ b/modo-sqlite-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "modo-sqlite-macros"
+version.workspace = true
+edition = "2024"
+license.workspace = true
+repository.workspace = true
+description = "Proc macros for modo-sqlite (embed_migrations)"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/modo-sqlite-macros/src/lib.rs
+++ b/modo-sqlite-macros/src/lib.rs
@@ -144,10 +144,13 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
             .into();
         }
 
-        // Read SQL content
-        let sql_path = entry.path();
-        let sql = std::fs::read_to_string(&sql_path)
-            .unwrap_or_else(|e| panic!("failed to read {}: {e}", sql_path.display()));
+        // Use include_str!() so rustc tracks the file as a dependency
+        let sql_path_str = entry
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|e| panic!("failed to canonicalize {}: {e}", entry.path().display()))
+            .to_string_lossy()
+            .to_string();
 
         submissions.push(quote! {
             ::modo_sqlite::inventory::submit! {
@@ -155,7 +158,7 @@ pub fn embed_migrations(input: TokenStream) -> TokenStream {
                     version: #version,
                     description: #description,
                     group: #group,
-                    sql: #sql,
+                    sql: include_str!(#sql_path_str),
                 }
             }
         });

--- a/modo-sqlite-macros/src/lib.rs
+++ b/modo-sqlite-macros/src/lib.rs
@@ -1,4 +1,45 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use syn::parse::{Parse, ParseStream};
+use syn::{Ident, LitStr, Token};
+
+struct EmbedMigrationsInput {
+    path: Option<String>,
+    group: Option<String>,
+}
+
+impl Parse for EmbedMigrationsInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut path = None;
+        let mut group = None;
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+            let value: LitStr = input.parse()?;
+
+            match key.to_string().as_str() {
+                "path" => path = Some(value.value()),
+                "group" => group = Some(value.value()),
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!("unknown argument: {other}"),
+                    ));
+                }
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(EmbedMigrationsInput { path, group })
+    }
+}
 
 /// Embed SQL migration files from a directory at compile time.
 ///
@@ -11,6 +52,115 @@ use proc_macro::TokenStream;
 /// modo_sqlite::embed_migrations!(path = "db/migrations", group = "jobs");
 /// ```
 #[proc_macro]
-pub fn embed_migrations(_input: TokenStream) -> TokenStream {
-    TokenStream::new() // stub — implemented in Task 7
+pub fn embed_migrations(input: TokenStream) -> TokenStream {
+    let args = syn::parse_macro_input!(input as EmbedMigrationsInput);
+
+    let migrations_path = args.path.unwrap_or_else(|| "migrations".to_string());
+    let group = args.group.unwrap_or_else(|| "default".to_string());
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let dir = PathBuf::from(&manifest_dir).join(&migrations_path);
+
+    // If directory doesn't exist, emit nothing (no migrations)
+    if !dir.exists() {
+        return TokenStream::new();
+    }
+
+    // Read and filter .sql files
+    let mut entries: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("failed to read migrations directory {}: {e}", dir.display()))
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "sql"))
+        .collect();
+
+    // Sort by filename for deterministic order
+    entries.sort_by_key(|e| e.file_name());
+
+    let mut seen_versions = HashSet::new();
+    let mut submissions = Vec::new();
+
+    for entry in entries {
+        let file_name = entry.file_name();
+        let file_name_str = file_name.to_string_lossy().to_string();
+        let stem = entry
+            .path()
+            .file_stem()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+
+        // Parse: {14-digit-timestamp}_{description}
+        let underscore_pos = match stem.find('_') {
+            Some(pos) if pos == 14 => pos,
+            Some(pos) => {
+                return syn::Error::new(
+                    Span::call_site(),
+                    format!(
+                        "migration filename '{file_name_str}': timestamp must be exactly \
+                         14 digits, found {pos} characters before first underscore"
+                    ),
+                )
+                .to_compile_error()
+                .into();
+            }
+            None => {
+                return syn::Error::new(
+                    Span::call_site(),
+                    format!(
+                        "migration filename '{file_name_str}': missing '_' separator \
+                         after timestamp"
+                    ),
+                )
+                .to_compile_error()
+                .into();
+            }
+        };
+
+        let timestamp_str = &stem[..underscore_pos];
+        let description = &stem[underscore_pos + 1..];
+
+        // Validate timestamp is all digits
+        if !timestamp_str.chars().all(|c| c.is_ascii_digit()) {
+            return syn::Error::new(
+                Span::call_site(),
+                format!(
+                    "migration filename '{file_name_str}': timestamp '{timestamp_str}' \
+                     contains non-numeric characters"
+                ),
+            )
+            .to_compile_error()
+            .into();
+        }
+
+        let version: u64 = timestamp_str.parse().unwrap();
+
+        // Check for duplicates
+        if !seen_versions.insert(version) {
+            return syn::Error::new(
+                Span::call_site(),
+                format!("duplicate migration version: {version}"),
+            )
+            .to_compile_error()
+            .into();
+        }
+
+        // Read SQL content
+        let sql_path = entry.path();
+        let sql = std::fs::read_to_string(&sql_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", sql_path.display()));
+
+        submissions.push(quote! {
+            ::modo_sqlite::inventory::submit! {
+                ::modo_sqlite::MigrationRegistration {
+                    version: #version,
+                    description: #description,
+                    group: #group,
+                    sql: #sql,
+                }
+            }
+        });
+    }
+
+    let expanded = quote! { #(#submissions)* };
+    expanded.into()
 }

--- a/modo-sqlite-macros/src/lib.rs
+++ b/modo-sqlite-macros/src/lib.rs
@@ -1,0 +1,16 @@
+use proc_macro::TokenStream;
+
+/// Embed SQL migration files from a directory at compile time.
+///
+/// Scans `CARGO_MANIFEST_DIR/migrations/*.sql` by default.
+/// Each file must be named `{YYYYMMDDHHmmss}_{description}.sql`.
+///
+/// # Usage
+/// ```ignore
+/// modo_sqlite::embed_migrations!();
+/// modo_sqlite::embed_migrations!(path = "db/migrations", group = "jobs");
+/// ```
+#[proc_macro]
+pub fn embed_migrations(_input: TokenStream) -> TokenStream {
+    TokenStream::new() // stub — implemented in Task 7
+}

--- a/modo-sqlite/Cargo.toml
+++ b/modo-sqlite/Cargo.toml
@@ -20,3 +20,4 @@ tracing = "0.1"
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 serde_yaml_ng.workspace = true
+tempfile = "3"

--- a/modo-sqlite/Cargo.toml
+++ b/modo-sqlite/Cargo.toml
@@ -12,7 +12,6 @@ modo-sqlite-macros.workspace = true
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-native-tls"] }
 inventory.workspace = true
 serde = { version = "1", features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"] }
 rand = "0.9"
 thiserror = "2"
 tracing = "0.1"

--- a/modo-sqlite/Cargo.toml
+++ b/modo-sqlite/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "modo-sqlite"
+version.workspace = true
+edition = "2024"
+license.workspace = true
+repository.workspace = true
+description = "Pure sqlx SQLite layer for modo with read/write split and embedded migrations"
+
+[dependencies]
+modo.workspace = true
+modo-sqlite-macros.workspace = true
+sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-native-tls"] }
+inventory.workspace = true
+serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
+rand = "0.9"
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+serde_yaml_ng.workspace = true

--- a/modo-sqlite/src/config.rs
+++ b/modo-sqlite/src/config.rs
@@ -1,0 +1,179 @@
+use serde::Deserialize;
+use std::fmt;
+
+/// SQLite WAL journal mode variant.
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum JournalMode {
+    /// Write-Ahead Logging — best for concurrent reads and writes.
+    #[default]
+    Wal,
+    /// Classic rollback journal, one writer at a time.
+    Delete,
+    /// Rollback journal truncated instead of deleted on commit.
+    Truncate,
+    /// Rollback journal persisted (zeroed header) between transactions.
+    Persist,
+    /// No journal — no rollback on crash.
+    Off,
+}
+
+impl fmt::Display for JournalMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Wal => write!(f, "WAL"),
+            Self::Delete => write!(f, "DELETE"),
+            Self::Truncate => write!(f, "TRUNCATE"),
+            Self::Persist => write!(f, "PERSIST"),
+            Self::Off => write!(f, "OFF"),
+        }
+    }
+}
+
+/// SQLite synchronous PRAGMA value.
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum SynchronousMode {
+    /// Maximum durability — fsync on every write.
+    Full,
+    /// Good balance of safety and performance (default).
+    #[default]
+    Normal,
+    /// No fsync — fastest but unsafe on power loss.
+    Off,
+}
+
+impl fmt::Display for SynchronousMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Full => write!(f, "FULL"),
+            Self::Normal => write!(f, "NORMAL"),
+            Self::Off => write!(f, "OFF"),
+        }
+    }
+}
+
+/// Where SQLite stores temporary tables and indices.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TempStore {
+    /// Use the compile-time default (usually FILE).
+    Default,
+    /// Store temp data on disk.
+    File,
+    /// Store temp data in memory.
+    Memory,
+}
+
+impl fmt::Display for TempStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Default => write!(f, "DEFAULT"),
+            Self::File => write!(f, "FILE"),
+            Self::Memory => write!(f, "MEMORY"),
+        }
+    }
+}
+
+/// Per-pool overrides for `connect_rw()`.
+///
+/// All fields are optional and fall back to the top-level [`SqliteConfig`] values when `None`.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+pub struct PoolOverrides {
+    /// Override the maximum number of connections in the pool.
+    pub max_connections: Option<u32>,
+    /// Override the minimum number of connections in the pool.
+    pub min_connections: Option<u32>,
+    /// Override the acquire timeout in seconds.
+    pub acquire_timeout_secs: Option<u64>,
+    /// Override the idle timeout in seconds.
+    pub idle_timeout_secs: Option<u64>,
+    /// Override the maximum connection lifetime in seconds.
+    pub max_lifetime_secs: Option<u64>,
+    /// Override the SQLite `busy_timeout` PRAGMA (milliseconds).
+    pub busy_timeout: Option<u32>,
+    /// Override the SQLite `cache_size` PRAGMA (negative = KiB).
+    pub cache_size: Option<i32>,
+    /// Override the SQLite `mmap_size` PRAGMA (bytes).
+    pub mmap_size: Option<i64>,
+    /// Override the SQLite `temp_store` PRAGMA.
+    pub temp_store: Option<TempStore>,
+    /// Override the WAL auto-checkpoint threshold (pages).
+    pub wal_autocheckpoint: Option<u32>,
+}
+
+/// Configuration for a SQLite connection pool.
+///
+/// Supports optional per-pool overrides via [`reader`](Self::reader) and
+/// [`writer`](Self::writer) for read/write split workloads.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SqliteConfig {
+    /// Path to the SQLite database file. Defaults to `"data/app.db"`.
+    pub path: String,
+    /// Maximum number of connections in the pool. Defaults to `10`.
+    pub max_connections: u32,
+    /// Minimum number of idle connections kept open. Defaults to `1`.
+    pub min_connections: u32,
+    /// Seconds to wait for a connection from the pool. Defaults to `30`.
+    pub acquire_timeout_secs: u64,
+    /// Seconds a connection may sit idle before being closed. Defaults to `600`.
+    pub idle_timeout_secs: u64,
+    /// Maximum lifetime of a connection in seconds. Defaults to `1800`.
+    pub max_lifetime_secs: u64,
+    /// SQLite `journal_mode` PRAGMA. Defaults to [`JournalMode::Wal`].
+    pub journal_mode: JournalMode,
+    /// SQLite `busy_timeout` PRAGMA in milliseconds. Defaults to `5000`.
+    pub busy_timeout: u32,
+    /// SQLite `synchronous` PRAGMA. Defaults to [`SynchronousMode::Normal`].
+    pub synchronous: SynchronousMode,
+    /// Whether to enable foreign key enforcement. Defaults to `true`.
+    pub foreign_keys: bool,
+    /// SQLite `cache_size` PRAGMA (negative = KiB). Defaults to `-2000` (2 MiB).
+    pub cache_size: i32,
+    /// SQLite `mmap_size` PRAGMA in bytes. Defaults to `None` (opt-in).
+    pub mmap_size: Option<i64>,
+    /// SQLite `temp_store` PRAGMA. Defaults to `None` (opt-in).
+    pub temp_store: Option<TempStore>,
+    /// WAL auto-checkpoint threshold in pages. Defaults to `None` (SQLite default).
+    pub wal_autocheckpoint: Option<u32>,
+    /// Per-pool overrides applied to the reader pool in read/write split mode.
+    pub reader: PoolOverrides,
+    /// Per-pool overrides applied to the writer pool in read/write split mode.
+    pub writer: PoolOverrides,
+}
+
+impl Default for SqliteConfig {
+    fn default() -> Self {
+        Self {
+            path: String::from("data/app.db"),
+            max_connections: 10,
+            min_connections: 1,
+            acquire_timeout_secs: 30,
+            idle_timeout_secs: 600,
+            max_lifetime_secs: 1800,
+            journal_mode: JournalMode::Wal,
+            busy_timeout: 5000,
+            synchronous: SynchronousMode::Normal,
+            foreign_keys: true,
+            cache_size: -2000,
+            mmap_size: None,
+            temp_store: None,
+            wal_autocheckpoint: None,
+            reader: PoolOverrides {
+                busy_timeout: Some(1000),
+                cache_size: Some(-16000),
+                mmap_size: Some(268_435_456),
+                ..Default::default()
+            },
+            writer: PoolOverrides {
+                max_connections: Some(1),
+                busy_timeout: Some(2000),
+                cache_size: Some(-16000),
+                mmap_size: Some(268_435_456),
+                ..Default::default()
+            },
+        }
+    }
+}

--- a/modo-sqlite/src/connect.rs
+++ b/modo-sqlite/src/connect.rs
@@ -1,0 +1,206 @@
+use sqlx::sqlite::{SqliteConnectOptions, SqliteConnection, SqlitePoolOptions};
+use std::str::FromStr;
+
+use crate::{
+    config::{JournalMode, PoolOverrides, SqliteConfig, SynchronousMode, TempStore},
+    pool::{Pool, ReadPool, WritePool},
+};
+
+/// Builds the SQLite connection URL from the given path.
+///
+/// - `:memory:` → `sqlite::memory:`
+/// - Any other path → creates parent directories and returns `sqlite://{path}?mode=rwc`
+fn build_url(path: &str) -> Result<String, crate::Error> {
+    if path == ":memory:" {
+        return Ok("sqlite::memory:".to_string());
+    }
+
+    // Create parent directories if they don't exist
+    if let Some(parent) = std::path::Path::new(path).parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).map_err(|e| crate::Error::Query(sqlx::Error::Io(e)))?;
+    }
+
+    Ok(format!("sqlite://{}?mode=rwc", path))
+}
+
+/// Parameters for building a connection pool.
+struct PoolParams {
+    url: String,
+    max_connections: u32,
+    min_connections: u32,
+    acquire_timeout_secs: u64,
+    idle_timeout_secs: u64,
+    max_lifetime_secs: u64,
+    journal_mode: JournalMode,
+    busy_timeout: u32,
+    synchronous: SynchronousMode,
+    foreign_keys: bool,
+    cache_size: i32,
+    mmap_size: Option<i64>,
+    temp_store: Option<TempStore>,
+    wal_autocheckpoint: Option<u32>,
+}
+
+/// Builds a raw `sqlx::SqlitePool` from the given parameters.
+async fn build_pool(params: PoolParams) -> Result<sqlx::SqlitePool, sqlx::Error> {
+    let options = SqliteConnectOptions::from_str(&params.url)?;
+
+    // Clone/copy all values that need to be moved into the 'static closure
+    let journal_mode = params.journal_mode.to_string();
+    let busy_timeout = params.busy_timeout;
+    let synchronous = params.synchronous.to_string();
+    let foreign_keys = params.foreign_keys;
+    let cache_size = params.cache_size;
+    let mmap_size = params.mmap_size;
+    let temp_store = params.temp_store.map(|ts| ts.to_string());
+    let wal_autocheckpoint = params.wal_autocheckpoint;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(params.max_connections)
+        .min_connections(params.min_connections)
+        .acquire_timeout(std::time::Duration::from_secs(params.acquire_timeout_secs))
+        .idle_timeout(std::time::Duration::from_secs(params.idle_timeout_secs))
+        .max_lifetime(std::time::Duration::from_secs(params.max_lifetime_secs))
+        .after_connect(move |conn: &mut SqliteConnection, _meta| {
+            let journal_mode = journal_mode.clone();
+            let synchronous = synchronous.clone();
+            let temp_store = temp_store.clone();
+            Box::pin(async move {
+                sqlx::query(&format!("PRAGMA journal_mode = {journal_mode}"))
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query(&format!("PRAGMA busy_timeout = {busy_timeout}"))
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query(&format!("PRAGMA synchronous = {synchronous}"))
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query(&format!(
+                    "PRAGMA foreign_keys = {}",
+                    if foreign_keys { 1 } else { 0 }
+                ))
+                .execute(&mut *conn)
+                .await?;
+                sqlx::query(&format!("PRAGMA cache_size = {cache_size}"))
+                    .execute(&mut *conn)
+                    .await?;
+                if let Some(mmap) = mmap_size {
+                    sqlx::query(&format!("PRAGMA mmap_size = {mmap}"))
+                        .execute(&mut *conn)
+                        .await?;
+                }
+                if let Some(ref ts) = temp_store {
+                    sqlx::query(&format!("PRAGMA temp_store = {ts}"))
+                        .execute(&mut *conn)
+                        .await?;
+                }
+                if let Some(wal_ac) = wal_autocheckpoint {
+                    sqlx::query(&format!("PRAGMA wal_autocheckpoint = {wal_ac}"))
+                        .execute(&mut *conn)
+                        .await?;
+                }
+                Ok(())
+            })
+        })
+        .connect_with(options)
+        .await?;
+
+    Ok(pool)
+}
+
+/// Opens a single general-purpose SQLite connection pool.
+///
+/// All PRAGMAs are applied to every connection on connect, using the top-level
+/// values in `config`. Works with `:memory:` databases.
+///
+/// # Errors
+///
+/// Returns [`crate::Error`] if the database file cannot be created, the URL is
+/// invalid, or the pool cannot connect.
+pub async fn connect(config: &SqliteConfig) -> Result<Pool, crate::Error> {
+    let url = build_url(&config.path)?;
+
+    let params = PoolParams {
+        url,
+        max_connections: config.max_connections,
+        min_connections: config.min_connections,
+        acquire_timeout_secs: config.acquire_timeout_secs,
+        idle_timeout_secs: config.idle_timeout_secs,
+        max_lifetime_secs: config.max_lifetime_secs,
+        journal_mode: config.journal_mode,
+        busy_timeout: config.busy_timeout,
+        synchronous: config.synchronous,
+        foreign_keys: config.foreign_keys,
+        cache_size: config.cache_size,
+        mmap_size: config.mmap_size,
+        temp_store: config.temp_store,
+        wal_autocheckpoint: config.wal_autocheckpoint,
+    };
+
+    let pool = build_pool(params).await?;
+    Ok(Pool(pool))
+}
+
+/// Opens a read/write split pair of SQLite connection pools.
+///
+/// Returns `(ReadPool, WritePool)`. Per-pool overrides in `config.reader` and
+/// `config.writer` take precedence over the top-level values for their
+/// respective pools.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::Query`] with a configuration error if `path` is
+/// `:memory:` — in-memory databases cannot be shared between two pools.
+///
+/// Also returns an error if pool creation fails for either pool.
+pub async fn connect_rw(config: &SqliteConfig) -> Result<(ReadPool, WritePool), crate::Error> {
+    if config.path == ":memory:" {
+        return Err(crate::Error::Query(sqlx::Error::Configuration(
+            "connect_rw() does not support :memory: databases — \
+             in-memory databases cannot be shared between two separate pools"
+                .into(),
+        )));
+    }
+
+    let url = build_url(&config.path)?;
+
+    let reader_params = pool_params_with_overrides(&url, config, &config.reader);
+    let writer_params = pool_params_with_overrides(&url, config, &config.writer);
+
+    let reader_pool = build_pool(reader_params).await?;
+    let writer_pool = build_pool(writer_params).await?;
+
+    Ok((ReadPool(reader_pool), WritePool(writer_pool)))
+}
+
+/// Builds [`PoolParams`] by merging top-level `config` values with per-pool `overrides`.
+fn pool_params_with_overrides(
+    url: &str,
+    config: &SqliteConfig,
+    overrides: &PoolOverrides,
+) -> PoolParams {
+    PoolParams {
+        url: url.to_string(),
+        max_connections: overrides.max_connections.unwrap_or(config.max_connections),
+        min_connections: overrides.min_connections.unwrap_or(config.min_connections),
+        acquire_timeout_secs: overrides
+            .acquire_timeout_secs
+            .unwrap_or(config.acquire_timeout_secs),
+        idle_timeout_secs: overrides
+            .idle_timeout_secs
+            .unwrap_or(config.idle_timeout_secs),
+        max_lifetime_secs: overrides
+            .max_lifetime_secs
+            .unwrap_or(config.max_lifetime_secs),
+        journal_mode: config.journal_mode,
+        busy_timeout: overrides.busy_timeout.unwrap_or(config.busy_timeout),
+        synchronous: config.synchronous,
+        foreign_keys: config.foreign_keys,
+        cache_size: overrides.cache_size.unwrap_or(config.cache_size),
+        mmap_size: overrides.mmap_size.or(config.mmap_size),
+        temp_store: overrides.temp_store.or(config.temp_store),
+        wal_autocheckpoint: overrides.wal_autocheckpoint.or(config.wal_autocheckpoint),
+    }
+}

--- a/modo-sqlite/src/error.rs
+++ b/modo-sqlite/src/error.rs
@@ -1,0 +1,51 @@
+/// Error type for modo-sqlite operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// No matching record was found.
+    #[error("record not found")]
+    NotFound,
+
+    /// A unique constraint was violated.
+    #[error("unique constraint violation: {0}")]
+    UniqueViolation(String),
+
+    /// A foreign key constraint was violated.
+    #[error("foreign key violation: {0}")]
+    ForeignKeyViolation(String),
+
+    /// The connection pool timed out waiting for an available connection.
+    #[error("database pool timeout")]
+    PoolTimeout,
+
+    /// A generic database query error.
+    #[error("database error: {0}")]
+    Query(sqlx::Error),
+}
+
+impl From<sqlx::Error> for Error {
+    fn from(e: sqlx::Error) -> Self {
+        match e {
+            sqlx::Error::RowNotFound => Error::NotFound,
+            sqlx::Error::Database(ref db_err) if db_err.is_unique_violation() => {
+                Error::UniqueViolation(db_err.to_string())
+            }
+            sqlx::Error::Database(ref db_err) if db_err.is_foreign_key_violation() => {
+                Error::ForeignKeyViolation(db_err.to_string())
+            }
+            sqlx::Error::PoolTimedOut => Error::PoolTimeout,
+            other => Error::Query(other),
+        }
+    }
+}
+
+impl From<Error> for modo::Error {
+    fn from(e: Error) -> Self {
+        match e {
+            Error::NotFound => modo::error::HttpError::NotFound.into(),
+            Error::UniqueViolation(msg) => modo::error::HttpError::Conflict.with_message(msg),
+            Error::ForeignKeyViolation(msg) => modo::error::HttpError::BadRequest.with_message(msg),
+            Error::PoolTimeout => modo::Error::internal("database pool timeout"),
+            Error::Query(e) => modo::Error::internal(format!("database error: {e}")),
+        }
+    }
+}

--- a/modo-sqlite/src/extractor.rs
+++ b/modo-sqlite/src/extractor.rs
@@ -1,0 +1,95 @@
+use crate::pool::{Pool, ReadPool, WritePool};
+use modo::app::AppState;
+use modo::axum::extract::FromRequestParts;
+use modo::axum::http::request::Parts;
+use modo::error::Error;
+
+/// Single-pool extractor. Use with [`crate::connect()`].
+#[derive(Debug, Clone)]
+pub struct Db(pub Pool);
+
+impl FromRequestParts<AppState> for Db {
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        state
+            .services
+            .get::<Pool>()
+            .map(|pool| Db((*pool).clone()))
+            .ok_or_else(|| {
+                Error::internal(
+                    "database not configured — register Pool via app.managed_service(db)",
+                )
+            })
+    }
+}
+
+impl Db {
+    /// Returns a reference to the underlying [`sqlx::SqlitePool`].
+    pub fn pool(&self) -> &sqlx::SqlitePool {
+        self.0.pool()
+    }
+}
+
+/// Reader extractor. Use with [`crate::connect_rw()`].
+#[derive(Debug, Clone)]
+pub struct DbReader(pub ReadPool);
+
+impl FromRequestParts<AppState> for DbReader {
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        state
+            .services
+            .get::<ReadPool>()
+            .map(|pool| DbReader((*pool).clone()))
+            .ok_or_else(|| {
+                Error::internal(
+                    "reader database not configured — register ReadPool via app.managed_service(reader)",
+                )
+            })
+    }
+}
+
+impl DbReader {
+    /// Returns a reference to the underlying [`sqlx::SqlitePool`].
+    pub fn pool(&self) -> &sqlx::SqlitePool {
+        self.0.pool()
+    }
+}
+
+/// Writer extractor. Use with [`crate::connect_rw()`].
+#[derive(Debug, Clone)]
+pub struct DbWriter(pub WritePool);
+
+impl FromRequestParts<AppState> for DbWriter {
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        state
+            .services
+            .get::<WritePool>()
+            .map(|pool| DbWriter((*pool).clone()))
+            .ok_or_else(|| {
+                Error::internal(
+                    "writer database not configured — register WritePool via app.managed_service(writer)",
+                )
+            })
+    }
+}
+
+impl DbWriter {
+    /// Returns a reference to the underlying [`sqlx::SqlitePool`].
+    pub fn pool(&self) -> &sqlx::SqlitePool {
+        self.0.pool()
+    }
+}

--- a/modo-sqlite/src/id.rs
+++ b/modo-sqlite/src/id.rs
@@ -1,0 +1,33 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const BASE36_CHARS: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+const SHORT_ID_LEN: usize = 13;
+
+/// Generate a new ULID string (26 chars, Crockford Base32).
+pub fn generate_ulid() -> String {
+    modo::ulid::Ulid::new().to_string()
+}
+
+/// Generate a short, time-sortable ID (13 chars, Base36 `[0-9a-z]`).
+///
+/// Layout: 42-bit ms timestamp (high) | 22-bit random (low) → u64 → Base36,
+/// zero-padded to 13 characters.
+pub fn generate_short_id() -> String {
+    let ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_millis() as u64;
+    let ts = ms & ((1u64 << 42) - 1);
+    let rand_bits = rand::random::<u32>() & ((1u32 << 22) - 1);
+    let combined = (ts << 22) | (rand_bits as u64);
+    encode_base36(combined)
+}
+
+fn encode_base36(mut n: u64) -> String {
+    let mut buf = [b'0'; SHORT_ID_LEN];
+    for i in (0..SHORT_ID_LEN).rev() {
+        buf[i] = BASE36_CHARS[(n % 36) as usize];
+        n /= 36;
+    }
+    String::from_utf8(buf.to_vec()).expect("base36 chars are valid UTF-8")
+}

--- a/modo-sqlite/src/id.rs
+++ b/modo-sqlite/src/id.rs
@@ -12,6 +12,10 @@ pub fn generate_ulid() -> String {
 ///
 /// Layout: 42-bit ms timestamp (high) | 22-bit random (low) → u64 → Base36,
 /// zero-padded to 13 characters.
+///
+/// With 22 bits of randomness there are ~4M unique values per millisecond.
+/// For high-throughput bulk inserts, prefer [`generate_ulid()`] which has
+/// 80 bits of randomness.
 pub fn generate_short_id() -> String {
     let ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/modo-sqlite/src/lib.rs
+++ b/modo-sqlite/src/lib.rs
@@ -8,6 +8,7 @@ pub mod connect;
 pub mod error;
 pub mod extractor;
 pub mod id;
+pub mod migration;
 pub mod pool;
 
 pub use config::{JournalMode, PoolOverrides, SqliteConfig, SynchronousMode, TempStore};
@@ -15,4 +16,7 @@ pub use connect::{connect, connect_rw};
 pub use error::Error;
 pub use extractor::{Db, DbReader, DbWriter};
 pub use id::{generate_short_id, generate_ulid};
+pub use migration::{
+    MigrationRegistration, run_migrations, run_migrations_except, run_migrations_group,
+};
 pub use pool::{AsPool, Pool, ReadPool, WritePool};

--- a/modo-sqlite/src/lib.rs
+++ b/modo-sqlite/src/lib.rs
@@ -6,9 +6,11 @@
 pub mod config;
 pub mod connect;
 pub mod error;
+pub mod extractor;
 pub mod pool;
 
 pub use config::{JournalMode, PoolOverrides, SqliteConfig, SynchronousMode, TempStore};
 pub use connect::{connect, connect_rw};
 pub use error::Error;
+pub use extractor::{Db, DbReader, DbWriter};
 pub use pool::{AsPool, Pool, ReadPool, WritePool};

--- a/modo-sqlite/src/lib.rs
+++ b/modo-sqlite/src/lib.rs
@@ -3,6 +3,10 @@
 //! Provides connection pool management with optional read/write split,
 //! configurable SQLite PRAGMAs, and embedded SQL migrations via `inventory`.
 
+pub mod config;
+pub mod error;
 pub mod pool;
 
+pub use config::{JournalMode, PoolOverrides, SqliteConfig, SynchronousMode, TempStore};
+pub use error::Error;
 pub use pool::{AsPool, Pool, ReadPool, WritePool};

--- a/modo-sqlite/src/lib.rs
+++ b/modo-sqlite/src/lib.rs
@@ -7,10 +7,12 @@ pub mod config;
 pub mod connect;
 pub mod error;
 pub mod extractor;
+pub mod id;
 pub mod pool;
 
 pub use config::{JournalMode, PoolOverrides, SqliteConfig, SynchronousMode, TempStore};
 pub use connect::{connect, connect_rw};
 pub use error::Error;
 pub use extractor::{Db, DbReader, DbWriter};
+pub use id::{generate_short_id, generate_ulid};
 pub use pool::{AsPool, Pool, ReadPool, WritePool};

--- a/modo-sqlite/src/lib.rs
+++ b/modo-sqlite/src/lib.rs
@@ -4,9 +4,11 @@
 //! configurable SQLite PRAGMAs, and embedded SQL migrations via `inventory`.
 
 pub mod config;
+pub mod connect;
 pub mod error;
 pub mod pool;
 
 pub use config::{JournalMode, PoolOverrides, SqliteConfig, SynchronousMode, TempStore};
+pub use connect::{connect, connect_rw};
 pub use error::Error;
 pub use pool::{AsPool, Pool, ReadPool, WritePool};

--- a/modo-sqlite/src/lib.rs
+++ b/modo-sqlite/src/lib.rs
@@ -19,4 +19,7 @@ pub use id::{generate_short_id, generate_ulid};
 pub use migration::{
     MigrationRegistration, run_migrations, run_migrations_except, run_migrations_group,
 };
+pub use modo_sqlite_macros::embed_migrations;
 pub use pool::{AsPool, Pool, ReadPool, WritePool};
+
+pub use inventory;

--- a/modo-sqlite/src/lib.rs
+++ b/modo-sqlite/src/lib.rs
@@ -1,0 +1,4 @@
+//! Pure sqlx SQLite layer for the modo framework.
+//!
+//! Provides connection pool management with optional read/write split,
+//! configurable SQLite PRAGMAs, and embedded SQL migrations via `inventory`.

--- a/modo-sqlite/src/lib.rs
+++ b/modo-sqlite/src/lib.rs
@@ -2,3 +2,7 @@
 //!
 //! Provides connection pool management with optional read/write split,
 //! configurable SQLite PRAGMAs, and embedded SQL migrations via `inventory`.
+
+pub mod pool;
+
+pub use pool::{AsPool, Pool, ReadPool, WritePool};

--- a/modo-sqlite/src/migration.rs
+++ b/modo-sqlite/src/migration.rs
@@ -1,0 +1,98 @@
+use crate::pool::AsPool;
+
+/// Registration entry for an embedded SQL migration.
+/// Collected via `inventory` from `embed_migrations!()` calls.
+pub struct MigrationRegistration {
+    pub version: u64,
+    pub description: &'static str,
+    pub group: &'static str,
+    pub sql: &'static str,
+}
+
+inventory::collect!(MigrationRegistration);
+
+/// Run ALL pending migrations (every group).
+pub async fn run_migrations(pool: &impl AsPool) -> Result<(), crate::Error> {
+    run_migrations_filtered(pool, |_| true).await
+}
+
+/// Run pending migrations for a specific group only.
+pub async fn run_migrations_group(pool: &impl AsPool, group: &str) -> Result<(), crate::Error> {
+    run_migrations_filtered(pool, |m| m.group == group).await
+}
+
+/// Run pending migrations for all groups except the excluded ones.
+pub async fn run_migrations_except(
+    pool: &impl AsPool,
+    exclude: &[&str],
+) -> Result<(), crate::Error> {
+    run_migrations_filtered(pool, |m| !exclude.contains(&m.group)).await
+}
+
+async fn run_migrations_filtered(
+    pool: &impl AsPool,
+    filter_fn: impl Fn(&MigrationRegistration) -> bool,
+) -> Result<(), crate::Error> {
+    // Create migrations table if not exists
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS _modo_sqlite_migrations (
+            version     BIGINT PRIMARY KEY,
+            description TEXT NOT NULL,
+            executed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+    )
+    .execute(pool.pool())
+    .await?;
+
+    // Collect from inventory
+    let mut migrations: Vec<&MigrationRegistration> = inventory::iter::<MigrationRegistration>
+        .into_iter()
+        .filter(|m| filter_fn(m))
+        .collect();
+
+    // Sort by version
+    migrations.sort_by_key(|m| m.version);
+
+    // Check for duplicate versions
+    for window in migrations.windows(2) {
+        if window[0].version == window[1].version {
+            return Err(crate::Error::Query(sqlx::Error::Protocol(format!(
+                "duplicate migration version: {}",
+                window[0].version
+            ))));
+        }
+    }
+
+    // Query already-executed versions
+    let executed: Vec<(i64,)> = sqlx::query_as("SELECT version FROM _modo_sqlite_migrations")
+        .fetch_all(pool.pool())
+        .await?;
+    let executed_set: std::collections::HashSet<u64> =
+        executed.iter().map(|r| r.0 as u64).collect();
+
+    // Run pending migrations
+    for m in migrations {
+        if executed_set.contains(&m.version) {
+            continue;
+        }
+
+        tracing::info!(
+            version = m.version,
+            description = m.description,
+            group = m.group,
+            "running migration"
+        );
+
+        // Execute the SQL
+        sqlx::query(m.sql).execute(pool.pool()).await?;
+
+        // Record it
+        sqlx::query("INSERT INTO _modo_sqlite_migrations (version, description) VALUES (?, ?)")
+            .bind(m.version as i64)
+            .bind(m.description)
+            .execute(pool.pool())
+            .await?;
+    }
+
+    Ok(())
+}

--- a/modo-sqlite/src/migration.rs
+++ b/modo-sqlite/src/migration.rs
@@ -83,15 +83,15 @@ async fn run_migrations_filtered(
             "running migration"
         );
 
-        // Execute the SQL
-        sqlx::query(m.sql).execute(pool.pool()).await?;
-
-        // Record it
+        // Execute the SQL and record it in a transaction
+        let mut tx = pool.pool().begin().await?;
+        sqlx::query(m.sql).execute(&mut *tx).await?;
         sqlx::query("INSERT INTO _modo_sqlite_migrations (version, description) VALUES (?, ?)")
             .bind(m.version as i64)
             .bind(m.description)
-            .execute(pool.pool())
+            .execute(&mut *tx)
             .await?;
+        tx.commit().await?;
     }
 
     Ok(())

--- a/modo-sqlite/src/migration.rs
+++ b/modo-sqlite/src/migration.rs
@@ -44,7 +44,23 @@ async fn run_migrations_filtered(
     .execute(pool.pool())
     .await?;
 
-    // Collect from inventory
+    // Check for duplicate versions across ALL groups (versions must be globally unique)
+    {
+        let mut all: Vec<&MigrationRegistration> = inventory::iter::<MigrationRegistration>
+            .into_iter()
+            .collect();
+        all.sort_by_key(|m| m.version);
+        for window in all.windows(2) {
+            if window[0].version == window[1].version {
+                return Err(crate::Error::Query(sqlx::Error::Protocol(format!(
+                    "duplicate migration version {} (groups '{}' and '{}')",
+                    window[0].version, window[0].group, window[1].group
+                ))));
+            }
+        }
+    }
+
+    // Collect from inventory, filtered by group
     let mut migrations: Vec<&MigrationRegistration> = inventory::iter::<MigrationRegistration>
         .into_iter()
         .filter(|m| filter_fn(m))
@@ -52,16 +68,6 @@ async fn run_migrations_filtered(
 
     // Sort by version
     migrations.sort_by_key(|m| m.version);
-
-    // Check for duplicate versions
-    for window in migrations.windows(2) {
-        if window[0].version == window[1].version {
-            return Err(crate::Error::Query(sqlx::Error::Protocol(format!(
-                "duplicate migration version: {}",
-                window[0].version
-            ))));
-        }
-    }
 
     // Query already-executed versions
     let executed: Vec<(i64,)> = sqlx::query_as("SELECT version FROM _modo_sqlite_migrations")

--- a/modo-sqlite/src/pool.rs
+++ b/modo-sqlite/src/pool.rs
@@ -1,0 +1,97 @@
+use std::future::Future;
+use std::pin::Pin;
+
+/// Trait implemented by pool types that can be used for database writes
+/// (and therefore for running migrations).
+///
+/// # Design rationale
+///
+/// [`ReadPool`] intentionally does NOT implement `AsPool`. This ensures
+/// migrations — and any other write-path code that accepts `&impl AsPool` —
+/// can only be called with a writable pool (`Pool` or `WritePool`).
+///
+/// To verify the compile-time enforcement, the following snippet must fail:
+/// ```compile_fail
+/// # use modo_sqlite::pool::{AsPool, ReadPool};
+/// fn _assert(_: &impl AsPool) {}
+/// _assert(&ReadPool(todo!()));
+/// ```
+pub trait AsPool {
+    fn pool(&self) -> &sqlx::SqlitePool;
+}
+
+// ReadPool intentionally does NOT implement AsPool.
+// This ensures migrations can only run through writable pools.
+// To verify: `fn _assert(_: &impl AsPool) {} _assert(&ReadPool(...))` would fail to compile.
+
+/// A general-purpose SQLite connection pool (readable and writable).
+#[derive(Debug, Clone)]
+pub struct Pool(pub(crate) sqlx::SqlitePool);
+
+/// A read-only SQLite connection pool.
+///
+/// Does **not** implement [`AsPool`] — write-path operations (e.g. migrations)
+/// are intentionally unavailable through this type.
+#[derive(Debug, Clone)]
+pub struct ReadPool(pub(crate) sqlx::SqlitePool);
+
+/// A write-only SQLite connection pool.
+#[derive(Debug, Clone)]
+pub struct WritePool(pub(crate) sqlx::SqlitePool);
+
+impl Pool {
+    /// Returns a reference to the underlying [`sqlx::SqlitePool`].
+    pub fn pool(&self) -> &sqlx::SqlitePool {
+        &self.0
+    }
+}
+
+impl ReadPool {
+    /// Returns a reference to the underlying [`sqlx::SqlitePool`].
+    pub fn pool(&self) -> &sqlx::SqlitePool {
+        &self.0
+    }
+}
+
+impl WritePool {
+    /// Returns a reference to the underlying [`sqlx::SqlitePool`].
+    pub fn pool(&self) -> &sqlx::SqlitePool {
+        &self.0
+    }
+}
+
+impl AsPool for Pool {
+    fn pool(&self) -> &sqlx::SqlitePool {
+        &self.0
+    }
+}
+
+impl AsPool for WritePool {
+    fn pool(&self) -> &sqlx::SqlitePool {
+        &self.0
+    }
+}
+
+impl modo::GracefulShutdown for Pool {
+    fn graceful_shutdown(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {
+            self.0.close().await;
+        })
+    }
+}
+
+impl modo::GracefulShutdown for ReadPool {
+    fn graceful_shutdown(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {
+            self.0.close().await;
+        })
+    }
+}
+
+impl modo::GracefulShutdown for WritePool {
+    fn graceful_shutdown(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {
+            self.0.close().await;
+        })
+    }
+}

--- a/modo-sqlite/tests/config.rs
+++ b/modo-sqlite/tests/config.rs
@@ -1,0 +1,55 @@
+use modo_sqlite::{JournalMode, SqliteConfig, SynchronousMode};
+
+#[test]
+fn default_config() {
+    let config = SqliteConfig::default();
+    assert_eq!(config.path, "data/app.db");
+    assert_eq!(config.max_connections, 10);
+    assert_eq!(config.min_connections, 1);
+    assert_eq!(config.busy_timeout, 5000);
+    assert_eq!(config.cache_size, -2000);
+    assert!(matches!(config.journal_mode, JournalMode::Wal));
+    assert!(matches!(config.synchronous, SynchronousMode::Normal));
+    assert!(config.foreign_keys);
+    assert!(config.mmap_size.is_none());
+}
+
+#[test]
+fn yaml_deserialization() {
+    let yaml = r#"
+path: "test.db"
+max_connections: 20
+busy_timeout: 3000
+journal_mode: DELETE
+synchronous: FULL
+reader:
+    busy_timeout: 500
+    max_connections: 50
+writer:
+    busy_timeout: 5000
+    max_connections: 1
+"#;
+    let config: SqliteConfig = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(config.path, "test.db");
+    assert_eq!(config.max_connections, 20);
+    assert_eq!(config.busy_timeout, 3000);
+    assert!(matches!(config.journal_mode, JournalMode::Delete));
+    assert_eq!(config.reader.busy_timeout, Some(500));
+    assert_eq!(config.reader.max_connections, Some(50));
+    assert_eq!(config.writer.busy_timeout, Some(5000));
+    assert_eq!(config.writer.max_connections, Some(1));
+}
+
+#[test]
+fn pool_overrides_have_smart_defaults() {
+    let config = SqliteConfig::default();
+    // Reader defaults: lower busy_timeout, higher cache for read-heavy workloads
+    assert_eq!(config.reader.busy_timeout, Some(1000));
+    assert_eq!(config.reader.cache_size, Some(-16000));
+    assert_eq!(config.reader.mmap_size, Some(268435456));
+    // Writer defaults: single connection, moderate timeout
+    assert_eq!(config.writer.max_connections, Some(1));
+    assert_eq!(config.writer.busy_timeout, Some(2000));
+    assert_eq!(config.writer.cache_size, Some(-16000));
+    assert_eq!(config.writer.mmap_size, Some(268435456));
+}

--- a/modo-sqlite/tests/connect.rs
+++ b/modo-sqlite/tests/connect.rs
@@ -1,0 +1,91 @@
+use modo_sqlite::SqliteConfig;
+
+#[tokio::test]
+async fn connect_in_memory() {
+    let config = SqliteConfig {
+        path: ":memory:".to_string(),
+        ..Default::default()
+    };
+    let pool = modo_sqlite::connect(&config).await.unwrap();
+    let row: (i32,) = sqlx::query_as("SELECT 1")
+        .fetch_one(pool.pool())
+        .await
+        .unwrap();
+    assert_eq!(row.0, 1);
+}
+
+#[tokio::test]
+async fn connect_pragmas_applied() {
+    let config = SqliteConfig {
+        path: ":memory:".to_string(),
+        busy_timeout: 7777,
+        ..Default::default()
+    };
+    let pool = modo_sqlite::connect(&config).await.unwrap();
+    let row: (i32,) = sqlx::query_as("PRAGMA busy_timeout")
+        .fetch_one(pool.pool())
+        .await
+        .unwrap();
+    assert_eq!(row.0, 7777);
+}
+
+#[tokio::test]
+async fn connect_rw_returns_two_pools() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.db");
+    let config = SqliteConfig {
+        path: path.to_string_lossy().to_string(),
+        ..Default::default()
+    };
+    let (reader, writer) = modo_sqlite::connect_rw(&config).await.unwrap();
+
+    // Write through writer
+    sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        .execute(writer.pool())
+        .await
+        .unwrap();
+
+    // Read through reader
+    let row: (i32,) = sqlx::query_as("SELECT count(*) FROM t")
+        .fetch_one(reader.pool())
+        .await
+        .unwrap();
+    assert_eq!(row.0, 0);
+}
+
+#[tokio::test]
+async fn connect_rw_rejects_memory() {
+    let config = SqliteConfig {
+        path: ":memory:".to_string(),
+        ..Default::default()
+    };
+    let result = modo_sqlite::connect_rw(&config).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn connect_rw_different_pragmas() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.db");
+    let mut config = SqliteConfig {
+        path: path.to_string_lossy().to_string(),
+        busy_timeout: 5000,
+        ..Default::default()
+    };
+    config.reader.busy_timeout = Some(1111);
+    config.writer.busy_timeout = Some(2222);
+
+    let (reader, writer) = modo_sqlite::connect_rw(&config).await.unwrap();
+
+    let r: (i32,) = sqlx::query_as("PRAGMA busy_timeout")
+        .fetch_one(reader.pool())
+        .await
+        .unwrap();
+    assert_eq!(r.0, 1111);
+
+    let w: (i32,) = sqlx::query_as("PRAGMA busy_timeout")
+        .fetch_one(writer.pool())
+        .await
+        .unwrap();
+    assert_eq!(w.0, 2222);
+}

--- a/modo-sqlite/tests/error.rs
+++ b/modo-sqlite/tests/error.rs
@@ -1,0 +1,28 @@
+use modo_sqlite::Error;
+
+#[test]
+fn not_found_to_modo_error() {
+    let modo_err: modo::Error = Error::NotFound.into();
+    assert_eq!(
+        modo_err.status_code(),
+        modo::axum::http::StatusCode::NOT_FOUND
+    );
+}
+
+#[test]
+fn unique_violation_to_modo_error() {
+    let modo_err: modo::Error = Error::UniqueViolation("duplicate".into()).into();
+    assert_eq!(
+        modo_err.status_code(),
+        modo::axum::http::StatusCode::CONFLICT
+    );
+}
+
+#[test]
+fn pool_timeout_to_modo_error() {
+    let modo_err: modo::Error = Error::PoolTimeout.into();
+    assert_eq!(
+        modo_err.status_code(),
+        modo::axum::http::StatusCode::INTERNAL_SERVER_ERROR
+    );
+}

--- a/modo-sqlite/tests/migration.rs
+++ b/modo-sqlite/tests/migration.rs
@@ -1,6 +1,7 @@
 use modo_sqlite::SqliteConfig;
 
 modo_sqlite::embed_migrations!(path = "tests/migrations");
+modo_sqlite::embed_migrations!(path = "tests/migrations_jobs", group = "jobs");
 
 #[tokio::test]
 async fn embed_and_run_migrations() {
@@ -42,6 +43,64 @@ async fn run_migrations_creates_table() {
             .await
             .unwrap();
     assert_eq!(row.0, 1);
+}
+
+#[tokio::test]
+async fn run_migrations_group_only_runs_specified_group() {
+    let config = SqliteConfig {
+        path: ":memory:".to_string(),
+        ..Default::default()
+    };
+    let pool = modo_sqlite::connect(&config).await.unwrap();
+    modo_sqlite::run_migrations_group(&pool, "jobs")
+        .await
+        .unwrap();
+
+    // Jobs table should exist
+    let row: (i32,) =
+        sqlx::query_as("SELECT count(*) FROM sqlite_master WHERE type='table' AND name = 'jobs'")
+            .fetch_one(pool.pool())
+            .await
+            .unwrap();
+    assert_eq!(row.0, 1);
+
+    // test_items table should NOT exist (it's in the "default" group)
+    let row: (i32,) = sqlx::query_as(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name = 'test_items'",
+    )
+    .fetch_one(pool.pool())
+    .await
+    .unwrap();
+    assert_eq!(row.0, 0);
+}
+
+#[tokio::test]
+async fn run_migrations_except_excludes_specified_groups() {
+    let config = SqliteConfig {
+        path: ":memory:".to_string(),
+        ..Default::default()
+    };
+    let pool = modo_sqlite::connect(&config).await.unwrap();
+    modo_sqlite::run_migrations_except(&pool, &["jobs"])
+        .await
+        .unwrap();
+
+    // test_items table should exist (default group not excluded)
+    let row: (i32,) = sqlx::query_as(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name = 'test_items'",
+    )
+    .fetch_one(pool.pool())
+    .await
+    .unwrap();
+    assert_eq!(row.0, 1);
+
+    // Jobs table should NOT exist (excluded)
+    let row: (i32,) =
+        sqlx::query_as("SELECT count(*) FROM sqlite_master WHERE type='table' AND name = 'jobs'")
+            .fetch_one(pool.pool())
+            .await
+            .unwrap();
+    assert_eq!(row.0, 0);
 }
 
 #[tokio::test]

--- a/modo-sqlite/tests/migration.rs
+++ b/modo-sqlite/tests/migration.rs
@@ -1,5 +1,32 @@
 use modo_sqlite::SqliteConfig;
 
+modo_sqlite::embed_migrations!(path = "tests/migrations");
+
+#[tokio::test]
+async fn embed_and_run_migrations() {
+    let config = modo_sqlite::SqliteConfig {
+        path: ":memory:".to_string(),
+        ..Default::default()
+    };
+    let pool = modo_sqlite::connect(&config).await.unwrap();
+    modo_sqlite::run_migrations(&pool).await.unwrap();
+
+    // Table should exist with the added column
+    sqlx::query("INSERT INTO test_items (id, name, status) VALUES ('1', 'test', 'done')")
+        .execute(pool.pool())
+        .await
+        .unwrap();
+
+    let row: (String, String, String) =
+        sqlx::query_as("SELECT id, name, status FROM test_items WHERE id = '1'")
+            .fetch_one(pool.pool())
+            .await
+            .unwrap();
+    assert_eq!(row.0, "1");
+    assert_eq!(row.1, "test");
+    assert_eq!(row.2, "done");
+}
+
 #[tokio::test]
 async fn run_migrations_creates_table() {
     let config = SqliteConfig {

--- a/modo-sqlite/tests/migration.rs
+++ b/modo-sqlite/tests/migration.rs
@@ -1,0 +1,29 @@
+use modo_sqlite::SqliteConfig;
+
+#[tokio::test]
+async fn run_migrations_creates_table() {
+    let config = SqliteConfig {
+        path: ":memory:".to_string(),
+        ..Default::default()
+    };
+    let pool = modo_sqlite::connect(&config).await.unwrap();
+    modo_sqlite::run_migrations(&pool).await.unwrap();
+
+    let row: (i32,) =
+        sqlx::query_as("SELECT count(*) FROM sqlite_master WHERE name = '_modo_sqlite_migrations'")
+            .fetch_one(pool.pool())
+            .await
+            .unwrap();
+    assert_eq!(row.0, 1);
+}
+
+#[tokio::test]
+async fn run_migrations_is_idempotent() {
+    let config = SqliteConfig {
+        path: ":memory:".to_string(),
+        ..Default::default()
+    };
+    let pool = modo_sqlite::connect(&config).await.unwrap();
+    modo_sqlite::run_migrations(&pool).await.unwrap();
+    modo_sqlite::run_migrations(&pool).await.unwrap(); // second call should be fine
+}

--- a/modo-sqlite/tests/migrations/20260317120000_create_test_table.sql
+++ b/modo-sqlite/tests/migrations/20260317120000_create_test_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS test_items (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/modo-sqlite/tests/migrations/20260317120100_add_status.sql
+++ b/modo-sqlite/tests/migrations/20260317120100_add_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE test_items ADD COLUMN status TEXT NOT NULL DEFAULT 'active';

--- a/modo-sqlite/tests/migrations_jobs/20260317130000_create_jobs.sql
+++ b/modo-sqlite/tests/migrations_jobs/20260317130000_create_jobs.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT PRIMARY KEY,
+    payload TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary

- Add `modo-sqlite` crate: pure sqlx SQLite layer with read/write pool split, configurable PRAGMAs via `after_connect`, axum extractors (`Db`, `DbReader`, `DbWriter`), migration runner with group filtering, and ID generation utilities
- Add `modo-sqlite-macros` crate: `embed_migrations!()` proc macro that reads SQL files at compile time and registers them via `inventory` for auto-discovery
- 16 tests covering config defaults/deserialization, error conversions, connection/PRAGMA verification, migration runner with group filtering, and end-to-end embed+run integration

## Test plan
- [x] `cargo test -p modo-sqlite` — 16 tests pass (config, error, connect, migration)
- [x] `cargo check -p modo-sqlite-macros` — compiles cleanly
- [x] `just fmt` — no formatting changes
- [x] `just lint` — zero clippy warnings
- [x] `just test` — full workspace tests pass with zero failures