### PR TITLE
feat: add domain-verified signup module

### DIFF
--- a/docs/superpowers/plans/2026-03-27-domain-signup.md
+++ b/docs/superpowers/plans/2026-03-27-domain-signup.md
@@ -1,0 +1,1378 @@
+# Domain-Verified Signup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the `domain_signup` module — lets tenants claim email domains so users with matching verified email auto-join the tenant.
+
+**Architecture:** Concrete `DomainRegistry` struct using `Arc<Inner>` pattern (no trait). Feature-gated behind `dns`. Uses `DomainVerifier::check_txt()` for DNS verification. SQLite-backed with `Pool`. Time-based expiry (48h) for pending claims — `Failed` status is computed on read, never stored.
+
+**Tech Stack:** Rust, sqlx (SQLite), chrono, serde, modo's `dns` module for verification, modo's `id` module for ULID generation.
+
+**Naming note:** The design spec calls the status enum `DomainStatus`, but `dns::DomainStatus` already exists and is re-exported from `lib.rs`. This plan uses `ClaimStatus` instead to avoid the naming conflict.
+
+---
+
+### Task 1: Module scaffold + types
+
+**Files:**
+- Create: `src/domain_signup/mod.rs`
+- Create: `src/domain_signup/types.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Create types.rs**
+
+```rust
+// src/domain_signup/types.rs
+
+use serde::Serialize;
+
+/// Status of a domain ownership claim.
+///
+/// `Pending` and `Verified` are stored in the database. `Failed` is computed
+/// on read when a pending claim has exceeded the 48-hour verification window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ClaimStatus {
+    Pending,
+    Verified,
+    Failed,
+}
+
+/// A tenant's claim on an email domain.
+#[derive(Debug, Clone, Serialize)]
+pub struct DomainClaim {
+    pub id: String,
+    pub tenant_id: String,
+    pub domain: String,
+    pub verification_token: String,
+    pub status: ClaimStatus,
+    pub created_at: String,
+    pub verified_at: Option<String>,
+}
+
+/// Result of a successful domain lookup — identifies which tenant owns a
+/// verified domain.
+#[derive(Debug, Clone, Serialize)]
+pub struct TenantMatch {
+    pub tenant_id: String,
+    pub domain: String,
+}
+```
+
+- [ ] **Step 2: Create mod.rs**
+
+```rust
+// src/domain_signup/mod.rs
+
+//! Domain-verified signup.
+//!
+//! Lets tenants claim email domains so that users with matching verified
+//! email addresses auto-join the tenant. Domain ownership is proved via
+//! DNS TXT record verification using the [`dns`](crate::dns) module.
+//!
+//! # Feature flag
+//!
+//! This module is only compiled when the `dns` feature is enabled.
+//!
+//! ```toml
+//! [dependencies]
+//! modo = { version = "*", features = ["dns"] }
+//! ```
+
+mod types;
+
+pub use types::{ClaimStatus, DomainClaim, TenantMatch};
+```
+
+- [ ] **Step 3: Add module to lib.rs**
+
+Add after the existing `dns` module declaration (after line 74 in `src/lib.rs`):
+
+```rust
+#[cfg(feature = "dns")]
+pub mod domain_signup;
+```
+
+Add re-exports after the existing `dns` re-exports (after line 133 in `src/lib.rs`):
+
+```rust
+#[cfg(feature = "dns")]
+pub use domain_signup::{ClaimStatus, DomainClaim, DomainRegistry, TenantMatch};
+```
+
+**Note:** `DomainRegistry` doesn't exist yet — this line will cause a compile error until Task 4. To keep this step green, temporarily omit `DomainRegistry` from the re-export and add it in Task 4.
+
+Temporary re-export (replace in Task 4):
+```rust
+#[cfg(feature = "dns")]
+pub use domain_signup::{ClaimStatus, DomainClaim, TenantMatch};
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check --features dns`
+
+Expected: compiles with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain_signup/mod.rs src/domain_signup/types.rs src/lib.rs
+git commit -m "feat(domain_signup): add module scaffold and types"
+```
+
+---
+
+### Task 2: Domain validation (TDD)
+
+**Files:**
+- Create: `src/domain_signup/validate.rs`
+- Modify: `src/domain_signup/mod.rs`
+
+- [ ] **Step 1: Create validate.rs with tests only**
+
+```rust
+// src/domain_signup/validate.rs
+
+use crate::error::Result;
+
+/// Validate and normalize a domain name.
+///
+/// Trims whitespace, lowercases, strips a trailing dot, then checks structural
+/// rules (at least one dot, labels are alphanumeric + hyphens, no leading or
+/// trailing hyphens per label, label length ≤ 63, total length ≤ 253).
+///
+/// Returns the normalized domain or `Error::bad_request`.
+pub(crate) fn validate_domain(_domain: &str) -> Result<String> {
+    todo!()
+}
+
+/// Validate an email address and extract its lowercased domain.
+///
+/// Checks for exactly one `@` with a non-empty local part, then validates the
+/// domain portion via [`validate_domain`].
+///
+/// Returns the lowercased domain or `Error::bad_request`.
+pub(crate) fn extract_email_domain(_email: &str) -> Result<String> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- validate_domain: valid inputs --
+
+    #[test]
+    fn valid_simple_domain() {
+        assert_eq!(validate_domain("example.com").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn valid_subdomain() {
+        assert_eq!(validate_domain("sub.example.com").unwrap(), "sub.example.com");
+    }
+
+    #[test]
+    fn valid_trims_whitespace() {
+        assert_eq!(validate_domain("  example.com  ").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn valid_lowercases() {
+        assert_eq!(validate_domain("Example.COM").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn valid_strips_trailing_dot() {
+        assert_eq!(validate_domain("example.com.").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn valid_with_hyphens() {
+        assert_eq!(validate_domain("my-domain.co.uk").unwrap(), "my-domain.co.uk");
+    }
+
+    #[test]
+    fn valid_with_digits() {
+        assert_eq!(validate_domain("123.example.com").unwrap(), "123.example.com");
+    }
+
+    // -- validate_domain: invalid inputs --
+
+    #[test]
+    fn invalid_empty() {
+        let err = validate_domain("").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_whitespace_only() {
+        let err = validate_domain("   ").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_no_dots() {
+        let err = validate_domain("localhost").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_starts_with_hyphen() {
+        let err = validate_domain("-example.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_ends_with_hyphen() {
+        let err = validate_domain("example-.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_empty_label() {
+        let err = validate_domain("example..com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_label_too_long() {
+        let long_label = "a".repeat(64);
+        let err = validate_domain(&format!("{long_label}.com")).unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_total_too_long() {
+        // 254 chars total (over 253 limit)
+        let label = "a".repeat(63);
+        let domain = format!("{label}.{label}.{label}.{label}.com");
+        let err = validate_domain(&domain).unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_contains_space() {
+        let err = validate_domain("exam ple.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_contains_underscore() {
+        let err = validate_domain("ex_ample.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    // -- extract_email_domain --
+
+    #[test]
+    fn email_valid_extracts_domain() {
+        assert_eq!(extract_email_domain("user@example.com").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn email_valid_lowercases_domain() {
+        assert_eq!(extract_email_domain("user@Example.COM").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn email_valid_preserves_complex_local() {
+        assert_eq!(
+            extract_email_domain("user+tag@example.com").unwrap(),
+            "example.com"
+        );
+    }
+
+    #[test]
+    fn email_invalid_no_at() {
+        let err = extract_email_domain("userexample.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn email_invalid_empty_local() {
+        let err = extract_email_domain("@example.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn email_invalid_empty_string() {
+        let err = extract_email_domain("").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn email_invalid_domain_part() {
+        let err = extract_email_domain("user@localhost").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+}
+```
+
+- [ ] **Step 2: Add validate module to mod.rs**
+
+Update `src/domain_signup/mod.rs` — add before the `pub use` line:
+
+```rust
+mod validate;
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test --features dns domain_signup::validate 2>&1 | head -30`
+
+Expected: All tests FAIL with `not yet implemented`.
+
+- [ ] **Step 4: Implement validate_domain**
+
+Replace the `validate_domain` function body in `src/domain_signup/validate.rs`:
+
+```rust
+pub(crate) fn validate_domain(domain: &str) -> Result<String> {
+    use crate::error::Error;
+
+    let domain = domain.trim().to_lowercase();
+    let domain = domain.strip_suffix('.').unwrap_or(&domain);
+
+    if domain.is_empty() {
+        return Err(Error::bad_request("Invalid domain: empty"));
+    }
+
+    if domain.len() > 253 {
+        return Err(Error::bad_request("Invalid domain: exceeds 253 characters"));
+    }
+
+    if !domain.contains('.') {
+        return Err(Error::bad_request("Invalid domain: must contain at least one dot"));
+    }
+
+    for label in domain.split('.') {
+        if label.is_empty() {
+            return Err(Error::bad_request("Invalid domain: empty label"));
+        }
+        if label.len() > 63 {
+            return Err(Error::bad_request("Invalid domain: label exceeds 63 characters"));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(Error::bad_request(
+                "Invalid domain: label must not start or end with a hyphen",
+            ));
+        }
+        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return Err(Error::bad_request(
+                "Invalid domain: labels may only contain alphanumeric characters and hyphens",
+            ));
+        }
+    }
+
+    Ok(domain.to_owned())
+}
+```
+
+- [ ] **Step 5: Implement extract_email_domain**
+
+Replace the `extract_email_domain` function body in `src/domain_signup/validate.rs`:
+
+```rust
+pub(crate) fn extract_email_domain(email: &str) -> Result<String> {
+    use crate::error::Error;
+
+    let (local, domain) = email
+        .rsplit_once('@')
+        .ok_or_else(|| Error::bad_request("Invalid email address"))?;
+
+    if local.is_empty() {
+        return Err(Error::bad_request("Invalid email address"));
+    }
+
+    validate_domain(domain)
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --features dns domain_signup::validate`
+
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/domain_signup/validate.rs src/domain_signup/mod.rs
+git commit -m "feat(domain_signup): add domain and email validation"
+```
+
+---
+
+### Task 3: DNS test helper
+
+**Files:**
+- Modify: `src/dns/verifier.rs`
+
+The `DomainVerifier` struct keeps its `inner` field private (per modo convention). To enable `domain_signup` tests to create a verifier with a mock DNS resolver, add a `pub(crate)` test constructor.
+
+- [ ] **Step 1: Add with_resolver constructor to DomainVerifier**
+
+Add this method to the `impl DomainVerifier` block in `src/dns/verifier.rs`, after the `from_config` method (after line 81):
+
+```rust
+    /// Create a verifier with a custom resolver and TXT record prefix.
+    ///
+    /// Used by other in-crate modules to build a `DomainVerifier` backed by a
+    /// mock resolver for testing.
+    #[cfg_attr(not(any(test, feature = "dns-test")), allow(dead_code))]
+    pub(crate) fn with_resolver(
+        resolver: impl DnsResolver + 'static,
+        txt_prefix: impl Into<String>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                resolver: Arc::new(resolver),
+                txt_prefix: txt_prefix.into(),
+            }),
+        }
+    }
+```
+
+- [ ] **Step 2: Verify existing dns tests still pass**
+
+Run: `cargo test --features dns dns::`
+
+Expected: All existing dns tests PASS (no regressions).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/dns/verifier.rs
+git commit -m "feat(dns): add pub(crate) test constructor for DomainVerifier"
+```
+
+---
+
+### Task 4: DomainRegistry struct + register() (TDD)
+
+**Files:**
+- Create: `src/domain_signup/registry.rs`
+- Modify: `src/domain_signup/mod.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Create registry.rs with struct, constructor, DomainRow, row_to_claim, and register() stubs**
+
+```rust
+// src/domain_signup/registry.rs
+
+use std::sync::Arc;
+
+use crate::db::Pool;
+use crate::dns::DomainVerifier;
+use crate::error::{Error, Result};
+
+use super::types::{ClaimStatus, DomainClaim, TenantMatch};
+use super::validate;
+
+/// Hours before a pending domain claim expires.
+const VERIFICATION_DURATION_HOURS: i64 = 48;
+
+struct Inner {
+    pool: Pool,
+    verifier: DomainVerifier,
+}
+
+/// Domain ownership registry.
+///
+/// Manages tenant domain claims and DNS-based verification. Tenants register
+/// domains, prove ownership via TXT records, and verified domains are used to
+/// auto-assign users with matching email addresses to the tenant.
+///
+/// Cheap to clone (`Arc<Inner>`). Inject into handlers via
+/// [`Service<DomainRegistry>`](crate::Service).
+pub struct DomainRegistry {
+    inner: Arc<Inner>,
+}
+
+impl Clone for DomainRegistry {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl DomainRegistry {
+    /// Create a new registry backed by the given database pool and DNS
+    /// verifier.
+    pub fn new(pool: Pool, verifier: DomainVerifier) -> Self {
+        Self {
+            inner: Arc::new(Inner { pool, verifier }),
+        }
+    }
+
+    /// Register a domain claim for a tenant.
+    ///
+    /// Validates the domain format, generates a verification token, and
+    /// inserts a new pending claim. The admin must set a TXT record at
+    /// `_modo-verify.{domain}` with the returned token value, then call
+    /// [`verify`](Self::verify) to complete ownership verification.
+    pub async fn register(&self, _tenant_id: &str, _domain: &str) -> Result<DomainClaim> {
+        todo!()
+    }
+}
+
+/// Internal row type for sqlx queries.
+#[derive(sqlx::FromRow)]
+struct DomainRow {
+    id: String,
+    tenant_id: String,
+    domain: String,
+    verification_token: String,
+    status: String,
+    created_at: String,
+    verified_at: Option<String>,
+}
+
+/// Convert a database row to a `DomainClaim`, computing `Failed` status for
+/// expired pending claims.
+fn row_to_claim(row: DomainRow) -> DomainClaim {
+    let status = match row.status.as_str() {
+        "verified" => ClaimStatus::Verified,
+        _ => {
+            if let Ok(created) = chrono::DateTime::parse_from_rfc3339(&row.created_at) {
+                let elapsed = chrono::Utc::now() - created.with_timezone(&chrono::Utc);
+                if elapsed > chrono::Duration::hours(VERIFICATION_DURATION_HOURS) {
+                    ClaimStatus::Failed
+                } else {
+                    ClaimStatus::Pending
+                }
+            } else {
+                ClaimStatus::Pending
+            }
+        }
+    };
+
+    DomainClaim {
+        id: row.id,
+        tenant_id: row.tenant_id,
+        domain: row.domain,
+        verification_token: row.verification_token,
+        status,
+        created_at: row.created_at,
+        verified_at: row.verified_at,
+    }
+}
+```
+
+- [ ] **Step 2: Add registry module to mod.rs and update re-exports**
+
+Update `src/domain_signup/mod.rs`:
+
+```rust
+//! Domain-verified signup.
+//!
+//! Lets tenants claim email domains so that users with matching verified
+//! email addresses auto-join the tenant. Domain ownership is proved via
+//! DNS TXT record verification using the [`dns`](crate::dns) module.
+//!
+//! # Feature flag
+//!
+//! This module is only compiled when the `dns` feature is enabled.
+//!
+//! ```toml
+//! [dependencies]
+//! modo = { version = "*", features = ["dns"] }
+//! ```
+
+mod registry;
+mod types;
+mod validate;
+
+pub use registry::DomainRegistry;
+pub use types::{ClaimStatus, DomainClaim, TenantMatch};
+```
+
+- [ ] **Step 3: Add DomainRegistry to lib.rs re-exports**
+
+In `src/lib.rs`, update the domain_signup re-export line to include `DomainRegistry`:
+
+```rust
+#[cfg(feature = "dns")]
+pub use domain_signup::{ClaimStatus, DomainClaim, DomainRegistry, TenantMatch};
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check --features dns`
+
+Expected: compiles (the `todo!()` is fine at type-check time).
+
+- [ ] **Step 5: Write register() tests**
+
+Add at the bottom of `src/domain_signup/registry.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dns::resolver::DnsResolver;
+    use std::collections::HashMap;
+    use std::pin::Pin;
+    use std::sync::Mutex;
+
+    // -- Test infrastructure --
+
+    const CREATE_TABLE: &str = "\
+        CREATE TABLE tenant_domains (\
+            id                 TEXT PRIMARY KEY,\
+            tenant_id          TEXT NOT NULL,\
+            domain             TEXT NOT NULL,\
+            verification_token TEXT NOT NULL,\
+            status             TEXT NOT NULL DEFAULT 'pending',\
+            created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),\
+            verified_at        TEXT\
+        )";
+    const CREATE_INDEX_TD: &str =
+        "CREATE INDEX idx_tenant_domains_tenant_domain ON tenant_domains(tenant_id, domain)";
+    const CREATE_INDEX_VERIFIED: &str =
+        "CREATE UNIQUE INDEX idx_tenant_domains_verified ON tenant_domains(domain) WHERE status = 'verified'";
+
+    /// Mock DNS resolver with mutable TXT record state.
+    #[derive(Clone)]
+    struct MockResolver {
+        txt_records: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    }
+
+    impl MockResolver {
+        fn new() -> Self {
+            Self {
+                txt_records: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        fn set_txt(&self, domain: &str, records: Vec<String>) {
+            self.txt_records
+                .lock()
+                .unwrap()
+                .insert(domain.to_owned(), records);
+        }
+    }
+
+    impl DnsResolver for MockResolver {
+        fn resolve_txt(
+            &self,
+            domain: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + '_>> {
+            let records = self
+                .txt_records
+                .lock()
+                .unwrap()
+                .get(domain)
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move { Ok(records) })
+        }
+
+        fn resolve_cname(
+            &self,
+            _domain: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<String>>> + Send + '_>> {
+            Box::pin(async { Ok(None) })
+        }
+    }
+
+    async fn setup() -> (DomainRegistry, MockResolver) {
+        let config = crate::db::SqliteConfig {
+            path: ":memory:".to_string(),
+            ..Default::default()
+        };
+        let pool = crate::db::connect(&config).await.unwrap();
+
+        sqlx::query(CREATE_TABLE).execute(&*pool).await.unwrap();
+        sqlx::query(CREATE_INDEX_TD).execute(&*pool).await.unwrap();
+        sqlx::query(CREATE_INDEX_VERIFIED)
+            .execute(&*pool)
+            .await
+            .unwrap();
+
+        let mock = MockResolver::new();
+        let verifier = DomainVerifier::with_resolver(mock.clone(), "_modo-verify");
+        let registry = DomainRegistry::new(pool, verifier);
+
+        (registry, mock)
+    }
+
+    // -- register tests --
+
+    #[tokio::test]
+    async fn register_creates_pending_claim() {
+        let (reg, _mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+
+        assert_eq!(claim.tenant_id, "tenant1");
+        assert_eq!(claim.domain, "example.com");
+        assert_eq!(claim.status, ClaimStatus::Pending);
+        assert!(!claim.id.is_empty());
+        assert!(!claim.verification_token.is_empty());
+        assert!(!claim.created_at.is_empty());
+        assert!(claim.verified_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn register_lowercases_domain() {
+        let (reg, _mock) = setup().await;
+        let claim = reg.register("tenant1", "EXAMPLE.COM").await.unwrap();
+        assert_eq!(claim.domain, "example.com");
+    }
+
+    #[tokio::test]
+    async fn register_invalid_domain_returns_bad_request() {
+        let (reg, _mock) = setup().await;
+        let err = reg.register("tenant1", "localhost").await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn register_multiple_domains_for_same_tenant() {
+        let (reg, _mock) = setup().await;
+        let c1 = reg.register("tenant1", "example.com").await.unwrap();
+        let c2 = reg.register("tenant1", "example.org").await.unwrap();
+        assert_ne!(c1.id, c2.id);
+        assert_ne!(c1.domain, c2.domain);
+    }
+
+    #[tokio::test]
+    async fn register_same_domain_multiple_tenants() {
+        let (reg, _mock) = setup().await;
+        let c1 = reg.register("tenant1", "example.com").await.unwrap();
+        let c2 = reg.register("tenant2", "example.com").await.unwrap();
+        assert_ne!(c1.id, c2.id);
+        assert_eq!(c1.domain, c2.domain);
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `cargo test --features dns domain_signup::registry::tests::register 2>&1 | head -20`
+
+Expected: FAIL with `not yet implemented`.
+
+- [ ] **Step 7: Implement register()**
+
+Replace the `register` method body in `src/domain_signup/registry.rs`:
+
+```rust
+    pub async fn register(&self, tenant_id: &str, domain: &str) -> Result<DomainClaim> {
+        let domain = validate::validate_domain(domain)?;
+        let id = crate::id::ulid();
+        let token = crate::dns::generate_verification_token();
+        let now = chrono::Utc::now()
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+            .to_string();
+
+        match sqlx::query(
+            "INSERT INTO tenant_domains (id, tenant_id, domain, verification_token, created_at) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(tenant_id)
+        .bind(&domain)
+        .bind(&token)
+        .bind(&now)
+        .execute(&*self.inner.pool)
+        .await
+        {
+            Ok(_) => Ok(DomainClaim {
+                id,
+                tenant_id: tenant_id.to_owned(),
+                domain,
+                verification_token: token,
+                status: ClaimStatus::Pending,
+                created_at: now,
+                verified_at: None,
+            }),
+            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                Err(Error::conflict("Domain already verified by this tenant"))
+            }
+            Err(e) => Err(Error::internal(format!("register domain: {e}"))),
+        }
+    }
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cargo test --features dns domain_signup::registry::tests::register`
+
+Expected: All register tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/domain_signup/registry.rs src/domain_signup/mod.rs src/lib.rs
+git commit -m "feat(domain_signup): add DomainRegistry struct and register()"
+```
+
+---
+
+### Task 5: DomainRegistry::verify() (TDD)
+
+**Files:**
+- Modify: `src/domain_signup/registry.rs`
+
+- [ ] **Step 1: Add verify() stub**
+
+Add to the `impl DomainRegistry` block in `src/domain_signup/registry.rs`, after `register()`:
+
+```rust
+    /// Check DNS verification for a pending claim.
+    ///
+    /// If the TXT record at `_modo-verify.{domain}` matches the claim's token,
+    /// the claim transitions to `Verified`. If the 48-hour verification window
+    /// has expired, returns the claim with `Failed` status. If the DNS record
+    /// is not yet present, returns the claim as `Pending`.
+    ///
+    /// Returns `Error::not_found` if no claim exists with this id.
+    /// Returns `Error::conflict` if another tenant has already verified this
+    /// domain.
+    pub async fn verify(&self, id: &str) -> Result<DomainClaim> {
+        todo!()
+    }
+```
+
+- [ ] **Step 2: Write verify() tests**
+
+Add to the `#[cfg(test)] mod tests` block in `src/domain_signup/registry.rs`:
+
+```rust
+    // -- verify tests --
+
+    #[tokio::test]
+    async fn verify_success_transitions_to_verified() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+
+        // Configure mock to return the generated token.
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+
+        let verified = reg.verify(&claim.id).await.unwrap();
+        assert_eq!(verified.status, ClaimStatus::Verified);
+        assert!(verified.verified_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn verify_dns_miss_stays_pending() {
+        let (reg, _mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        // Mock has no TXT records → DNS miss.
+
+        let result = reg.verify(&claim.id).await.unwrap();
+        assert_eq!(result.status, ClaimStatus::Pending);
+        assert!(result.verified_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn verify_expired_claim_returns_failed() {
+        let (reg, _mock) = setup().await;
+
+        // Insert a claim with a created_at in the distant past.
+        let id = crate::id::ulid();
+        let token = crate::dns::generate_verification_token();
+        sqlx::query(
+            "INSERT INTO tenant_domains (id, tenant_id, domain, verification_token, status, created_at) \
+             VALUES (?, ?, ?, ?, 'pending', ?)",
+        )
+        .bind(&id)
+        .bind("tenant1")
+        .bind("expired.com")
+        .bind(&token)
+        .bind("2020-01-01T00:00:00.000Z")
+        .execute(&*reg.inner.pool)
+        .await
+        .unwrap();
+
+        let result = reg.verify(&id).await.unwrap();
+        assert_eq!(result.status, ClaimStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn verify_already_verified_returns_as_is() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        let first = reg.verify(&claim.id).await.unwrap();
+        assert_eq!(first.status, ClaimStatus::Verified);
+
+        // Clear mock — second verify should still return Verified from DB.
+        mock.set_txt(&format!("_modo-verify.{}", claim.domain), vec![]);
+        let second = reg.verify(&claim.id).await.unwrap();
+        assert_eq!(second.status, ClaimStatus::Verified);
+    }
+
+    #[tokio::test]
+    async fn verify_not_found_returns_error() {
+        let (reg, _mock) = setup().await;
+        let err = reg.verify("nonexistent-id").await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn verify_conflict_when_domain_already_verified_by_other_tenant() {
+        let (reg, mock) = setup().await;
+
+        // Tenant 1 registers and verifies.
+        let c1 = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", c1.domain),
+            vec![c1.verification_token.clone()],
+        );
+        let v1 = reg.verify(&c1.id).await.unwrap();
+        assert_eq!(v1.status, ClaimStatus::Verified);
+
+        // Tenant 2 registers the same domain.
+        let c2 = reg.register("tenant2", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", c2.domain),
+            vec![c2.verification_token.clone()],
+        );
+
+        // Tenant 2 tries to verify → conflict.
+        let err = reg.verify(&c2.id).await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::CONFLICT);
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test --features dns domain_signup::registry::tests::verify 2>&1 | head -20`
+
+Expected: FAIL with `not yet implemented`.
+
+- [ ] **Step 4: Implement verify()**
+
+Replace the `verify` method body in `src/domain_signup/registry.rs`:
+
+```rust
+    pub async fn verify(&self, id: &str) -> Result<DomainClaim> {
+        let row = sqlx::query_as::<_, DomainRow>(
+            "SELECT id, tenant_id, domain, verification_token, status, created_at, verified_at \
+             FROM tenant_domains WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&*self.inner.pool)
+        .await
+        .map_err(|e| Error::internal(format!("fetch domain claim: {e}")))?
+        .ok_or_else(|| Error::not_found("Domain claim not found"))?;
+
+        // Already verified — return as-is.
+        if row.status == "verified" {
+            return Ok(row_to_claim(row));
+        }
+
+        // Check expiry.
+        let created = chrono::DateTime::parse_from_rfc3339(&row.created_at)
+            .map_err(|e| Error::internal(format!("parse created_at: {e}")))?
+            .with_timezone(&chrono::Utc);
+        if chrono::Utc::now() - created > chrono::Duration::hours(VERIFICATION_DURATION_HOURS) {
+            return Ok(DomainClaim {
+                status: ClaimStatus::Failed,
+                ..row_to_claim(row)
+            });
+        }
+
+        // DNS check.
+        let verified = self
+            .inner
+            .verifier
+            .check_txt(&row.domain, &row.verification_token)
+            .await?;
+
+        if !verified {
+            return Ok(row_to_claim(row));
+        }
+
+        // Transition to verified.
+        let now = chrono::Utc::now()
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+            .to_string();
+        match sqlx::query(
+            "UPDATE tenant_domains SET status = 'verified', verified_at = ? WHERE id = ?",
+        )
+        .bind(&now)
+        .bind(id)
+        .execute(&*self.inner.pool)
+        .await
+        {
+            Ok(_) => Ok(DomainClaim {
+                id: row.id,
+                tenant_id: row.tenant_id,
+                domain: row.domain,
+                verification_token: row.verification_token,
+                status: ClaimStatus::Verified,
+                created_at: row.created_at,
+                verified_at: Some(now),
+            }),
+            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                Err(Error::conflict("Domain already verified by another tenant"))
+            }
+            Err(e) => Err(Error::internal(format!("update domain status: {e}"))),
+        }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --features dns domain_signup::registry::tests::verify`
+
+Expected: All verify tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain_signup/registry.rs
+git commit -m "feat(domain_signup): implement verify() with expiry and conflict handling"
+```
+
+---
+
+### Task 6: remove(), lookup, and list methods (TDD)
+
+**Files:**
+- Modify: `src/domain_signup/registry.rs`
+
+- [ ] **Step 1: Add method stubs**
+
+Add to the `impl DomainRegistry` block, after `verify()`:
+
+```rust
+    /// Remove a domain claim by id.
+    ///
+    /// Idempotent — returns `Ok(())` even if no claim exists with this id.
+    pub async fn remove(&self, id: &str) -> Result<()> {
+        todo!()
+    }
+
+    /// Look up which tenant owns a verified domain.
+    ///
+    /// Validates the domain format. Returns `None` if no tenant has a verified
+    /// claim for this domain.
+    pub async fn lookup_domain(&self, domain: &str) -> Result<Option<TenantMatch>> {
+        todo!()
+    }
+
+    /// Look up which tenant owns the domain of a given email address.
+    ///
+    /// Validates the email format, extracts and lowercases the domain, then
+    /// checks for a verified claim. Returns `None` if no match.
+    pub async fn lookup_email(&self, email: &str) -> Result<Option<TenantMatch>> {
+        todo!()
+    }
+
+    /// List all domain claims for a tenant.
+    ///
+    /// Returns claims in all states. Expired pending claims are returned with
+    /// `ClaimStatus::Failed`.
+    pub async fn list(&self, tenant_id: &str) -> Result<Vec<DomainClaim>> {
+        todo!()
+    }
+```
+
+- [ ] **Step 2: Write tests for all remaining methods**
+
+Add to the `#[cfg(test)] mod tests` block:
+
+```rust
+    // -- remove tests --
+
+    #[tokio::test]
+    async fn remove_deletes_claim() {
+        let (reg, _mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+
+        reg.remove(&claim.id).await.unwrap();
+
+        let list = reg.list("tenant1").await.unwrap();
+        assert!(list.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remove_idempotent_on_missing_id() {
+        let (reg, _mock) = setup().await;
+        reg.remove("nonexistent-id").await.unwrap();
+    }
+
+    // -- lookup_domain tests --
+
+    #[tokio::test]
+    async fn lookup_domain_finds_verified() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        reg.verify(&claim.id).await.unwrap();
+
+        let result = reg.lookup_domain("example.com").await.unwrap();
+        assert!(result.is_some());
+        let m = result.unwrap();
+        assert_eq!(m.tenant_id, "tenant1");
+        assert_eq!(m.domain, "example.com");
+    }
+
+    #[tokio::test]
+    async fn lookup_domain_ignores_pending() {
+        let (reg, _mock) = setup().await;
+        reg.register("tenant1", "example.com").await.unwrap();
+
+        let result = reg.lookup_domain("example.com").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn lookup_domain_validates_input() {
+        let (reg, _mock) = setup().await;
+        let err = reg.lookup_domain("localhost").await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn lookup_domain_case_insensitive() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        reg.verify(&claim.id).await.unwrap();
+
+        let result = reg.lookup_domain("EXAMPLE.COM").await.unwrap();
+        assert!(result.is_some());
+    }
+
+    // -- lookup_email tests --
+
+    #[tokio::test]
+    async fn lookup_email_finds_match() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        reg.verify(&claim.id).await.unwrap();
+
+        let result = reg.lookup_email("user@example.com").await.unwrap();
+        assert!(result.is_some());
+        let m = result.unwrap();
+        assert_eq!(m.tenant_id, "tenant1");
+        assert_eq!(m.domain, "example.com");
+    }
+
+    #[tokio::test]
+    async fn lookup_email_case_insensitive() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        reg.verify(&claim.id).await.unwrap();
+
+        let result = reg.lookup_email("User@EXAMPLE.COM").await.unwrap();
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn lookup_email_invalid_returns_bad_request() {
+        let (reg, _mock) = setup().await;
+        let err = reg.lookup_email("not-an-email").await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn lookup_email_no_match_returns_none() {
+        let (reg, _mock) = setup().await;
+        let result = reg.lookup_email("user@unknown.com").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    // -- list tests --
+
+    #[tokio::test]
+    async fn list_returns_all_claims_for_tenant() {
+        let (reg, _mock) = setup().await;
+        reg.register("tenant1", "example.com").await.unwrap();
+        reg.register("tenant1", "example.org").await.unwrap();
+        reg.register("tenant2", "other.com").await.unwrap();
+
+        let list = reg.list("tenant1").await.unwrap();
+        assert_eq!(list.len(), 2);
+        assert!(list.iter().all(|c| c.tenant_id == "tenant1"));
+    }
+
+    #[tokio::test]
+    async fn list_computes_failed_for_expired() {
+        let (reg, _mock) = setup().await;
+
+        // Insert an expired claim directly.
+        let id = crate::id::ulid();
+        let token = crate::dns::generate_verification_token();
+        sqlx::query(
+            "INSERT INTO tenant_domains (id, tenant_id, domain, verification_token, status, created_at) \
+             VALUES (?, ?, ?, ?, 'pending', ?)",
+        )
+        .bind(&id)
+        .bind("tenant1")
+        .bind("expired.com")
+        .bind(&token)
+        .bind("2020-01-01T00:00:00.000Z")
+        .execute(&*reg.inner.pool)
+        .await
+        .unwrap();
+
+        let list = reg.list("tenant1").await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].status, ClaimStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn list_empty_for_unknown_tenant() {
+        let (reg, _mock) = setup().await;
+        let list = reg.list("unknown").await.unwrap();
+        assert!(list.is_empty());
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test --features dns domain_signup::registry::tests 2>&1 | tail -20`
+
+Expected: New tests FAIL with `not yet implemented`, register/verify tests still PASS.
+
+- [ ] **Step 4: Implement remove()**
+
+Replace the `remove` method body:
+
+```rust
+    pub async fn remove(&self, id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM tenant_domains WHERE id = ?")
+            .bind(id)
+            .execute(&*self.inner.pool)
+            .await
+            .map_err(|e| Error::internal(format!("remove domain: {e}")))?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 5: Implement lookup helpers**
+
+Add a private helper method to `impl DomainRegistry`, before `lookup_domain()`:
+
+```rust
+    /// Shared query for lookup_domain and lookup_email.
+    async fn lookup_verified_domain(&self, domain: &str) -> Result<Option<TenantMatch>> {
+        let row = sqlx::query_as::<_, (String, String)>(
+            "SELECT tenant_id, domain FROM tenant_domains \
+             WHERE domain = ? AND status = 'verified'",
+        )
+        .bind(domain)
+        .fetch_optional(&*self.inner.pool)
+        .await
+        .map_err(|e| Error::internal(format!("lookup domain: {e}")))?;
+
+        Ok(row.map(|(tenant_id, domain)| TenantMatch { tenant_id, domain }))
+    }
+```
+
+- [ ] **Step 6: Implement lookup_domain()**
+
+Replace the `lookup_domain` method body:
+
+```rust
+    pub async fn lookup_domain(&self, domain: &str) -> Result<Option<TenantMatch>> {
+        let domain = validate::validate_domain(domain)?;
+        self.lookup_verified_domain(&domain).await
+    }
+```
+
+- [ ] **Step 7: Implement lookup_email()**
+
+Replace the `lookup_email` method body:
+
+```rust
+    pub async fn lookup_email(&self, email: &str) -> Result<Option<TenantMatch>> {
+        let domain = validate::extract_email_domain(email)?;
+        self.lookup_verified_domain(&domain).await
+    }
+```
+
+- [ ] **Step 8: Implement list()**
+
+Replace the `list` method body:
+
+```rust
+    pub async fn list(&self, tenant_id: &str) -> Result<Vec<DomainClaim>> {
+        let rows = sqlx::query_as::<_, DomainRow>(
+            "SELECT id, tenant_id, domain, verification_token, status, created_at, verified_at \
+             FROM tenant_domains WHERE tenant_id = ?",
+        )
+        .bind(tenant_id)
+        .fetch_all(&*self.inner.pool)
+        .await
+        .map_err(|e| Error::internal(format!("list domains: {e}")))?;
+
+        Ok(rows.into_iter().map(row_to_claim).collect())
+    }
+```
+
+- [ ] **Step 9: Run all tests**
+
+Run: `cargo test --features dns domain_signup::registry::tests`
+
+Expected: All tests PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/domain_signup/registry.rs
+git commit -m "feat(domain_signup): implement remove, lookup, and list methods"
+```
+
+---
+
+### Task 7: Final verification
+
+**Files:** None (read-only checks).
+
+- [ ] **Step 1: Run full test suite with dns feature**
+
+Run: `cargo test --features dns`
+
+Expected: All tests PASS (domain_signup + existing modules).
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy --features dns --tests -- -D warnings`
+
+Expected: No warnings. If there are warnings, fix them.
+
+- [ ] **Step 3: Run formatter check**
+
+Run: `cargo fmt --check`
+
+Expected: No formatting issues. If there are issues, run `cargo fmt` and commit.
+
+- [ ] **Step 4: Final commit (if any fixes needed)**
+
+```bash
+git add -A
+git commit -m "fix(domain_signup): address clippy and formatting issues"
+```
+
+Only create this commit if Step 2 or Step 3 required changes.

--- a/docs/superpowers/specs/2026-03-27-domain-signup-design.md
+++ b/docs/superpowers/specs/2026-03-27-domain-signup-design.md
@@ -1,0 +1,339 @@
+# Domain-Verified Signup (`domain_signup`) — Design Spec
+
+Module for the modo Rust framework that lets tenants claim email domains so users with matching verified email addresses auto-join the tenant. Enables "everyone at @acme.com can sign in" without SSO/IdP integration.
+
+## Feature Gate
+
+Gated behind `#[cfg(feature = "dns")]`. The module requires `dns::DomainVerifier` and `dns::generate_verification_token()`, so it compiles only when the `dns` feature is enabled. No new feature flag or dependency.
+
+## Module Structure
+
+```
+src/domain_signup/
+  mod.rs        — pub use re-exports only
+  registry.rs   — DomainRegistry struct + all methods
+  types.rs      — DomainClaim, DomainStatus, TenantMatch
+  validate.rs   — validate_domain(), extract_email_domain()
+```
+
+Re-exported from `lib.rs`:
+
+```rust
+#[cfg(feature = "dns")]
+pub mod domain_signup;
+
+#[cfg(feature = "dns")]
+pub use domain_signup::{DomainClaim, DomainRegistry, DomainStatus, TenantMatch};
+```
+
+---
+
+## Types
+
+```rust
+pub struct DomainClaim {
+    pub id: String,                  // ULID
+    pub tenant_id: String,
+    pub domain: String,
+    pub verification_token: String,
+    pub status: DomainStatus,
+    pub created_at: String,          // ISO 8601
+    pub verified_at: Option<String>, // ISO 8601
+}
+
+pub enum DomainStatus {
+    Pending,
+    Verified,
+    Failed,  // computed, never stored — see Verification Duration
+}
+
+pub struct TenantMatch {
+    pub tenant_id: String,
+    pub domain: String,
+}
+```
+
+- `DomainStatus` serializes as lowercase: `"pending"`, `"verified"`, `"failed"`.
+- `DomainClaim` implements `Serialize` for JSON API responses.
+- `DomainStatus::Failed` is never written to the database. It is computed when reading a row where `status = 'pending'` and `created_at + 48h < now()`.
+
+---
+
+## Verification Duration
+
+A pending claim has a 48-hour window to complete DNS verification.
+
+```rust
+const VERIFICATION_DURATION: Duration = Duration::from_secs(48 * 3600);
+```
+
+Hardcoded constant — not configurable per deployment.
+
+**Status derivation when reading a pending row:**
+- DNS check fails and `created_at + 48h > now()` → `Pending` (still in window, can retry)
+- DNS check fails and `created_at + 48h < now()` → `Failed` (expired)
+
+A `Failed` claim cannot be retried. The admin must `remove()` and `register()` again to get a fresh 48-hour window.
+
+Expired claims are not automatically cleaned up. They remain in the DB with `status = 'pending'` until the admin explicitly removes them. The `Failed` status is computed on read.
+
+---
+
+## DomainRegistry
+
+Concrete struct using the `Arc<Inner>` pattern. No trait — tests use the real struct with a test DB.
+
+```rust
+pub struct DomainRegistry {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    pool: Pool,
+    verifier: DomainVerifier,
+}
+```
+
+Cheaply cloneable. Injected into handlers via `Service<DomainRegistry>`.
+
+### Constructor
+
+```rust
+impl DomainRegistry {
+    pub fn new(pool: Pool, verifier: DomainVerifier) -> Self
+}
+```
+
+### Methods
+
+```rust
+impl DomainRegistry {
+    /// Register a domain claim for a tenant. Validates domain format,
+    /// generates a verification token. Always creates a new row.
+    pub async fn register(&self, tenant_id: &str, domain: &str) -> Result<DomainClaim>
+
+    /// Check DNS verification for a claim by id. If within 48h window and
+    /// TXT record matches, transitions to Verified. If past 48h, returns
+    /// Failed status. Returns error if claim not found.
+    pub async fn verify(&self, id: &str) -> Result<DomainClaim>
+
+    /// Remove a domain claim by id. Idempotent — no error if not found.
+    pub async fn remove(&self, id: &str) -> Result<()>
+
+    /// Look up which tenant owns a verified domain. Returns None if no
+    /// verified claim exists.
+    pub async fn lookup_domain(&self, domain: &str) -> Result<Option<TenantMatch>>
+
+    /// Extract domain from email, look up verified tenant. Validates email
+    /// format. Returns None if no verified match.
+    pub async fn lookup_email(&self, email: &str) -> Result<Option<TenantMatch>>
+
+    /// List all domain claims for a tenant. Computes Failed status for
+    /// expired pending claims.
+    pub async fn list(&self, tenant_id: &str) -> Result<Vec<DomainClaim>>
+}
+```
+
+### Method Behavior
+
+**`register(tenant_id, domain)`**
+1. Validate domain via `validate_domain()` → lowercased, structural checks.
+2. Generate token via `dns::generate_verification_token()`.
+3. Generate id via `id::ulid()`.
+4. `INSERT INTO tenant_domains (id, tenant_id, domain, verification_token) VALUES (?, ?, ?, ?)`.
+5. A tenant can register multiple domains. Multiple tenants can have pending claims for the same domain. If this tenant already has a verified claim for this domain, the partial unique index fires — catch `is_unique_violation()` → `Error::conflict("Domain already verified by this tenant")`.
+6. Return the new `DomainClaim` with `Pending` status.
+
+**`verify(id)`**
+1. Fetch the claim by id. Not found → `Error::not_found("Domain claim not found")`.
+2. If already `verified`, return as-is.
+3. Check expiry: if `created_at + 48h < now()`, return `DomainClaim` with `Failed` status. Do not update DB. Skip DNS check — return early.
+4. Call `verifier.check_txt(domain, token)`.
+5. DNS miss → return claim as `Pending`.
+6. DNS match → `UPDATE tenant_domains SET status = 'verified', verified_at = ... WHERE id = ?`. Catch `is_unique_violation()` → `Error::conflict("Domain already verified by another tenant")`.
+7. Return updated `DomainClaim`.
+
+**`remove(id)`**
+1. `DELETE FROM tenant_domains WHERE id = ?`.
+2. Idempotent — no error if row doesn't exist.
+
+**`lookup_domain(domain)`**
+1. Validate domain via `validate_domain()`.
+2. `SELECT tenant_id, domain FROM tenant_domains WHERE domain = ? AND status = 'verified'`.
+3. Return `Some(TenantMatch)` or `None`.
+
+**`lookup_email(email)`**
+1. Extract domain via `extract_email_domain()` — validates email, lowercases domain.
+2. Same query as `lookup_domain()`.
+3. Return `Some(TenantMatch)` or `None`.
+
+**`list(tenant_id)`**
+1. `SELECT * FROM tenant_domains WHERE tenant_id = ?`.
+2. For each row where `status = 'pending'`: if `created_at + 48h < now()`, set `DomainStatus::Failed` in the returned struct.
+3. Return `Vec<DomainClaim>`.
+
+---
+
+## Validation
+
+```rust
+// validate.rs — pub(crate)
+
+/// Validates and normalizes a domain name. Returns lowercased domain.
+pub(crate) fn validate_domain(domain: &str) -> Result<String>
+
+/// Validates basic email structure, extracts and lowercases the domain.
+pub(crate) fn extract_email_domain(email: &str) -> Result<String>
+```
+
+**`validate_domain` rules:**
+- Trim whitespace, lowercase, strip trailing dot.
+- Reject: empty, no dots, total length > 253 chars.
+- Per-label: alphanumeric + hyphens only, no start/end with hyphen, max 63 chars, no empty labels.
+- Returns `Error::bad_request("Invalid domain: {reason}")`.
+
+**`extract_email_domain` rules:**
+- `rsplit_once('@')` — reject if no `@` or empty local part.
+- Run `validate_domain()` on the domain portion.
+- Returns `Error::bad_request("Invalid email address")`.
+
+---
+
+## SQL Schema
+
+Documented in module docs. Migration owned by end app.
+
+```sql
+CREATE TABLE tenant_domains (
+    id                 TEXT PRIMARY KEY,
+    tenant_id          TEXT NOT NULL,
+    domain             TEXT NOT NULL,
+    verification_token TEXT NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'pending',
+    created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    verified_at        TEXT
+);
+
+CREATE INDEX idx_tenant_domains_tenant_domain
+    ON tenant_domains(tenant_id, domain);
+
+CREATE UNIQUE INDEX idx_tenant_domains_verified
+    ON tenant_domains(domain) WHERE status = 'verified';
+```
+
+- `id` is a ULID primary key.
+- `(tenant_id, domain)` is a non-unique index for lookups and listing.
+- Partial unique index on `domain WHERE status = 'verified'` ensures one tenant per verified domain.
+- Multiple tenants can have pending claims for the same domain. First to verify wins.
+- No `ON CONFLICT` — use `INSERT`/`UPDATE` and catch `is_unique_violation()` per modo convention.
+- Only `'pending'` and `'verified'` are stored. `'failed'` is computed on read.
+
+---
+
+## Error Handling
+
+All errors use `modo::Error` constructors. No custom error enum.
+
+| Method | Condition | Error |
+|--------|-----------|-------|
+| `register()` | Invalid domain format | `Error::bad_request("Invalid domain: {reason}")` |
+| `register()` | Domain already verified by this tenant | `Error::conflict("Domain already verified by this tenant")` |
+| `verify()` | Claim not found | `Error::not_found("Domain claim not found")` |
+| `verify()` | Domain already verified by another tenant | `Error::conflict("Domain already verified by another tenant")` |
+| `verify()` | DNS network error | `Error::internal()` via `?` propagation |
+| `verify()` | Expired claim | Not an error — returns `DomainClaim` with `Failed` status |
+| `verify()` | TXT record not found | Not an error — returns `DomainClaim` with `Pending` status |
+| `remove()` | Claim not found | Silent success (idempotent) |
+| `lookup_email()` | Invalid email | `Error::bad_request("Invalid email address")` |
+| `lookup_domain()` | Invalid domain | `Error::bad_request("Invalid domain: {reason}")` |
+| `lookup_*()` | No verified match | `None` — not an error |
+
+---
+
+## Integration
+
+**Wiring:**
+```rust
+let verifier = DomainVerifier::from_config(&config.dns)?;
+let registry = DomainRegistry::new(pool.clone(), verifier);
+app.service(registry);
+```
+
+**Handler usage (signup):**
+```rust
+async fn signup(
+    Service(registry): Service<DomainRegistry>,
+    body: JsonRequest<SignupForm>,
+) -> Result<Response> {
+    if let Some(m) = registry.lookup_email(&body.email).await? {
+        // auto-assign user to m.tenant_id
+    } else {
+        // normal signup without tenant
+    }
+}
+```
+
+**Handler usage (admin domain management):**
+```rust
+async fn add_domain(
+    tenant: Tenant<MyTenant>,
+    Service(registry): Service<DomainRegistry>,
+    body: JsonRequest<AddDomainForm>,
+) -> Result<Json<DomainClaim>> {
+    let claim = registry.register(tenant.tenant_id(), &body.domain).await?;
+    // Response includes verification_token
+    // Admin sets TXT record: _modo-verify.{domain} → {token}
+    Ok(Json(claim))
+}
+
+async fn verify_domain(
+    Service(registry): Service<DomainRegistry>,
+    Path(id): Path<String>,
+) -> Result<Json<DomainClaim>> {
+    let claim = registry.verify(&id).await?;
+    Ok(Json(claim))
+}
+
+async fn remove_domain(
+    Service(registry): Service<DomainRegistry>,
+    Path(id): Path<String>,
+) -> Result<()> {
+    registry.remove(&id).await
+}
+
+async fn list_domains(
+    tenant: Tenant<MyTenant>,
+    Service(registry): Service<DomainRegistry>,
+) -> Result<Json<Vec<DomainClaim>>> {
+    let claims = registry.list(tenant.tenant_id()).await?;
+    Ok(Json(claims))
+}
+```
+
+---
+
+## Testing
+
+**Unit tests** in `validate.rs`:
+- Valid domains (simple, multi-label, international-friendly ASCII)
+- Invalid domains (empty, no dots, leading/trailing hyphens, too long, invalid chars)
+- Valid emails with domain extraction
+- Invalid emails (no @, empty local part, invalid domain)
+
+**Integration tests** in `tests/domain_signup.rs` (`#![cfg(feature = "dns")]`):
+- `register` — creates claim, returns pending status with token
+- `register` multiple domains for one tenant
+- `register` same domain by multiple tenants (all pending)
+- `verify` — success path with matching TXT record
+- `verify` — DNS miss returns pending
+- `verify` — expired claim returns failed
+- `verify` — conflict when another tenant already verified
+- `verify` — already verified returns as-is
+- `remove` — deletes claim
+- `remove` — idempotent on missing id
+- `lookup_domain` — finds verified, ignores pending
+- `lookup_email` — extracts domain, finds match
+- `lookup_email` — case-insensitive matching
+- `list` — returns all claims, computes failed for expired
+
+Tests use `TestDb` with the schema applied. `DomainVerifier` is constructed with a test `DnsResolver` that returns controlled TXT records.

--- a/src/dns/verifier.rs
+++ b/src/dns/verifier.rs
@@ -80,6 +80,23 @@ impl DomainVerifier {
         })
     }
 
+    /// Create a verifier with a custom resolver and TXT record prefix.
+    ///
+    /// Used by other in-crate modules to build a `DomainVerifier` backed by a
+    /// mock resolver for testing.
+    #[cfg_attr(not(any(test, feature = "dns-test")), allow(dead_code))]
+    pub(crate) fn with_resolver(
+        resolver: impl DnsResolver + 'static,
+        txt_prefix: impl Into<String>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                resolver: Arc::new(resolver),
+                txt_prefix: txt_prefix.into(),
+            }),
+        }
+    }
+
     /// Check whether a TXT record matches the expected verification token.
     ///
     /// Looks up `{txt_prefix}.{domain}` and returns `true` if any TXT record

--- a/src/dns/verifier.rs
+++ b/src/dns/verifier.rs
@@ -83,7 +83,10 @@ impl DomainVerifier {
     /// Create a verifier with a custom resolver and TXT record prefix.
     ///
     /// Used by other in-crate modules to build a `DomainVerifier` backed by a
-    /// mock resolver for testing.
+    /// mock resolver for testing. Only called from `#[cfg(test)]` blocks in
+    /// other modules, so it has zero callers on the lib target — hence
+    /// `allow(dead_code)`. Cannot use `#[cfg(test)]` here because that would
+    /// make it invisible to other modules' test blocks.
     #[allow(dead_code)]
     pub(crate) fn with_resolver(
         resolver: impl DnsResolver + 'static,

--- a/src/dns/verifier.rs
+++ b/src/dns/verifier.rs
@@ -84,7 +84,7 @@ impl DomainVerifier {
     ///
     /// Used by other in-crate modules to build a `DomainVerifier` backed by a
     /// mock resolver for testing.
-    #[cfg_attr(not(any(test, feature = "dns-test")), allow(dead_code))]
+    #[allow(dead_code)]
     pub(crate) fn with_resolver(
         resolver: impl DnsResolver + 'static,
         txt_prefix: impl Into<String>,

--- a/src/domain_signup/mod.rs
+++ b/src/domain_signup/mod.rs
@@ -13,7 +13,9 @@
 //! modo = { version = "*", features = ["dns"] }
 //! ```
 
+mod registry;
 mod types;
 mod validate;
 
+pub use registry::DomainRegistry;
 pub use types::{ClaimStatus, DomainClaim, TenantMatch};

--- a/src/domain_signup/mod.rs
+++ b/src/domain_signup/mod.rs
@@ -1,0 +1,18 @@
+//! Domain-verified signup.
+//!
+//! Lets tenants claim email domains so that users with matching verified
+//! email addresses auto-join the tenant. Domain ownership is proved via
+//! DNS TXT record verification using the [`dns`](crate::dns) module.
+//!
+//! # Feature flag
+//!
+//! This module is only compiled when the `dns` feature is enabled.
+//!
+//! ```toml
+//! [dependencies]
+//! modo = { version = "*", features = ["dns"] }
+//! ```
+
+mod types;
+
+pub use types::{ClaimStatus, DomainClaim, TenantMatch};

--- a/src/domain_signup/mod.rs
+++ b/src/domain_signup/mod.rs
@@ -14,5 +14,6 @@
 //! ```
 
 mod types;
+mod validate;
 
 pub use types::{ClaimStatus, DomainClaim, TenantMatch};

--- a/src/domain_signup/registry.rs
+++ b/src/domain_signup/registry.rs
@@ -56,7 +56,7 @@ impl DomainRegistry {
         let token = crate::dns::generate_verification_token();
         let now = chrono::Utc::now().to_rfc3339();
 
-        match sqlx::query(
+        sqlx::query(
             "INSERT INTO tenant_domains (id, tenant_id, domain, verification_token, created_at) \
              VALUES (?, ?, ?, ?, ?)",
         )
@@ -67,21 +67,17 @@ impl DomainRegistry {
         .bind(&now)
         .execute(&*self.inner.pool)
         .await
-        {
-            Ok(_) => Ok(DomainClaim {
-                id,
-                tenant_id: tenant_id.to_owned(),
-                domain,
-                verification_token: token,
-                status: ClaimStatus::Pending,
-                created_at: now,
-                verified_at: None,
-            }),
-            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
-                Err(Error::conflict("Domain is already verified"))
-            }
-            Err(e) => Err(Error::internal(format!("register domain: {e}"))),
-        }
+        .map_err(|e| Error::internal(format!("register domain: {e}")))?;
+
+        Ok(DomainClaim {
+            id,
+            tenant_id: tenant_id.to_owned(),
+            domain,
+            verification_token: token,
+            status: ClaimStatus::Pending,
+            created_at: now,
+            verified_at: None,
+        })
     }
 
     /// Check DNS verification for a pending claim.
@@ -209,7 +205,7 @@ impl DomainRegistry {
     pub async fn list(&self, tenant_id: &str) -> Result<Vec<DomainClaim>> {
         let rows = sqlx::query_as::<_, DomainRow>(
             "SELECT id, tenant_id, domain, verification_token, status, created_at, verified_at \
-             FROM tenant_domains WHERE tenant_id = ?",
+             FROM tenant_domains WHERE tenant_id = ? ORDER BY created_at ASC",
         )
         .bind(tenant_id)
         .fetch_all(&*self.inner.pool)

--- a/src/domain_signup/registry.rs
+++ b/src/domain_signup/registry.rs
@@ -78,7 +78,7 @@ impl DomainRegistry {
                 verified_at: None,
             }),
             Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => Err(
-                Error::conflict("Domain is already verified by another tenant"),
+                Error::conflict("Domain is already verified"),
             ),
             Err(e) => Err(Error::internal(format!("register domain: {e}"))),
         }

--- a/src/domain_signup/registry.rs
+++ b/src/domain_signup/registry.rs
@@ -77,9 +77,9 @@ impl DomainRegistry {
                 created_at: now,
                 verified_at: None,
             }),
-            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => Err(
-                Error::conflict("Domain is already verified"),
-            ),
+            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                Err(Error::conflict("Domain is already verified"))
+            }
             Err(e) => Err(Error::internal(format!("register domain: {e}"))),
         }
     }

--- a/src/domain_signup/registry.rs
+++ b/src/domain_signup/registry.rs
@@ -77,9 +77,9 @@ impl DomainRegistry {
                 created_at: now,
                 verified_at: None,
             }),
-            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
-                Err(Error::conflict("Domain is already verified by another tenant"))
-            }
+            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => Err(
+                Error::conflict("Domain is already verified by another tenant"),
+            ),
             Err(e) => Err(Error::internal(format!("register domain: {e}"))),
         }
     }
@@ -284,8 +284,7 @@ mod tests {
         )";
     const CREATE_INDEX_TD: &str =
         "CREATE INDEX idx_tenant_domains_tenant_domain ON tenant_domains(tenant_id, domain)";
-    const CREATE_INDEX_VERIFIED: &str =
-        "CREATE UNIQUE INDEX idx_tenant_domains_verified ON tenant_domains(domain) WHERE status = 'verified'";
+    const CREATE_INDEX_VERIFIED: &str = "CREATE UNIQUE INDEX idx_tenant_domains_verified ON tenant_domains(domain) WHERE status = 'verified'";
 
     /// Mock DNS resolver with mutable TXT record state.
     #[derive(Clone)]

--- a/src/domain_signup/registry.rs
+++ b/src/domain_signup/registry.rs
@@ -54,9 +54,7 @@ impl DomainRegistry {
         let domain = validate::validate_domain(domain)?;
         let id = crate::id::ulid();
         let token = crate::dns::generate_verification_token();
-        let now = chrono::Utc::now()
-            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
-            .to_string();
+        let now = chrono::Utc::now().to_rfc3339();
 
         match sqlx::query(
             "INSERT INTO tenant_domains (id, tenant_id, domain, verification_token, created_at) \
@@ -80,7 +78,7 @@ impl DomainRegistry {
                 verified_at: None,
             }),
             Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
-                Err(Error::conflict("Domain already verified by this tenant"))
+                Err(Error::conflict("Domain is already verified by another tenant"))
             }
             Err(e) => Err(Error::internal(format!("register domain: {e}"))),
         }

--- a/src/domain_signup/registry.rs
+++ b/src/domain_signup/registry.rs
@@ -83,6 +83,80 @@ impl DomainRegistry {
             Err(e) => Err(Error::internal(format!("register domain: {e}"))),
         }
     }
+
+    /// Check DNS verification for a pending claim.
+    ///
+    /// If the TXT record at `_modo-verify.{domain}` matches the claim's token,
+    /// the claim transitions to `Verified`. If the 48-hour verification window
+    /// has expired, returns the claim with `Failed` status. If the DNS record
+    /// is not yet present, returns the claim as `Pending`.
+    ///
+    /// Returns `Error::not_found` if no claim exists with this id.
+    /// Returns `Error::conflict` if another tenant has already verified this
+    /// domain.
+    pub async fn verify(&self, id: &str) -> Result<DomainClaim> {
+        let row = sqlx::query_as::<_, DomainRow>(
+            "SELECT id, tenant_id, domain, verification_token, status, created_at, verified_at \
+             FROM tenant_domains WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(&*self.inner.pool)
+        .await
+        .map_err(|e| Error::internal(format!("fetch domain claim: {e}")))?
+        .ok_or_else(|| Error::not_found("Domain claim not found"))?;
+
+        // Already verified — return as-is.
+        if row.status == "verified" {
+            return Ok(row_to_claim(row));
+        }
+
+        // Check expiry.
+        let created = chrono::DateTime::parse_from_rfc3339(&row.created_at)
+            .map_err(|e| Error::internal(format!("parse created_at: {e}")))?
+            .with_timezone(&chrono::Utc);
+        if chrono::Utc::now() - created > chrono::Duration::hours(VERIFICATION_DURATION_HOURS) {
+            return Ok(DomainClaim {
+                status: ClaimStatus::Failed,
+                ..row_to_claim(row)
+            });
+        }
+
+        // DNS check.
+        let verified = self
+            .inner
+            .verifier
+            .check_txt(&row.domain, &row.verification_token)
+            .await?;
+
+        if !verified {
+            return Ok(row_to_claim(row));
+        }
+
+        // Transition to verified.
+        let now = chrono::Utc::now().to_rfc3339();
+        match sqlx::query(
+            "UPDATE tenant_domains SET status = 'verified', verified_at = ? WHERE id = ?",
+        )
+        .bind(&now)
+        .bind(id)
+        .execute(&*self.inner.pool)
+        .await
+        {
+            Ok(_) => Ok(DomainClaim {
+                id: row.id,
+                tenant_id: row.tenant_id,
+                domain: row.domain,
+                verification_token: row.verification_token,
+                status: ClaimStatus::Verified,
+                created_at: row.created_at,
+                verified_at: Some(now),
+            }),
+            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                Err(Error::conflict("Domain already verified by another tenant"))
+            }
+            Err(e) => Err(Error::internal(format!("update domain status: {e}"))),
+        }
+    }
 }
 
 /// Internal row type for sqlx queries.
@@ -263,5 +337,108 @@ mod tests {
         let c2 = reg.register("tenant2", "example.com").await.unwrap();
         assert_ne!(c1.id, c2.id);
         assert_eq!(c1.domain, c2.domain);
+    }
+
+    // -- verify tests --
+
+    #[tokio::test]
+    async fn verify_success_transitions_to_verified() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+
+        // Configure mock to return the generated token.
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+
+        let verified = reg.verify(&claim.id).await.unwrap();
+        assert_eq!(verified.status, ClaimStatus::Verified);
+        assert!(verified.verified_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn verify_dns_miss_stays_pending() {
+        let (reg, _mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        // Mock has no TXT records → DNS miss.
+
+        let result = reg.verify(&claim.id).await.unwrap();
+        assert_eq!(result.status, ClaimStatus::Pending);
+        assert!(result.verified_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn verify_expired_claim_returns_failed() {
+        let (reg, _mock) = setup().await;
+
+        // Insert a claim with a created_at in the distant past.
+        let id = crate::id::ulid();
+        let token = crate::dns::generate_verification_token();
+        sqlx::query(
+            "INSERT INTO tenant_domains (id, tenant_id, domain, verification_token, status, created_at) \
+             VALUES (?, ?, ?, ?, 'pending', ?)",
+        )
+        .bind(&id)
+        .bind("tenant1")
+        .bind("expired.com")
+        .bind(&token)
+        .bind("2020-01-01T00:00:00.000Z")
+        .execute(&*reg.inner.pool)
+        .await
+        .unwrap();
+
+        let result = reg.verify(&id).await.unwrap();
+        assert_eq!(result.status, ClaimStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn verify_already_verified_returns_as_is() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        let first = reg.verify(&claim.id).await.unwrap();
+        assert_eq!(first.status, ClaimStatus::Verified);
+
+        // Clear mock — second verify should still return Verified from DB.
+        mock.set_txt(&format!("_modo-verify.{}", claim.domain), vec![]);
+        let second = reg.verify(&claim.id).await.unwrap();
+        assert_eq!(second.status, ClaimStatus::Verified);
+    }
+
+    #[tokio::test]
+    async fn verify_not_found_returns_error() {
+        let (reg, _mock) = setup().await;
+        let err = reg.verify("nonexistent-id").await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn verify_conflict_when_domain_already_verified_by_other_tenant() {
+        let (reg, mock) = setup().await;
+
+        // Tenant 1 registers and verifies.
+        let c1 = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", c1.domain),
+            vec![c1.verification_token.clone()],
+        );
+        let v1 = reg.verify(&c1.id).await.unwrap();
+        assert_eq!(v1.status, ClaimStatus::Verified);
+
+        // Tenant 2 registers the same domain.
+        let c2 = reg.register("tenant2", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", c2.domain),
+            vec![c2.verification_token.clone()],
+        );
+
+        // Tenant 2 tries to verify → conflict.
+        let err = reg.verify(&c2.id).await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::CONFLICT);
     }
 }

--- a/src/domain_signup/registry.rs
+++ b/src/domain_signup/registry.rs
@@ -4,7 +4,7 @@ use crate::db::Pool;
 use crate::dns::DomainVerifier;
 use crate::error::{Error, Result};
 
-use super::types::{ClaimStatus, DomainClaim};
+use super::types::{ClaimStatus, DomainClaim, TenantMatch};
 use super::validate;
 
 /// Hours before a pending domain claim expires.
@@ -156,6 +156,67 @@ impl DomainRegistry {
             }
             Err(e) => Err(Error::internal(format!("update domain status: {e}"))),
         }
+    }
+
+    /// Remove a domain claim by id.
+    ///
+    /// Idempotent — returns `Ok(())` even if no claim exists with this id.
+    pub async fn remove(&self, id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM tenant_domains WHERE id = ?")
+            .bind(id)
+            .execute(&*self.inner.pool)
+            .await
+            .map_err(|e| Error::internal(format!("remove domain: {e}")))?;
+        Ok(())
+    }
+
+    /// Shared query for lookup_domain and lookup_email.
+    async fn lookup_verified_domain(&self, domain: &str) -> Result<Option<TenantMatch>> {
+        let row = sqlx::query_as::<_, (String, String)>(
+            "SELECT tenant_id, domain FROM tenant_domains \
+             WHERE domain = ? AND status = 'verified'",
+        )
+        .bind(domain)
+        .fetch_optional(&*self.inner.pool)
+        .await
+        .map_err(|e| Error::internal(format!("lookup domain: {e}")))?;
+
+        Ok(row.map(|(tenant_id, domain)| TenantMatch { tenant_id, domain }))
+    }
+
+    /// Look up which tenant owns a verified domain.
+    ///
+    /// Validates the domain format. Returns `None` if no tenant has a verified
+    /// claim for this domain.
+    pub async fn lookup_domain(&self, domain: &str) -> Result<Option<TenantMatch>> {
+        let domain = validate::validate_domain(domain)?;
+        self.lookup_verified_domain(&domain).await
+    }
+
+    /// Look up which tenant owns the domain of a given email address.
+    ///
+    /// Validates the email format, extracts and lowercases the domain, then
+    /// checks for a verified claim. Returns `None` if no match.
+    pub async fn lookup_email(&self, email: &str) -> Result<Option<TenantMatch>> {
+        let domain = validate::extract_email_domain(email)?;
+        self.lookup_verified_domain(&domain).await
+    }
+
+    /// List all domain claims for a tenant.
+    ///
+    /// Returns claims in all states. Expired pending claims are returned with
+    /// `ClaimStatus::Failed`.
+    pub async fn list(&self, tenant_id: &str) -> Result<Vec<DomainClaim>> {
+        let rows = sqlx::query_as::<_, DomainRow>(
+            "SELECT id, tenant_id, domain, verification_token, status, created_at, verified_at \
+             FROM tenant_domains WHERE tenant_id = ?",
+        )
+        .bind(tenant_id)
+        .fetch_all(&*self.inner.pool)
+        .await
+        .map_err(|e| Error::internal(format!("list domains: {e}")))?;
+
+        Ok(rows.into_iter().map(row_to_claim).collect())
     }
 }
 
@@ -440,5 +501,166 @@ mod tests {
         // Tenant 2 tries to verify → conflict.
         let err = reg.verify(&c2.id).await.unwrap_err();
         assert_eq!(err.status(), http::StatusCode::CONFLICT);
+    }
+
+    // -- remove tests --
+
+    #[tokio::test]
+    async fn remove_deletes_claim() {
+        let (reg, _mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+
+        reg.remove(&claim.id).await.unwrap();
+
+        let list = reg.list("tenant1").await.unwrap();
+        assert!(list.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remove_idempotent_on_missing_id() {
+        let (reg, _mock) = setup().await;
+        reg.remove("nonexistent-id").await.unwrap();
+    }
+
+    // -- lookup_domain tests --
+
+    #[tokio::test]
+    async fn lookup_domain_finds_verified() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        reg.verify(&claim.id).await.unwrap();
+
+        let result = reg.lookup_domain("example.com").await.unwrap();
+        assert!(result.is_some());
+        let m = result.unwrap();
+        assert_eq!(m.tenant_id, "tenant1");
+        assert_eq!(m.domain, "example.com");
+    }
+
+    #[tokio::test]
+    async fn lookup_domain_ignores_pending() {
+        let (reg, _mock) = setup().await;
+        reg.register("tenant1", "example.com").await.unwrap();
+
+        let result = reg.lookup_domain("example.com").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn lookup_domain_validates_input() {
+        let (reg, _mock) = setup().await;
+        let err = reg.lookup_domain("localhost").await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn lookup_domain_case_insensitive() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        reg.verify(&claim.id).await.unwrap();
+
+        let result = reg.lookup_domain("EXAMPLE.COM").await.unwrap();
+        assert!(result.is_some());
+    }
+
+    // -- lookup_email tests --
+
+    #[tokio::test]
+    async fn lookup_email_finds_match() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        reg.verify(&claim.id).await.unwrap();
+
+        let result = reg.lookup_email("user@example.com").await.unwrap();
+        assert!(result.is_some());
+        let m = result.unwrap();
+        assert_eq!(m.tenant_id, "tenant1");
+        assert_eq!(m.domain, "example.com");
+    }
+
+    #[tokio::test]
+    async fn lookup_email_case_insensitive() {
+        let (reg, mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+        mock.set_txt(
+            &format!("_modo-verify.{}", claim.domain),
+            vec![claim.verification_token.clone()],
+        );
+        reg.verify(&claim.id).await.unwrap();
+
+        let result = reg.lookup_email("User@EXAMPLE.COM").await.unwrap();
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn lookup_email_invalid_returns_bad_request() {
+        let (reg, _mock) = setup().await;
+        let err = reg.lookup_email("not-an-email").await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn lookup_email_no_match_returns_none() {
+        let (reg, _mock) = setup().await;
+        let result = reg.lookup_email("user@unknown.com").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    // -- list tests --
+
+    #[tokio::test]
+    async fn list_returns_all_claims_for_tenant() {
+        let (reg, _mock) = setup().await;
+        reg.register("tenant1", "example.com").await.unwrap();
+        reg.register("tenant1", "example.org").await.unwrap();
+        reg.register("tenant2", "other.com").await.unwrap();
+
+        let list = reg.list("tenant1").await.unwrap();
+        assert_eq!(list.len(), 2);
+        assert!(list.iter().all(|c| c.tenant_id == "tenant1"));
+    }
+
+    #[tokio::test]
+    async fn list_computes_failed_for_expired() {
+        let (reg, _mock) = setup().await;
+
+        // Insert an expired claim directly.
+        let id = crate::id::ulid();
+        let token = crate::dns::generate_verification_token();
+        sqlx::query(
+            "INSERT INTO tenant_domains (id, tenant_id, domain, verification_token, status, created_at) \
+             VALUES (?, ?, ?, ?, 'pending', ?)",
+        )
+        .bind(&id)
+        .bind("tenant1")
+        .bind("expired.com")
+        .bind(&token)
+        .bind("2020-01-01T00:00:00.000Z")
+        .execute(&*reg.inner.pool)
+        .await
+        .unwrap();
+
+        let list = reg.list("tenant1").await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].status, ClaimStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn list_empty_for_unknown_tenant() {
+        let (reg, _mock) = setup().await;
+        let list = reg.list("unknown").await.unwrap();
+        assert!(list.is_empty());
     }
 }

--- a/src/domain_signup/registry.rs
+++ b/src/domain_signup/registry.rs
@@ -1,0 +1,269 @@
+use std::sync::Arc;
+
+use crate::db::Pool;
+use crate::dns::DomainVerifier;
+use crate::error::{Error, Result};
+
+use super::types::{ClaimStatus, DomainClaim};
+use super::validate;
+
+/// Hours before a pending domain claim expires.
+const VERIFICATION_DURATION_HOURS: i64 = 48;
+
+struct Inner {
+    pool: Pool,
+    verifier: DomainVerifier,
+}
+
+/// Domain ownership registry.
+///
+/// Manages tenant domain claims and DNS-based verification. Tenants register
+/// domains, prove ownership via TXT records, and verified domains are used to
+/// auto-assign users with matching email addresses to the tenant.
+///
+/// Cheap to clone (`Arc<Inner>`). Inject into handlers via
+/// [`Service<DomainRegistry>`](crate::Service).
+pub struct DomainRegistry {
+    inner: Arc<Inner>,
+}
+
+impl Clone for DomainRegistry {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl DomainRegistry {
+    /// Create a new registry backed by the given database pool and DNS
+    /// verifier.
+    pub fn new(pool: Pool, verifier: DomainVerifier) -> Self {
+        Self {
+            inner: Arc::new(Inner { pool, verifier }),
+        }
+    }
+
+    /// Register a domain claim for a tenant.
+    ///
+    /// Validates the domain format, generates a verification token, and
+    /// inserts a new pending claim. The admin must set a TXT record at
+    /// `_modo-verify.{domain}` with the returned token value, then call
+    /// [`verify`](Self::verify) to complete ownership verification.
+    pub async fn register(&self, tenant_id: &str, domain: &str) -> Result<DomainClaim> {
+        let domain = validate::validate_domain(domain)?;
+        let id = crate::id::ulid();
+        let token = crate::dns::generate_verification_token();
+        let now = chrono::Utc::now()
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+            .to_string();
+
+        match sqlx::query(
+            "INSERT INTO tenant_domains (id, tenant_id, domain, verification_token, created_at) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(tenant_id)
+        .bind(&domain)
+        .bind(&token)
+        .bind(&now)
+        .execute(&*self.inner.pool)
+        .await
+        {
+            Ok(_) => Ok(DomainClaim {
+                id,
+                tenant_id: tenant_id.to_owned(),
+                domain,
+                verification_token: token,
+                status: ClaimStatus::Pending,
+                created_at: now,
+                verified_at: None,
+            }),
+            Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                Err(Error::conflict("Domain already verified by this tenant"))
+            }
+            Err(e) => Err(Error::internal(format!("register domain: {e}"))),
+        }
+    }
+}
+
+/// Internal row type for sqlx queries.
+#[derive(sqlx::FromRow)]
+struct DomainRow {
+    id: String,
+    tenant_id: String,
+    domain: String,
+    verification_token: String,
+    status: String,
+    created_at: String,
+    verified_at: Option<String>,
+}
+
+/// Convert a database row to a `DomainClaim`, computing `Failed` status for
+/// expired pending claims.
+fn row_to_claim(row: DomainRow) -> DomainClaim {
+    let status = match row.status.as_str() {
+        "verified" => ClaimStatus::Verified,
+        _ => {
+            if let Ok(created) = chrono::DateTime::parse_from_rfc3339(&row.created_at) {
+                let elapsed = chrono::Utc::now() - created.with_timezone(&chrono::Utc);
+                if elapsed > chrono::Duration::hours(VERIFICATION_DURATION_HOURS) {
+                    ClaimStatus::Failed
+                } else {
+                    ClaimStatus::Pending
+                }
+            } else {
+                ClaimStatus::Pending
+            }
+        }
+    };
+
+    DomainClaim {
+        id: row.id,
+        tenant_id: row.tenant_id,
+        domain: row.domain,
+        verification_token: row.verification_token,
+        status,
+        created_at: row.created_at,
+        verified_at: row.verified_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dns::resolver::DnsResolver;
+    use std::collections::HashMap;
+    use std::pin::Pin;
+    use std::sync::Mutex;
+
+    // -- Test infrastructure --
+
+    const CREATE_TABLE: &str = "\
+        CREATE TABLE tenant_domains (\
+            id                 TEXT PRIMARY KEY,\
+            tenant_id          TEXT NOT NULL,\
+            domain             TEXT NOT NULL,\
+            verification_token TEXT NOT NULL,\
+            status             TEXT NOT NULL DEFAULT 'pending',\
+            created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),\
+            verified_at        TEXT\
+        )";
+    const CREATE_INDEX_TD: &str =
+        "CREATE INDEX idx_tenant_domains_tenant_domain ON tenant_domains(tenant_id, domain)";
+    const CREATE_INDEX_VERIFIED: &str =
+        "CREATE UNIQUE INDEX idx_tenant_domains_verified ON tenant_domains(domain) WHERE status = 'verified'";
+
+    /// Mock DNS resolver with mutable TXT record state.
+    #[derive(Clone)]
+    struct MockResolver {
+        txt_records: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    }
+
+    impl MockResolver {
+        fn new() -> Self {
+            Self {
+                txt_records: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        fn set_txt(&self, domain: &str, records: Vec<String>) {
+            self.txt_records
+                .lock()
+                .unwrap()
+                .insert(domain.to_owned(), records);
+        }
+    }
+
+    impl DnsResolver for MockResolver {
+        fn resolve_txt(
+            &self,
+            domain: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<String>>> + Send + '_>> {
+            let records = self
+                .txt_records
+                .lock()
+                .unwrap()
+                .get(domain)
+                .cloned()
+                .unwrap_or_default();
+            Box::pin(async move { Ok(records) })
+        }
+
+        fn resolve_cname(
+            &self,
+            _domain: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<String>>> + Send + '_>> {
+            Box::pin(async { Ok(None) })
+        }
+    }
+
+    async fn setup() -> (DomainRegistry, MockResolver) {
+        let config = crate::db::SqliteConfig {
+            path: ":memory:".to_string(),
+            ..Default::default()
+        };
+        let pool = crate::db::connect(&config).await.unwrap();
+
+        sqlx::query(CREATE_TABLE).execute(&*pool).await.unwrap();
+        sqlx::query(CREATE_INDEX_TD).execute(&*pool).await.unwrap();
+        sqlx::query(CREATE_INDEX_VERIFIED)
+            .execute(&*pool)
+            .await
+            .unwrap();
+
+        let mock = MockResolver::new();
+        let verifier = DomainVerifier::with_resolver(mock.clone(), "_modo-verify");
+        let registry = DomainRegistry::new(pool, verifier);
+
+        (registry, mock)
+    }
+
+    // -- register tests --
+
+    #[tokio::test]
+    async fn register_creates_pending_claim() {
+        let (reg, _mock) = setup().await;
+        let claim = reg.register("tenant1", "example.com").await.unwrap();
+
+        assert_eq!(claim.tenant_id, "tenant1");
+        assert_eq!(claim.domain, "example.com");
+        assert_eq!(claim.status, ClaimStatus::Pending);
+        assert!(!claim.id.is_empty());
+        assert!(!claim.verification_token.is_empty());
+        assert!(!claim.created_at.is_empty());
+        assert!(claim.verified_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn register_lowercases_domain() {
+        let (reg, _mock) = setup().await;
+        let claim = reg.register("tenant1", "EXAMPLE.COM").await.unwrap();
+        assert_eq!(claim.domain, "example.com");
+    }
+
+    #[tokio::test]
+    async fn register_invalid_domain_returns_bad_request() {
+        let (reg, _mock) = setup().await;
+        let err = reg.register("tenant1", "localhost").await.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn register_multiple_domains_for_same_tenant() {
+        let (reg, _mock) = setup().await;
+        let c1 = reg.register("tenant1", "example.com").await.unwrap();
+        let c2 = reg.register("tenant1", "example.org").await.unwrap();
+        assert_ne!(c1.id, c2.id);
+        assert_ne!(c1.domain, c2.domain);
+    }
+
+    #[tokio::test]
+    async fn register_same_domain_multiple_tenants() {
+        let (reg, _mock) = setup().await;
+        let c1 = reg.register("tenant1", "example.com").await.unwrap();
+        let c2 = reg.register("tenant2", "example.com").await.unwrap();
+        assert_ne!(c1.id, c2.id);
+        assert_eq!(c1.domain, c2.domain);
+    }
+}

--- a/src/domain_signup/types.rs
+++ b/src/domain_signup/types.rs
@@ -1,0 +1,33 @@
+use serde::Serialize;
+
+/// Status of a domain ownership claim.
+///
+/// `Pending` and `Verified` are stored in the database. `Failed` is computed
+/// on read when a pending claim has exceeded the 48-hour verification window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ClaimStatus {
+    Pending,
+    Verified,
+    Failed,
+}
+
+/// A tenant's claim on an email domain.
+#[derive(Debug, Clone, Serialize)]
+pub struct DomainClaim {
+    pub id: String,
+    pub tenant_id: String,
+    pub domain: String,
+    pub verification_token: String,
+    pub status: ClaimStatus,
+    pub created_at: String,
+    pub verified_at: Option<String>,
+}
+
+/// Result of a successful domain lookup — identifies which tenant owns a
+/// verified domain.
+#[derive(Debug, Clone, Serialize)]
+pub struct TenantMatch {
+    pub tenant_id: String,
+    pub domain: String,
+}

--- a/src/domain_signup/validate.rs
+++ b/src/domain_signup/validate.rs
@@ -22,7 +22,9 @@ pub(crate) fn validate_domain(domain: &str) -> Result<String> {
     }
 
     if !domain.contains('.') {
-        return Err(Error::bad_request("Invalid domain: must contain at least one dot"));
+        return Err(Error::bad_request(
+            "Invalid domain: must contain at least one dot",
+        ));
     }
 
     for label in domain.split('.') {
@@ -30,7 +32,9 @@ pub(crate) fn validate_domain(domain: &str) -> Result<String> {
             return Err(Error::bad_request("Invalid domain: empty label"));
         }
         if label.len() > 63 {
-            return Err(Error::bad_request("Invalid domain: label exceeds 63 characters"));
+            return Err(Error::bad_request(
+                "Invalid domain: label exceeds 63 characters",
+            ));
         }
         if label.starts_with('-') || label.ends_with('-') {
             return Err(Error::bad_request(
@@ -80,7 +84,10 @@ mod tests {
 
     #[test]
     fn valid_subdomain() {
-        assert_eq!(validate_domain("sub.example.com").unwrap(), "sub.example.com");
+        assert_eq!(
+            validate_domain("sub.example.com").unwrap(),
+            "sub.example.com"
+        );
     }
 
     #[test]
@@ -100,12 +107,18 @@ mod tests {
 
     #[test]
     fn valid_with_hyphens() {
-        assert_eq!(validate_domain("my-domain.co.uk").unwrap(), "my-domain.co.uk");
+        assert_eq!(
+            validate_domain("my-domain.co.uk").unwrap(),
+            "my-domain.co.uk"
+        );
     }
 
     #[test]
     fn valid_with_digits() {
-        assert_eq!(validate_domain("123.example.com").unwrap(), "123.example.com");
+        assert_eq!(
+            validate_domain("123.example.com").unwrap(),
+            "123.example.com"
+        );
     }
 
     // -- validate_domain: invalid inputs --
@@ -178,12 +191,18 @@ mod tests {
 
     #[test]
     fn email_valid_extracts_domain() {
-        assert_eq!(extract_email_domain("user@example.com").unwrap(), "example.com");
+        assert_eq!(
+            extract_email_domain("user@example.com").unwrap(),
+            "example.com"
+        );
     }
 
     #[test]
     fn email_valid_lowercases_domain() {
-        assert_eq!(extract_email_domain("user@Example.COM").unwrap(), "example.com");
+        assert_eq!(
+            extract_email_domain("user@Example.COM").unwrap(),
+            "example.com"
+        );
     }
 
     #[test]

--- a/src/domain_signup/validate.rs
+++ b/src/domain_signup/validate.rs
@@ -1,0 +1,220 @@
+use crate::error::Result;
+
+/// Validate and normalize a domain name.
+///
+/// Trims whitespace, lowercases, strips a trailing dot, then checks structural
+/// rules (at least one dot, labels are alphanumeric + hyphens, no leading or
+/// trailing hyphens per label, label length ≤ 63, total length ≤ 253).
+///
+/// Returns the normalized domain or `Error::bad_request`.
+pub(crate) fn validate_domain(domain: &str) -> Result<String> {
+    use crate::error::Error;
+
+    let domain = domain.trim().to_lowercase();
+    let domain = domain.strip_suffix('.').unwrap_or(&domain);
+
+    if domain.is_empty() {
+        return Err(Error::bad_request("Invalid domain: empty"));
+    }
+
+    if domain.len() > 253 {
+        return Err(Error::bad_request("Invalid domain: exceeds 253 characters"));
+    }
+
+    if !domain.contains('.') {
+        return Err(Error::bad_request("Invalid domain: must contain at least one dot"));
+    }
+
+    for label in domain.split('.') {
+        if label.is_empty() {
+            return Err(Error::bad_request("Invalid domain: empty label"));
+        }
+        if label.len() > 63 {
+            return Err(Error::bad_request("Invalid domain: label exceeds 63 characters"));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(Error::bad_request(
+                "Invalid domain: label must not start or end with a hyphen",
+            ));
+        }
+        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return Err(Error::bad_request(
+                "Invalid domain: labels may only contain alphanumeric characters and hyphens",
+            ));
+        }
+    }
+
+    Ok(domain.to_owned())
+}
+
+/// Validate an email address and extract its lowercased domain.
+///
+/// Checks for exactly one `@` with a non-empty local part, then validates the
+/// domain portion via [`validate_domain`].
+///
+/// Returns the lowercased domain or `Error::bad_request`.
+pub(crate) fn extract_email_domain(email: &str) -> Result<String> {
+    use crate::error::Error;
+
+    let (local, domain) = email
+        .rsplit_once('@')
+        .ok_or_else(|| Error::bad_request("Invalid email address"))?;
+
+    if local.is_empty() {
+        return Err(Error::bad_request("Invalid email address"));
+    }
+
+    validate_domain(domain)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- validate_domain: valid inputs --
+
+    #[test]
+    fn valid_simple_domain() {
+        assert_eq!(validate_domain("example.com").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn valid_subdomain() {
+        assert_eq!(validate_domain("sub.example.com").unwrap(), "sub.example.com");
+    }
+
+    #[test]
+    fn valid_trims_whitespace() {
+        assert_eq!(validate_domain("  example.com  ").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn valid_lowercases() {
+        assert_eq!(validate_domain("Example.COM").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn valid_strips_trailing_dot() {
+        assert_eq!(validate_domain("example.com.").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn valid_with_hyphens() {
+        assert_eq!(validate_domain("my-domain.co.uk").unwrap(), "my-domain.co.uk");
+    }
+
+    #[test]
+    fn valid_with_digits() {
+        assert_eq!(validate_domain("123.example.com").unwrap(), "123.example.com");
+    }
+
+    // -- validate_domain: invalid inputs --
+
+    #[test]
+    fn invalid_empty() {
+        let err = validate_domain("").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_whitespace_only() {
+        let err = validate_domain("   ").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_no_dots() {
+        let err = validate_domain("localhost").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_starts_with_hyphen() {
+        let err = validate_domain("-example.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_ends_with_hyphen() {
+        let err = validate_domain("example-.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_empty_label() {
+        let err = validate_domain("example..com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_label_too_long() {
+        let long_label = "a".repeat(64);
+        let err = validate_domain(&format!("{long_label}.com")).unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_total_too_long() {
+        // 254 chars total (over 253 limit)
+        let label = "a".repeat(63);
+        let domain = format!("{label}.{label}.{label}.{label}.com");
+        let err = validate_domain(&domain).unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_contains_space() {
+        let err = validate_domain("exam ple.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn invalid_contains_underscore() {
+        let err = validate_domain("ex_ample.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    // -- extract_email_domain --
+
+    #[test]
+    fn email_valid_extracts_domain() {
+        assert_eq!(extract_email_domain("user@example.com").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn email_valid_lowercases_domain() {
+        assert_eq!(extract_email_domain("user@Example.COM").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn email_valid_preserves_complex_local() {
+        assert_eq!(
+            extract_email_domain("user+tag@example.com").unwrap(),
+            "example.com"
+        );
+    }
+
+    #[test]
+    fn email_invalid_no_at() {
+        let err = extract_email_domain("userexample.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn email_invalid_empty_local() {
+        let err = extract_email_domain("@example.com").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn email_invalid_empty_string() {
+        let err = extract_email_domain("").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn email_invalid_domain_part() {
+        let err = extract_email_domain("user@localhost").unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,9 @@ pub mod webhook;
 #[cfg(feature = "dns")]
 pub mod dns;
 
+#[cfg(feature = "dns")]
+pub mod domain_signup;
+
 #[cfg(feature = "geolocation")]
 pub mod geolocation;
 
@@ -131,6 +134,9 @@ pub use webhook::{SignedHeaders, WebhookResponse, WebhookSecret, WebhookSender};
 
 #[cfg(feature = "dns")]
 pub use dns::{DnsConfig, DnsError, DomainStatus, DomainVerifier, generate_verification_token};
+
+#[cfg(feature = "dns")]
+pub use domain_signup::{ClaimStatus, DomainClaim, TenantMatch};
 
 #[cfg(feature = "geolocation")]
 pub use geolocation::{GeoLayer, GeoLocator, GeolocationConfig, Location};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub use webhook::{SignedHeaders, WebhookResponse, WebhookSecret, WebhookSender};
 pub use dns::{DnsConfig, DnsError, DomainStatus, DomainVerifier, generate_verification_token};
 
 #[cfg(feature = "dns")]
-pub use domain_signup::{ClaimStatus, DomainClaim, TenantMatch};
+pub use domain_signup::{ClaimStatus, DomainClaim, DomainRegistry, TenantMatch};
 
 #[cfg(feature = "geolocation")]
 pub use geolocation::{GeoLayer, GeoLocator, GeolocationConfig, Location};


### PR DESCRIPTION
## Summary

- Add `domain_signup` module gated behind the `dns` feature — lets tenants claim email domains so users with matching verified email auto-join the tenant
- `DomainRegistry` struct with 6 methods: `register`, `verify`, `remove`, `lookup_domain`, `lookup_email`, `list`
- DNS TXT record verification via existing `DomainVerifier`, with 48-hour expiry window for pending claims
- Domain/email validation, case-insensitive matching, partial unique index for one-verified-domain-per-tenant
- 48 unit tests covering all methods and edge cases, plus `DomainVerifier::with_resolver()` test helper

## Test Plan

- [x] `cargo test --features dns` — 370+ tests pass (48 new domain_signup tests)
- [x] `cargo clippy --features dns --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean