### PR TITLE
feat(http): add HTTP client module, consolidate hyper usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,24 +16,22 @@ name = "modo"
 
 [features]
 default = []
-full = ["templates", "sse", "auth", "sentry", "email", "storage", "webhooks", "dns", "geolocation", "qrcode"]
+full = ["http-client", "templates", "sse", "auth", "sentry", "email", "storage", "webhooks", "dns", "geolocation", "qrcode"]
 sentry = ["dep:sentry", "dep:sentry-tracing"]
 templates = ["dep:minijinja", "dep:minijinja-contrib", "dep:intl_pluralrules", "dep:unic-langid"]
 sse = ["dep:futures-util"]
+http-client = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:http-body-util"]
 auth = [
+  "http-client",
   "dep:argon2",
   "dep:hmac",
   "dep:sha1",
-  "dep:hyper",
-  "dep:hyper-rustls",
-  "dep:hyper-util",
-  "dep:http-body-util",
 ]
 email = ["dep:lettre", "dep:pulldown-cmark"]
 email-test = ["email"]
-storage = ["dep:hmac", "dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:http-body-util"]
+storage = ["http-client", "dep:hmac"]
 storage-test = ["storage"]
-webhooks = ["dep:hmac", "dep:base64", "dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:http-body-util"]
+webhooks = ["http-client", "dep:hmac", "dep:base64"]
 webhooks-test = ["webhooks"]
 dns = ["dep:simple-dns"]
 dns-test = ["dns"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ full = ["http-client", "templates", "sse", "auth", "sentry", "email", "storage",
 sentry = ["dep:sentry", "dep:sentry-tracing"]
 templates = ["dep:minijinja", "dep:minijinja-contrib", "dep:intl_pluralrules", "dep:unic-langid"]
 sse = ["dep:futures-util"]
-http-client = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:http-body-util"]
+http-client = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:http-body-util", "dep:base64"]
 auth = [
   "http-client",
   "dep:argon2",
@@ -31,7 +31,7 @@ email = ["dep:lettre", "dep:pulldown-cmark"]
 email-test = ["email"]
 storage = ["http-client", "dep:hmac"]
 storage-test = ["storage"]
-webhooks = ["http-client", "dep:hmac", "dep:base64"]
+webhooks = ["http-client", "dep:hmac"]
 webhooks-test = ["webhooks"]
 dns = ["dep:simple-dns"]
 dns-test = ["dns"]

--- a/docs/superpowers/plans/2026-03-27-http-client.md
+++ b/docs/superpowers/plans/2026-03-27-http-client.md
@@ -1,0 +1,2413 @@
+# HTTP Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an ergonomic async HTTP client module (`src/http/`) that consolidates three independent hyper client setups into one shared, cheaply-cloneable client.
+
+**Architecture:** Thin wrapper over `hyper_util::client::legacy::Client` with `Arc<Inner>` pattern. `Client` → `RequestBuilder` → `Response` flow. Retry loop with exponential backoff and tracing. Feature-gated under `http-client`. After the module ships, webhook/storage/oauth modules are refactored to use it.
+
+**Tech Stack:** hyper 1, hyper-rustls 0.27, hyper-util 0.1, http-body-util 0.1 (all already in dep tree)
+
+**Spec:** `docs/superpowers/specs/2026-03-27-http-client-design.md`
+
+---
+
+### Task 1: Feature Flag and Module Skeleton
+
+**Files:**
+- Modify: `Cargo.toml` (feature definitions)
+- Create: `src/http/mod.rs`
+- Create: `src/http/config.rs`
+- Modify: `src/lib.rs` (module declaration)
+- Modify: `src/config/modo.rs` (Config field)
+
+- [ ] **Step 1: Add `http-client` feature flag to `Cargo.toml`**
+
+In `Cargo.toml`, add the `http-client` feature after line 22 (after `sse`), and update `auth`, `storage`, `webhooks` to depend on it instead of listing hyper deps directly. Also add `http-client` to the `full` feature.
+
+```toml
+http-client = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:http-body-util"]
+auth = [
+  "http-client",
+  "dep:argon2",
+  "dep:hmac",
+  "dep:sha1",
+]
+storage = ["http-client", "dep:hmac"]
+webhooks = ["http-client", "dep:hmac", "dep:base64"]
+```
+
+Update the `full` feature to include `http-client`:
+```toml
+full = ["http-client", "templates", "sse", "auth", "sentry", "email", "storage", "webhooks", "dns", "geolocation", "qrcode"]
+```
+
+- [ ] **Step 2: Create `src/http/config.rs`**
+
+```rust
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// HTTP client configuration.
+///
+/// Deserializes from the `http:` section of the framework YAML config.
+/// All fields have sensible defaults so the section can be omitted entirely.
+#[non_exhaustive]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ClientConfig {
+    /// Default request timeout in seconds. `0` means no timeout.
+    pub timeout_secs: u64,
+    /// TCP connect timeout in seconds.
+    pub connect_timeout_secs: u64,
+    /// Default `User-Agent` header value.
+    pub user_agent: String,
+    /// Maximum retry attempts for retryable failures. `0` means no retries.
+    pub max_retries: u32,
+    /// Initial backoff between retries in milliseconds.
+    /// Actual backoff is `retry_backoff_ms * 2^attempt`.
+    pub retry_backoff_ms: u64,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            timeout_secs: 30,
+            connect_timeout_secs: 5,
+            user_agent: "modo/0.1".to_string(),
+            max_retries: 0,
+            retry_backoff_ms: 100,
+        }
+    }
+}
+
+impl ClientConfig {
+    /// Request timeout as a `Duration`. Returns `None` when `timeout_secs` is `0`.
+    pub(crate) fn timeout(&self) -> Option<Duration> {
+        if self.timeout_secs == 0 {
+            None
+        } else {
+            Some(Duration::from_secs(self.timeout_secs))
+        }
+    }
+
+    /// TCP connect timeout as a `Duration`.
+    pub(crate) fn connect_timeout(&self) -> Duration {
+        Duration::from_secs(self.connect_timeout_secs)
+    }
+
+    /// Retry backoff base as a `Duration`.
+    pub(crate) fn retry_backoff(&self) -> Duration {
+        Duration::from_millis(self.retry_backoff_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = ClientConfig::default();
+        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.connect_timeout_secs, 5);
+        assert_eq!(config.user_agent, "modo/0.1");
+        assert_eq!(config.max_retries, 0);
+        assert_eq!(config.retry_backoff_ms, 100);
+    }
+
+    #[test]
+    fn timeout_returns_none_for_zero() {
+        let config = ClientConfig {
+            timeout_secs: 0,
+            ..Default::default()
+        };
+        assert!(config.timeout().is_none());
+    }
+
+    #[test]
+    fn timeout_returns_duration_for_nonzero() {
+        let config = ClientConfig::default();
+        assert_eq!(config.timeout(), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn deserialize_from_yaml() {
+        let yaml = r#"
+timeout_secs: 10
+connect_timeout_secs: 2
+user_agent: "myapp/1.0"
+max_retries: 3
+retry_backoff_ms: 200
+"#;
+        let config: ClientConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.timeout_secs, 10);
+        assert_eq!(config.connect_timeout_secs, 2);
+        assert_eq!(config.user_agent, "myapp/1.0");
+        assert_eq!(config.max_retries, 3);
+        assert_eq!(config.retry_backoff_ms, 200);
+    }
+
+    #[test]
+    fn deserialize_empty_yaml_uses_defaults() {
+        let config: ClientConfig = serde_yaml_ng::from_str("{}").unwrap();
+        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.max_retries, 0);
+    }
+}
+```
+
+- [ ] **Step 3: Create `src/http/mod.rs`**
+
+```rust
+mod config;
+
+pub use config::ClientConfig;
+```
+
+- [ ] **Step 4: Add module declaration to `src/lib.rs`**
+
+After line 50 (after `pub mod tenant;`), add:
+
+```rust
+#[cfg(feature = "http-client")]
+pub mod http;
+```
+
+- [ ] **Step 5: Add config field to `src/config/modo.rs`**
+
+After the `pub session` field (line 34), add:
+
+```rust
+    /// HTTP client settings (timeout, retries, user agent).
+    /// Requires the `http-client` feature.
+    #[cfg(feature = "http-client")]
+    #[serde(default)]
+    pub http: crate::http::ClientConfig,
+```
+
+- [ ] **Step 6: Add re-export to `src/lib.rs`**
+
+After line 82 (`pub use error::{Error, Result};`), add:
+
+```rust
+#[cfg(feature = "http-client")]
+pub use http::ClientConfig as HttpClientConfig;
+```
+
+- [ ] **Step 7: Run tests and lint**
+
+Run: `cargo test --features http-client`
+Expected: All tests pass including the new config tests.
+
+Run: `cargo clippy --features http-client --tests -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Cargo.toml src/http/ src/lib.rs src/config/modo.rs
+git commit -m "feat(http): add http-client feature flag and ClientConfig"
+```
+
+---
+
+### Task 2: Response Type
+
+**Files:**
+- Create: `src/http/response.rs`
+- Modify: `src/http/mod.rs`
+
+- [ ] **Step 1: Create `src/http/response.rs`**
+
+```rust
+use bytes::Bytes;
+use http::{HeaderMap, StatusCode};
+use http_body_util::BodyExt;
+use serde::de::DeserializeOwned;
+
+use crate::error::{Error, Result};
+
+/// HTTP response returned by [`Client::send`](super::Client).
+///
+/// Body consumption methods (`json`, `text`, `bytes`) take ownership of `self`
+/// — the body can only be read once. For streaming large responses use
+/// [`stream`](Response::stream).
+pub struct Response {
+    status: StatusCode,
+    headers: HeaderMap,
+    url: String,
+    body: hyper::body::Incoming,
+}
+
+impl Response {
+    pub(crate) fn new(
+        status: StatusCode,
+        headers: HeaderMap,
+        url: String,
+        body: hyper::body::Incoming,
+    ) -> Self {
+        Self {
+            status,
+            headers,
+            url,
+            body,
+        }
+    }
+
+    /// HTTP status code of the response.
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    /// Response headers.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// The URL that was requested (after query-param appending, before redirects).
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Value of the `Content-Length` header, if present and parseable.
+    pub fn content_length(&self) -> Option<u64> {
+        self.headers
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse().ok())
+    }
+
+    /// Read the full body and deserialize as JSON.
+    pub async fn json<T: DeserializeOwned>(self) -> Result<T> {
+        let bytes = self.bytes().await?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| Error::internal(format!("failed to parse response JSON: {e}")).chain(e))
+    }
+
+    /// Read the full body as a UTF-8 string.
+    pub async fn text(self) -> Result<String> {
+        let bytes = self.bytes().await?;
+        String::from_utf8(bytes.into())
+            .map_err(|e| Error::internal("response body is not valid UTF-8").chain(e))
+    }
+
+    /// Read the full body as raw bytes.
+    pub async fn bytes(self) -> Result<Bytes> {
+        self.body
+            .collect()
+            .await
+            .map(|collected| collected.to_bytes())
+            .map_err(|e| Error::internal(format!("failed to read response body: {e}")).chain(e))
+    }
+
+    /// Return a stream of body chunks without buffering the full response.
+    pub fn stream(self) -> BodyStream {
+        BodyStream {
+            body: self.body,
+        }
+    }
+
+    /// Return `Ok(self)` if the status is 2xx, or `Err` otherwise.
+    ///
+    /// For fine-grained status handling, check [`status`](Response::status)
+    /// directly and build your own error.
+    pub fn error_for_status(self) -> Result<Self> {
+        if self.status.is_success() {
+            Ok(self)
+        } else {
+            Err(Error::internal(format!("HTTP {}: {}", self.status, self.url)))
+        }
+    }
+}
+
+/// Streaming body wrapper returned by [`Response::stream`].
+pub struct BodyStream {
+    body: hyper::body::Incoming,
+}
+
+impl BodyStream {
+    /// Yield the next chunk of body bytes.
+    ///
+    /// Returns `None` when the body is fully consumed.
+    pub async fn next(&mut self) -> Option<Result<Bytes>> {
+        use hyper::body::Frame;
+
+        loop {
+            let frame = std::pin::pin!(self.body.frame()).await?;
+            match frame {
+                Ok(frame) => {
+                    if let Some(data) = frame.into_data().ok() {
+                        return Some(Ok(data));
+                    }
+                    // Skip non-data frames (trailers) and continue
+                }
+                Err(e) => {
+                    return Some(Err(
+                        Error::internal(format!("failed to read response body: {e}")).chain(e),
+                    ));
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update `src/http/mod.rs`**
+
+```rust
+mod config;
+mod response;
+
+pub use config::ClientConfig;
+pub use response::{BodyStream, Response};
+```
+
+- [ ] **Step 3: Run tests and lint**
+
+Run: `cargo check --features http-client`
+Expected: Compiles without errors.
+
+Run: `cargo clippy --features http-client --tests -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/http/response.rs src/http/mod.rs
+git commit -m "feat(http): add Response and BodyStream types"
+```
+
+---
+
+### Task 3: Retry Policy
+
+**Files:**
+- Create: `src/http/retry.rs`
+- Modify: `src/http/mod.rs`
+
+- [ ] **Step 1: Create `src/http/retry.rs`**
+
+```rust
+use std::time::Duration;
+
+use bytes::Bytes;
+use http::{Method, StatusCode, Uri};
+use http::header::HeaderMap;
+use http_body_util::Full;
+use hyper_rustls::HttpsConnector;
+use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::HttpConnector;
+
+use super::response::Response;
+use crate::error::{Error, Result};
+
+/// Max duration we'll honour for a `Retry-After` header value.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+pub(crate) struct RetryPolicy {
+    pub max_retries: u32,
+    pub backoff: Duration,
+}
+
+/// Outcome of a single request attempt.
+enum Attempt {
+    /// A complete HTTP response was received.
+    Success(Response),
+    /// The attempt failed with a retryable condition.
+    /// Optional duration is the server-requested Retry-After delay.
+    Retryable(String, Option<Duration>),
+    /// The attempt failed with a non-retryable error.
+    Fatal(Error),
+}
+
+pub(crate) async fn execute(
+    client: &Client<HttpsConnector<HttpConnector>, Full<Bytes>>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Option<Bytes>,
+    timeout: Option<Duration>,
+    policy: &RetryPolicy,
+) -> Result<Response> {
+    let url_str = uri.to_string();
+    let method_str = method.as_str();
+    let max = policy.max_retries;
+
+    let mut last_error: Option<Error> = None;
+
+    for attempt in 0..=max {
+        tracing::debug!(
+            attempt,
+            url = %url_str,
+            method = %method_str,
+            "http.request",
+        );
+
+        let result = send_once(client, &method, &uri, &headers, body.as_ref(), timeout).await;
+
+        match classify(result, &url_str) {
+            Attempt::Success(resp) => return Ok(resp),
+            Attempt::Fatal(err) => return Err(err),
+            Attempt::Retryable(reason, retry_after) => {
+                if attempt < max {
+                    // Use Retry-After from server if provided, otherwise exponential backoff
+                    let delay = retry_after.unwrap_or_else(|| backoff_delay(policy.backoff, attempt));
+                    tracing::warn!(
+                        attempt,
+                        next_attempt = attempt + 1,
+                        reason = %reason,
+                        backoff_ms = delay.as_millis() as u64,
+                        "http.retry",
+                    );
+                    tokio::time::sleep(delay).await;
+                } else {
+                    last_error = Some(Error::internal(format!(
+                        "HTTP request failed after {max} retries: {reason}"
+                    )));
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| Error::internal("HTTP request failed")))
+}
+
+async fn send_once(
+    client: &Client<HttpsConnector<HttpConnector>, Full<Bytes>>,
+    method: &Method,
+    uri: &Uri,
+    headers: &HeaderMap,
+    body: Option<&Bytes>,
+    timeout: Option<Duration>,
+) -> std::result::Result<hyper::Response<hyper::body::Incoming>, SendError> {
+    let req_body = match body {
+        Some(b) => Full::new(b.clone()),
+        None => Full::new(Bytes::new()),
+    };
+
+    let mut builder = hyper::Request::builder().method(method).uri(uri);
+    for (name, value) in headers {
+        builder = builder.header(name, value);
+    }
+
+    let request = builder.body(req_body).map_err(|e| SendError::Fatal(e.to_string()))?;
+
+    let fut = client.request(request);
+    match timeout {
+        Some(dur) => tokio::time::timeout(dur, fut)
+            .await
+            .map_err(|_| SendError::Timeout)?
+            .map_err(|e| SendError::Connection(e.to_string())),
+        None => fut
+            .await
+            .map_err(|e| SendError::Connection(e.to_string())),
+    }
+}
+
+enum SendError {
+    Timeout,
+    Connection(String),
+    Fatal(String),
+}
+
+fn classify(
+    result: std::result::Result<hyper::Response<hyper::body::Incoming>, SendError>,
+    url: &str,
+) -> Attempt {
+    match result {
+        Ok(resp) => {
+            let status = resp.status();
+            match status {
+                s if s == StatusCode::BAD_GATEWAY || s == StatusCode::SERVICE_UNAVAILABLE => {
+                    Attempt::Retryable(format!("HTTP {s}"), None)
+                }
+                StatusCode::TOO_MANY_REQUESTS => {
+                    let retry_after = parse_retry_after(resp.headers());
+                    Attempt::Retryable("HTTP 429".to_string(), retry_after)
+                }
+                _ => {
+                    let headers = resp.headers().clone();
+                    let body = resp.into_body();
+                    Attempt::Success(Response::new(status, headers, url.to_string(), body))
+                }
+            }
+        }
+        Err(SendError::Timeout) => Attempt::Retryable("timeout".to_string(), None),
+        Err(SendError::Connection(msg)) => {
+            Attempt::Retryable(format!("connection error: {msg}"), None)
+        }
+        Err(SendError::Fatal(msg)) => {
+            Attempt::Fatal(Error::internal(format!("failed to build HTTP request: {msg}")))
+        }
+    }
+}
+
+/// Parse the `Retry-After` header as a number of seconds.
+/// Ignores HTTP-date format (uncommon for APIs). Caps at 60 seconds.
+fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
+    let value = headers.get("retry-after")?.to_str().ok()?;
+    let secs: u64 = value.trim().parse().ok()?;
+    Some(Duration::from_secs(secs).min(MAX_RETRY_AFTER))
+}
+
+fn backoff_delay(base: Duration, attempt: u32) -> Duration {
+    base.saturating_mul(2u32.saturating_pow(attempt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_delay_exponential() {
+        let base = Duration::from_millis(100);
+        assert_eq!(backoff_delay(base, 0), Duration::from_millis(100));
+        assert_eq!(backoff_delay(base, 1), Duration::from_millis(200));
+        assert_eq!(backoff_delay(base, 2), Duration::from_millis(400));
+        assert_eq!(backoff_delay(base, 3), Duration::from_millis(800));
+    }
+
+    #[test]
+    fn backoff_delay_does_not_overflow() {
+        let base = Duration::from_millis(100);
+        // Very high attempt should saturate, not panic
+        let delay = backoff_delay(base, 100);
+        assert!(delay >= base);
+    }
+
+    #[test]
+    fn parse_retry_after_valid_seconds() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", "5".parse().unwrap());
+        assert_eq!(parse_retry_after(&headers), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn parse_retry_after_capped_at_60() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", "120".parse().unwrap());
+        assert_eq!(parse_retry_after(&headers), Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn parse_retry_after_missing_header() {
+        let headers = HeaderMap::new();
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn parse_retry_after_non_numeric() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", "Wed, 21 Oct 2026 07:28:00 GMT".parse().unwrap());
+        // HTTP-date format is not supported — returns None
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+}
+```
+
+- [ ] **Step 2: Update `src/http/mod.rs`**
+
+```rust
+mod config;
+mod response;
+mod retry;
+
+pub use config::ClientConfig;
+pub use response::{BodyStream, Response};
+```
+
+- [ ] **Step 3: Run tests and lint**
+
+Run: `cargo test --features http-client`
+Expected: All tests pass including backoff unit tests.
+
+Run: `cargo clippy --features http-client --tests -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/http/retry.rs src/http/mod.rs
+git commit -m "feat(http): add retry policy with exponential backoff"
+```
+
+---
+
+### Task 4: Client and RequestBuilder
+
+**Files:**
+- Create: `src/http/client.rs`
+- Create: `src/http/request.rs`
+- Modify: `src/http/mod.rs`
+- Modify: `src/lib.rs` (re-exports)
+
+- [ ] **Step 1: Create `src/http/request.rs`**
+
+```rust
+use std::time::Duration;
+
+use bytes::Bytes;
+use http::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
+use http::{Method, Uri};
+
+use super::client::ClientInner;
+use super::response::Response;
+use super::retry::RetryPolicy;
+use crate::error::{Error, Result};
+
+use std::sync::Arc;
+
+/// Builder for an outgoing HTTP request.
+///
+/// Created by [`Client::get`](super::Client::get),
+/// [`Client::post`](super::Client::post), etc. Chain methods to add headers,
+/// body, and per-request overrides, then call [`send`](RequestBuilder::send).
+pub struct RequestBuilder {
+    pub(crate) client: Arc<ClientInner>,
+    pub(crate) method: Method,
+    pub(crate) url: Result<Uri>,
+    pub(crate) headers: HeaderMap,
+    pub(crate) body: Option<std::result::Result<Bytes, Error>>,
+    pub(crate) timeout: Option<Duration>,
+    pub(crate) max_retries: Option<u32>,
+}
+
+impl RequestBuilder {
+    /// Add a single header.
+    pub fn header(mut self, name: HeaderName, value: HeaderValue) -> Self {
+        self.headers.insert(name, value);
+        self
+    }
+
+    /// Merge multiple headers into the request.
+    pub fn headers(mut self, headers: HeaderMap) -> Self {
+        self.headers.extend(headers);
+        self
+    }
+
+    /// Set the `Authorization: Bearer {token}` header.
+    pub fn bearer_token(self, token: &str) -> Self {
+        let value = format!("Bearer {token}");
+        // HeaderValue::from_str can fail on non-visible ASCII.
+        // Tokens should always be valid header values.
+        let hv = match HeaderValue::from_str(&value) {
+            Ok(v) => v,
+            Err(_) => return self,
+        };
+        self.header(AUTHORIZATION, hv)
+    }
+
+    /// Set the `Authorization: Basic {credentials}` header.
+    ///
+    /// `password` is optional — some APIs use username-only basic auth.
+    pub fn basic_auth(self, username: &str, password: Option<&str>) -> Self {
+        use base64::Engine;
+        let credentials = match password {
+            Some(pw) => format!("{username}:{pw}"),
+            None => format!("{username}:"),
+        };
+        let encoded = base64::engine::general_purpose::STANDARD.encode(credentials);
+        let value = format!("Basic {encoded}");
+        let hv = match HeaderValue::from_str(&value) {
+            Ok(v) => v,
+            Err(_) => return self,
+        };
+        self.header(AUTHORIZATION, hv)
+    }
+
+    /// Append query parameters to the URL.
+    ///
+    /// Existing query parameters are preserved. Multiple calls accumulate.
+    pub fn query(mut self, params: &[(&str, &str)]) -> Self {
+        self.url = self.url.map(|uri| {
+            let mut parts = uri.into_parts();
+            let existing = parts
+                .path_and_query
+                .as_ref()
+                .and_then(|pq| pq.query())
+                .unwrap_or("");
+            let path = parts
+                .path_and_query
+                .as_ref()
+                .map(|pq| pq.path())
+                .unwrap_or("/");
+
+            let new_params: String = params
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencoding(k), urlencoding(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+
+            let query_string = if existing.is_empty() {
+                new_params
+            } else {
+                format!("{existing}&{new_params}")
+            };
+
+            let pq = if query_string.is_empty() {
+                path.to_string()
+            } else {
+                format!("{path}?{query_string}")
+            };
+
+            parts.path_and_query = Some(pq.parse().unwrap_or_else(|_| "/".parse().unwrap()));
+            Uri::from_parts(parts).unwrap_or_else(|_| Uri::from_static("/"))
+        });
+        self
+    }
+
+    /// Serialize `body` as JSON and set `Content-Type: application/json`.
+    pub fn json<T: serde::Serialize>(mut self, body: &T) -> Self {
+        match serde_json::to_vec(body) {
+            Ok(bytes) => {
+                self.body = Some(Ok(Bytes::from(bytes)));
+                self.headers
+                    .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+            }
+            Err(e) => {
+                self.body = Some(Err(
+                    Error::internal(format!("failed to serialize request body: {e}")).chain(e),
+                ));
+            }
+        }
+        self
+    }
+
+    /// URL-encode `body` as form data and set
+    /// `Content-Type: application/x-www-form-urlencoded`.
+    pub fn form<T: serde::Serialize>(mut self, body: &T) -> Self {
+        match serde_urlencoded::to_string(body) {
+            Ok(encoded) => {
+                self.body = Some(Ok(Bytes::from(encoded)));
+                self.headers.insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/x-www-form-urlencoded"),
+                );
+            }
+            Err(e) => {
+                self.body = Some(Err(
+                    Error::internal(format!("failed to serialize request body: {e}")).chain(e),
+                ));
+            }
+        }
+        self
+    }
+
+    /// Set a raw body.
+    pub fn body(mut self, bytes: Bytes) -> Self {
+        self.body = Some(Ok(bytes));
+        self
+    }
+
+    /// Override the client-level request timeout for this request.
+    pub fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+
+    /// Override the client-level retry count for this request.
+    pub fn max_retries(mut self, n: u32) -> Self {
+        self.max_retries = Some(n);
+        self
+    }
+
+    /// Send the request and return the response.
+    ///
+    /// Returns `Ok(Response)` for any completed HTTP exchange (including 4xx/5xx).
+    /// Returns `Err` only for connection failures, timeouts, and serialization errors.
+    pub async fn send(self) -> Result<Response> {
+        // Check deferred URL error
+        let uri = self.url?;
+
+        // Check deferred body serialization error
+        let body = match self.body {
+            Some(Ok(b)) => Some(b),
+            Some(Err(e)) => return Err(e),
+            None => None,
+        };
+
+        // Apply default User-Agent if not set by caller
+        let mut headers = self.headers;
+        if !headers.contains_key(USER_AGENT) {
+            if let Ok(ua) = HeaderValue::from_str(&self.client.config.user_agent) {
+                headers.insert(USER_AGENT, ua);
+            }
+        }
+
+        let timeout = self.timeout.or(self.client.config.timeout());
+        let max_retries = self.max_retries.unwrap_or(self.client.config.max_retries);
+
+        let policy = RetryPolicy {
+            max_retries,
+            backoff: self.client.config.retry_backoff(),
+        };
+
+        super::retry::execute(
+            &self.client.client,
+            self.method,
+            uri,
+            headers,
+            body,
+            timeout,
+            &policy,
+        )
+        .await
+    }
+}
+
+/// Percent-encode a string for use in query parameters.
+fn urlencoding(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(b as char);
+            }
+            _ => {
+                result.push_str(&format!("%{b:02X}"));
+            }
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn urlencoding_leaves_unreserved_intact() {
+        assert_eq!(urlencoding("hello"), "hello");
+        assert_eq!(urlencoding("a-b_c.d~e"), "a-b_c.d~e");
+    }
+
+    #[test]
+    fn urlencoding_encodes_special_chars() {
+        assert_eq!(urlencoding("a b"), "a%20b");
+        assert_eq!(urlencoding("a&b=c"), "a%26b%3Dc");
+    }
+}
+```
+
+- [ ] **Step 2: Create `src/http/client.rs`**
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use http::Method;
+use http::header::HeaderMap;
+use http_body_util::Full;
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::client::legacy::Client as HyperClient;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
+
+use super::config::ClientConfig;
+use super::request::RequestBuilder;
+
+pub(crate) struct ClientInner {
+    pub(crate) client: HyperClient<
+        hyper_rustls::HttpsConnector<HttpConnector>,
+        Full<Bytes>,
+    >,
+    pub(crate) config: ClientConfig,
+}
+
+/// Async HTTP client.
+///
+/// Cheaply cloneable (`Arc<Inner>` internally). All clones share one
+/// connection pool. Create with [`Client::new`] from a [`ClientConfig`] or
+/// use [`Client::default`] / [`Client::builder`].
+pub struct Client {
+    inner: Arc<ClientInner>,
+}
+
+impl Clone for Client {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl Client {
+    /// Create a client from a [`ClientConfig`].
+    ///
+    /// This is the primary constructor — [`Client::default`] and
+    /// [`ClientBuilder::build`] both funnel through it.
+    pub fn new(config: &ClientConfig) -> Self {
+        let mut http_connector = HttpConnector::new();
+        http_connector.set_connect_timeout(Some(config.connect_timeout()));
+
+        let connector = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_or_http()
+            .enable_http1()
+            .wrap_connector(http_connector);
+
+        let client = HyperClient::builder(TokioExecutor::new()).build(connector);
+
+        Self {
+            inner: Arc::new(ClientInner {
+                client,
+                config: config.clone(),
+            }),
+        }
+    }
+
+    /// Create a client with default configuration.
+    pub fn default() -> Self {
+        Self::new(&ClientConfig::default())
+    }
+
+    /// Start building a client with fine-grained settings.
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder {
+            config: ClientConfig::default(),
+        }
+    }
+
+    /// Start a GET request.
+    pub fn get(&self, url: &str) -> RequestBuilder {
+        self.request(Method::GET, url)
+    }
+
+    /// Start a POST request.
+    pub fn post(&self, url: &str) -> RequestBuilder {
+        self.request(Method::POST, url)
+    }
+
+    /// Start a PUT request.
+    pub fn put(&self, url: &str) -> RequestBuilder {
+        self.request(Method::PUT, url)
+    }
+
+    /// Start a PATCH request.
+    pub fn patch(&self, url: &str) -> RequestBuilder {
+        self.request(Method::PATCH, url)
+    }
+
+    /// Start a DELETE request.
+    pub fn delete(&self, url: &str) -> RequestBuilder {
+        self.request(Method::DELETE, url)
+    }
+
+    /// Start a request with an arbitrary HTTP method.
+    pub fn request(&self, method: Method, url: &str) -> RequestBuilder {
+        let url_result = url
+            .parse()
+            .map_err(|e| crate::Error::bad_request(format!("invalid URL: {e}")));
+        RequestBuilder {
+            client: Arc::clone(&self.inner),
+            method,
+            url: url_result,
+            headers: HeaderMap::new(),
+            body: None,
+            timeout: None,
+            max_retries: None,
+        }
+    }
+}
+
+/// Builder for constructing a [`Client`] with programmatic settings.
+pub struct ClientBuilder {
+    config: ClientConfig,
+}
+
+impl ClientBuilder {
+    /// Set the request timeout.
+    pub fn timeout(mut self, d: Duration) -> Self {
+        self.config.timeout_secs = d.as_secs();
+        self
+    }
+
+    /// Set the TCP connect timeout.
+    pub fn connect_timeout(mut self, d: Duration) -> Self {
+        self.config.connect_timeout_secs = d.as_secs();
+        self
+    }
+
+    /// Set the default User-Agent header.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.config.user_agent = ua.into();
+        self
+    }
+
+    /// Set the maximum number of retries for retryable failures.
+    pub fn max_retries(mut self, n: u32) -> Self {
+        self.config.max_retries = n;
+        self
+    }
+
+    /// Set the initial backoff duration between retries.
+    pub fn retry_backoff(mut self, d: Duration) -> Self {
+        self.config.retry_backoff_ms = d.as_millis() as u64;
+        self
+    }
+
+    /// Build the [`Client`].
+    pub fn build(self) -> Client {
+        Client::new(&self.config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_default_creates_without_panic() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = Client::default();
+    }
+
+    #[test]
+    fn client_from_config_creates_without_panic() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = Client::new(&ClientConfig::default());
+    }
+
+    #[test]
+    fn client_builder_creates_without_panic() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(2))
+            .user_agent("test/1.0")
+            .max_retries(3)
+            .retry_backoff(Duration::from_millis(200))
+            .build();
+    }
+
+    #[test]
+    fn client_is_clone_cheap() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let client = Client::default();
+        let _ = client.clone();
+    }
+}
+```
+
+- [ ] **Step 3: Update `src/http/mod.rs`**
+
+```rust
+mod client;
+mod config;
+mod request;
+mod response;
+mod retry;
+
+pub use client::{Client, ClientBuilder};
+pub use config::ClientConfig;
+pub use request::RequestBuilder;
+pub use response::{BodyStream, Response};
+```
+
+- [ ] **Step 4: Update re-exports in `src/lib.rs`**
+
+Replace the existing `http-client` re-export line with:
+
+```rust
+#[cfg(feature = "http-client")]
+pub use http::{Client as HttpClient, ClientBuilder as HttpClientBuilder, ClientConfig as HttpClientConfig};
+```
+
+- [ ] **Step 5: Add `base64` dependency to `http-client` feature**
+
+In `Cargo.toml`, update the `http-client` feature to include `dep:base64`:
+
+```toml
+http-client = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:http-body-util", "dep:base64"]
+```
+
+And remove `dep:base64` from `webhooks` since it now gets it transitively via `http-client`:
+
+```toml
+webhooks = ["http-client", "dep:hmac"]
+```
+
+- [ ] **Step 6: Run tests and lint**
+
+Run: `cargo test --features http-client`
+Expected: All tests pass.
+
+Run: `cargo clippy --features http-client --tests -- -D warnings`
+Expected: No warnings.
+
+Also verify existing features still compile:
+Run: `cargo check --features auth`
+Run: `cargo check --features storage`
+Run: `cargo check --features webhooks`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/http/ src/lib.rs Cargo.toml
+git commit -m "feat(http): add Client, RequestBuilder, and builder API"
+```
+
+---
+
+### Task 5: Integration Tests
+
+**Files:**
+- Create: `tests/http_client.rs`
+
+- [ ] **Step 1: Create `tests/http_client.rs`**
+
+```rust
+#![cfg(feature = "http-client")]
+
+use std::time::Duration;
+
+use modo::http::{Client, ClientConfig};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Start a test server that accepts one connection and sends a canned response.
+async fn start_server(
+    response: &'static str,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = stream.read(&mut buf).await.unwrap();
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    (url, handle)
+}
+
+/// Start a test server that handles multiple sequential connections.
+async fn start_multi_server(
+    responses: Vec<&'static str>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        for response in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await.unwrap();
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+    });
+
+    (url, handle)
+}
+
+fn test_client() -> Client {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+}
+
+#[tokio::test]
+async fn get_json_round_trip() {
+    let body = r#"{"name":"modo","version":1}"#;
+    let response_str = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    // Leak to get 'static lifetime for the test server
+    let response_static: &'static str = Box::leak(response_str.into_boxed_str());
+    let (url, handle) = start_server(response_static).await;
+    let client = test_client();
+
+    #[derive(serde::Deserialize)]
+    struct Info {
+        name: String,
+        version: u32,
+    }
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+
+    let info: Info = resp.json().await.unwrap();
+    assert_eq!(info.name, "modo");
+    assert_eq!(info.version, 1);
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn post_json_body() {
+    let response_str = "HTTP/1.1 201 Created\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    let (url, handle) = start_server(response_str).await;
+    let client = test_client();
+
+    #[derive(serde::Serialize)]
+    struct Payload {
+        key: String,
+    }
+
+    let resp = client
+        .post(&url)
+        .json(&Payload {
+            key: "value".into(),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), http::StatusCode::CREATED);
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn timeout_returns_error() {
+    // Server that never responds
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let _handle = tokio::spawn(async move {
+        let (mut _stream, _) = listener.accept().await.unwrap();
+        // Hold the connection open but never respond
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    });
+
+    let client = Client::builder()
+        .timeout(Duration::from_millis(100))
+        .build();
+
+    let result = client.get(&url).send().await;
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(
+        err.message().contains("timeout") || err.message().contains("retries"),
+        "unexpected error: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn connection_refused_returns_error() {
+    // Find a port nothing is listening on
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let url = format!("http://127.0.0.1:{port}");
+    let client = test_client();
+
+    let result = client.get(&url).send().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn error_for_status_on_4xx() {
+    let (url, handle) = start_server(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    )
+    .await;
+    let client = test_client();
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
+
+    // error_for_status should convert to Err
+    let (url2, handle2) = start_server(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    )
+    .await;
+    let result = client.get(&url2).send().await.unwrap().error_for_status();
+    assert!(result.is_err());
+
+    handle.await.unwrap();
+    handle2.await.unwrap();
+}
+
+#[tokio::test]
+async fn error_for_status_passes_2xx() {
+    let (url, handle) = start_server(
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    )
+    .await;
+    let client = test_client();
+
+    let result = client.get(&url).send().await.unwrap().error_for_status();
+    assert!(result.is_ok());
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn retry_on_503() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let responses = vec![
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+    ];
+    let (url, handle) = start_multi_server(responses).await;
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(5))
+        .max_retries(2)
+        .retry_backoff(Duration::from_millis(10))
+        .build();
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "ok");
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn text_response() {
+    let body = "hello world";
+    let response_str = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    let response_static: &'static str = Box::leak(response_str.into_boxed_str());
+    let (url, handle) = start_server(response_static).await;
+    let client = test_client();
+
+    let text = client.get(&url).send().await.unwrap().text().await.unwrap();
+    assert_eq!(text, "hello world");
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn bytes_response() {
+    let body = b"binary\x00data";
+    let response_str = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len(),
+    );
+    // For binary data, build the response manually
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 4096];
+        let _ = stream.read(&mut buf).await.unwrap();
+        stream.write_all(response_str.as_bytes()).await.unwrap();
+        stream.write_all(body).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    let client = test_client();
+    let data = client.get(&url).send().await.unwrap().bytes().await.unwrap();
+    assert_eq!(&data[..], body);
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn stream_yields_chunks() {
+    let body = "chunk data here";
+    let response_str = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    let response_static: &'static str = Box::leak(response_str.into_boxed_str());
+    let (url, handle) = start_server(response_static).await;
+    let client = test_client();
+
+    let resp = client.get(&url).send().await.unwrap();
+    let mut stream = resp.stream();
+    let mut collected = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        collected.extend_from_slice(&chunk.unwrap());
+    }
+    assert_eq!(String::from_utf8(collected).unwrap(), "chunk data here");
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn invalid_url_returns_error() {
+    let client = test_client();
+    let result = client.get("not a valid url").send().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn bearer_token_header() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 4096];
+        let n = stream.read(&mut buf).await.unwrap();
+        let request_text = String::from_utf8_lossy(&buf[..n]);
+
+        // Verify the Authorization header was sent
+        assert!(
+            request_text.contains("authorization: Bearer test-token"),
+            "missing bearer token in: {request_text}"
+        );
+
+        let resp = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        stream.write_all(resp.as_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    let client = test_client();
+    let resp = client
+        .get(&url)
+        .bearer_token("test-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn query_params_appended() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}/path", addr.port());
+
+    let handle = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 4096];
+        let n = stream.read(&mut buf).await.unwrap();
+        let request_text = String::from_utf8_lossy(&buf[..n]);
+
+        assert!(
+            request_text.contains("/path?foo=bar&baz=qux"),
+            "unexpected request line: {request_text}"
+        );
+
+        let resp = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        stream.write_all(resp.as_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    let client = test_client();
+    let resp = client
+        .get(&url)
+        .query(&[("foo", "bar"), ("baz", "qux")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn content_length_from_headers() {
+    let (url, handle) = start_server(
+        "HTTP/1.1 200 OK\r\nContent-Length: 42\r\nConnection: close\r\n\r\n",
+    )
+    .await;
+    let client = test_client();
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.content_length(), Some(42));
+
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn per_request_timeout_override() {
+    // Server that never responds
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let _handle = tokio::spawn(async move {
+        let (mut _stream, _) = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    });
+
+    // Client has long timeout, but request overrides to short
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build();
+
+    let result = client
+        .get(&url)
+        .timeout(Duration::from_millis(100))
+        .send()
+        .await;
+    assert!(result.is_err());
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `cargo test --features http-client --test http_client`
+Expected: All integration tests pass.
+
+- [ ] **Step 3: Run full test suite to check no regressions**
+
+Run: `cargo test --features full`
+Expected: All tests pass (existing modules still compile and work with transitive `http-client` dependency).
+
+Run: `cargo clippy --features full --tests -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/http_client.rs
+git commit -m "test(http): add integration tests for HTTP client"
+```
+
+---
+
+### Task 6: Consolidate webhook module
+
+**Files:**
+- Modify: `src/webhook/client.rs`
+- Modify: `src/webhook/sender.rs`
+- Modify: `src/webhook/mod.rs`
+- Modify: `src/lib.rs` (re-exports)
+
+- [ ] **Step 1: Rewrite `src/webhook/client.rs`**
+
+Remove `HyperClient`, `HttpClient` trait, and all direct hyper imports. Replace with a thin wrapper over `crate::http::Client`:
+
+```rust
+use bytes::Bytes;
+use http::{HeaderMap, StatusCode};
+
+use crate::error::Result;
+
+/// Response returned after a webhook delivery attempt.
+pub struct WebhookResponse {
+    /// HTTP status code returned by the endpoint.
+    pub status: StatusCode,
+    /// Response body bytes.
+    pub body: Bytes,
+}
+
+/// Send a webhook POST via the shared HTTP client.
+pub(crate) async fn post(
+    client: &crate::http::Client,
+    url: &str,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<WebhookResponse> {
+    let mut builder = client.post(url);
+    builder = builder.headers(headers);
+    builder = builder.body(body);
+
+    let response = builder.send().await?;
+    let status = response.status();
+    let response_body = response.bytes().await?;
+
+    Ok(WebhookResponse {
+        status,
+        body: response_body,
+    })
+}
+```
+
+- [ ] **Step 2: Rewrite `src/webhook/sender.rs`**
+
+Replace generic `C: HttpClient` with concrete `crate::http::Client`:
+
+```rust
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http::HeaderMap;
+
+use super::client::{self, WebhookResponse};
+use super::secret::WebhookSecret;
+use super::signature::sign_headers;
+use crate::error::{Error, Result};
+
+struct WebhookSenderInner {
+    client: crate::http::Client,
+    user_agent: String,
+}
+
+/// High-level webhook sender that signs and delivers payloads using the
+/// Standard Webhooks protocol.
+///
+/// Clone-cheap: the inner state is wrapped in `Arc`.
+pub struct WebhookSender {
+    inner: Arc<WebhookSenderInner>,
+}
+
+impl Clone for WebhookSender {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl WebhookSender {
+    /// Create a new sender with the given HTTP client.
+    pub fn new(client: crate::http::Client) -> Self {
+        Self {
+            inner: Arc::new(WebhookSenderInner {
+                client,
+                user_agent: format!("modo-webhooks/{}", env!("CARGO_PKG_VERSION")),
+            }),
+        }
+    }
+
+    /// Override the default `User-Agent` header sent with every request.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called after the sender has been cloned. Call this immediately
+    /// after [`WebhookSender::new`] before handing clones to other tasks.
+    pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        let inner =
+            Arc::get_mut(&mut self.inner).expect("with_user_agent must be called before cloning");
+        inner.user_agent = user_agent.into();
+        self
+    }
+
+    /// Convenience constructor using a default [`Client`](crate::http::Client).
+    pub fn default_client() -> Self {
+        use crate::http::Client;
+        Self::new(Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build())
+    }
+
+    /// Send a webhook following the Standard Webhooks protocol.
+    ///
+    /// Signs the payload with every secret in `secrets` (supports key rotation)
+    /// and POSTs to `url` with the three Standard Webhooks headers:
+    /// `webhook-id`, `webhook-timestamp`, and `webhook-signature`.
+    pub async fn send(
+        &self,
+        url: &str,
+        id: &str,
+        body: &[u8],
+        secrets: &[&WebhookSecret],
+    ) -> Result<WebhookResponse> {
+        if secrets.is_empty() {
+            return Err(Error::bad_request("at least one secret required"));
+        }
+        if id.is_empty() {
+            return Err(Error::bad_request("webhook id must not be empty"));
+        }
+        let _: http::Uri = url
+            .parse()
+            .map_err(|e| Error::bad_request(format!("invalid webhook url: {e}")))?;
+
+        let timestamp = chrono::Utc::now().timestamp();
+        let signed = sign_headers(secrets, id, timestamp, body);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        headers.insert("user-agent", self.inner.user_agent.parse().unwrap());
+        headers.insert(
+            "webhook-id",
+            signed
+                .webhook_id
+                .parse()
+                .map_err(|_| Error::bad_request("webhook id contains invalid header characters"))?,
+        );
+        headers.insert(
+            "webhook-timestamp",
+            signed.webhook_timestamp.to_string().parse().unwrap(),
+        );
+        headers.insert(
+            "webhook-signature",
+            signed
+                .webhook_signature
+                .parse()
+                .map_err(|_| Error::internal("generated invalid webhook-signature header"))?,
+        );
+
+        client::post(&self.inner.client, url, headers, Bytes::copy_from_slice(body)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::StatusCode;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn start_webhook_server(status: u16) -> (String, tokio::task::JoinHandle<Vec<u8>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 8192];
+            let n = stream.read(&mut buf).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+            buf[..n].to_vec()
+        });
+
+        (url, handle)
+    }
+
+    fn test_sender() -> WebhookSender {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        WebhookSender::default_client()
+    }
+
+    #[tokio::test]
+    async fn send_sets_correct_headers() {
+        let (url, handle) = start_webhook_server(200).await;
+        let sender = test_sender();
+        let secret = WebhookSecret::new(b"test-key".to_vec());
+
+        let result = sender.send(&url, "msg_123", b"{}", &[&secret]).await;
+        assert!(result.is_ok());
+
+        let request_bytes = handle.await.unwrap();
+        let request_text = String::from_utf8_lossy(&request_bytes);
+        assert!(request_text.contains("webhook-id: msg_123"));
+        assert!(request_text.contains("webhook-timestamp:"));
+        assert!(request_text.contains("webhook-signature: v1,"));
+        assert!(request_text.contains("content-type: application/json"));
+    }
+
+    #[tokio::test]
+    async fn send_empty_secrets_rejected() {
+        let sender = test_sender();
+        let result = sender
+            .send("http://example.com/hook", "msg_1", b"{}", &[])
+            .await;
+        assert!(result.is_err());
+        assert!(result.err().unwrap().message().contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn send_empty_id_rejected() {
+        let sender = test_sender();
+        let secret = WebhookSecret::new(b"key".to_vec());
+        let result = sender
+            .send("http://example.com/hook", "", b"{}", &[&secret])
+            .await;
+        assert!(result.is_err());
+        assert!(result.err().unwrap().message().contains("id"));
+    }
+
+    #[tokio::test]
+    async fn send_invalid_url_rejected() {
+        let sender = test_sender();
+        let secret = WebhookSecret::new(b"key".to_vec());
+        let result = sender
+            .send("not a valid url", "msg_1", b"{}", &[&secret])
+            .await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .message()
+                .contains("invalid webhook url")
+        );
+    }
+
+    #[tokio::test]
+    async fn send_returns_response_status() {
+        let (url, handle) = start_webhook_server(410).await;
+        let sender = test_sender();
+        let secret = WebhookSecret::new(b"key".to_vec());
+
+        let response = sender.send(&url, "msg_1", b"{}", &[&secret]).await.unwrap();
+        assert_eq!(response.status, StatusCode::GONE);
+        handle.await.unwrap();
+    }
+}
+```
+
+- [ ] **Step 3: Update `src/webhook/mod.rs`**
+
+```rust
+//! Outbound webhook delivery following the Standard Webhooks specification.
+//!
+//! This module provides signed outbound HTTP POST requests using HMAC-SHA256.
+//! All types require the `"webhooks"` feature.
+
+mod client;
+mod secret;
+mod sender;
+mod signature;
+
+pub use client::WebhookResponse;
+pub use secret::WebhookSecret;
+pub use sender::WebhookSender;
+pub use signature::{SignedHeaders, sign, sign_headers, verify, verify_headers};
+```
+
+- [ ] **Step 4: Update re-exports in `src/lib.rs`**
+
+Replace the existing webhooks re-export block:
+
+```rust
+#[cfg(feature = "webhooks")]
+pub use webhook::{SignedHeaders, WebhookResponse, WebhookSecret, WebhookSender};
+```
+
+(Removed `HttpClient` and `HyperClient` — they no longer exist.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --features webhooks`
+Expected: All webhook tests pass with the new implementation.
+
+Run: `cargo clippy --features webhooks --tests -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/webhook/ src/lib.rs
+git commit -m "refactor(webhook): use http::Client, remove HyperClient and HttpClient trait"
+```
+
+---
+
+### Task 7: Consolidate storage module
+
+**Files:**
+- Modify: `src/storage/client.rs`
+- Modify: `src/storage/backend.rs`
+- Modify: `src/storage/fetch.rs`
+- Modify: `src/storage/facade.rs`
+
+- [ ] **Step 1: Update `src/storage/client.rs`**
+
+Replace the hyper client construction and raw hyper types with `crate::http::Client`. The S3 signing logic stays — it still builds raw `hyper::Request` objects for signing, but the underlying connection comes from the shared client.
+
+Key changes:
+- `RemoteBackend.client` field type changes from verbose hyper generic to `crate::http::Client`
+- Remove `HttpsConnectorBuilder`, `hyper_util::client::legacy::Client`, `TokioExecutor` imports
+- Keep `hyper::Request`, `hyper::Method` imports — needed for building signed requests
+- The `client()` accessor return type changes to `&crate::http::Client`
+- `RemoteBackend::new()` takes `client: crate::http::Client` parameter instead of building one internally
+
+The S3 methods (`put`, `delete`, `exists`, `list`) need to send raw pre-signed `hyper::Request` objects through the underlying hyper client. Add a `pub(crate) fn raw_client(&self)` method to `crate::http::Client` that exposes the inner hyper client for this purpose. Add this to `src/http/client.rs`:
+
+```rust
+    /// Access the underlying hyper client for advanced use cases.
+    ///
+    /// This is intended for internal framework modules (like S3 storage) that
+    /// need to send pre-built `hyper::Request` objects with custom signing.
+    pub(crate) fn raw_client(
+        &self,
+    ) -> &hyper_util::client::legacy::Client<
+        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+        http_body_util::Full<bytes::Bytes>,
+    > {
+        &self.inner.client
+    }
+```
+
+Then update `RemoteBackend`:
+
+```rust
+use std::time::Duration;
+
+use bytes::Bytes;
+use http::Uri;
+use http_body_util::{BodyExt, Full};
+
+use super::options::PutOptions;
+use super::presign::{PresignParams, presign_url};
+use super::signing::{SigningParams, sign_request, uri_encode};
+use crate::error::{Error, Result};
+
+pub(crate) struct RemoteBackend {
+    client: crate::http::Client,
+    bucket: String,
+    endpoint: String,
+    endpoint_host: String,
+    access_key: String,
+    secret_key: String,
+    region: String,
+    path_style: bool,
+}
+```
+
+Update `RemoteBackend::new()` to accept a `crate::http::Client`:
+
+```rust
+    pub fn new(
+        client: crate::http::Client,
+        bucket: String,
+        endpoint: String,
+        access_key: String,
+        secret_key: String,
+        region: String,
+        path_style: bool,
+    ) -> Result<Self> {
+        let endpoint_host = strip_scheme(&endpoint).to_string();
+        Ok(Self {
+            client,
+            bucket,
+            endpoint,
+            endpoint_host,
+            access_key,
+            secret_key,
+            region,
+            path_style,
+        })
+    }
+```
+
+In all S3 methods (`put`, `delete`, `exists`, `list`), replace `self.client.request(request)` with `self.client.raw_client().request(request)`.
+
+Update the `client()` accessor:
+
+```rust
+    pub(crate) fn client(&self) -> &crate::http::Client {
+        &self.client
+    }
+```
+
+- [ ] **Step 2: Update `src/storage/backend.rs`**
+
+Replace the verbose hyper type with `crate::http::Client`:
+
+```rust
+use super::client::RemoteBackend;
+use super::memory::MemoryBackend;
+use crate::error::{Error, Result};
+
+pub(crate) enum BackendKind {
+    Remote(Box<RemoteBackend>),
+    #[cfg_attr(not(any(test, feature = "storage-test")), allow(dead_code))]
+    Memory(MemoryBackend),
+}
+
+impl BackendKind {
+    pub(crate) fn http_client(&self) -> Result<&crate::http::Client> {
+        match self {
+            BackendKind::Remote(b) => Ok(b.client()),
+            BackendKind::Memory(_) => {
+                Err(Error::internal("URL fetch not supported in memory backend"))
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Update `src/storage/fetch.rs`**
+
+Replace the verbose hyper client type with `crate::http::Client`:
+
+```rust
+use std::time::Duration;
+
+use bytes::Bytes;
+use http::Uri;
+use http_body_util::{BodyExt, Full};
+
+use crate::error::{Error, Result};
+
+pub(crate) struct FetchResult {
+    pub data: Bytes,
+    pub content_type: String,
+}
+
+fn validate_url(url: &str) -> Result<Uri> {
+    let uri: Uri = url
+        .parse()
+        .map_err(|e| Error::bad_request(format!("invalid URL: {e}")))?;
+    match uri.scheme_str() {
+        Some("http") | Some("https") => Ok(uri),
+        Some(scheme) => Err(Error::bad_request(format!(
+            "URL must use http or https scheme, got {scheme}"
+        ))),
+        None => Err(Error::bad_request("URL must use http or https scheme")),
+    }
+}
+
+pub(crate) async fn fetch_url(
+    client: &crate::http::Client,
+    url: &str,
+    max_size: Option<usize>,
+) -> Result<FetchResult> {
+    let uri = validate_url(url)?;
+
+    let request = hyper::Request::builder()
+        .method(hyper::Method::GET)
+        .uri(&uri)
+        .body(Full::new(Bytes::new()))
+        .map_err(|e| Error::internal(format!("failed to build request: {e}")))?;
+
+    let response = tokio::time::timeout(
+        Duration::from_secs(30),
+        client.raw_client().request(request),
+    )
+    .await
+    .map_err(|_| Error::internal("URL fetch timed out"))?
+    .map_err(|e| Error::internal(format!("failed to fetch URL: {e}")))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(Error::bad_request(format!(
+            "failed to fetch URL ({status})"
+        )));
+    }
+
+    let content_type = response
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    let mut body = response.into_body();
+    let mut buf: Vec<u8> = Vec::new();
+
+    loop {
+        let frame = match std::pin::pin!(body.frame()).await {
+            Some(Ok(frame)) => frame,
+            Some(Err(e)) => {
+                return Err(Error::internal(format!(
+                    "failed to read response body: {e}"
+                )));
+            }
+            None => break,
+        };
+
+        if let Some(chunk) = frame.data_ref() {
+            buf.extend_from_slice(chunk);
+            if let Some(max) = max_size
+                && buf.len() > max
+            {
+                return Err(Error::payload_too_large(format!(
+                    "fetched file size exceeds maximum {max}"
+                )));
+            }
+        }
+    }
+
+    Ok(FetchResult {
+        data: Bytes::from(buf),
+        content_type,
+    })
+}
+```
+
+Tests in `fetch.rs` need updating — the `build_test_client()` helper changes to return `crate::http::Client`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn build_test_client() -> crate::http::Client {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        crate::http::Client::default()
+    }
+
+    // All test functions stay the same but use `build_test_client()` which now
+    // returns `crate::http::Client`. The `fetch_url` signature now takes
+    // `&crate::http::Client` so the call sites are unchanged.
+    // ... (keep all existing test functions, they work as-is with the new type)
+}
+```
+
+- [ ] **Step 4: Update `src/storage/facade.rs`**
+
+Update `Storage::new()` to create a `crate::http::Client` and pass it to `RemoteBackend::new()`:
+
+```rust
+    pub fn new(config: &BucketConfig) -> Result<Self> {
+        config.validate()?;
+
+        let http_client = crate::http::Client::default();
+        let region = config
+            .region
+            .clone()
+            .unwrap_or_else(|| "us-east-1".to_string());
+        let backend = RemoteBackend::new(
+            http_client,
+            config.bucket.clone(),
+            config.endpoint.clone(),
+            config.access_key.clone(),
+            config.secret_key.clone(),
+            region,
+            config.path_style,
+        )?;
+
+        Ok(Self {
+            inner: Arc::new(StorageInner {
+                backend: BackendKind::Remote(Box::new(backend)),
+                public_url: config.normalized_public_url(),
+                max_file_size: config.max_file_size_bytes()?,
+            }),
+        })
+    }
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --features storage`
+Expected: All storage tests pass.
+
+Run: `cargo test --features storage-test`
+Expected: All storage integration tests pass.
+
+Run: `cargo clippy --features storage --tests -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/http/client.rs src/storage/
+git commit -m "refactor(storage): use http::Client, remove direct hyper client setup"
+```
+
+---
+
+### Task 8: Consolidate auth::oauth module
+
+**Files:**
+- Modify: `src/auth/oauth/client.rs`
+- Modify: `src/auth/oauth/google.rs`
+- Modify: `src/auth/oauth/github.rs`
+
+- [ ] **Step 1: Rewrite `src/auth/oauth/client.rs`**
+
+Replace the fresh-client-per-call pattern with `crate::http::Client`:
+
+```rust
+//! Internal HTTP helpers used by provider implementations.
+//!
+//! Functions take a shared `http::Client` reference, gaining connection pooling
+//! via the framework-wide HTTP client.
+
+use serde::de::DeserializeOwned;
+
+pub(crate) async fn post_form<T: DeserializeOwned>(
+    client: &crate::http::Client,
+    url: &str,
+    params: &[(&str, &str)],
+) -> crate::Result<T> {
+    client
+        .post(url)
+        .form(&params)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await
+}
+
+pub(crate) async fn get_json<T: DeserializeOwned>(
+    client: &crate::http::Client,
+    url: &str,
+    token: &str,
+) -> crate::Result<T> {
+    client
+        .get(url)
+        .bearer_token(token)
+        .header(
+            http::header::ACCEPT,
+            http::header::HeaderValue::from_static("application/json"),
+        )
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await
+}
+```
+
+- [ ] **Step 2: Update `src/auth/oauth/google.rs`**
+
+Add `http_client: crate::http::Client` field to `Google` struct and pass it through to `client::post_form` and `client::get_json`:
+
+In the struct:
+```rust
+pub struct Google {
+    config: OAuthProviderConfig,
+    cookie_config: CookieConfig,
+    key: Key,
+    http_client: crate::http::Client,
+}
+```
+
+In `Google::new()`:
+```rust
+    pub fn new(
+        config: &OAuthProviderConfig,
+        cookie_config: &CookieConfig,
+        key: &Key,
+        http_client: crate::http::Client,
+    ) -> Self {
+        Self {
+            config: config.clone(),
+            cookie_config: cookie_config.clone(),
+            key: key.clone(),
+            http_client,
+        }
+    }
+```
+
+In `exchange()`, update the calls:
+```rust
+        let token: TokenResponse = client::post_form(
+            &self.http_client,
+            TOKEN_URL,
+            &[
+                ("grant_type", "authorization_code"),
+                ("code", &params.code),
+                ("redirect_uri", &self.config.redirect_uri),
+                ("client_id", &self.config.client_id),
+                ("client_secret", &self.config.client_secret),
+                ("code_verifier", state.pkce_verifier()),
+            ],
+        )
+        .await?;
+
+        let raw: serde_json::Value =
+            client::get_json(&self.http_client, USERINFO_URL, &token.access_token).await?;
+```
+
+- [ ] **Step 3: Update `src/auth/oauth/github.rs`**
+
+Same pattern as Google — add `http_client: crate::http::Client` field:
+
+In the struct:
+```rust
+pub struct GitHub {
+    config: OAuthProviderConfig,
+    cookie_config: CookieConfig,
+    key: Key,
+    http_client: crate::http::Client,
+}
+```
+
+In `GitHub::new()`:
+```rust
+    pub fn new(
+        config: &OAuthProviderConfig,
+        cookie_config: &CookieConfig,
+        key: &Key,
+        http_client: crate::http::Client,
+    ) -> Self {
+        Self {
+            config: config.clone(),
+            cookie_config: cookie_config.clone(),
+            key: key.clone(),
+            http_client,
+        }
+    }
+```
+
+In `exchange()`, update the three calls:
+```rust
+        let token: TokenResponse = client::post_form(
+            &self.http_client,
+            TOKEN_URL,
+            &[...],
+        )
+        .await?;
+
+        let raw: serde_json::Value =
+            client::get_json(&self.http_client, USER_URL, &token.access_token).await?;
+
+        // ...
+
+        let emails: Vec<GitHubEmail> =
+            client::get_json(&self.http_client, EMAILS_URL, &token.access_token).await?;
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --features auth`
+Expected: All auth tests pass.
+
+Run: `cargo clippy --features auth --tests -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/auth/oauth/
+git commit -m "refactor(oauth): use http::Client, remove per-call hyper client creation"
+```
+
+---
+
+### Task 9: Final Verification
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cargo test --features full`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run full lint**
+
+Run: `cargo clippy --features full --tests -- -D warnings`
+Expected: No warnings.
+
+- [ ] **Step 3: Run format check**
+
+Run: `cargo fmt --check`
+Expected: No formatting issues.
+
+- [ ] **Step 4: Verify each feature compiles independently**
+
+Run these in parallel:
+```
+cargo check --features http-client
+cargo check --features auth
+cargo check --features storage
+cargo check --features webhooks
+cargo check --features "auth,storage"
+cargo check --features "auth,webhooks"
+cargo check --features full
+```
+Expected: All compile without errors.
+
+- [ ] **Step 5: Verify no leftover hyper imports in consolidated modules**
+
+Grep for direct hyper imports in the three consolidated modules:
+```
+rg "use hyper_rustls" src/webhook/ src/auth/oauth/ src/storage/backend.rs
+rg "use hyper_util::client" src/webhook/ src/auth/oauth/ src/storage/backend.rs
+rg "HttpsConnectorBuilder" src/webhook/ src/auth/oauth/ src/storage/backend.rs
+```
+Expected: No matches (only `src/http/` and `src/storage/client.rs` + `src/storage/fetch.rs` should have hyper imports for S3 signing).
+
+- [ ] **Step 6: Commit (if any fmt fixes were needed)**
+
+```bash
+cargo fmt
+git add -A
+git commit -m "chore: format code"
+```

--- a/docs/superpowers/specs/2026-03-27-http-client-design.md
+++ b/docs/superpowers/specs/2026-03-27-http-client-design.md
@@ -1,0 +1,427 @@
+# HTTP Client Module Design — 2026-03-27
+
+Ergonomic async HTTP client built on hyper/hyper-rustls. Single shared client replacing per-module HTTP implementations in `storage`, `webhook`, and `auth::oauth`.
+
+## Approach
+
+Thin wrapper over `hyper_util::client::legacy::Client`. RequestBuilder + Response types, retry loop with tracing, timeout handling. No new dependencies — hyper stack is already in the dep tree. Consolidates three independent connector/pool setups into one.
+
+## Feature Flag
+
+`http-client` — pulls in `hyper`, `hyper-rustls`, `hyper-util`, `http-body-util`.
+
+Modules that need HTTP depend on `http-client` in their feature definitions:
+
+```toml
+# Cargo.toml
+http-client = ["dep:hyper", "dep:hyper-rustls", "dep:hyper-util", "dep:http-body-util"]
+auth = ["http-client", ...]      # replaces direct hyper deps
+storage = ["http-client", ...]
+webhooks = ["http-client", ...]
+```
+
+Apps that don't use any HTTP-dependent module pay no cost.
+
+Top-level `Config` struct gets:
+
+```rust
+#[cfg(feature = "http-client")]
+#[serde(default)]
+pub http: crate::http::ClientConfig,
+```
+
+## Module Structure
+
+```
+src/http/
+  mod.rs          — mod imports + re-exports
+  client.rs       — Client struct (Arc<Inner>), constructors, method dispatchers
+  request.rs      — RequestBuilder (headers, body, auth, query, timeout, send)
+  response.rs     — Response (status, headers, json, text, bytes, stream, error_for_status)
+  config.rs       — ClientConfig (YAML deserialization)
+  retry.rs        — RetryPolicy + retry loop with tracing spans
+```
+
+No `error.rs` file — all errors use `modo::Error` constructors directly (`.internal()`, `.bad_request()`) with `.chain()` for source errors. Error creation is inline in each file where it occurs.
+
+## Client
+
+### Inner Structure
+
+```rust
+struct ClientInner {
+    client: hyper_util::client::legacy::Client<
+        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+        http_body_util::Full<bytes::Bytes>,
+    >,
+    config: ClientConfig,
+}
+
+pub struct Client {
+    inner: Arc<ClientInner>,
+}
+
+impl Clone for Client { /* Arc::clone */ }
+```
+
+Cheaply cloneable. Single connection pool shared across all clones and all framework modules.
+
+### Constructors
+
+```rust
+impl Client {
+    /// Primary — from config struct.
+    pub fn new(config: &ClientConfig) -> Client
+
+    /// Default config.
+    pub fn default() -> Client
+
+    /// Fine-grained programmatic construction.
+    pub fn builder() -> ClientBuilder
+}
+```
+
+`Client::new(&ClientConfig)` is the single place that builds the hyper connector and `Arc<ClientInner>`. Both `default()` and `builder().build()` funnel through it.
+
+### Connector Setup
+
+```rust
+let mut http_connector = HttpConnector::new();
+http_connector.set_connect_timeout(Some(connect_timeout));
+
+let connector = HttpsConnectorBuilder::new()
+    .with_webpki_roots()
+    .https_or_http()
+    .enable_http1()
+    .wrap_connector(http_connector);
+
+let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new())
+    .build(connector);
+```
+
+Matches existing modo connector setup. HTTP/1.1 only, webpki roots, both http and https schemes.
+
+### Method Dispatchers
+
+Each returns `RequestBuilder`:
+
+```rust
+client.get(url)
+client.post(url)
+client.put(url)
+client.patch(url)
+client.delete(url)
+client.request(method, url)   // escape hatch
+```
+
+URL parsing is deferred — invalid URLs become errors at `.send()` time. This keeps builder chaining ergonomic (no `?` after the method call).
+
+## RequestBuilder
+
+```rust
+pub struct RequestBuilder {
+    client: Arc<ClientInner>,
+    method: Method,
+    url: Result<Uri>,           // deferred error
+    headers: HeaderMap,
+    body: Option<Bytes>,
+    timeout: Option<Duration>,  // per-request override
+    max_retries: Option<u32>,   // per-request override
+}
+```
+
+### Chaining Methods (all `-> Self`)
+
+```rust
+.header(name, value)           // single header
+.headers(HeaderMap)            // merge multiple
+.bearer_token(token)           // Authorization: Bearer {token}
+.basic_auth(user, pass)        // Authorization: Basic {base64}
+.query(&[(k, v)])              // append query params to URL
+.json(&body)                   // serialize T, set Content-Type: application/json
+.form(&body)                   // url-encode T, set Content-Type: application/x-www-form-urlencoded
+.body(bytes)                   // raw Bytes body
+.timeout(Duration)             // override client-level timeout
+.max_retries(n)                // override client-level retry count
+```
+
+### Terminal Method
+
+```rust
+.send() -> Result<Response>
+```
+
+`send()` does:
+1. Check deferred URL error
+2. Build `hyper::Request` from accumulated state
+3. Apply default User-Agent header if not set by caller
+4. Enter retry loop (delegates to `retry.rs`)
+5. Each attempt: clone request, send via hyper client, wrap in `tokio::time::timeout`
+6. Return `Ok(Response)` for any completed HTTP response, or `Err` on connection/timeout failure after retries exhausted
+
+### Deferred Errors
+
+`.json()` and `.form()` serialize eagerly and store as `Bytes`. Serialization errors are deferred and surface at `.send()`. Invalid URLs from the method dispatcher are also deferred. All deferred errors surface at `.send()` — they never silently disappear.
+
+### Notes
+
+- `.query()` appends to existing query string, does not replace
+- `.basic_auth()` takes `Option<&str>` for password (some APIs use username-only basic auth)
+
+## Response
+
+```rust
+pub struct Response {
+    status: StatusCode,
+    headers: HeaderMap,
+    url: String,
+    body: hyper::body::Incoming,
+}
+```
+
+### Methods
+
+```rust
+.status() -> StatusCode
+.headers() -> &HeaderMap
+.content_length() -> Option<u64>
+
+// Body consumers (each consumes self — one-shot):
+.json<T: DeserializeOwned>(self) -> Result<T>
+.text(self) -> Result<String>
+.bytes(self) -> Result<Bytes>
+.stream(self) -> impl Stream<Item = Result<Bytes>>
+
+// Convenience:
+.error_for_status(self) -> Result<Response>
+```
+
+### Body Consumption
+
+- `.json()`, `.text()`, `.bytes()` collect the full body using `BodyExt::collect().await`
+- `.stream()` returns a wrapper that yields frames via `BodyExt::frame()` loop — no full buffering
+- All consumers take `self` — body consumed exactly once. Calling `.json()` after `.text()` is a compile-time error
+
+### error_for_status()
+
+- 2xx → returns `Ok(self)`
+- non-2xx → returns `Err(Error::internal("HTTP {status}: {url}"))`
+
+Callers who need fine-grained status handling check `.status()` directly and build their own error. `error_for_status()` is a convenience for the common case.
+
+### No Redirect Following
+
+Redirects are not followed. 3xx responses are returned as-is. This matches current modo behavior — webhook delivery and S3 operations treat redirects as errors, not expected flow.
+
+## Retry Policy
+
+```rust
+struct RetryPolicy {
+    max_retries: u32,
+    backoff_ms: u64,
+}
+```
+
+### Retryable Conditions
+
+- Connection errors (refused, reset, DNS failure)
+- Timeouts
+- HTTP 502, 503
+- HTTP 429 (with Retry-After header respect)
+
+### Not Retried
+
+- 4xx (except 429)
+- 5xx other than 502/503
+- TLS handshake failures
+- Request serialization errors
+
+### Retry Loop
+
+```
+for attempt in 0..=max_retries:
+    tracing::debug!(attempt, url, method, "http.request")
+
+    result = timeout(duration, client.request(req)).await
+
+    match result:
+        connection error or timeout → retryable
+        status 502, 503 → retryable
+        status 429 →
+            read Retry-After header, sleep (capped at 60s)
+            if no Retry-After → use normal backoff
+            retryable
+        any other response → return Ok(Response)
+        non-retryable error → return Err immediately
+
+    if attempt < max_retries:
+        sleep(backoff_ms * 2^attempt)
+        tracing::warn!(attempt, status, "http.retry")
+```
+
+### Backoff
+
+Exponential: `backoff_ms * 2^attempt` (100ms → 200ms → 400ms → ...).
+
+### Exhausted Retries
+
+- If last failure was connection/timeout → return `Err`
+- If last failure was retryable HTTP status (502, 503, 429) → return `Ok(Response)` with that status. The caller decides what to do
+
+### Observability
+
+Transparent to the caller. Each attempt gets a `tracing::debug!` event. Retries get a `tracing::warn!` event with the reason. No API surface for retry outcomes.
+
+### Request Cloning
+
+Method + URL + headers are cheap to clone. Body is `Bytes` (refcounted via Arc internally), also cheap. `RequestBuilder` always stores body as `Bytes`, so retries are always safe.
+
+## Configuration
+
+```rust
+#[non_exhaustive]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ClientConfig {
+    pub timeout_secs: u64,           // default: 30
+    pub connect_timeout_secs: u64,   // default: 5
+    pub user_agent: String,          // default: "modo/0.1"
+    pub max_retries: u32,            // default: 0 (no retries)
+    pub retry_backoff_ms: u64,       // default: 100
+}
+```
+
+### YAML
+
+```yaml
+http:
+  timeout_secs: 30
+  connect_timeout_secs: 5
+  user_agent: "myapp/1.0"
+  max_retries: 3
+  retry_backoff_ms: 200
+```
+
+### ClientBuilder
+
+For programmatic construction:
+
+```rust
+pub struct ClientBuilder {
+    config: ClientConfig,
+}
+
+impl ClientBuilder {
+    pub fn timeout(mut self, d: Duration) -> Self
+    pub fn connect_timeout(mut self, d: Duration) -> Self
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self
+    pub fn max_retries(mut self, n: u32) -> Self
+    pub fn retry_backoff(mut self, d: Duration) -> Self
+    pub fn build(self) -> Client
+}
+```
+
+`build()` calls `Client::new(&self.config)` internally.
+
+### Zero Timeout
+
+If `timeout_secs == 0`, no `tokio::time::timeout` wrapper is applied — requests have no timeout (rely on TCP/TLS defaults).
+
+## Error Handling
+
+All errors use `modo::Error` with `.chain(source_err)` to preserve the original error.
+
+| Failure | Error | Phase |
+|---------|-------|-------|
+| Invalid URL | `Error::bad_request("invalid URL: {url}")` | `.send()` (deferred) |
+| JSON/form serialization | `Error::internal("failed to serialize request body: {err}")` | `.send()` (deferred) |
+| Connection failure | `Error::internal("HTTP connection failed: {err}")` | `.send()` after retries |
+| Timeout | `Error::internal("HTTP request timed out")` | `.send()` after retries |
+| TLS failure | `Error::internal("HTTP connection failed: {err}")` | `.send()` (not retried) |
+| Response body read | `Error::internal("failed to read response body: {err}")` | `.json()`, `.text()`, `.bytes()` |
+| JSON deserialization | `Error::internal("failed to parse response JSON: {err}")` | `.json::<T>()` |
+| UTF-8 decode | `Error::internal("response body is not valid UTF-8")` | `.text()` |
+| `error_for_status()` | `Error::internal("HTTP {status}: {url}")` | explicit caller opt-in |
+
+No `error_code` — HTTP client errors are internal plumbing, not API-response-boundary errors. Callers who need specific error identity check `.status()` on the `Response`.
+
+## Consolidation
+
+After the `http` module ships, three modules are simplified. No backward compatibility needed.
+
+### webhook
+
+Remove `HttpClient` trait and `HyperClient`. `WebhookSender` takes `http::Client` directly:
+
+```rust
+struct WebhookSenderInner {
+    client: http::Client,
+    user_agent: String,
+}
+```
+
+All direct hyper/hyper-rustls/hyper-util imports removed from `src/webhook/`.
+
+### storage
+
+`RemoteBackend` uses `http::Client` instead of raw hyper client:
+
+```rust
+pub(crate) struct RemoteBackend {
+    client: http::Client,
+    // bucket, endpoint, keys, etc. unchanged
+}
+```
+
+`fetch_url()` takes `&http::Client` instead of `&Client<HttpsConnector<HttpConnector>, Full<Bytes>>`.
+
+All connector setup and raw hyper types removed from `src/storage/`.
+
+### auth::oauth
+
+`post_form()` and `get_json()` take `&http::Client` as a parameter instead of building a fresh hyper client per call. They gain connection pooling for free:
+
+```rust
+pub(crate) async fn post_form<T: DeserializeOwned>(
+    client: &http::Client,
+    url: &str,
+    params: &[(&str, &str)],
+) -> Result<T> {
+    client.post(url)
+        .form(&params)
+        .send().await?
+        .error_for_status()?
+        .json().await
+}
+```
+
+All direct hyper imports removed from `src/auth/oauth/`.
+
+### Feature Flag Cleanup
+
+`auth`, `storage`, `webhooks` features switch from listing individual hyper deps to depending on `http-client`. The direct `dep:hyper`, `dep:hyper-rustls`, `dep:hyper-util`, `dep:http-body-util` entries move under `http-client` only.
+
+## Testing
+
+### Unit Tests (in `src/http/`)
+
+- `config.rs` — `ClientConfig` deserialization: defaults, custom values, zero-timeout behavior
+- `request.rs` — header accumulation, query param appending, deferred URL error, `.json()`/`.form()` serialization
+- `retry.rs` — backoff calculation, Retry-After parsing, max retry capping
+
+### Integration Tests (`tests/http_client.rs`, `#![cfg(feature = "http-client")]`)
+
+Use a local `tokio::net::TcpListener` as a test HTTP server (no external deps):
+
+- GET/POST with JSON body round-trip
+- Timeout behavior (server that never responds)
+- Retry on 503 (server returns 503 twice then 200)
+- Retry on 429 with Retry-After header
+- Connection refused (nothing listening)
+- `.error_for_status()` on 4xx/5xx
+- `.stream()` yields chunks correctly
+- Large response body via `.bytes()`
+
+### Test Helper (`http-client-test` companion feature)
+
+`http::test::mock_server()` — spins up a local TCP listener returning configurable responses.

--- a/src/auth/oauth/client.rs
+++ b/src/auth/oauth/client.rs
@@ -10,14 +10,25 @@ pub(crate) async fn post_form<T: DeserializeOwned>(
     url: &str,
     params: &[(&str, &str)],
 ) -> crate::Result<T> {
-    client
+    let resp = client
         .post(url)
+        .header(
+            http::header::ACCEPT,
+            http::header::HeaderValue::from_static("application/json"),
+        )
         .form(&params)
         .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await
+        .await?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(crate::Error::internal(format!(
+            "OAuth token exchange failed ({status}): {body}"
+        )));
+    }
+
+    resp.json().await
 }
 
 pub(crate) async fn get_json<T: DeserializeOwned>(
@@ -25,7 +36,7 @@ pub(crate) async fn get_json<T: DeserializeOwned>(
     url: &str,
     token: &str,
 ) -> crate::Result<T> {
-    client
+    let resp = client
         .get(url)
         .bearer_token(token)
         .header(
@@ -33,8 +44,15 @@ pub(crate) async fn get_json<T: DeserializeOwned>(
             http::header::HeaderValue::from_static("application/json"),
         )
         .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await
+        .await?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(crate::Error::internal(format!(
+            "OAuth API request failed ({status}): {body}"
+        )));
+    }
+
+    resp.json().await
 }

--- a/src/auth/oauth/client.rs
+++ b/src/auth/oauth/client.rs
@@ -1,108 +1,40 @@
 //! Internal HTTP helpers used by provider implementations.
 //!
-//! Both functions build a fresh hyper HTTPS client per call. They are intentionally
-//! simple — no connection pooling, no retry logic. OAuth token exchanges are
-//! low-frequency operations that do not need pooling.
+//! Functions take a shared `http::Client` reference, gaining connection pooling
+//! via the framework-wide HTTP client.
 
-use http::Uri;
-use http_body_util::{BodyExt, Full};
-use hyper::body::Bytes;
-use hyper_rustls::HttpsConnectorBuilder;
-use hyper_util::client::legacy::Client;
-use hyper_util::rt::TokioExecutor;
 use serde::de::DeserializeOwned;
 
 pub(crate) async fn post_form<T: DeserializeOwned>(
+    client: &crate::http::Client,
     url: &str,
     params: &[(&str, &str)],
 ) -> crate::Result<T> {
-    let body = serde_urlencoded::to_string(params)
-        .map_err(|e| crate::Error::internal(format!("failed to encode form: {e}")))?;
-
-    let uri: Uri = url
-        .parse()
-        .map_err(|e| crate::Error::internal(format!("invalid URL: {e}")))?;
-
-    let connector = HttpsConnectorBuilder::new()
-        .with_webpki_roots()
-        .https_only()
-        .enable_http1()
-        .build();
-    let client = Client::builder(TokioExecutor::new()).build(connector);
-
-    let request = hyper::Request::builder()
-        .method(hyper::Method::POST)
-        .uri(uri)
-        .header("content-type", "application/x-www-form-urlencoded")
-        .header("accept", "application/json")
-        .body(Full::new(Bytes::from(body)))
-        .map_err(|e| crate::Error::internal(format!("failed to build request: {e}")))?;
-
-    let response = client
-        .request(request)
+    client
+        .post(url)
+        .form(&params)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
         .await
-        .map_err(|e| crate::Error::internal(format!("HTTP request failed: {e}")))?;
-
-    let status = response.status();
-    let body_bytes = response
-        .into_body()
-        .collect()
-        .await
-        .map_err(|e| crate::Error::internal(format!("failed to read response body: {e}")))?
-        .to_bytes();
-
-    if !status.is_success() {
-        let body_str = String::from_utf8_lossy(&body_bytes);
-        return Err(crate::Error::internal(format!(
-            "OAuth token exchange failed ({status}): {body_str}"
-        )));
-    }
-
-    serde_json::from_slice(&body_bytes)
-        .map_err(|e| crate::Error::internal(format!("failed to parse response JSON: {e}")))
 }
 
-pub(crate) async fn get_json<T: DeserializeOwned>(url: &str, token: &str) -> crate::Result<T> {
-    let uri: Uri = url
-        .parse()
-        .map_err(|e| crate::Error::internal(format!("invalid URL: {e}")))?;
-
-    let connector = HttpsConnectorBuilder::new()
-        .with_webpki_roots()
-        .https_only()
-        .enable_http1()
-        .build();
-    let client = Client::builder(TokioExecutor::new()).build(connector);
-
-    let request = hyper::Request::builder()
-        .method(hyper::Method::GET)
-        .uri(uri)
-        .header("authorization", format!("Bearer {token}"))
-        .header("accept", "application/json")
-        .header("user-agent", "modo/0.1")
-        .body(Full::new(Bytes::new()))
-        .map_err(|e| crate::Error::internal(format!("failed to build request: {e}")))?;
-
-    let response = client
-        .request(request)
+pub(crate) async fn get_json<T: DeserializeOwned>(
+    client: &crate::http::Client,
+    url: &str,
+    token: &str,
+) -> crate::Result<T> {
+    client
+        .get(url)
+        .bearer_token(token)
+        .header(
+            http::header::ACCEPT,
+            http::header::HeaderValue::from_static("application/json"),
+        )
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
         .await
-        .map_err(|e| crate::Error::internal(format!("HTTP request failed: {e}")))?;
-
-    let status = response.status();
-    let body_bytes = response
-        .into_body()
-        .collect()
-        .await
-        .map_err(|e| crate::Error::internal(format!("failed to read response body: {e}")))?
-        .to_bytes();
-
-    if !status.is_success() {
-        let body_str = String::from_utf8_lossy(&body_bytes);
-        return Err(crate::Error::internal(format!(
-            "OAuth API request failed ({status}): {body_str}"
-        )));
-    }
-
-    serde_json::from_slice(&body_bytes)
-        .map_err(|e| crate::Error::internal(format!("failed to parse response JSON: {e}")))
 }

--- a/src/auth/oauth/github.rs
+++ b/src/auth/oauth/github.rs
@@ -31,6 +31,7 @@ pub struct GitHub {
     config: OAuthProviderConfig,
     cookie_config: CookieConfig,
     key: Key,
+    http_client: crate::http::Client,
 }
 
 impl GitHub {
@@ -38,11 +39,17 @@ impl GitHub {
     ///
     /// `cookie_config` and `key` are used to sign the `_oauth_state` cookie that carries the
     /// PKCE verifier and state nonce across the redirect.
-    pub fn new(config: &OAuthProviderConfig, cookie_config: &CookieConfig, key: &Key) -> Self {
+    pub fn new(
+        config: &OAuthProviderConfig,
+        cookie_config: &CookieConfig,
+        key: &Key,
+        http_client: crate::http::Client,
+    ) -> Self {
         Self {
             config: config.clone(),
             cookie_config: cookie_config.clone(),
             key: key.clone(),
+            http_client,
         }
     }
 
@@ -100,6 +107,7 @@ impl OAuthProvider for GitHub {
         }
 
         let token: TokenResponse = client::post_form(
+            &self.http_client,
             TOKEN_URL,
             &[
                 ("client_id", &self.config.client_id),
@@ -111,7 +119,8 @@ impl OAuthProvider for GitHub {
         )
         .await?;
 
-        let raw: serde_json::Value = client::get_json(USER_URL, &token.access_token).await?;
+        let raw: serde_json::Value =
+            client::get_json(&self.http_client, USER_URL, &token.access_token).await?;
 
         let provider_user_id = raw["id"]
             .as_u64()
@@ -129,7 +138,8 @@ impl OAuthProvider for GitHub {
             verified: bool,
         }
 
-        let emails: Vec<GitHubEmail> = client::get_json(EMAILS_URL, &token.access_token).await?;
+        let emails: Vec<GitHubEmail> =
+            client::get_json(&self.http_client, EMAILS_URL, &token.access_token).await?;
 
         let primary = emails
             .iter()

--- a/src/auth/oauth/google.rs
+++ b/src/auth/oauth/google.rs
@@ -26,6 +26,7 @@ pub struct Google {
     config: OAuthProviderConfig,
     cookie_config: CookieConfig,
     key: Key,
+    http_client: crate::http::Client,
 }
 
 impl Google {
@@ -33,11 +34,17 @@ impl Google {
     ///
     /// `cookie_config` and `key` are used to sign the `_oauth_state` cookie that carries the
     /// PKCE verifier and state nonce across the redirect.
-    pub fn new(config: &OAuthProviderConfig, cookie_config: &CookieConfig, key: &Key) -> Self {
+    pub fn new(
+        config: &OAuthProviderConfig,
+        cookie_config: &CookieConfig,
+        key: &Key,
+        http_client: crate::http::Client,
+    ) -> Self {
         Self {
             config: config.clone(),
             cookie_config: cookie_config.clone(),
             key: key.clone(),
+            http_client,
         }
     }
 
@@ -95,6 +102,7 @@ impl OAuthProvider for Google {
         }
 
         let token: TokenResponse = client::post_form(
+            &self.http_client,
             TOKEN_URL,
             &[
                 ("grant_type", "authorization_code"),
@@ -107,7 +115,8 @@ impl OAuthProvider for Google {
         )
         .await?;
 
-        let raw: serde_json::Value = client::get_json(USERINFO_URL, &token.access_token).await?;
+        let raw: serde_json::Value =
+            client::get_json(&self.http_client, USERINFO_URL, &token.access_token).await?;
 
         let provider_user_id = raw["id"]
             .as_str()

--- a/src/config/modo.rs
+++ b/src/config/modo.rs
@@ -32,6 +32,11 @@ pub struct Config {
     /// Session TTL, cookie name, fingerprint validation, touch interval, and
     /// per-user session limit.
     pub session: crate::session::SessionConfig,
+    /// HTTP client settings (timeout, retries, user agent).
+    /// Requires the `http-client` feature.
+    #[cfg(feature = "http-client")]
+    #[serde(default)]
+    pub http: crate::http::ClientConfig,
     /// Background job queue settings.
     pub job: crate::job::JobConfig,
     /// CIDR ranges of trusted reverse proxies used by [`crate::ip::ClientIpLayer`].

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,0 +1,161 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::client::legacy;
+use hyper_util::rt::TokioExecutor;
+
+use super::config::ClientConfig;
+use super::request::RequestBuilder;
+
+/// Type alias for the hyper HTTPS client used internally.
+pub(crate) type InnerHttpsClient = legacy::Client<
+    hyper_rustls::HttpsConnector<legacy::connect::HttpConnector>,
+    Full<Bytes>,
+>;
+
+/// Shared inner state for [`Client`].
+pub(crate) struct ClientInner {
+    pub(crate) client: InnerHttpsClient,
+    pub(crate) config: ClientConfig,
+}
+
+/// A reusable HTTP client with connection pooling, timeouts, and retry support.
+///
+/// `Client` is cheap to clone — it wraps its state in an `Arc`. All clones
+/// share the same connection pool and configuration.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use modo::http::{Client, ClientConfig};
+///
+/// let client = Client::new(&ClientConfig::default());
+/// let resp = client.get("https://api.example.com/data").send().await?;
+/// let body = resp.text().await?;
+/// ```
+#[derive(Clone)]
+pub struct Client {
+    inner: Arc<ClientInner>,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new(&ClientConfig::default())
+    }
+}
+
+impl Client {
+    /// Create a new client from the given configuration.
+    pub fn new(config: &ClientConfig) -> Self {
+        let mut http_connector = legacy::connect::HttpConnector::new();
+        http_connector.set_connect_timeout(Some(config.connect_timeout()));
+
+        let connector = HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_or_http()
+            .enable_http1()
+            .wrap_connector(http_connector);
+
+        let client = legacy::Client::builder(TokioExecutor::new()).build(connector);
+
+        Self {
+            inner: Arc::new(ClientInner {
+                client,
+                config: config.clone(),
+            }),
+        }
+    }
+
+    /// Start building a client with a [`ClientBuilder`].
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder {
+            config: ClientConfig::default(),
+        }
+    }
+
+    /// Start a GET request to the given URL.
+    pub fn get(&self, url: &str) -> RequestBuilder {
+        self.request(http::Method::GET, url)
+    }
+
+    /// Start a POST request to the given URL.
+    pub fn post(&self, url: &str) -> RequestBuilder {
+        self.request(http::Method::POST, url)
+    }
+
+    /// Start a PUT request to the given URL.
+    pub fn put(&self, url: &str) -> RequestBuilder {
+        self.request(http::Method::PUT, url)
+    }
+
+    /// Start a PATCH request to the given URL.
+    pub fn patch(&self, url: &str) -> RequestBuilder {
+        self.request(http::Method::PATCH, url)
+    }
+
+    /// Start a DELETE request to the given URL.
+    pub fn delete(&self, url: &str) -> RequestBuilder {
+        self.request(http::Method::DELETE, url)
+    }
+
+    /// Start a request with an arbitrary HTTP method and URL.
+    pub fn request(&self, method: http::Method, url: &str) -> RequestBuilder {
+        RequestBuilder::new(self.inner.clone(), method, url)
+    }
+}
+
+/// A fluent builder for constructing a [`Client`].
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use modo::http::Client;
+///
+/// let client = Client::builder()
+///     .timeout(Duration::from_secs(10))
+///     .max_retries(3)
+///     .build();
+/// ```
+pub struct ClientBuilder {
+    config: ClientConfig,
+}
+
+impl ClientBuilder {
+    /// Set the default request timeout.
+    pub fn timeout(mut self, d: Duration) -> Self {
+        self.config.timeout_secs = d.as_secs();
+        self
+    }
+
+    /// Set the TCP connect timeout.
+    pub fn connect_timeout(mut self, d: Duration) -> Self {
+        self.config.connect_timeout_secs = d.as_secs();
+        self
+    }
+
+    /// Set the `User-Agent` header value.
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.config.user_agent = ua.into();
+        self
+    }
+
+    /// Set the maximum number of retry attempts for retryable failures.
+    pub fn max_retries(mut self, n: u32) -> Self {
+        self.config.max_retries = n;
+        self
+    }
+
+    /// Set the initial retry backoff duration.
+    pub fn retry_backoff(mut self, d: Duration) -> Self {
+        self.config.retry_backoff_ms = d.as_millis() as u64;
+        self
+    }
+
+    /// Build the client.
+    pub fn build(self) -> Client {
+        Client::new(&self.config)
+    }
+}

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -110,6 +110,7 @@ impl Client {
     ///
     /// Used internally by the storage module for AWS Signature V4 requests
     /// that need full control over request construction.
+    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
     pub(crate) fn raw_client(&self) -> &InnerHttpsClient {
         &self.inner.client
     }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -11,10 +11,8 @@ use super::config::ClientConfig;
 use super::request::RequestBuilder;
 
 /// Type alias for the hyper HTTPS client used internally.
-pub(crate) type InnerHttpsClient = legacy::Client<
-    hyper_rustls::HttpsConnector<legacy::connect::HttpConnector>,
-    Full<Bytes>,
->;
+pub(crate) type InnerHttpsClient =
+    legacy::Client<hyper_rustls::HttpsConnector<legacy::connect::HttpConnector>, Full<Bytes>>;
 
 /// Shared inner state for [`Client`].
 pub(crate) struct ClientInner {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -105,6 +105,14 @@ impl Client {
     pub fn request(&self, method: http::Method, url: &str) -> RequestBuilder {
         RequestBuilder::new(self.inner.clone(), method, url)
     }
+
+    /// Access the underlying hyper client for pre-signed request dispatch.
+    ///
+    /// Used internally by the storage module for AWS Signature V4 requests
+    /// that need full control over request construction.
+    pub(crate) fn raw_client(&self) -> &InnerHttpsClient {
+        &self.inner.client
+    }
 }
 
 /// A fluent builder for constructing a [`Client`].

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -49,7 +49,7 @@ impl Client {
     /// Create a new client from the given configuration.
     pub fn new(config: &ClientConfig) -> Self {
         let mut http_connector = legacy::connect::HttpConnector::new();
-        http_connector.set_connect_timeout(Some(config.connect_timeout()));
+        http_connector.set_connect_timeout(config.connect_timeout());
 
         let connector = HttpsConnectorBuilder::new()
             .with_webpki_roots()
@@ -133,13 +133,13 @@ pub struct ClientBuilder {
 impl ClientBuilder {
     /// Set the default request timeout.
     pub fn timeout(mut self, d: Duration) -> Self {
-        self.config.timeout_secs = d.as_secs();
+        self.config.timeout_ms = d.as_millis() as u64;
         self
     }
 
     /// Set the TCP connect timeout.
     pub fn connect_timeout(mut self, d: Duration) -> Self {
-        self.config.connect_timeout_secs = d.as_secs();
+        self.config.connect_timeout_ms = d.as_millis() as u64;
         self
     }
 

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -1,0 +1,112 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// HTTP client configuration.
+///
+/// Deserializes from the `http:` section of the framework YAML config.
+/// All fields have sensible defaults so the section can be omitted entirely.
+#[non_exhaustive]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ClientConfig {
+    /// Default request timeout in seconds. `0` means no timeout.
+    pub timeout_secs: u64,
+    /// TCP connect timeout in seconds.
+    pub connect_timeout_secs: u64,
+    /// Default `User-Agent` header value.
+    pub user_agent: String,
+    /// Maximum retry attempts for retryable failures. `0` means no retries.
+    pub max_retries: u32,
+    /// Initial backoff between retries in milliseconds.
+    /// Actual backoff is `retry_backoff_ms * 2^attempt`.
+    pub retry_backoff_ms: u64,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            timeout_secs: 30,
+            connect_timeout_secs: 5,
+            user_agent: "modo/0.1".to_string(),
+            max_retries: 0,
+            retry_backoff_ms: 100,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl ClientConfig {
+    /// Request timeout as a `Duration`. Returns `None` when `timeout_secs` is `0`.
+    pub(crate) fn timeout(&self) -> Option<Duration> {
+        if self.timeout_secs == 0 {
+            None
+        } else {
+            Some(Duration::from_secs(self.timeout_secs))
+        }
+    }
+
+    /// TCP connect timeout as a `Duration`.
+    pub(crate) fn connect_timeout(&self) -> Duration {
+        Duration::from_secs(self.connect_timeout_secs)
+    }
+
+    /// Retry backoff base as a `Duration`.
+    pub(crate) fn retry_backoff(&self) -> Duration {
+        Duration::from_millis(self.retry_backoff_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = ClientConfig::default();
+        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.connect_timeout_secs, 5);
+        assert_eq!(config.user_agent, "modo/0.1");
+        assert_eq!(config.max_retries, 0);
+        assert_eq!(config.retry_backoff_ms, 100);
+    }
+
+    #[test]
+    fn timeout_returns_none_for_zero() {
+        let config = ClientConfig {
+            timeout_secs: 0,
+            ..Default::default()
+        };
+        assert!(config.timeout().is_none());
+    }
+
+    #[test]
+    fn timeout_returns_duration_for_nonzero() {
+        let config = ClientConfig::default();
+        assert_eq!(config.timeout(), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn deserialize_from_yaml() {
+        let yaml = r#"
+timeout_secs: 10
+connect_timeout_secs: 2
+user_agent: "myapp/1.0"
+max_retries: 3
+retry_backoff_ms: 200
+"#;
+        let config: ClientConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.timeout_secs, 10);
+        assert_eq!(config.connect_timeout_secs, 2);
+        assert_eq!(config.user_agent, "myapp/1.0");
+        assert_eq!(config.max_retries, 3);
+        assert_eq!(config.retry_backoff_ms, 200);
+    }
+
+    #[test]
+    fn deserialize_empty_yaml_uses_defaults() {
+        let config: ClientConfig = serde_yaml_ng::from_str("{}").unwrap();
+        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.max_retries, 0);
+    }
+}

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -10,10 +10,10 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct ClientConfig {
-    /// Default request timeout in seconds. `0` means no timeout.
-    pub timeout_secs: u64,
-    /// TCP connect timeout in seconds.
-    pub connect_timeout_secs: u64,
+    /// Default request timeout in milliseconds. `0` means no timeout.
+    pub timeout_ms: u64,
+    /// TCP connect timeout in milliseconds. `0` means no connect timeout.
+    pub connect_timeout_ms: u64,
     /// Default `User-Agent` header value.
     pub user_agent: String,
     /// Maximum retry attempts for retryable failures. `0` means no retries.
@@ -26,8 +26,8 @@ pub struct ClientConfig {
 impl Default for ClientConfig {
     fn default() -> Self {
         Self {
-            timeout_secs: 30,
-            connect_timeout_secs: 5,
+            timeout_ms: 30_000,
+            connect_timeout_ms: 5_000,
             user_agent: "modo/0.1".to_string(),
             max_retries: 0,
             retry_backoff_ms: 100,
@@ -36,18 +36,22 @@ impl Default for ClientConfig {
 }
 
 impl ClientConfig {
-    /// Request timeout as a `Duration`. Returns `None` when `timeout_secs` is `0`.
+    /// Request timeout as a `Duration`. Returns `None` when `timeout_ms` is `0`.
     pub(crate) fn timeout(&self) -> Option<Duration> {
-        if self.timeout_secs == 0 {
+        if self.timeout_ms == 0 {
             None
         } else {
-            Some(Duration::from_secs(self.timeout_secs))
+            Some(Duration::from_millis(self.timeout_ms))
         }
     }
 
-    /// TCP connect timeout as a `Duration`.
-    pub(crate) fn connect_timeout(&self) -> Duration {
-        Duration::from_secs(self.connect_timeout_secs)
+    /// TCP connect timeout as a `Duration`. Returns `None` when `connect_timeout_ms` is `0`.
+    pub(crate) fn connect_timeout(&self) -> Option<Duration> {
+        if self.connect_timeout_ms == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(self.connect_timeout_ms))
+        }
     }
 
     /// Retry backoff base as a `Duration`.
@@ -63,8 +67,8 @@ mod tests {
     #[test]
     fn default_values() {
         let config = ClientConfig::default();
-        assert_eq!(config.timeout_secs, 30);
-        assert_eq!(config.connect_timeout_secs, 5);
+        assert_eq!(config.timeout_ms, 30_000);
+        assert_eq!(config.connect_timeout_ms, 5_000);
         assert_eq!(config.user_agent, "modo/0.1");
         assert_eq!(config.max_retries, 0);
         assert_eq!(config.retry_backoff_ms, 100);
@@ -73,30 +77,45 @@ mod tests {
     #[test]
     fn timeout_returns_none_for_zero() {
         let config = ClientConfig {
-            timeout_secs: 0,
+            timeout_ms: 0,
             ..Default::default()
         };
         assert!(config.timeout().is_none());
     }
 
     #[test]
+    fn connect_timeout_returns_none_for_zero() {
+        let config = ClientConfig {
+            connect_timeout_ms: 0,
+            ..Default::default()
+        };
+        assert!(config.connect_timeout().is_none());
+    }
+
+    #[test]
     fn timeout_returns_duration_for_nonzero() {
         let config = ClientConfig::default();
-        assert_eq!(config.timeout(), Some(Duration::from_secs(30)));
+        assert_eq!(config.timeout(), Some(Duration::from_millis(30_000)));
+    }
+
+    #[test]
+    fn connect_timeout_returns_duration_for_nonzero() {
+        let config = ClientConfig::default();
+        assert_eq!(config.connect_timeout(), Some(Duration::from_millis(5_000)));
     }
 
     #[test]
     fn deserialize_from_yaml() {
         let yaml = r#"
-timeout_secs: 10
-connect_timeout_secs: 2
+timeout_ms: 10000
+connect_timeout_ms: 2000
 user_agent: "myapp/1.0"
 max_retries: 3
 retry_backoff_ms: 200
 "#;
         let config: ClientConfig = serde_yaml_ng::from_str(yaml).unwrap();
-        assert_eq!(config.timeout_secs, 10);
-        assert_eq!(config.connect_timeout_secs, 2);
+        assert_eq!(config.timeout_ms, 10_000);
+        assert_eq!(config.connect_timeout_ms, 2_000);
         assert_eq!(config.user_agent, "myapp/1.0");
         assert_eq!(config.max_retries, 3);
         assert_eq!(config.retry_backoff_ms, 200);
@@ -105,7 +124,7 @@ retry_backoff_ms: 200
     #[test]
     fn deserialize_empty_yaml_uses_defaults() {
         let config: ClientConfig = serde_yaml_ng::from_str("{}").unwrap();
-        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.timeout_ms, 30_000);
         assert_eq!(config.max_retries, 0);
     }
 }

--- a/src/http/config.rs
+++ b/src/http/config.rs
@@ -35,7 +35,6 @@ impl Default for ClientConfig {
     }
 }
 
-#[allow(dead_code)]
 impl ClientConfig {
     /// Request timeout as a `Duration`. Returns `None` when `timeout_secs` is `0`.
     pub(crate) fn timeout(&self) -> Option<Duration> {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,3 +1,10 @@
+mod client;
 mod config;
+mod request;
+mod response;
+mod retry;
 
+pub use client::{Client, ClientBuilder};
 pub use config::ClientConfig;
+pub use request::RequestBuilder;
+pub use response::{BodyStream, Response};

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,0 +1,3 @@
+mod config;
+
+pub use config::ClientConfig;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,0 +1,265 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use http::HeaderMap;
+use http_body_util::Full;
+use serde::Serialize;
+
+use super::client::ClientInner;
+use super::response::Response;
+use super::retry::RetryPolicy;
+use crate::error::{Error, Result};
+
+/// A builder for constructing and sending an HTTP request.
+///
+/// Obtained from [`Client::get`](super::Client::get),
+/// [`Client::post`](super::Client::post), etc. Chaining methods configure
+/// headers, body, authentication, and retry behaviour. The terminal
+/// [`send`](RequestBuilder::send) method dispatches the request.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let resp = client
+///     .post("https://api.example.com/items")
+///     .bearer_token("tok_abc")
+///     .json(&payload)
+///     .send()
+///     .await?;
+/// ```
+pub struct RequestBuilder {
+    inner: Arc<ClientInner>,
+    method: http::Method,
+    url: std::result::Result<http::Uri, Error>,
+    headers: HeaderMap,
+    body: Option<std::result::Result<Bytes, Error>>,
+    timeout: Option<Duration>,
+    max_retries: Option<u32>,
+}
+
+impl RequestBuilder {
+    /// Create a new request builder. Called internally by `Client`.
+    pub(crate) fn new(inner: Arc<ClientInner>, method: http::Method, url: &str) -> Self {
+        let url_result = url
+            .parse::<http::Uri>()
+            .map_err(|e| Error::bad_request(format!("invalid URL: {e}")).chain(e));
+        Self {
+            inner,
+            method,
+            url: url_result,
+            headers: HeaderMap::new(),
+            body: None,
+            timeout: None,
+            max_retries: None,
+        }
+    }
+
+    /// Append a single header.
+    pub fn header(mut self, name: http::header::HeaderName, value: http::header::HeaderValue) -> Self {
+        self.headers.insert(name, value);
+        self
+    }
+
+    /// Merge additional headers into the request.
+    pub fn headers(mut self, headers: HeaderMap) -> Self {
+        self.headers.extend(headers);
+        self
+    }
+
+    /// Set a `Bearer` authorization header.
+    pub fn bearer_token(self, token: impl AsRef<str>) -> Self {
+        let value = format!("Bearer {}", token.as_ref());
+        let hv = match http::header::HeaderValue::from_str(&value) {
+            Ok(v) => v,
+            Err(_) => return self,
+        };
+        self.header(http::header::AUTHORIZATION, hv)
+    }
+
+    /// Set a `Basic` authorization header from username and password.
+    pub fn basic_auth(self, username: &str, password: Option<&str>) -> Self {
+        use base64::Engine;
+        let credentials = match password {
+            Some(pw) => format!("{username}:{pw}"),
+            None => format!("{username}:"),
+        };
+        let encoded = base64::engine::general_purpose::STANDARD.encode(credentials);
+        let value = format!("Basic {encoded}");
+        let hv = match http::header::HeaderValue::from_str(&value) {
+            Ok(v) => v,
+            Err(_) => return self,
+        };
+        self.header(http::header::AUTHORIZATION, hv)
+    }
+
+    /// Append query parameters to the URL.
+    ///
+    /// Parameters are URL-encoded and appended to any existing query string.
+    pub fn query(mut self, params: &[(&str, &str)]) -> Self {
+        self.url = self.url.map(|uri| {
+            let encoded = params
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencoding(k), urlencoding(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+
+            if encoded.is_empty() {
+                return uri;
+            }
+
+            let url = uri.to_string();
+            let sep = if url.contains('?') { "&" } else { "?" };
+            let new_url = format!("{url}{sep}{encoded}");
+            new_url.parse::<http::Uri>().unwrap_or(uri)
+        });
+        self
+    }
+
+    /// Set a JSON request body. Also sets `Content-Type: application/json`.
+    pub fn json(mut self, value: &impl Serialize) -> Self {
+        match serde_json::to_vec(value) {
+            Ok(bytes) => {
+                self.body = Some(Ok(Bytes::from(bytes)));
+                self.headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("application/json"),
+                );
+            }
+            Err(e) => {
+                self.body = Some(Err(
+                    Error::internal(format!("failed to serialize request body: {e}")).chain(e),
+                ));
+            }
+        }
+        self
+    }
+
+    /// Set a URL-encoded form body. Also sets `Content-Type: application/x-www-form-urlencoded`.
+    pub fn form<T: Serialize>(mut self, body: &T) -> Self {
+        match serde_urlencoded::to_string(body) {
+            Ok(encoded) => {
+                self.body = Some(Ok(Bytes::from(encoded)));
+                self.headers.insert(
+                    http::header::CONTENT_TYPE,
+                    http::HeaderValue::from_static("application/x-www-form-urlencoded"),
+                );
+            }
+            Err(e) => {
+                self.body = Some(Err(
+                    Error::internal(format!("failed to serialize request body: {e}")).chain(e),
+                ));
+            }
+        }
+        self
+    }
+
+    /// Set a raw byte body.
+    pub fn body(mut self, bytes: impl Into<Bytes>) -> Self {
+        self.body = Some(Ok(bytes.into()));
+        self
+    }
+
+    /// Override the request timeout for this request.
+    pub fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+
+    /// Override the maximum retry count for this request.
+    pub fn max_retries(mut self, n: u32) -> Self {
+        self.max_retries = Some(n);
+        self
+    }
+
+    /// Send the request and return the response.
+    pub async fn send(self) -> Result<Response> {
+        // Check deferred URL error first.
+        let uri = self.url?;
+
+        // Check deferred body error next.
+        let body_bytes = match self.body {
+            Some(Ok(b)) => b,
+            Some(Err(e)) => return Err(e),
+            None => Bytes::new(),
+        };
+
+        let inner = self.inner;
+        let method = self.method;
+        let mut headers = self.headers;
+        let timeout = self.timeout.or_else(|| inner.config.timeout());
+        let max_retries = self.max_retries.unwrap_or(inner.config.max_retries);
+
+        // Apply default User-Agent only if not set by caller.
+        if !headers.contains_key(http::header::USER_AGENT)
+            && let Ok(ua) = http::header::HeaderValue::from_str(&inner.config.user_agent)
+        {
+            headers.insert(http::header::USER_AGENT, ua);
+        }
+
+        let url_string = uri.to_string();
+
+        let policy = RetryPolicy {
+            max_retries,
+            backoff: inner.config.retry_backoff(),
+        };
+
+        let build_request = || {
+            let mut builder = hyper::Request::builder()
+                .method(method.clone())
+                .uri(uri.clone());
+
+            for (name, value) in &headers {
+                builder = builder.header(name, value);
+            }
+
+            builder
+                .body(Full::new(body_bytes.clone()))
+                .map_err(|e| Error::internal(format!("failed to build request: {e}")).chain(e))
+        };
+
+        super::retry::execute(&inner.client, &policy, &url_string, timeout, build_request).await
+    }
+}
+
+/// Percent-encode a string for use in URL query parameters.
+fn urlencoding(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(char::from(HEX[(b >> 4) as usize]));
+                out.push(char::from(HEX[(b & 0x0F) as usize]));
+            }
+        }
+    }
+    out
+}
+
+/// Hex digits for percent-encoding.
+const HEX: [u8; 16] = *b"0123456789ABCDEF";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn urlencoding_plain() {
+        assert_eq!(urlencoding("hello"), "hello");
+    }
+
+    #[test]
+    fn urlencoding_special() {
+        assert_eq!(urlencoding("a b"), "a%20b");
+        assert_eq!(urlencoding("k=v&x"), "k%3Dv%26x");
+    }
+
+    #[test]
+    fn urlencoding_preserves_unreserved() {
+        assert_eq!(urlencoding("a-b_c.d~e"), "a-b_c.d~e");
+    }
+}

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -34,6 +34,7 @@ pub struct RequestBuilder {
     url: std::result::Result<http::Uri, Error>,
     headers: HeaderMap,
     body: Option<std::result::Result<Bytes, Error>>,
+    deferred_error: Option<Error>,
     timeout: Option<Duration>,
     max_retries: Option<u32>,
 }
@@ -50,6 +51,7 @@ impl RequestBuilder {
             url: url_result,
             headers: HeaderMap::new(),
             body: None,
+            deferred_error: None,
             timeout: None,
             max_retries: None,
         }
@@ -72,17 +74,21 @@ impl RequestBuilder {
     }
 
     /// Set a `Bearer` authorization header.
-    pub fn bearer_token(self, token: impl AsRef<str>) -> Self {
+    pub fn bearer_token(mut self, token: impl AsRef<str>) -> Self {
         let value = format!("Bearer {}", token.as_ref());
-        let hv = match http::header::HeaderValue::from_str(&value) {
-            Ok(v) => v,
-            Err(_) => return self,
-        };
-        self.header(http::header::AUTHORIZATION, hv)
+        match http::header::HeaderValue::from_str(&value) {
+            Ok(hv) => self.header(http::header::AUTHORIZATION, hv),
+            Err(e) => {
+                self.deferred_error = Some(
+                    Error::bad_request(format!("invalid bearer token header value: {e}")).chain(e),
+                );
+                self
+            }
+        }
     }
 
     /// Set a `Basic` authorization header from username and password.
-    pub fn basic_auth(self, username: &str, password: Option<&str>) -> Self {
+    pub fn basic_auth(mut self, username: &str, password: Option<&str>) -> Self {
         use base64::Engine;
         let credentials = match password {
             Some(pw) => format!("{username}:{pw}"),
@@ -90,18 +96,22 @@ impl RequestBuilder {
         };
         let encoded = base64::engine::general_purpose::STANDARD.encode(credentials);
         let value = format!("Basic {encoded}");
-        let hv = match http::header::HeaderValue::from_str(&value) {
-            Ok(v) => v,
-            Err(_) => return self,
-        };
-        self.header(http::header::AUTHORIZATION, hv)
+        match http::header::HeaderValue::from_str(&value) {
+            Ok(hv) => self.header(http::header::AUTHORIZATION, hv),
+            Err(e) => {
+                self.deferred_error = Some(
+                    Error::bad_request(format!("invalid basic auth header value: {e}")).chain(e),
+                );
+                self
+            }
+        }
     }
 
     /// Append query parameters to the URL.
     ///
     /// Parameters are URL-encoded and appended to any existing query string.
     pub fn query(mut self, params: &[(&str, &str)]) -> Self {
-        self.url = self.url.map(|uri| {
+        self.url = self.url.and_then(|uri| {
             let encoded = params
                 .iter()
                 .map(|(k, v)| format!("{}={}", urlencoding(k), urlencoding(v)))
@@ -109,13 +119,16 @@ impl RequestBuilder {
                 .join("&");
 
             if encoded.is_empty() {
-                return uri;
+                return Ok(uri);
             }
 
             let url = uri.to_string();
             let sep = if url.contains('?') { "&" } else { "?" };
             let new_url = format!("{url}{sep}{encoded}");
-            new_url.parse::<http::Uri>().unwrap_or(uri)
+            new_url.parse::<http::Uri>().map_err(|e| {
+                Error::bad_request(format!("invalid URL after appending query params: {e}"))
+                    .chain(e)
+            })
         });
         self
     }
@@ -182,6 +195,11 @@ impl RequestBuilder {
     pub async fn send(self) -> Result<Response> {
         // Check deferred URL error first.
         let uri = self.url?;
+
+        // Check deferred builder errors (auth header failures, etc.).
+        if let Some(e) = self.deferred_error {
+            return Err(e);
+        }
 
         // Check deferred body error next.
         let body_bytes = match self.body {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -57,7 +57,7 @@ impl RequestBuilder {
         }
     }
 
-    /// Append a single header.
+    /// Set a single header, replacing any existing value with the same name.
     pub fn header(
         mut self,
         name: http::header::HeaderName,

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -56,7 +56,11 @@ impl RequestBuilder {
     }
 
     /// Append a single header.
-    pub fn header(mut self, name: http::header::HeaderName, value: http::header::HeaderValue) -> Self {
+    pub fn header(
+        mut self,
+        name: http::header::HeaderName,
+        value: http::header::HeaderValue,
+    ) -> Self {
         self.headers.insert(name, value);
         self
     }
@@ -127,9 +131,10 @@ impl RequestBuilder {
                 );
             }
             Err(e) => {
-                self.body = Some(Err(
-                    Error::internal(format!("failed to serialize request body: {e}")).chain(e),
-                ));
+                self.body = Some(Err(Error::internal(format!(
+                    "failed to serialize request body: {e}"
+                ))
+                .chain(e)));
             }
         }
         self
@@ -146,9 +151,10 @@ impl RequestBuilder {
                 );
             }
             Err(e) => {
-                self.body = Some(Err(
-                    Error::internal(format!("failed to serialize request body: {e}")).chain(e),
-                ));
+                self.body = Some(Err(Error::internal(format!(
+                    "failed to serialize request body: {e}"
+                ))
+                .chain(e)));
             }
         }
         self

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -1,0 +1,138 @@
+use bytes::Bytes;
+use http::{HeaderMap, StatusCode};
+use http_body_util::BodyExt;
+use serde::de::DeserializeOwned;
+
+use crate::error::{Error, Result};
+
+/// An HTTP response received from an outgoing request.
+///
+/// Provides typed accessors for status, headers, and URL, plus terminal methods
+/// to consume the body as JSON, UTF-8 text, raw bytes, or a streaming iterator.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let resp = client.get("https://api.example.com/data").send().await?;
+/// let data: MyStruct = resp.error_for_status()?.json().await?;
+/// ```
+pub struct Response {
+    status: StatusCode,
+    headers: HeaderMap,
+    url: String,
+    body: hyper::body::Incoming,
+}
+
+impl Response {
+    /// Create a new `Response` from its constituent parts.
+    pub(crate) fn new(
+        status: StatusCode,
+        headers: HeaderMap,
+        url: String,
+        body: hyper::body::Incoming,
+    ) -> Self {
+        Self {
+            status,
+            headers,
+            url,
+            body,
+        }
+    }
+
+    /// Returns the HTTP status code.
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    /// Returns the response headers.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// Returns the URL that produced this response.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Returns the `Content-Length` header value, if present and valid.
+    pub fn content_length(&self) -> Option<u64> {
+        self.headers
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse().ok())
+    }
+
+    /// Consume the body and deserialize it as JSON.
+    pub async fn json<T: DeserializeOwned>(self) -> Result<T> {
+        let bytes = self.bytes().await?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| Error::internal(format!("failed to parse response JSON: {e}")).chain(e))
+    }
+
+    /// Consume the body and return it as a UTF-8 string.
+    pub async fn text(self) -> Result<String> {
+        let bytes = self.bytes().await?;
+        String::from_utf8(bytes.into())
+            .map_err(|e| Error::internal("response body is not valid UTF-8").chain(e))
+    }
+
+    /// Consume the body and return it as raw bytes.
+    pub async fn bytes(self) -> Result<Bytes> {
+        self.body
+            .collect()
+            .await
+            .map(|collected| collected.to_bytes())
+            .map_err(|e| Error::internal(format!("failed to read response body: {e}")).chain(e))
+    }
+
+    /// Convert this response into a streaming body reader.
+    pub fn stream(self) -> BodyStream {
+        BodyStream { body: self.body }
+    }
+
+    /// Return `Ok(self)` if the status is 2xx, otherwise return an error.
+    pub fn error_for_status(self) -> Result<Self> {
+        if self.status.is_success() {
+            Ok(self)
+        } else {
+            Err(Error::internal(format!(
+                "HTTP {}: {}",
+                self.status, self.url
+            )))
+        }
+    }
+}
+
+/// A streaming reader over a response body.
+///
+/// Each call to [`next`](BodyStream::next) yields the next data frame as raw bytes,
+/// skipping trailers and other non-data frames. Returns `None` when the body is
+/// exhausted.
+pub struct BodyStream {
+    body: hyper::body::Incoming,
+}
+
+impl BodyStream {
+    /// Read the next data frame from the body stream.
+    ///
+    /// Returns `None` when the stream is complete.
+    pub async fn next(&mut self) -> Option<Result<Bytes>> {
+        loop {
+            let frame = std::pin::pin!(self.body.frame()).await?;
+            match frame {
+                Ok(frame) => {
+                    if let Ok(data) = frame.into_data() {
+                        return Some(Ok(data));
+                    }
+                    // Non-data frame (e.g. trailers) — skip and read next.
+                }
+                Err(e) => {
+                    return Some(Err(Error::internal(format!(
+                        "failed to read response body: {e}"
+                    ))
+                    .chain(e)));
+                }
+            }
+        }
+    }
+}

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -57,9 +57,8 @@ where
     for attempt in 0..=policy.max_retries {
         let request = build_request()?;
         let method_str = request.method().to_string();
-        let url_str = url;
 
-        tracing::debug!(attempt, url = %url_str, method = %method_str, "http.request");
+        tracing::debug!(attempt, url = %url, method = %method_str, "http.request");
 
         match classify(send_once(client, request, url, timeout).await) {
             Attempt::Success(resp) => return Ok(resp),

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -1,0 +1,249 @@
+use std::time::Duration;
+
+use bytes::Bytes;
+use http_body_util::Full;
+
+use super::client::InnerHttpsClient;
+use super::response::Response;
+use crate::error::{Error, Result};
+
+/// Maximum duration honoured from a `Retry-After` header.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+/// Retry configuration for a single request.
+pub(crate) struct RetryPolicy {
+    /// Maximum number of retry attempts (0 = no retries).
+    pub max_retries: u32,
+    /// Base backoff duration; actual delay is `backoff * 2^attempt`.
+    pub backoff: Duration,
+}
+
+/// Classification of a single send attempt.
+enum Attempt {
+    /// Received a successful (or non-retryable) response.
+    Success(Response),
+    /// Got an HTTP response with a retryable status (502, 503, 429).
+    RetryableResponse(Response, String, Option<Duration>),
+    /// Transient connection/timeout failure that can be retried.
+    RetryableError(String, Option<Duration>),
+    /// Fatal error that must not be retried.
+    Fatal(Error),
+}
+
+/// Classification of a low-level send error.
+enum SendError {
+    Timeout,
+    Connection(String),
+    Fatal(String),
+}
+
+/// Execute a request with the configured retry policy.
+///
+/// The `build_request` closure is called once per attempt so that the request body
+/// (which is consumed by hyper) is recreated each time.
+pub(crate) async fn execute<F>(
+    client: &InnerHttpsClient,
+    policy: &RetryPolicy,
+    url: &str,
+    timeout: Option<Duration>,
+    build_request: F,
+) -> Result<Response>
+where
+    F: Fn() -> Result<hyper::Request<Full<Bytes>>>,
+{
+    let mut last_retryable_response: Option<Response> = None;
+    let mut last_err: Option<Error> = None;
+
+    let method_str = ""; // extracted per-attempt below
+    let _ = method_str;
+
+    for attempt in 0..=policy.max_retries {
+        let request = build_request()?;
+        let method_str = request.method().to_string();
+        let url_str = url;
+
+        tracing::debug!(attempt, url = %url_str, method = %method_str, "http.request");
+
+        match classify(send_once(client, request, url, timeout).await) {
+            Attempt::Success(resp) => return Ok(resp),
+            Attempt::Fatal(e) => return Err(e),
+            Attempt::RetryableResponse(resp, reason, retry_after) => {
+                // Don't sleep after the final attempt.
+                if attempt < policy.max_retries {
+                    let delay =
+                        retry_after.unwrap_or_else(|| backoff_delay(policy.backoff, attempt));
+                    tracing::warn!(
+                        attempt,
+                        next_attempt = attempt + 1,
+                        reason = %reason,
+                        backoff_ms = delay.as_millis() as u64,
+                        "http.retry"
+                    );
+                    // Store before sleeping so we have it if we exhaust retries.
+                    last_retryable_response = Some(resp);
+                    tokio::time::sleep(delay).await;
+                } else {
+                    // Final attempt with retryable HTTP status — return the response.
+                    last_retryable_response = Some(resp);
+                }
+            }
+            Attempt::RetryableError(reason, retry_after) => {
+                last_err = Some(Error::internal(reason.clone()));
+                last_retryable_response = None;
+
+                // Don't sleep after the final attempt.
+                if attempt < policy.max_retries {
+                    let delay =
+                        retry_after.unwrap_or_else(|| backoff_delay(policy.backoff, attempt));
+                    tracing::warn!(
+                        attempt,
+                        next_attempt = attempt + 1,
+                        reason = %reason,
+                        backoff_ms = delay.as_millis() as u64,
+                        "http.retry"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    // Exhausted retries: if the last attempt was a retryable HTTP response, return it.
+    if let Some(resp) = last_retryable_response {
+        return Ok(resp);
+    }
+
+    Err(last_err.unwrap_or_else(|| Error::internal("HTTP request failed after retries")))
+}
+
+/// Send a single HTTP request, applying the optional timeout.
+async fn send_once(
+    client: &InnerHttpsClient,
+    request: hyper::Request<Full<Bytes>>,
+    url: &str,
+    timeout: Option<Duration>,
+) -> std::result::Result<Response, SendError> {
+    let fut = client.request(request);
+
+    let hyper_resp = if let Some(dur) = timeout {
+        match tokio::time::timeout(dur, fut).await {
+            Ok(result) => result.map_err(classify_hyper_error)?,
+            Err(_) => return Err(SendError::Timeout),
+        }
+    } else {
+        fut.await.map_err(classify_hyper_error)?
+    };
+
+    let status = hyper_resp.status();
+    let headers = hyper_resp.headers().clone();
+    let body = hyper_resp.into_body();
+
+    Ok(Response::new(status, headers, url.to_string(), body))
+}
+
+/// Classify a hyper client error as connection or fatal.
+fn classify_hyper_error(e: hyper_util::client::legacy::Error) -> SendError {
+    let msg = e.to_string();
+    if e.is_connect() || msg.contains("connection") || msg.contains("dns") {
+        SendError::Connection(msg)
+    } else {
+        SendError::Fatal(msg)
+    }
+}
+
+/// Classify an attempt result into success, retryable, or fatal.
+fn classify(result: std::result::Result<Response, SendError>) -> Attempt {
+    match result {
+        Ok(resp) => {
+            let status = resp.status();
+            if status == http::StatusCode::TOO_MANY_REQUESTS {
+                let retry_after = resp
+                    .headers()
+                    .get(http::header::RETRY_AFTER)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(parse_retry_after);
+                Attempt::RetryableResponse(resp, format!("HTTP {status}"), retry_after)
+            } else if status == http::StatusCode::BAD_GATEWAY
+                || status == http::StatusCode::SERVICE_UNAVAILABLE
+            {
+                Attempt::RetryableResponse(resp, format!("HTTP {status}"), None)
+            } else {
+                Attempt::Success(resp)
+            }
+        }
+        Err(SendError::Timeout) => Attempt::RetryableError("request timed out".into(), None),
+        Err(SendError::Connection(msg)) => Attempt::RetryableError(msg, None),
+        Err(SendError::Fatal(msg)) => {
+            Attempt::Fatal(Error::internal(format!("HTTP request failed: {msg}")))
+        }
+    }
+}
+
+/// Parse a `Retry-After` header value (seconds or HTTP-date), capped at [`MAX_RETRY_AFTER`].
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    // Try integer seconds first.
+    if let Ok(secs) = value.trim().parse::<u64>() {
+        return Some(Duration::from_secs(secs).min(MAX_RETRY_AFTER));
+    }
+
+    // Try HTTP-date (RFC 7231 section 7.1.1.1).
+    if let Ok(date) = chrono::DateTime::parse_from_rfc2822(value.trim()) {
+        let now = chrono::Utc::now();
+        let target = date.with_timezone(&chrono::Utc);
+        if target > now {
+            let delta = (target - now).to_std().ok()?;
+            return Some(delta.min(MAX_RETRY_AFTER));
+        }
+        // Date is in the past — retry immediately.
+        return Some(Duration::ZERO);
+    }
+
+    None
+}
+
+/// Compute exponential backoff: `base * 2^attempt`.
+fn backoff_delay(base: Duration, attempt: u32) -> Duration {
+    base.saturating_mul(2u32.saturating_pow(attempt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_exponential() {
+        let base = Duration::from_millis(100);
+        assert_eq!(backoff_delay(base, 0), Duration::from_millis(100));
+        assert_eq!(backoff_delay(base, 1), Duration::from_millis(200));
+        assert_eq!(backoff_delay(base, 2), Duration::from_millis(400));
+        assert_eq!(backoff_delay(base, 3), Duration::from_millis(800));
+    }
+
+    #[test]
+    fn backoff_saturates() {
+        let base = Duration::from_secs(1);
+        // Very large exponent should saturate rather than overflow.
+        let delay = backoff_delay(base, 100);
+        assert!(delay >= Duration::from_secs(1));
+    }
+
+    #[test]
+    fn parse_retry_after_seconds() {
+        assert_eq!(parse_retry_after("5"), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn parse_retry_after_caps_at_max() {
+        assert_eq!(parse_retry_after("3600"), Some(MAX_RETRY_AFTER));
+    }
+
+    #[test]
+    fn parse_retry_after_invalid() {
+        assert_eq!(parse_retry_after("not-a-number"), None);
+    }
+
+    #[test]
+    fn parse_retry_after_zero() {
+        assert_eq!(parse_retry_after("0"), Some(Duration::ZERO));
+    }
+}

--- a/src/http/retry.rs
+++ b/src/http/retry.rs
@@ -54,9 +54,6 @@ where
     let mut last_retryable_response: Option<Response> = None;
     let mut last_err: Option<Error> = None;
 
-    let method_str = ""; // extracted per-attempt below
-    let _ = method_str;
-
     for attempt in 0..=policy.max_retries {
         let request = build_request()?;
         let method_str = request.method().to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,9 @@ pub use extractor::Service;
 pub use flash::{Flash, FlashEntry, FlashLayer};
 pub use health::{HealthCheck, HealthChecks};
 #[cfg(feature = "http-client")]
-pub use http::{Client as HttpClient, ClientBuilder as HttpClientBuilder, ClientConfig as HttpClientConfig};
+pub use http::{
+    Client as HttpClient, ClientBuilder as HttpClientBuilder, ClientConfig as HttpClientConfig,
+};
 pub use ip::{ClientIp, ClientIpLayer};
 pub use rbac::{Role, RoleExtractor};
 pub use sanitize::Sanitize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,11 +84,11 @@ pub mod testing;
 pub use config::Config;
 pub use error::{Error, Result};
 
-#[cfg(feature = "http-client")]
-pub use http::ClientConfig as HttpClientConfig;
 pub use extractor::Service;
 pub use flash::{Flash, FlashEntry, FlashLayer};
 pub use health::{HealthCheck, HealthChecks};
+#[cfg(feature = "http-client")]
+pub use http::{Client as HttpClient, ClientBuilder as HttpClientBuilder, ClientConfig as HttpClientConfig};
 pub use ip::{ClientIp, ClientIpLayer};
 pub use rbac::{Role, RoleExtractor};
 pub use sanitize::Sanitize;
@@ -122,7 +122,8 @@ pub use storage::{Acl, BucketConfig, Buckets, PutFromUrlInput, PutInput, PutOpti
 
 #[cfg(feature = "webhooks")]
 pub use webhook::{
-    HttpClient, HyperClient, SignedHeaders, WebhookResponse, WebhookSecret, WebhookSender,
+    HttpClient as WebhookHttpClient, HyperClient, SignedHeaders, WebhookResponse, WebhookSecret,
+    WebhookSender,
 };
 
 #[cfg(feature = "dns")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,10 +121,7 @@ pub use template::{
 pub use storage::{Acl, BucketConfig, Buckets, PutFromUrlInput, PutInput, PutOptions, Storage};
 
 #[cfg(feature = "webhooks")]
-pub use webhook::{
-    HttpClient as WebhookHttpClient, HyperClient, SignedHeaders, WebhookResponse, WebhookSecret,
-    WebhookSender,
-};
+pub use webhook::{SignedHeaders, WebhookResponse, WebhookSecret, WebhookSender};
 
 #[cfg(feature = "dns")]
 pub use dns::{DnsConfig, DnsError, DomainStatus, DomainVerifier, generate_verification_token};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub mod job;
 pub mod rbac;
 pub mod tenant;
 
+#[cfg(feature = "http-client")]
+pub mod http;
+
 #[cfg(feature = "auth")]
 pub mod auth;
 
@@ -80,6 +83,9 @@ pub mod testing;
 
 pub use config::Config;
 pub use error::{Error, Result};
+
+#[cfg(feature = "http-client")]
+pub use http::ClientConfig as HttpClientConfig;
 pub use extractor::Service;
 pub use flash::{Flash, FlashEntry, FlashLayer};
 pub use health::{HealthCheck, HealthChecks};

--- a/src/storage/backend.rs
+++ b/src/storage/backend.rs
@@ -1,7 +1,3 @@
-use bytes::Bytes;
-use http_body_util::Full;
-use hyper_util::client::legacy::Client;
-
 use super::client::RemoteBackend;
 use super::memory::MemoryBackend;
 use crate::error::{Error, Result};
@@ -13,16 +9,9 @@ pub(crate) enum BackendKind {
 }
 
 impl BackendKind {
-    /// Returns a reference to the hyper HTTP client.
+    /// Returns a reference to the HTTP client.
     /// Only available for the Remote backend — Memory returns an error.
-    pub(crate) fn http_client(
-        &self,
-    ) -> Result<
-        &Client<
-            hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-            Full<Bytes>,
-        >,
-    > {
+    pub(crate) fn http_client(&self) -> Result<&crate::http::Client> {
         match self {
             BackendKind::Remote(b) => Ok(b.client()),
             BackendKind::Memory(_) => {

--- a/src/storage/client.rs
+++ b/src/storage/client.rs
@@ -3,9 +3,6 @@ use std::time::Duration;
 use bytes::Bytes;
 use http::Uri;
 use http_body_util::{BodyExt, Full};
-use hyper_rustls::HttpsConnectorBuilder;
-use hyper_util::client::legacy::Client;
-use hyper_util::rt::TokioExecutor;
 
 use super::options::PutOptions;
 use super::presign::{PresignParams, presign_url};
@@ -13,10 +10,7 @@ use super::signing::{SigningParams, sign_request, uri_encode};
 use crate::error::{Error, Result};
 
 pub(crate) struct RemoteBackend {
-    client: Client<
-        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-        Full<Bytes>,
-    >,
+    client: crate::http::Client,
     bucket: String,
     endpoint: String,
     endpoint_host: String,
@@ -31,6 +25,7 @@ const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495
 
 impl RemoteBackend {
     pub fn new(
+        client: crate::http::Client,
         bucket: String,
         endpoint: String,
         access_key: String,
@@ -39,13 +34,6 @@ impl RemoteBackend {
         path_style: bool,
     ) -> Result<Self> {
         let endpoint_host = strip_scheme(&endpoint).to_string();
-
-        let connector = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_or_http()
-            .enable_http1()
-            .build();
-        let client = Client::builder(TokioExecutor::new()).build(connector);
 
         Ok(Self {
             client,
@@ -116,6 +104,7 @@ impl RemoteBackend {
 
         let response = self
             .client
+            .raw_client()
             .request(request)
             .await
             .map_err(|e| Error::internal(format!("PUT request failed: {e}")))?;
@@ -174,6 +163,7 @@ impl RemoteBackend {
 
         let response = self
             .client
+            .raw_client()
             .request(request)
             .await
             .map_err(|e| Error::internal(format!("DELETE request failed: {e}")))?;
@@ -232,6 +222,7 @@ impl RemoteBackend {
 
         let response = self
             .client
+            .raw_client()
             .request(request)
             .await
             .map_err(|e| Error::internal(format!("HEAD request failed: {e}")))?;
@@ -304,6 +295,7 @@ impl RemoteBackend {
 
             let response = self
                 .client
+                .raw_client()
                 .request(request)
                 .await
                 .map_err(|e| Error::internal(format!("LIST request failed: {e}")))?;
@@ -361,12 +353,7 @@ impl RemoteBackend {
         Ok(presign_url(&params))
     }
 
-    pub(crate) fn client(
-        &self,
-    ) -> &Client<
-        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-        Full<Bytes>,
-    > {
+    pub(crate) fn client(&self) -> &crate::http::Client {
         &self.client
     }
 

--- a/src/storage/facade.rs
+++ b/src/storage/facade.rs
@@ -111,11 +111,13 @@ impl Storage {
     pub fn new(config: &BucketConfig) -> Result<Self> {
         config.validate()?;
 
+        let http_client = crate::http::Client::default();
         let region = config
             .region
             .clone()
             .unwrap_or_else(|| "us-east-1".to_string());
         let backend = RemoteBackend::new(
+            http_client,
             config.bucket.clone(),
             config.endpoint.clone(),
             config.access_key.clone(),

--- a/src/storage/facade.rs
+++ b/src/storage/facade.rs
@@ -107,17 +107,19 @@ impl Clone for Storage {
 }
 
 impl Storage {
-    /// Create from a bucket configuration (builds RemoteBackend).
-    pub fn new(config: &BucketConfig) -> Result<Self> {
+    /// Create from a bucket configuration using a shared HTTP client.
+    ///
+    /// This allows multiple `Storage` instances (and other modules) to share
+    /// the same connection pool and configuration.
+    pub fn with_client(config: &BucketConfig, client: crate::http::Client) -> Result<Self> {
         config.validate()?;
 
-        let http_client = crate::http::Client::default();
         let region = config
             .region
             .clone()
             .unwrap_or_else(|| "us-east-1".to_string());
         let backend = RemoteBackend::new(
-            http_client,
+            client,
             config.bucket.clone(),
             config.endpoint.clone(),
             config.access_key.clone(),
@@ -133,6 +135,13 @@ impl Storage {
                 max_file_size: config.max_file_size_bytes()?,
             }),
         })
+    }
+
+    /// Create from a bucket configuration (builds its own default HTTP client).
+    ///
+    /// For shared connection pooling, prefer [`Storage::with_client`].
+    pub fn new(config: &BucketConfig) -> Result<Self> {
+        Self::with_client(config, crate::http::Client::default())
     }
 
     /// In-memory storage for testing.

--- a/src/storage/fetch.rs
+++ b/src/storage/fetch.rs
@@ -43,11 +43,13 @@ pub(crate) async fn fetch_url(
         .body(Full::new(Bytes::new()))
         .map_err(|e| Error::internal(format!("failed to build request: {e}")))?;
 
-    let response =
-        tokio::time::timeout(Duration::from_secs(30), client.raw_client().request(request))
-        .await
-        .map_err(|_| Error::internal("URL fetch timed out"))?
-        .map_err(|e| Error::internal(format!("failed to fetch URL: {e}")))?;
+    let response = tokio::time::timeout(
+        Duration::from_secs(30),
+        client.raw_client().request(request),
+    )
+    .await
+    .map_err(|_| Error::internal("URL fetch timed out"))?
+    .map_err(|e| Error::internal(format!("failed to fetch URL: {e}")))?;
 
     let status = response.status();
     if !status.is_success() {

--- a/src/storage/fetch.rs
+++ b/src/storage/fetch.rs
@@ -3,9 +3,6 @@ use std::time::Duration;
 use bytes::Bytes;
 use http::Uri;
 use http_body_util::{BodyExt, Full};
-use hyper_rustls::HttpsConnector;
-use hyper_util::client::legacy::Client;
-use hyper_util::client::legacy::connect::HttpConnector;
 
 use crate::error::{Error, Result};
 
@@ -28,13 +25,13 @@ fn validate_url(url: &str) -> Result<Uri> {
     }
 }
 
-/// Fetch a file from a URL using the provided hyper client.
+/// Fetch a file from a URL using the provided HTTP client.
 ///
 /// Streams the response body and aborts if `max_size` is exceeded.
 /// Returns the body bytes and content type from the response.
 /// Hard-coded 30s timeout. No redirect following.
 pub(crate) async fn fetch_url(
-    client: &Client<HttpsConnector<HttpConnector>, Full<Bytes>>,
+    client: &crate::http::Client,
     url: &str,
     max_size: Option<usize>,
 ) -> Result<FetchResult> {
@@ -46,7 +43,8 @@ pub(crate) async fn fetch_url(
         .body(Full::new(Bytes::new()))
         .map_err(|e| Error::internal(format!("failed to build request: {e}")))?;
 
-    let response = tokio::time::timeout(Duration::from_secs(30), client.request(request))
+    let response =
+        tokio::time::timeout(Duration::from_secs(30), client.raw_client().request(request))
         .await
         .map_err(|_| Error::internal("URL fetch timed out"))?
         .map_err(|e| Error::internal(format!("failed to fetch URL: {e}")))?;
@@ -100,9 +98,6 @@ pub(crate) async fn fetch_url(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper_rustls::HttpsConnectorBuilder;
-    use hyper_util::client::legacy::Client;
-    use hyper_util::rt::TokioExecutor;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
@@ -138,17 +133,9 @@ mod tests {
         assert!(validate_url("not a url at all").is_err());
     }
 
-    fn build_test_client() -> Client<
-        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-        Full<Bytes>,
-    > {
+    fn build_test_client() -> crate::http::Client {
         let _ = rustls::crypto::ring::default_provider().install_default();
-        let connector = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_or_http()
-            .enable_http1()
-            .build();
-        Client::builder(TokioExecutor::new()).build(connector)
+        crate::http::Client::default()
     }
 
     async fn start_server(

--- a/src/webhook/client.rs
+++ b/src/webhook/client.rs
@@ -1,15 +1,7 @@
-use std::future::Future;
-use std::time::Duration;
-
 use bytes::Bytes;
-use http::HeaderMap;
-use http::StatusCode;
-use http_body_util::{BodyExt, Full};
-use hyper_rustls::HttpsConnectorBuilder;
-use hyper_util::client::legacy::Client;
-use hyper_util::rt::TokioExecutor;
+use http::{HeaderMap, StatusCode};
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 
 /// Response returned after a webhook delivery attempt.
 pub struct WebhookResponse {
@@ -19,87 +11,19 @@ pub struct WebhookResponse {
     pub body: Bytes,
 }
 
-/// Trait for sending a single webhook HTTP POST request.
-///
-/// Uses return-position `impl Trait` (not object-safe). Use a concrete
-/// type parameter such as `WebhookSender<HyperClient>` rather than `dyn HttpClient`.
-pub trait HttpClient: Send + Sync + 'static {
-    /// Send an HTTP POST to `url` with the given `headers` and `body`.
-    fn post(
-        &self,
-        url: &str,
-        headers: HeaderMap,
-        body: Bytes,
-    ) -> impl Future<Output = Result<WebhookResponse>> + Send;
-}
+/// Send a webhook POST via the shared HTTP client.
+pub(crate) async fn post(
+    client: &crate::http::Client,
+    url: &str,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<WebhookResponse> {
+    let response = client.post(url).headers(headers).body(body).send().await?;
+    let status = response.status();
+    let response_body = response.bytes().await?;
 
-/// Default hyper-based HTTP client with TLS support.
-pub struct HyperClient {
-    client: Client<
-        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-        Full<Bytes>,
-    >,
-    timeout: Duration,
-}
-
-impl HyperClient {
-    /// Create a new client. Requests that exceed `timeout` return an error.
-    pub fn new(timeout: Duration) -> Self {
-        let connector = HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_or_http()
-            .enable_http1()
-            .build();
-        let client = Client::builder(TokioExecutor::new()).build(connector);
-        Self { client, timeout }
-    }
-}
-
-impl HttpClient for HyperClient {
-    async fn post(&self, url: &str, headers: HeaderMap, body: Bytes) -> Result<WebhookResponse> {
-        let uri: http::Uri = url
-            .parse()
-            .map_err(|e| Error::bad_request(format!("invalid webhook url: {e}")))?;
-
-        let mut builder = hyper::Request::builder()
-            .method(hyper::Method::POST)
-            .uri(uri);
-
-        for (name, value) in &headers {
-            builder = builder.header(name, value);
-        }
-
-        let request = builder
-            .body(Full::new(body))
-            .map_err(|e| Error::internal(format!("failed to build webhook request: {e}")))?;
-
-        let response = tokio::time::timeout(self.timeout, self.client.request(request))
-            .await
-            .map_err(|_| Error::internal("webhook request timed out"))?
-            .map_err(|e| Error::internal(format!("webhook request failed: {e}")))?;
-
-        let status = response.status();
-        let response_body = response
-            .into_body()
-            .collect()
-            .await
-            .map_err(|e| Error::internal(format!("failed to read webhook response: {e}")))?
-            .to_bytes();
-
-        Ok(WebhookResponse {
-            status,
-            body: response_body,
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn hyper_client_creates_without_panic() {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-        let _ = HyperClient::new(Duration::from_secs(30));
-    }
+    Ok(WebhookResponse {
+        status,
+        body: response_body,
+    })
 }

--- a/src/webhook/mod.rs
+++ b/src/webhook/mod.rs
@@ -8,7 +8,7 @@ mod secret;
 mod sender;
 mod signature;
 
-pub use client::{HttpClient, HyperClient, WebhookResponse};
+pub use client::WebhookResponse;
 pub use secret::WebhookSecret;
 pub use sender::WebhookSender;
 pub use signature::{SignedHeaders, sign, sign_headers, verify, verify_headers};

--- a/src/webhook/sender.rs
+++ b/src/webhook/sender.rs
@@ -116,7 +116,13 @@ impl WebhookSender {
                 .map_err(|_| Error::internal("generated invalid webhook-signature header"))?,
         );
 
-        client::post(&self.inner.client, url, headers, Bytes::copy_from_slice(body)).await
+        client::post(
+            &self.inner.client,
+            url,
+            headers,
+            Bytes::copy_from_slice(body),
+        )
+        .await
     }
 }
 
@@ -131,9 +137,7 @@ mod tests {
     use super::*;
 
     /// Start a minimal HTTP server that captures the request and returns the given status.
-    async fn start_test_server(
-        response_status: u16,
-    ) -> (String, tokio::task::JoinHandle<String>) {
+    async fn start_test_server(response_status: u16) -> (String, tokio::task::JoinHandle<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let url = format!("http://127.0.0.1:{}", addr.port());
@@ -256,10 +260,7 @@ mod tests {
         let sender = WebhookSender::new(test_client());
         let secret = WebhookSecret::new(b"key".to_vec());
 
-        let response = sender
-            .send(&url, "msg_1", b"{}", &[&secret])
-            .await
-            .unwrap();
+        let response = sender.send(&url, "msg_1", b"{}", &[&secret]).await.unwrap();
         assert_eq!(response.status, StatusCode::GONE);
 
         handle.await.unwrap();

--- a/src/webhook/sender.rs
+++ b/src/webhook/sender.rs
@@ -42,14 +42,22 @@ impl WebhookSender {
 
     /// Override the default `User-Agent` header sent with every request.
     ///
+    /// The value must be a valid HTTP header value (visible ASCII only, no
+    /// control characters). Invalid values are silently ignored.
+    ///
     /// # Panics
     ///
     /// Panics if called after the sender has been cloned. Call this immediately
     /// after [`WebhookSender::new`] before handing clones to other tasks.
     pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        let ua = user_agent.into();
+        // Validate before storing — prevents panic in send().
+        if http::header::HeaderValue::from_str(&ua).is_err() {
+            return self;
+        }
         let inner =
             Arc::get_mut(&mut self.inner).expect("with_user_agent must be called before cloning");
-        inner.user_agent = user_agent.into();
+        inner.user_agent = ua;
         self
     }
 
@@ -96,7 +104,13 @@ impl WebhookSender {
 
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/json".parse().unwrap());
-        headers.insert("user-agent", self.inner.user_agent.parse().unwrap());
+        headers.insert(
+            "user-agent",
+            self.inner
+                .user_agent
+                .parse()
+                .map_err(|_| Error::internal("invalid user-agent header value"))?,
+        );
         headers.insert(
             "webhook-id",
             signed

--- a/src/webhook/sender.rs
+++ b/src/webhook/sender.rs
@@ -1,16 +1,15 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use bytes::Bytes;
 use http::HeaderMap;
 
-use super::client::{HttpClient, HyperClient, WebhookResponse};
+use super::client::{self, WebhookResponse};
 use super::secret::WebhookSecret;
 use super::signature::sign_headers;
 use crate::error::{Error, Result};
 
-struct WebhookSenderInner<C: HttpClient> {
-    client: C,
+struct WebhookSenderInner {
+    client: crate::http::Client,
     user_agent: String,
 }
 
@@ -18,11 +17,11 @@ struct WebhookSenderInner<C: HttpClient> {
 /// Standard Webhooks protocol.
 ///
 /// Clone-cheap: the inner state is wrapped in `Arc`.
-pub struct WebhookSender<C: HttpClient> {
-    inner: Arc<WebhookSenderInner<C>>,
+pub struct WebhookSender {
+    inner: Arc<WebhookSenderInner>,
 }
 
-impl<C: HttpClient> Clone for WebhookSender<C> {
+impl Clone for WebhookSender {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
@@ -30,9 +29,9 @@ impl<C: HttpClient> Clone for WebhookSender<C> {
     }
 }
 
-impl<C: HttpClient> WebhookSender<C> {
+impl WebhookSender {
     /// Create a new sender with the given HTTP client.
-    pub fn new(client: C) -> Self {
+    pub fn new(client: crate::http::Client) -> Self {
         Self {
             inner: Arc::new(WebhookSenderInner {
                 client,
@@ -52,6 +51,16 @@ impl<C: HttpClient> WebhookSender<C> {
             Arc::get_mut(&mut self.inner).expect("with_user_agent must be called before cloning");
         inner.user_agent = user_agent.into();
         self
+    }
+
+    /// Convenience constructor using a default [`crate::http::Client`] with a
+    /// 30-second timeout.
+    pub fn default_client() -> Self {
+        Self::new(
+            crate::http::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build(),
+        )
     }
 
     /// Send a webhook following the Standard Webhooks protocol.
@@ -107,125 +116,102 @@ impl<C: HttpClient> WebhookSender<C> {
                 .map_err(|_| Error::internal("generated invalid webhook-signature header"))?,
         );
 
-        self.inner
-            .client
-            .post(url, headers, Bytes::copy_from_slice(body))
-            .await
-    }
-}
-
-impl WebhookSender<HyperClient> {
-    /// Convenience constructor using [`HyperClient`] with a 30-second timeout.
-    pub fn default_client() -> Self {
-        Self::new(HyperClient::new(Duration::from_secs(30)))
+        client::post(&self.inner.client, url, headers, Bytes::copy_from_slice(body)).await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::time::Duration;
+
     use http::StatusCode;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
-    struct MockClient {
-        response_status: StatusCode,
-        captured_headers: std::sync::Mutex<Option<HeaderMap>>,
-        captured_body: std::sync::Mutex<Option<Bytes>>,
+    use super::*;
+
+    /// Start a minimal HTTP server that captures the request and returns the given status.
+    async fn start_test_server(
+        response_status: u16,
+    ) -> (String, tokio::task::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 8192];
+            let n = stream.read(&mut buf).await.unwrap();
+            buf.truncate(n);
+            let raw = String::from_utf8_lossy(&buf).to_string();
+
+            let response = format!(
+                "HTTP/1.1 {response_status} OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+
+            raw
+        });
+
+        (url, handle)
     }
 
-    impl MockClient {
-        fn new(status: StatusCode) -> Self {
-            Self {
-                response_status: status,
-                captured_headers: std::sync::Mutex::new(None),
-                captured_body: std::sync::Mutex::new(None),
-            }
-        }
-
-        fn captured_headers(&self) -> HeaderMap {
-            self.captured_headers.lock().unwrap().clone().unwrap()
-        }
-
-        fn captured_body(&self) -> Bytes {
-            self.captured_body.lock().unwrap().clone().unwrap()
-        }
-    }
-
-    impl HttpClient for MockClient {
-        async fn post(
-            &self,
-            _url: &str,
-            headers: HeaderMap,
-            body: Bytes,
-        ) -> Result<WebhookResponse> {
-            *self.captured_headers.lock().unwrap() = Some(headers);
-            *self.captured_body.lock().unwrap() = Some(body);
-            Ok(WebhookResponse {
-                status: self.response_status,
-                body: Bytes::new(),
-            })
-        }
+    fn test_client() -> crate::http::Client {
+        crate::http::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
     }
 
     #[tokio::test]
     async fn send_sets_correct_headers() {
-        let mock = MockClient::new(StatusCode::OK);
-        let sender = WebhookSender::new(mock);
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (url, handle) = start_test_server(200).await;
+
+        let sender = WebhookSender::new(test_client());
         let secret = WebhookSecret::new(b"test-key".to_vec());
 
-        let result = sender
-            .send("http://example.com/hook", "msg_123", b"{}", &[&secret])
-            .await;
+        let result = sender.send(&url, "msg_123", b"{}", &[&secret]).await;
         assert!(result.is_ok());
 
-        let headers = sender.inner.client.captured_headers();
-        assert_eq!(headers.get("content-type").unwrap(), "application/json");
-        assert_eq!(headers.get("webhook-id").unwrap(), "msg_123");
-        assert!(headers.get("webhook-timestamp").is_some());
-        assert!(
-            headers
-                .get("webhook-signature")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .starts_with("v1,")
-        );
+        let raw = handle.await.unwrap();
+        assert!(raw.contains("content-type: application/json"));
+        assert!(raw.contains("webhook-id: msg_123"));
+        assert!(raw.contains("webhook-timestamp:"));
+        assert!(raw.contains("webhook-signature: v1,"));
     }
 
     #[tokio::test]
     async fn send_default_user_agent() {
-        let mock = MockClient::new(StatusCode::OK);
-        let sender = WebhookSender::new(mock);
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (url, handle) = start_test_server(200).await;
+
+        let sender = WebhookSender::new(test_client());
         let secret = WebhookSecret::new(b"key".to_vec());
 
-        sender
-            .send("http://example.com/hook", "msg_1", b"{}", &[&secret])
-            .await
-            .unwrap();
+        sender.send(&url, "msg_1", b"{}", &[&secret]).await.unwrap();
 
-        let headers = sender.inner.client.captured_headers();
-        let ua = headers.get("user-agent").unwrap().to_str().unwrap();
-        assert!(ua.starts_with("modo-webhooks/"));
+        let raw = handle.await.unwrap();
+        assert!(raw.contains("user-agent: modo-webhooks/"));
     }
 
     #[tokio::test]
     async fn send_custom_user_agent() {
-        let mock = MockClient::new(StatusCode::OK);
-        let sender = WebhookSender::new(mock).with_user_agent("my-app/2.0");
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (url, handle) = start_test_server(200).await;
+
+        let sender = WebhookSender::new(test_client()).with_user_agent("my-app/2.0");
         let secret = WebhookSecret::new(b"key".to_vec());
 
-        sender
-            .send("http://example.com/hook", "msg_1", b"{}", &[&secret])
-            .await
-            .unwrap();
+        sender.send(&url, "msg_1", b"{}", &[&secret]).await.unwrap();
 
-        let headers = sender.inner.client.captured_headers();
-        assert_eq!(headers.get("user-agent").unwrap(), "my-app/2.0");
+        let raw = handle.await.unwrap();
+        assert!(raw.contains("user-agent: my-app/2.0"));
     }
 
     #[tokio::test]
     async fn send_empty_secrets_rejected() {
-        let mock = MockClient::new(StatusCode::OK);
-        let sender = WebhookSender::new(mock);
+        let sender = WebhookSender::new(test_client());
 
         let result = sender
             .send("http://example.com/hook", "msg_1", b"{}", &[])
@@ -236,8 +222,7 @@ mod tests {
 
     #[tokio::test]
     async fn send_empty_id_rejected() {
-        let mock = MockClient::new(StatusCode::OK);
-        let sender = WebhookSender::new(mock);
+        let sender = WebhookSender::new(test_client());
         let secret = WebhookSecret::new(b"key".to_vec());
 
         let result = sender
@@ -249,34 +234,40 @@ mod tests {
 
     #[tokio::test]
     async fn send_empty_body_accepted() {
-        let mock = MockClient::new(StatusCode::OK);
-        let sender = WebhookSender::new(mock);
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (url, handle) = start_test_server(200).await;
+
+        let sender = WebhookSender::new(test_client());
         let secret = WebhookSecret::new(b"key".to_vec());
 
-        let result = sender
-            .send("http://example.com/hook", "msg_1", b"", &[&secret])
-            .await;
+        let result = sender.send(&url, "msg_1", b"", &[&secret]).await;
         assert!(result.is_ok());
-        assert!(sender.inner.client.captured_body().is_empty());
+
+        let raw = handle.await.unwrap();
+        // The request was sent — verify it reached the server
+        assert!(raw.contains("POST / HTTP/1.1"));
     }
 
     #[tokio::test]
     async fn send_returns_response_status() {
-        let mock = MockClient::new(StatusCode::GONE);
-        let sender = WebhookSender::new(mock);
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let (url, handle) = start_test_server(410).await;
+
+        let sender = WebhookSender::new(test_client());
         let secret = WebhookSecret::new(b"key".to_vec());
 
         let response = sender
-            .send("http://example.com/hook", "msg_1", b"{}", &[&secret])
+            .send(&url, "msg_1", b"{}", &[&secret])
             .await
             .unwrap();
         assert_eq!(response.status, StatusCode::GONE);
+
+        handle.await.unwrap();
     }
 
     #[tokio::test]
     async fn send_invalid_url_rejected() {
-        let mock = MockClient::new(StatusCode::OK);
-        let sender = WebhookSender::new(mock);
+        let sender = WebhookSender::new(test_client());
         let secret = WebhookSecret::new(b"key".to_vec());
 
         let result = sender

--- a/tests/http_client.rs
+++ b/tests/http_client.rs
@@ -1,0 +1,377 @@
+#![cfg(feature = "http-client")]
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+use modo::http::Client;
+
+// ---------------------------------------------------------------------------
+// Test server helpers
+// ---------------------------------------------------------------------------
+
+/// Start a single-connection server that reads the request and sends a canned response.
+/// Returns `(url, handle)` where the handle resolves with the raw request bytes.
+async fn start_server(response: &'static str) -> (String, JoinHandle<Vec<u8>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 8192];
+        let n = stream.read(&mut buf).await.unwrap();
+        buf.truncate(n);
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+        buf
+    });
+
+    (url, handle)
+}
+
+/// Start a multi-connection server that handles each response in order.
+/// Returns `(url, handle)` where the handle resolves when all connections are served.
+async fn start_multi_server(responses: Vec<&'static str>) -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+    let handle = tokio::spawn(async move {
+        for response in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await.unwrap();
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+    });
+    (url, handle)
+}
+
+// ---------------------------------------------------------------------------
+// Canned HTTP responses
+// ---------------------------------------------------------------------------
+
+const OK_JSON: &str = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Type: application/json\r\n",
+    "Content-Length: 14\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "{\"value\":\"hi\"}"
+);
+
+const OK_TEXT: &str = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Type: text/plain\r\n",
+    "Content-Length: 11\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "hello world"
+);
+
+const OK_BYTES: &str = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Type: application/octet-stream\r\n",
+    "Content-Length: 5\r\n",
+    "Connection: close\r\n",
+    "\r\n",
+    "ABCDE"
+);
+
+const OK_EMPTY: &str = concat!(
+    "HTTP/1.1 200 OK\r\n",
+    "Content-Length: 0\r\n",
+    "Connection: close\r\n",
+    "\r\n"
+);
+
+const NOT_FOUND: &str = concat!(
+    "HTTP/1.1 404 Not Found\r\n",
+    "Content-Length: 0\r\n",
+    "Connection: close\r\n",
+    "\r\n"
+);
+
+const SERVICE_UNAVAILABLE: &str = concat!(
+    "HTTP/1.1 503 Service Unavailable\r\n",
+    "Content-Length: 0\r\n",
+    "Connection: close\r\n",
+    "\r\n"
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// GET request with JSON body — deserialise with `.json::<T>()`.
+#[tokio::test]
+async fn get_json_round_trip() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    #[derive(Deserialize)]
+    struct Payload {
+        value: String,
+    }
+
+    let (url, _handle) = start_server(OK_JSON).await;
+    let client = Client::default();
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+    let payload: Payload = resp.json().await.unwrap();
+    assert_eq!(payload.value, "hi");
+}
+
+/// POST with `.json(&payload)` — server receives `Content-Type: application/json`.
+#[tokio::test]
+async fn post_json_body() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    #[derive(Serialize)]
+    struct Body {
+        name: String,
+    }
+
+    let (url, handle) = start_server(OK_EMPTY).await;
+    let client = Client::default();
+    let body = Body { name: "modo".into() };
+    let resp = client.post(&url).json(&body).send().await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+
+    let raw = handle.await.unwrap();
+    let raw_str = String::from_utf8_lossy(&raw);
+    assert!(raw_str.contains("content-type: application/json"));
+    assert!(raw_str.contains(r#""name":"modo""#));
+}
+
+/// Server never responds — request with short per-request timeout returns `Err`.
+#[tokio::test]
+async fn timeout_returns_error() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    // Accept but never respond.
+    let _handle = tokio::spawn(async move {
+        let (_stream, _) = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    });
+
+    // Use a client with no retries and send with a 100ms per-request timeout override.
+    let client = Client::builder().max_retries(0).build();
+    let result = client
+        .get(&url)
+        .timeout(Duration::from_millis(100))
+        .send()
+        .await;
+    assert!(result.is_err(), "expected error, got Ok");
+}
+
+/// Connect to a port that nothing listens on — returns `Err`.
+#[tokio::test]
+async fn connection_refused_returns_error() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    // Bind a listener, get a port, then immediately drop it so nothing is listening.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let url = format!("http://127.0.0.1:{port}");
+    let client = Client::default();
+    let result = client.get(&url).send().await;
+    assert!(result.is_err(), "expected error on refused connection");
+}
+
+/// Server returns 404 — `.error_for_status()` returns `Err`.
+#[tokio::test]
+async fn error_for_status_on_4xx() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, _handle) = start_server(NOT_FOUND).await;
+    let client = Client::default();
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
+    let result = resp.error_for_status();
+    assert!(result.is_err(), "expected Err for 404");
+}
+
+/// Server returns 200 — `.error_for_status()` returns `Ok`.
+#[tokio::test]
+async fn error_for_status_passes_2xx() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, _handle) = start_server(OK_EMPTY).await;
+    let client = Client::default();
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+    let result = resp.error_for_status();
+    assert!(result.is_ok(), "expected Ok for 200");
+}
+
+/// Server returns 503 on first attempt, then 200. Client with max_retries(2) gets 200.
+#[tokio::test]
+async fn retry_on_503() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, _handle) =
+        start_multi_server(vec![SERVICE_UNAVAILABLE, OK_EMPTY]).await;
+
+    let client = Client::builder()
+        .max_retries(2)
+        .retry_backoff(Duration::ZERO)
+        .build();
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), http::StatusCode::OK);
+}
+
+/// `.text()` returns body as UTF-8 string.
+#[tokio::test]
+async fn text_response() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, _handle) = start_server(OK_TEXT).await;
+    let client = Client::default();
+    let resp = client.get(&url).send().await.unwrap();
+    let text = resp.text().await.unwrap();
+    assert_eq!(text, "hello world");
+}
+
+/// `.bytes()` returns raw bytes.
+#[tokio::test]
+async fn bytes_response() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, _handle) = start_server(OK_BYTES).await;
+    let client = Client::default();
+    let resp = client.get(&url).send().await.unwrap();
+    let bytes = resp.bytes().await.unwrap();
+    assert_eq!(&bytes[..], b"ABCDE");
+}
+
+/// `.stream().next()` yields body data.
+#[tokio::test]
+async fn stream_yields_chunks() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, _handle) = start_server(OK_TEXT).await;
+    let client = Client::default();
+    let resp = client.get(&url).send().await.unwrap();
+    let mut stream = resp.stream();
+
+    let mut collected = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.unwrap();
+        collected.extend_from_slice(&bytes);
+    }
+
+    assert_eq!(collected, b"hello world");
+}
+
+/// `client.get("not a url").send().await` returns `Err`.
+#[tokio::test]
+async fn invalid_url_returns_error() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let client = Client::default();
+    let result = client.get("not a url").send().await;
+    assert!(result.is_err(), "expected Err for invalid URL");
+}
+
+/// Server receives `Authorization: Bearer test-token`.
+#[tokio::test]
+async fn bearer_token_header() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, handle) = start_server(OK_EMPTY).await;
+    let client = Client::default();
+    client
+        .get(&url)
+        .bearer_token("test-token")
+        .send()
+        .await
+        .unwrap();
+
+    let raw = handle.await.unwrap();
+    let raw_str = String::from_utf8_lossy(&raw);
+    assert!(
+        raw_str.contains("authorization: Bearer test-token"),
+        "authorization header not found in: {raw_str}"
+    );
+}
+
+/// Server receives URL with `?foo=bar&baz=qux`.
+#[tokio::test]
+async fn query_params_appended() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, handle) = start_server(OK_EMPTY).await;
+    let client = Client::default();
+    client
+        .get(&url)
+        .query(&[("foo", "bar"), ("baz", "qux")])
+        .send()
+        .await
+        .unwrap();
+
+    let raw = handle.await.unwrap();
+    let raw_str = String::from_utf8_lossy(&raw);
+    // The request line should include the query string.
+    assert!(
+        raw_str.contains("?foo=bar&baz=qux"),
+        "query params not found in: {raw_str}"
+    );
+}
+
+/// `response.content_length()` returns the value from the `Content-Length` header.
+#[tokio::test]
+async fn content_length_from_headers() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (url, _handle) = start_server(OK_TEXT).await;
+    let client = Client::default();
+    let resp = client.get(&url).send().await.unwrap();
+    let cl = resp.content_length();
+    assert_eq!(cl, Some(11), "content_length should be 11 for 'hello world'");
+}
+
+/// Client has 30s default timeout; per-request override of 100ms fires quickly.
+#[tokio::test]
+async fn per_request_timeout_override() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    // Accept but never respond.
+    let _handle = tokio::spawn(async move {
+        let (_stream, _) = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    });
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build();
+
+    let start = std::time::Instant::now();
+    let result = client
+        .get(&url)
+        .timeout(Duration::from_millis(100))
+        .send()
+        .await;
+    let elapsed = start.elapsed();
+
+    assert!(result.is_err(), "expected timeout error");
+    // Should have timed out well before the 30s default.
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "per-request timeout did not fire in time: {elapsed:?}"
+    );
+}

--- a/tests/http_client.rs
+++ b/tests/http_client.rs
@@ -137,7 +137,9 @@ async fn post_json_body() {
 
     let (url, handle) = start_server(OK_EMPTY).await;
     let client = Client::default();
-    let body = Body { name: "modo".into() };
+    let body = Body {
+        name: "modo".into(),
+    };
     let resp = client.post(&url).json(&body).send().await.unwrap();
     assert_eq!(resp.status(), http::StatusCode::OK);
 
@@ -219,8 +221,7 @@ async fn error_for_status_passes_2xx() {
 async fn retry_on_503() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let (url, _handle) =
-        start_multi_server(vec![SERVICE_UNAVAILABLE, OK_EMPTY]).await;
+    let (url, _handle) = start_multi_server(vec![SERVICE_UNAVAILABLE, OK_EMPTY]).await;
 
     let client = Client::builder()
         .max_retries(2)
@@ -338,7 +339,11 @@ async fn content_length_from_headers() {
     let client = Client::default();
     let resp = client.get(&url).send().await.unwrap();
     let cl = resp.content_length();
-    assert_eq!(cl, Some(11), "content_length should be 11 for 'hello world'");
+    assert_eq!(
+        cl,
+        Some(11),
+        "content_length should be 11 for 'hello world'"
+    );
 }
 
 /// Client has 30s default timeout; per-request override of 100ms fires quickly.
@@ -356,9 +361,7 @@ async fn per_request_timeout_override() {
         tokio::time::sleep(Duration::from_secs(60)).await;
     });
 
-    let client = Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build();
+    let client = Client::builder().timeout(Duration::from_secs(30)).build();
 
     let start = std::time::Instant::now();
     let result = client

--- a/tests/http_client.rs
+++ b/tests/http_client.rs
@@ -346,6 +346,20 @@ async fn content_length_from_headers() {
     );
 }
 
+/// `bearer_token` with invalid characters (newlines) returns a deferred error at `send()`.
+#[tokio::test]
+async fn bearer_token_invalid_chars_returns_error() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let client = Client::default();
+    let result = client
+        .get("http://127.0.0.1:1")
+        .bearer_token("token\nwith\nnewlines")
+        .send()
+        .await;
+    assert!(result.is_err(), "expected error for invalid bearer token");
+}
+
 /// Client has 30s default timeout; per-request override of 100ms fires quickly.
 #[tokio::test]
 async fn per_request_timeout_override() {

--- a/tests/webhook_integration.rs
+++ b/tests/webhook_integration.rs
@@ -7,7 +7,7 @@ use http::StatusCode;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
-use modo::webhook::{HttpClient, HyperClient, WebhookSecret, WebhookSender, verify_headers};
+use modo::webhook::{WebhookSecret, WebhookSender, verify_headers};
 
 /// Start a minimal HTTP server that captures the request and returns the given status.
 async fn start_test_server(
@@ -37,22 +37,31 @@ async fn start_test_server(
     (url, handle)
 }
 
+fn test_client() -> modo::http::Client {
+    modo::http::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+}
+
 #[tokio::test]
-async fn hyper_client_post_reaches_server() {
+async fn http_client_post_reaches_server() {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let (url, handle) = start_test_server(200).await;
-    let client = HyperClient::new(Duration::from_secs(5));
+    let client = test_client();
 
     let mut headers = http::HeaderMap::new();
     headers.insert("content-type", "application/json".parse().unwrap());
     headers.insert("x-test", "hello".parse().unwrap());
 
     let response = client
-        .post(&url, headers, Bytes::from_static(b"test-body"))
+        .post(&url)
+        .headers(headers)
+        .body(Bytes::from_static(b"test-body"))
+        .send()
         .await
         .unwrap();
 
-    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
 
     let (raw_request, _) = handle.await.unwrap();
     assert!(raw_request.contains("POST / HTTP/1.1"));
@@ -61,7 +70,7 @@ async fn hyper_client_post_reaches_server() {
 }
 
 #[tokio::test]
-async fn hyper_client_timeout_on_slow_server() {
+async fn http_client_timeout_on_slow_server() {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -74,9 +83,13 @@ async fn hyper_client_timeout_on_slow_server() {
         drop(stream);
     });
 
-    let client = HyperClient::new(Duration::from_millis(100));
+    let client = modo::http::Client::builder().build();
+
     let result = client
-        .post(&url, http::HeaderMap::new(), Bytes::new())
+        .post(&url)
+        .body(Bytes::new())
+        .timeout(Duration::from_millis(100))
+        .send()
         .await;
 
     assert!(result.is_err());
@@ -87,7 +100,7 @@ async fn hyper_client_timeout_on_slow_server() {
 async fn end_to_end_send_and_verify() {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let (url, handle) = start_test_server(200).await;
-    let sender = WebhookSender::new(HyperClient::new(Duration::from_secs(5)));
+    let sender = WebhookSender::new(test_client());
     let secret = WebhookSecret::new(b"e2e-test-secret".to_vec());
 
     let body = b"{\"event\":\"test\"}";


### PR DESCRIPTION
## Summary

- Add `http` module (`src/http/`) — ergonomic async HTTP client built on hyper/hyper-rustls with `Arc<Inner>` pattern, connection pooling, retry with exponential backoff and Retry-After support
- New `http-client` feature flag consolidating `dep:hyper`, `dep:hyper-rustls`, `dep:hyper-util`, `dep:http-body-util` — `auth`, `storage`, `webhooks` now depend on it transitively
- Refactor `webhook` module: remove `HttpClient` trait and `HyperClient`, use `http::Client` directly
- Refactor `storage` module: replace per-module hyper connector setup with shared `http::Client`
- Refactor `auth::oauth` module: replace per-call hyper client creation with shared `http::Client`

### Public API

```rust
// Construction
let client = Client::new(&config.http);     // from YAML config
let client = Client::default();             // sensible defaults
let client = Client::builder()              // programmatic
    .timeout(Duration::from_secs(10))
    .max_retries(3)
    .retry_backoff(Duration::from_millis(200))
    .build();

// Request → Response
let resp = client.get("https://api.example.com/data")
    .bearer_token("tok_abc")
    .query(&[("page", "1")])
    .send().await?;

let data: MyStruct = resp.json().await?;
```

### Breaking changes

- `webhook::HttpClient` trait removed — `WebhookSender` now takes `http::Client` directly
- `webhook::HyperClient` removed
- `Google::new()` and `GitHub::new()` now require an `http_client: http::Client` parameter

## Test plan

- [ ] `cargo test --features http-client` — 15 integration tests + unit tests for config, retry, urlencoding
- [ ] `cargo test --features webhooks` — webhook sender tests rewritten with TCP test servers
- [ ] `cargo test --features storage` — storage tests pass with shared client
- [ ] `cargo test --features auth` — OAuth tests pass with shared client
- [ ] `cargo test --features full` — full suite passes
- [ ] `cargo clippy --features full --tests -- -D warnings` — clean