### PR TITLE
feat(server): add HostRouter for host-based request routing

### DIFF
--- a/skills/dev/references/handlers.md
+++ b/skills/dev/references/handlers.md
@@ -366,7 +366,7 @@ server:
 
 ### Starting the Server
 
-`modo::server::http()` binds a TCP listener and returns an `HttpServer` (a public struct) that implements `Task`:
+`modo::server::http()` binds a TCP listener and returns an `HttpServer` (a public struct) that implements `Task`. Accepts `impl Into<axum::Router>`, so both a plain `axum::Router` and a `HostRouter` can be passed directly:
 
 ```rust
 use modo::server::{Config, http};
@@ -383,6 +383,44 @@ async fn main() -> modo::Result<()> {
 
 async fn health() -> &'static str { "ok" }
 ```
+
+### Host-Based Routing
+
+`HostRouter` dispatches requests to different `axum::Router`s based on the `Host` header. Supports exact matches, single-level wildcard subdomains (`*.acme.com`), and an optional fallback. Both use `HashMap` lookups for O(1) matching.
+
+```rust
+use modo::server::{self, Config, HostRouter};
+
+let app = HostRouter::new()
+    .host("acme.com", landing_router)
+    .host("app.acme.com", admin_router)
+    .host("*.acme.com", tenant_router)
+    .fallback(not_found_router);
+
+let server = server::http(app, &config).await?;
+```
+
+Builder methods panic on misconfiguration (duplicates, invalid wildcards like `*.com`). Complete all route registration before passing the router to `http()` or cloning it.
+
+**`MatchedHost` extractor** -- available in handlers on wildcard-matched routes. Contains `subdomain` (e.g. `"tenant1"`) and `pattern` (e.g. `"*.acme.com"`):
+
+```rust,ignore
+use modo::server::MatchedHost;
+
+async fn handler(matched: MatchedHost) -> String {
+    format!("tenant: {}", matched.subdomain)
+}
+
+// For handlers serving both exact and wildcard routes:
+async fn handler(matched: Option<MatchedHost>) -> String {
+    match matched {
+        Some(h) => format!("tenant: {}", h.subdomain),
+        None => "no tenant".to_string(),
+    }
+}
+```
+
+Host resolution checks headers in order: `Forwarded` (RFC 7239 `host=` directive), `X-Forwarded-Host`, then `Host`. Values are lowercased and port-stripped.
 
 ### Graceful Shutdown
 

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,22 +1,26 @@
 # modo::server
 
-HTTP server startup and graceful shutdown for the modo framework.
+HTTP server startup, host-based routing, and graceful shutdown.
 
 ## Overview
 
-The module exposes three items:
+The module provides:
 
 - `Config` — bind address and shutdown timeout, loaded from the `server` YAML section.
 - `http(router, config)` — binds a TCP port, starts serving on a background task, and
   returns an `HttpServer` handle.
 - `HttpServer` — opaque handle to the running server; implements the `Task` trait, so it
   integrates directly with the `modo::run!` macro for coordinated, signal-driven shutdown.
+- `HostRouter` — routes requests to different axum routers based on the `Host` header,
+  supporting exact matches and single-level wildcard subdomains.
+- `MatchedHost` — axum extractor that provides the subdomain captured by a wildcard
+  pattern match.
 
 ## Usage
 
 ### Minimal server
 
-```rust
+```rust,no_run
 use modo::server::{Config, http};
 
 #[tokio::main]
@@ -28,9 +32,52 @@ async fn main() -> modo::Result<()> {
 }
 ```
 
+### Host-based routing
+
+`HostRouter` dispatches requests to different routers based on the `Host` header.
+Exact hosts take priority over wildcards, and an optional fallback catches unmatched
+hosts.
+
+```rust,no_run
+use modo::server::{self, Config, HostRouter};
+
+#[tokio::main]
+async fn main() -> modo::Result<()> {
+    let config = Config::default();
+
+    let app = HostRouter::new()
+        .host("acme.com", modo::axum::Router::new())         // exact match
+        .host("app.acme.com", modo::axum::Router::new())     // exact match
+        .host("*.acme.com", modo::axum::Router::new())       // wildcard subdomain
+        .fallback(modo::axum::Router::new());                 // unmatched hosts
+
+    // HostRouter implements Into<axum::Router>, so it can be passed directly to http()
+    let server = server::http(app, &config).await?;
+    modo::run!(server).await
+}
+```
+
+### Extracting the matched subdomain
+
+When a request matches a wildcard pattern, `MatchedHost` is available as an axum
+extractor. Use `Option<MatchedHost>` for handlers that serve both exact and wildcard
+routes.
+
+```rust,ignore
+use modo::server::MatchedHost;
+use axum::response::IntoResponse;
+
+async fn handler(matched: MatchedHost) -> impl IntoResponse {
+    // For a request to "tenant1.acme.com" matching "*.acme.com":
+    //   matched.subdomain == "tenant1"
+    //   matched.pattern   == "*.acme.com"
+    format!("Hello, {}!", matched.subdomain)
+}
+```
+
 ### Loading config from YAML
 
-```rust
+```rust,ignore
 use modo::config::load;
 
 // Reads config/development.yaml (or the file named after APP_ENV)
@@ -44,7 +91,7 @@ let _ = config.server;
 `modo::run!` accepts any number of `Task` values and shuts them down in order
 after a `SIGTERM` or `Ctrl-C` signal is received.
 
-```rust
+```rust,no_run
 use modo::server::{Config, http};
 
 #[tokio::main]
@@ -78,10 +125,23 @@ server:
   shutdown_timeout_secs: 30
 ```
 
-## Key Types
+## Key types
 
-| Symbol       | Description                                                                  |
-| ------------ | ---------------------------------------------------------------------------- |
-| `Config`     | Server bind address and shutdown timeout; deserializes from YAML             |
-| `HttpServer` | Opaque handle to the running server; implements `Task` for graceful shutdown |
-| `http`       | `async fn http(router: axum::Router, config: &Config) -> Result<HttpServer>` |
+| Type          | Description                                                                          |
+| ------------- | ------------------------------------------------------------------------------------ |
+| `Config`      | Server bind address and shutdown timeout; deserializes from YAML                     |
+| `HttpServer`  | Opaque handle to the running server; implements `Task` for graceful shutdown         |
+| `http`        | Binds a TCP listener and starts serving; accepts `impl Into<axum::Router>`           |
+| `HostRouter`  | Routes requests to different routers by `Host` header; exact and wildcard matching   |
+| `MatchedHost` | Axum extractor providing the subdomain captured by a wildcard `HostRouter` pattern   |
+
+## Host resolution
+
+`HostRouter` resolves the effective host from incoming requests by checking headers in
+this order:
+
+1. `Forwarded` header (RFC 7239) -- `host=` directive
+2. `X-Forwarded-Host` header
+3. `Host` header
+
+The resolved value is lowercased and any trailing port is stripped before matching.

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -311,8 +311,7 @@ fn resolve_host(parts: &Parts) -> Result<String, Error> {
         && let Ok(fwd_str) = fwd.to_str()
     {
         // Comma-separated entries represent multiple hops; only the first is relevant.
-        // split() always yields at least one element on a non-empty string.
-        let first_element = fwd_str.split(',').next().unwrap();
+        let first_element = fwd_str.split(',').next().unwrap_or(fwd_str);
         for directive in first_element.split(';') {
             let directive = directive.trim();
             // RFC 7239: directive names are case-insensitive

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::Router;
+use axum::extract::{FromRequestParts, OptionalFromRequestParts};
 use http::request::Parts;
 
 use crate::Error;
@@ -155,6 +156,59 @@ impl HostRouterInner {
             Some(router) => Match::Fallback(router),
             None => Match::NotFound,
         }
+    }
+}
+
+/// Information about a wildcard host match.
+///
+/// Inserted into request extensions when a request matches a wildcard
+/// pattern (e.g. `*.acme.com`). Not present for exact or fallback matches.
+///
+/// Use `Option<MatchedHost>` for handlers that serve both exact and wildcard
+/// routes.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// async fn handler(matched: MatchedHost) -> impl IntoResponse {
+///     format!("subdomain: {}", matched.subdomain)
+/// }
+/// ```
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug, Clone)]
+pub struct MatchedHost {
+    /// The subdomain that matched (e.g. `"tenant1"` from `"tenant1.acme.com"`).
+    pub subdomain: String,
+    /// The wildcard pattern that matched (e.g. `"*.acme.com"`).
+    pub pattern: String,
+}
+
+impl<S> FromRequestParts<S> for MatchedHost
+where
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<MatchedHost>()
+            .cloned()
+            .ok_or_else(|| Error::internal("MatchedHost not found in request extensions"))
+    }
+}
+
+impl<S> OptionalFromRequestParts<S> for MatchedHost
+where
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> Result<Option<Self>, Self::Rejection> {
+        Ok(parts.extensions.get::<MatchedHost>().cloned())
     }
 }
 
@@ -408,5 +462,58 @@ mod tests {
     #[should_panic(expected = "empty suffix")]
     fn panic_on_star_dot_only() {
         HostRouter::new().host("*.", router_with_body("a"));
+    }
+
+    // ── MatchedHost extractor ─────────────────────────────────
+
+    #[tokio::test]
+    async fn extract_matched_host_present() {
+        let (mut parts, _) = http::Request::builder().body(()).unwrap().into_parts();
+        parts.extensions.insert(MatchedHost {
+            subdomain: "tenant1".into(),
+            pattern: "*.acme.com".into(),
+        });
+
+        let result =
+            <MatchedHost as FromRequestParts<()>>::from_request_parts(&mut parts, &()).await;
+        let matched = result.unwrap();
+        assert_eq!(matched.subdomain, "tenant1");
+        assert_eq!(matched.pattern, "*.acme.com");
+    }
+
+    #[tokio::test]
+    async fn extract_matched_host_missing_returns_500() {
+        let (mut parts, _) = http::Request::builder().body(()).unwrap().into_parts();
+
+        let result =
+            <MatchedHost as FromRequestParts<()>>::from_request_parts(&mut parts, &()).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn optional_matched_host_none_when_missing() {
+        let (mut parts, _) = http::Request::builder().body(()).unwrap().into_parts();
+
+        let result =
+            <MatchedHost as OptionalFromRequestParts<()>>::from_request_parts(&mut parts, &())
+                .await;
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn optional_matched_host_some_when_present() {
+        let (mut parts, _) = http::Request::builder().body(()).unwrap().into_parts();
+        parts.extensions.insert(MatchedHost {
+            subdomain: "t1".into(),
+            pattern: "*.acme.com".into(),
+        });
+
+        let result =
+            <MatchedHost as OptionalFromRequestParts<()>>::from_request_parts(&mut parts, &())
+                .await;
+        let matched = result.unwrap().unwrap();
+        assert_eq!(matched.subdomain, "t1");
+        assert_eq!(matched.pattern, "*.acme.com");
     }
 }

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -25,7 +25,7 @@ use crate::Error;
 ///
 /// The [`host`](Self::host) and [`fallback`](Self::fallback) methods panic if
 /// called after the `HostRouter` has been cloned or converted. Complete all
-/// route registration before passing the router to [`server::http()`](crate::server::http)
+/// route registration before passing the router to [`server::http()`](crate::server::http())
 /// or cloning it.
 ///
 /// The [`host`](Self::host) method also panics on:

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -1,6 +1,162 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::Router;
 use http::request::Parts;
 
 use crate::Error;
+
+/// Routes requests to different axum [`Router`]s based on the `Host` header.
+///
+/// Supports exact host matches (`acme.com`, `app.acme.com`) and single-level
+/// wildcard subdomains (`*.acme.com`). Both use `HashMap` lookups for O(1)
+/// matching.
+///
+/// # Panics
+///
+/// The [`host`](Self::host) method panics on:
+/// - Duplicate exact host patterns
+/// - Duplicate wildcard suffixes
+/// - Invalid wildcard patterns (suffix must contain at least one dot)
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use modo::server::HostRouter;
+/// use axum::Router;
+///
+/// let app = HostRouter::new()
+///     .host("acme.com", Router::new())
+///     .host("app.acme.com", Router::new())
+///     .host("*.acme.com", Router::new())
+///     .fallback(Router::new());
+/// ```
+#[allow(dead_code)]
+pub struct HostRouter {
+    inner: Arc<HostRouterInner>,
+}
+
+struct HostRouterInner {
+    exact: HashMap<String, Router>,
+    wildcard: HashMap<String, Router>,
+    fallback: Option<Router>,
+}
+
+#[allow(dead_code)]
+enum Match<'a> {
+    Exact(&'a Router),
+    Wildcard {
+        router: &'a Router,
+        subdomain: String,
+        pattern: String,
+    },
+    Fallback(&'a Router),
+    NotFound,
+}
+
+impl Default for HostRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(dead_code)]
+impl HostRouter {
+    /// Create a new empty `HostRouter` with no registered hosts and no fallback.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(HostRouterInner {
+                exact: HashMap::new(),
+                wildcard: HashMap::new(),
+                fallback: None,
+            }),
+        }
+    }
+
+    /// Register a host pattern with a router.
+    ///
+    /// Exact patterns (e.g. `"acme.com"`, `"app.acme.com"`) match the host
+    /// literally. Wildcard patterns (e.g. `"*.acme.com"`) match any single
+    /// subdomain level.
+    ///
+    /// # Panics
+    ///
+    /// - If an exact host is registered twice.
+    /// - If a wildcard suffix is registered twice.
+    /// - If a wildcard suffix contains no dot (e.g. `"*.com"`).
+    pub fn host(mut self, pattern: &str, router: Router) -> Self {
+        let inner = Arc::get_mut(&mut self.inner).expect("HostRouter::host called after clone");
+        let pattern = strip_port(pattern.trim()).to_lowercase();
+
+        if let Some(suffix) = pattern.strip_prefix("*.") {
+            // Wildcard validation: suffix must be non-empty and contain at least one dot
+            assert!(
+                !suffix.is_empty(),
+                "invalid wildcard pattern \"{pattern}\": empty suffix"
+            );
+            assert!(
+                suffix.contains('.'),
+                "invalid wildcard pattern \"{pattern}\": suffix must contain at least one dot (e.g. \"*.example.com\")"
+            );
+            let prev = inner.wildcard.insert(suffix.to_owned(), router);
+            assert!(
+                prev.is_none(),
+                "duplicate wildcard suffix: \"*.{suffix}\" registered twice"
+            );
+        } else {
+            assert!(!pattern.is_empty(), "host pattern must not be empty");
+            assert!(
+                !pattern.starts_with('*'),
+                "invalid wildcard pattern \"{pattern}\": use \"*.domain.com\" format"
+            );
+            let prev = inner.exact.insert(pattern.clone(), router);
+            assert!(
+                prev.is_none(),
+                "duplicate exact host: \"{pattern}\" registered twice"
+            );
+        }
+
+        self
+    }
+
+    /// Set a fallback router for requests whose host doesn't match any pattern.
+    ///
+    /// If no fallback is set, unmatched hosts receive a 404 response.
+    pub fn fallback(mut self, router: Router) -> Self {
+        let inner = Arc::get_mut(&mut self.inner).expect("HostRouter::fallback called after clone");
+        inner.fallback = Some(router);
+        self
+    }
+}
+
+impl HostRouterInner {
+    #[allow(dead_code)]
+    fn match_host(&self, host: &str) -> Match<'_> {
+        // 1. Exact match
+        if let Some(router) = self.exact.get(host) {
+            return Match::Exact(router);
+        }
+
+        // 2. Wildcard match — split at first dot
+        if let Some(dot) = host.find('.') {
+            let subdomain = &host[..dot];
+            let suffix = &host[dot + 1..];
+            if let Some(router) = self.wildcard.get(suffix) {
+                return Match::Wildcard {
+                    router,
+                    subdomain: subdomain.to_owned(),
+                    pattern: format!("*.{suffix}"),
+                };
+            }
+        }
+
+        // 3. Fallback or 404
+        match &self.fallback {
+            Some(router) => Match::Fallback(router),
+            None => Match::NotFound,
+        }
+    }
+}
 
 /// Resolve the effective host from a request, checking proxy headers first.
 ///
@@ -137,5 +293,120 @@ mod tests {
             ("host", "fallback.com"),
         ]);
         assert_eq!(resolve_host(&parts).unwrap(), "fallback.com");
+    }
+
+    // ── Matching ──────────────────────────────────────────────
+
+    fn router_with_body(body: &'static str) -> Router {
+        Router::new().route("/", axum::routing::get(move || async move { body }))
+    }
+
+    #[test]
+    fn match_exact() {
+        let hr = HostRouter::new().host("acme.com", router_with_body("landing"));
+        assert!(matches!(hr.inner.match_host("acme.com"), Match::Exact(_)));
+    }
+
+    #[test]
+    fn match_wildcard() {
+        let hr = HostRouter::new().host("*.acme.com", router_with_body("tenant"));
+        match hr.inner.match_host("tenant1.acme.com") {
+            Match::Wildcard {
+                subdomain, pattern, ..
+            } => {
+                assert_eq!(subdomain, "tenant1");
+                assert_eq!(pattern, "*.acme.com");
+            }
+            other => panic!("expected Wildcard, got {}", match_name(&other)),
+        }
+    }
+
+    #[test]
+    fn exact_wins_over_wildcard() {
+        let hr = HostRouter::new()
+            .host("app.acme.com", router_with_body("admin"))
+            .host("*.acme.com", router_with_body("tenant"));
+        assert!(matches!(
+            hr.inner.match_host("app.acme.com"),
+            Match::Exact(_)
+        ));
+    }
+
+    #[test]
+    fn bare_domain_does_not_match_wildcard() {
+        let hr = HostRouter::new().host("*.acme.com", router_with_body("tenant"));
+        assert!(matches!(hr.inner.match_host("acme.com"), Match::NotFound));
+    }
+
+    #[test]
+    fn multi_level_subdomain_does_not_match_wildcard() {
+        let hr = HostRouter::new().host("*.acme.com", router_with_body("tenant"));
+        // "a.b.acme.com" splits to subdomain="a", suffix="b.acme.com" — not in wildcard map
+        assert!(matches!(
+            hr.inner.match_host("a.b.acme.com"),
+            Match::NotFound
+        ));
+    }
+
+    #[test]
+    fn fallback_when_no_match() {
+        let hr = HostRouter::new()
+            .host("acme.com", router_with_body("landing"))
+            .fallback(router_with_body("fallback"));
+        assert!(matches!(
+            hr.inner.match_host("other.com"),
+            Match::Fallback(_)
+        ));
+    }
+
+    #[test]
+    fn not_found_when_no_match_and_no_fallback() {
+        let hr = HostRouter::new().host("acme.com", router_with_body("landing"));
+        assert!(matches!(hr.inner.match_host("other.com"), Match::NotFound));
+    }
+
+    fn match_name(m: &Match<'_>) -> &'static str {
+        match m {
+            Match::Exact(_) => "Exact",
+            Match::Wildcard { .. } => "Wildcard",
+            Match::Fallback(_) => "Fallback",
+            Match::NotFound => "NotFound",
+        }
+    }
+
+    // ── Construction panics ───────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "duplicate exact host")]
+    fn panic_on_duplicate_exact() {
+        HostRouter::new()
+            .host("acme.com", router_with_body("a"))
+            .host("acme.com", router_with_body("b"));
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate wildcard suffix")]
+    fn panic_on_duplicate_wildcard() {
+        HostRouter::new()
+            .host("*.acme.com", router_with_body("a"))
+            .host("*.acme.com", router_with_body("b"));
+    }
+
+    #[test]
+    #[should_panic(expected = "suffix must contain at least one dot")]
+    fn panic_on_tld_wildcard() {
+        HostRouter::new().host("*.com", router_with_body("a"));
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid wildcard pattern")]
+    fn panic_on_bare_star() {
+        HostRouter::new().host("*", router_with_body("a"));
+    }
+
+    #[test]
+    #[should_panic(expected = "empty suffix")]
+    fn panic_on_star_dot_only() {
+        HostRouter::new().host("*.", router_with_body("a"));
     }
 }

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -583,6 +583,7 @@ mod tests {
             <MatchedHost as FromRequestParts<()>>::from_request_parts(&mut parts, &()).await;
         let err = result.unwrap_err();
         assert_eq!(err.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.to_string(), "internal routing error");
     }
 
     #[tokio::test]

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -311,7 +311,8 @@ fn resolve_host(parts: &Parts) -> Result<String, Error> {
         && let Ok(fwd_str) = fwd.to_str()
     {
         // Comma-separated entries represent multiple hops; only the first is relevant.
-        let first_element = fwd_str.split(',').next().unwrap_or(fwd_str);
+        // split() always yields at least one element on a non-empty string.
+        let first_element = fwd_str.split(',').next().unwrap();
         for directive in first_element.split(';') {
             let directive = directive.trim();
             // RFC 7239: directive names are case-insensitive

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -39,10 +40,12 @@ use crate::Error;
 ///     .host("*.acme.com", Router::new())
 ///     .fallback(Router::new());
 /// ```
+#[derive(Clone)]
 pub struct HostRouter {
     inner: Arc<HostRouterInner>,
 }
 
+#[derive(Clone)]
 struct HostRouterInner {
     exact: HashMap<String, Router>,
     wildcard: HashMap<String, Router>,
@@ -60,17 +63,27 @@ enum Match<'a> {
     NotFound,
 }
 
-impl Default for HostRouter {
-    fn default() -> Self {
-        Self::new()
+impl fmt::Debug for HostRouter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HostRouter")
+            .field("exact_hosts", &self.inner.exact.keys().collect::<Vec<_>>())
+            .field(
+                "wildcard_hosts",
+                &self
+                    .inner
+                    .wildcard
+                    .keys()
+                    .map(|k| format!("*.{k}"))
+                    .collect::<Vec<_>>(),
+            )
+            .field("has_fallback", &self.inner.fallback.is_some())
+            .finish()
     }
 }
 
-impl Clone for HostRouter {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
+impl Default for HostRouter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -222,16 +235,6 @@ where
     }
 }
 
-impl Clone for HostRouterInner {
-    fn clone(&self) -> Self {
-        Self {
-            exact: self.exact.clone(),
-            wildcard: self.wildcard.clone(),
-            fallback: self.fallback.clone(),
-        }
-    }
-}
-
 impl Service<Request<Body>> for HostRouterInner {
     type Response = http::Response<Body>;
     type Error = Infallible;
@@ -242,9 +245,7 @@ impl Service<Request<Body>> for HostRouterInner {
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let exact = self.exact.clone();
-        let wildcard = self.wildcard.clone();
-        let fallback = self.fallback.clone();
+        let inner = self.clone();
 
         Box::pin(async move {
             let (mut parts, body) = req.into_parts();
@@ -252,13 +253,6 @@ impl Service<Request<Body>> for HostRouterInner {
             let host = match resolve_host(&parts) {
                 Ok(h) => h,
                 Err(e) => return Ok(e.into_response()),
-            };
-
-            // Build a temporary inner for matching
-            let inner = HostRouterInner {
-                exact,
-                wildcard,
-                fallback,
             };
 
             match inner.match_host(&host) {
@@ -312,8 +306,9 @@ fn resolve_host(parts: &Parts) -> Result<String, Error> {
         let first_element = fwd_str.split(',').next().unwrap_or(fwd_str);
         for directive in first_element.split(';') {
             let directive = directive.trim();
-            if let Some(host) = directive.strip_prefix("host=") {
-                let host = host.trim();
+            // RFC 7239: directive names are case-insensitive
+            if directive.len() > 5 && directive[..5].eq_ignore_ascii_case("host=") {
+                let host = directive[5..].trim();
                 if !host.is_empty() {
                     return Ok(strip_port(host).to_lowercase());
                 }
@@ -417,6 +412,12 @@ mod tests {
         let parts = parts_with_headers(&[]);
         let err = resolve_host(&parts).unwrap_err();
         assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn resolve_forwarded_case_insensitive_host_directive() {
+        let parts = parts_with_headers(&[("forwarded", "for=1.2.3.4; Host=acme.com")]);
+        assert_eq!(resolve_host(&parts).unwrap(), "acme.com");
     }
 
     #[test]

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -53,7 +53,10 @@ pub struct HostRouter {
 #[derive(Clone)]
 struct HostRouterInner {
     exact: HashMap<String, Router>,
-    wildcard: HashMap<String, Router>,
+    /// Key is the suffix (e.g. `"acme.com"`), value is `(pattern, router)` where
+    /// pattern is the full wildcard string (e.g. `"*.acme.com"`), preformatted at
+    /// registration time to avoid per-request allocation.
+    wildcard: HashMap<String, (String, Router)>,
     fallback: Option<Router>,
 }
 
@@ -129,7 +132,10 @@ impl HostRouter {
                 suffix.contains('.'),
                 "invalid wildcard pattern \"{pattern}\": suffix must contain at least one dot (e.g. \"*.example.com\")"
             );
-            let prev = inner.wildcard.insert(suffix.to_owned(), router);
+            let full_pattern = format!("*.{suffix}");
+            let prev = inner
+                .wildcard
+                .insert(suffix.to_owned(), (full_pattern, router));
             assert!(
                 prev.is_none(),
                 "duplicate wildcard suffix: \"*.{suffix}\" registered twice"
@@ -162,25 +168,22 @@ impl HostRouter {
 
 impl HostRouterInner {
     fn match_host(&self, host: &str) -> Match<'_> {
-        // 1. Exact match
         if let Some(router) = self.exact.get(host) {
             return Match::Exact(router);
         }
 
-        // 2. Wildcard match — split at first dot
         if let Some(dot) = host.find('.') {
             let subdomain = &host[..dot];
             let suffix = &host[dot + 1..];
-            if let Some(router) = self.wildcard.get(suffix) {
+            if let Some((pattern, router)) = self.wildcard.get(suffix) {
                 return Match::Wildcard {
                     router,
                     subdomain: subdomain.to_owned(),
-                    pattern: format!("*.{suffix}"),
+                    pattern: pattern.clone(),
                 };
             }
         }
 
-        // 3. Fallback or 404
         match &self.fallback {
             Some(router) => Match::Fallback(router),
             None => Match::NotFound,
@@ -266,26 +269,23 @@ impl Service<Request<Body>> for HostRouterService {
                 Err(e) => return Ok(e.into_response()),
             };
 
-            match inner.match_host(&host) {
-                Match::Exact(router) => {
-                    let req = Request::from_parts(parts, body);
-                    Ok(router.clone().call(req).await.into_response())
-                }
+            let router = match inner.match_host(&host) {
+                Match::Exact(router) | Match::Fallback(router) => router,
                 Match::Wildcard {
                     router,
                     subdomain,
                     pattern,
                 } => {
                     parts.extensions.insert(MatchedHost { subdomain, pattern });
-                    let req = Request::from_parts(parts, body);
-                    Ok(router.clone().call(req).await.into_response())
+                    router
                 }
-                Match::Fallback(router) => {
-                    let req = Request::from_parts(parts, body);
-                    Ok(router.clone().call(req).await.into_response())
+                Match::NotFound => {
+                    return Ok(Error::not_found("no route for host").into_response());
                 }
-                Match::NotFound => Ok(Error::not_found("no route for host").into_response()),
-            }
+            };
+
+            let req = Request::from_parts(parts, body);
+            Ok(router.clone().call(req).await.into_response())
         })
     }
 }
@@ -305,20 +305,20 @@ impl From<HostRouter> for axum::Router {
 ///
 /// After extraction the value is lowercased and any trailing port is stripped.
 fn resolve_host(parts: &Parts) -> Result<String, Error> {
-    // 1. Forwarded: host=...
+    const HOST_DIRECTIVE: &str = "host=";
+
     if let Some(fwd) = parts.headers.get("forwarded")
         && let Ok(fwd_str) = fwd.to_str()
     {
-        // Parse "host=" directive from the first element.
-        // The Forwarded header can have comma-separated entries for multiple hops;
-        // only the first element is relevant.
-        // Format: "for=...; host=example.com; proto=https"
+        // Comma-separated entries represent multiple hops; only the first is relevant.
         let first_element = fwd_str.split(',').next().unwrap_or(fwd_str);
         for directive in first_element.split(';') {
             let directive = directive.trim();
             // RFC 7239: directive names are case-insensitive
-            if directive.len() > 5 && directive[..5].eq_ignore_ascii_case("host=") {
-                let host = directive[5..].trim();
+            if directive.len() >= HOST_DIRECTIVE.len()
+                && directive[..HOST_DIRECTIVE.len()].eq_ignore_ascii_case(HOST_DIRECTIVE)
+            {
+                let host = directive[HOST_DIRECTIVE.len()..].trim();
                 if !host.is_empty() {
                     return Ok(strip_port(host).to_lowercase());
                 }
@@ -326,7 +326,6 @@ fn resolve_host(parts: &Parts) -> Result<String, Error> {
         }
     }
 
-    // 2. X-Forwarded-Host
     if let Some(xfh) = parts.headers.get("x-forwarded-host")
         && let Ok(host) = xfh.to_str()
     {
@@ -336,7 +335,6 @@ fn resolve_host(parts: &Parts) -> Result<String, Error> {
         }
     }
 
-    // 3. Host header
     if let Some(h) = parts.headers.get(http::header::HOST)
         && let Ok(host) = h.to_str()
     {

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -23,7 +23,12 @@ use crate::Error;
 ///
 /// # Panics
 ///
-/// The [`host`](Self::host) method panics on:
+/// The [`host`](Self::host) and [`fallback`](Self::fallback) methods panic if
+/// called after the `HostRouter` has been cloned or converted. Complete all
+/// route registration before passing the router to [`server::http()`](crate::server::http)
+/// or cloning it.
+///
+/// The [`host`](Self::host) method also panics on:
 /// - Duplicate exact host patterns
 /// - Duplicate wildcard suffixes
 /// - Invalid wildcard patterns (suffix must contain at least one dot)
@@ -217,7 +222,7 @@ where
             .extensions
             .get::<MatchedHost>()
             .cloned()
-            .ok_or_else(|| Error::internal("MatchedHost not found in request extensions"))
+            .ok_or_else(|| Error::internal("internal routing error"))
     }
 }
 
@@ -235,7 +240,13 @@ where
     }
 }
 
-impl Service<Request<Body>> for HostRouterInner {
+/// Newtype around `Arc<HostRouterInner>` so we can implement `tower::Service`
+/// without hitting orphan rules. Each `call()` does a cheap `Arc::clone`
+/// instead of cloning all `HashMap`s.
+#[derive(Clone)]
+struct HostRouterService(Arc<HostRouterInner>);
+
+impl Service<Request<Body>> for HostRouterService {
     type Response = http::Response<Body>;
     type Error = Infallible;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
@@ -245,7 +256,7 @@ impl Service<Request<Body>> for HostRouterInner {
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let inner = self.clone();
+        let inner = Arc::clone(&self.0);
 
         Box::pin(async move {
             let (mut parts, body) = req.into_parts();
@@ -281,8 +292,7 @@ impl Service<Request<Body>> for HostRouterInner {
 
 impl From<HostRouter> for axum::Router {
     fn from(host_router: HostRouter) -> axum::Router {
-        let inner = Arc::try_unwrap(host_router.inner).unwrap_or_else(|arc| (*arc).clone());
-        axum::Router::new().fallback_service(inner)
+        axum::Router::new().fallback_service(HostRouterService(host_router.inner))
     }
 }
 
@@ -340,6 +350,10 @@ fn resolve_host(parts: &Parts) -> Result<String, Error> {
 }
 
 /// Strip an optional `:port` suffix from a host string.
+///
+/// Assumes RFC 7230 formatting: IPv6 addresses must be bracketed (e.g.
+/// `[::1]:8080`), so a bare `::1` would not be correctly handled. In
+/// practice, all valid Host header values follow this convention.
 fn strip_port(host: &str) -> &str {
     match host.rfind(':') {
         Some(pos) if host[pos + 1..].bytes().all(|b| b.is_ascii_digit()) => &host[..pos],

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -1,0 +1,141 @@
+use http::request::Parts;
+
+use crate::Error;
+
+/// Resolve the effective host from a request, checking proxy headers first.
+///
+/// Checks in order:
+/// 1. `Forwarded` header (RFC 7239) — `host=` directive
+/// 2. `X-Forwarded-Host` header
+/// 3. `Host` header
+///
+/// After extraction the value is lowercased and any trailing port is stripped.
+#[cfg_attr(not(test), expect(dead_code))]
+fn resolve_host(parts: &Parts) -> Result<String, Error> {
+    // 1. Forwarded: host=...
+    if let Some(fwd) = parts.headers.get("forwarded")
+        && let Ok(fwd_str) = fwd.to_str()
+    {
+        // Parse "host=" directive from the first element.
+        // The Forwarded header can have comma-separated entries for multiple hops;
+        // only the first element is relevant.
+        // Format: "for=...; host=example.com; proto=https"
+        let first_element = fwd_str.split(',').next().unwrap_or(fwd_str);
+        for directive in first_element.split(';') {
+            let directive = directive.trim();
+            if let Some(host) = directive.strip_prefix("host=") {
+                let host = host.trim();
+                if !host.is_empty() {
+                    return Ok(strip_port(host).to_lowercase());
+                }
+            }
+        }
+    }
+
+    // 2. X-Forwarded-Host
+    if let Some(xfh) = parts.headers.get("x-forwarded-host")
+        && let Ok(host) = xfh.to_str()
+    {
+        let host = host.trim();
+        if !host.is_empty() {
+            return Ok(strip_port(host).to_lowercase());
+        }
+    }
+
+    // 3. Host header
+    if let Some(h) = parts.headers.get(http::header::HOST)
+        && let Ok(host) = h.to_str()
+    {
+        let host = host.trim();
+        if !host.is_empty() {
+            return Ok(strip_port(host).to_lowercase());
+        }
+    }
+
+    Err(Error::bad_request("missing or invalid Host header"))
+}
+
+/// Strip an optional `:port` suffix from a host string.
+fn strip_port(host: &str) -> &str {
+    match host.rfind(':') {
+        Some(pos) if host[pos + 1..].bytes().all(|b| b.is_ascii_digit()) => &host[..pos],
+        _ => host,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parts_with_headers(headers: &[(&str, &str)]) -> Parts {
+        let mut builder = http::Request::builder();
+        for &(name, value) in headers {
+            builder = builder.header(name, value);
+        }
+        let (parts, _) = builder.body(()).unwrap().into_parts();
+        parts
+    }
+
+    #[test]
+    fn resolve_from_host_header() {
+        let parts = parts_with_headers(&[("host", "acme.com")]);
+        assert_eq!(resolve_host(&parts).unwrap(), "acme.com");
+    }
+
+    #[test]
+    fn resolve_strips_port() {
+        let parts = parts_with_headers(&[("host", "acme.com:8080")]);
+        assert_eq!(resolve_host(&parts).unwrap(), "acme.com");
+    }
+
+    #[test]
+    fn resolve_lowercases() {
+        let parts = parts_with_headers(&[("host", "ACME.COM")]);
+        assert_eq!(resolve_host(&parts).unwrap(), "acme.com");
+    }
+
+    #[test]
+    fn resolve_x_forwarded_host_over_host() {
+        let parts =
+            parts_with_headers(&[("host", "proxy.internal"), ("x-forwarded-host", "acme.com")]);
+        assert_eq!(resolve_host(&parts).unwrap(), "acme.com");
+    }
+
+    #[test]
+    fn resolve_forwarded_over_x_forwarded_host() {
+        let parts = parts_with_headers(&[
+            ("host", "proxy.internal"),
+            ("x-forwarded-host", "xfh.com"),
+            ("forwarded", "for=1.2.3.4; host=acme.com; proto=https"),
+        ]);
+        assert_eq!(resolve_host(&parts).unwrap(), "acme.com");
+    }
+
+    #[test]
+    fn resolve_forwarded_strips_port() {
+        let parts = parts_with_headers(&[("forwarded", "host=acme.com:443")]);
+        assert_eq!(resolve_host(&parts).unwrap(), "acme.com");
+    }
+
+    #[test]
+    fn resolve_x_forwarded_host_strips_port() {
+        let parts = parts_with_headers(&[("x-forwarded-host", "acme.com:8080")]);
+        assert_eq!(resolve_host(&parts).unwrap(), "acme.com");
+    }
+
+    #[test]
+    fn resolve_missing_all_headers_returns_400() {
+        let parts = parts_with_headers(&[]);
+        let err = resolve_host(&parts).unwrap_err();
+        assert_eq!(err.status(), http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn resolve_forwarded_without_host_falls_through() {
+        let parts = parts_with_headers(&[
+            ("forwarded", "for=1.2.3.4; proto=https"),
+            ("host", "fallback.com"),
+        ]);
+        assert_eq!(resolve_host(&parts).unwrap(), "fallback.com");
+    }
+}

--- a/src/server/host_router.rs
+++ b/src/server/host_router.rs
@@ -1,9 +1,16 @@
 use std::collections::HashMap;
+use std::convert::Infallible;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use axum::Router;
+use axum::body::Body;
 use axum::extract::{FromRequestParts, OptionalFromRequestParts};
+use axum::response::IntoResponse;
+use http::Request;
 use http::request::Parts;
+use tower::Service;
 
 use crate::Error;
 
@@ -32,7 +39,6 @@ use crate::Error;
 ///     .host("*.acme.com", Router::new())
 ///     .fallback(Router::new());
 /// ```
-#[allow(dead_code)]
 pub struct HostRouter {
     inner: Arc<HostRouterInner>,
 }
@@ -43,7 +49,6 @@ struct HostRouterInner {
     fallback: Option<Router>,
 }
 
-#[allow(dead_code)]
 enum Match<'a> {
     Exact(&'a Router),
     Wildcard {
@@ -61,7 +66,14 @@ impl Default for HostRouter {
     }
 }
 
-#[allow(dead_code)]
+impl Clone for HostRouter {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
 impl HostRouter {
     /// Create a new empty `HostRouter` with no registered hosts and no fallback.
     pub fn new() -> Self {
@@ -131,7 +143,6 @@ impl HostRouter {
 }
 
 impl HostRouterInner {
-    #[allow(dead_code)]
     fn match_host(&self, host: &str) -> Match<'_> {
         // 1. Exact match
         if let Some(router) = self.exact.get(host) {
@@ -174,7 +185,6 @@ impl HostRouterInner {
 ///     format!("subdomain: {}", matched.subdomain)
 /// }
 /// ```
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub struct MatchedHost {
     /// The subdomain that matched (e.g. `"tenant1"` from `"tenant1.acme.com"`).
@@ -212,6 +222,76 @@ where
     }
 }
 
+impl Clone for HostRouterInner {
+    fn clone(&self) -> Self {
+        Self {
+            exact: self.exact.clone(),
+            wildcard: self.wildcard.clone(),
+            fallback: self.fallback.clone(),
+        }
+    }
+}
+
+impl Service<Request<Body>> for HostRouterInner {
+    type Response = http::Response<Body>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let exact = self.exact.clone();
+        let wildcard = self.wildcard.clone();
+        let fallback = self.fallback.clone();
+
+        Box::pin(async move {
+            let (mut parts, body) = req.into_parts();
+
+            let host = match resolve_host(&parts) {
+                Ok(h) => h,
+                Err(e) => return Ok(e.into_response()),
+            };
+
+            // Build a temporary inner for matching
+            let inner = HostRouterInner {
+                exact,
+                wildcard,
+                fallback,
+            };
+
+            match inner.match_host(&host) {
+                Match::Exact(router) => {
+                    let req = Request::from_parts(parts, body);
+                    Ok(router.clone().call(req).await.into_response())
+                }
+                Match::Wildcard {
+                    router,
+                    subdomain,
+                    pattern,
+                } => {
+                    parts.extensions.insert(MatchedHost { subdomain, pattern });
+                    let req = Request::from_parts(parts, body);
+                    Ok(router.clone().call(req).await.into_response())
+                }
+                Match::Fallback(router) => {
+                    let req = Request::from_parts(parts, body);
+                    Ok(router.clone().call(req).await.into_response())
+                }
+                Match::NotFound => Ok(Error::not_found("no route for host").into_response()),
+            }
+        })
+    }
+}
+
+impl From<HostRouter> for axum::Router {
+    fn from(host_router: HostRouter) -> axum::Router {
+        let inner = Arc::try_unwrap(host_router.inner).unwrap_or_else(|arc| (*arc).clone());
+        axum::Router::new().fallback_service(inner)
+    }
+}
+
 /// Resolve the effective host from a request, checking proxy headers first.
 ///
 /// Checks in order:
@@ -220,7 +300,6 @@ where
 /// 3. `Host` header
 ///
 /// After extraction the value is lowercased and any trailing port is stripped.
-#[cfg_attr(not(test), expect(dead_code))]
 fn resolve_host(parts: &Parts) -> Result<String, Error> {
     // 1. Forwarded: host=...
     if let Some(fwd) = parts.headers.get("forwarded")
@@ -515,5 +594,154 @@ mod tests {
         let matched = result.unwrap().unwrap();
         assert_eq!(matched.subdomain, "t1");
         assert_eq!(matched.pattern, "*.acme.com");
+    }
+
+    // ── Full dispatch tests ──────────────────────────────────
+
+    use axum::body::Body;
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    async fn response_body(resp: http::Response<Body>) -> String {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn dispatch_exact_match() {
+        let hr = HostRouter::new()
+            .host("acme.com", router_with_body("landing"))
+            .host("app.acme.com", router_with_body("admin"));
+
+        let router: axum::Router = hr.into();
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "acme.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(response_body(resp).await, "landing");
+    }
+
+    #[tokio::test]
+    async fn dispatch_wildcard_match() {
+        let hr = HostRouter::new().host("*.acme.com", router_with_body("tenant"));
+
+        let router: axum::Router = hr.into();
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "tenant1.acme.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(response_body(resp).await, "tenant");
+    }
+
+    #[tokio::test]
+    async fn dispatch_wildcard_injects_matched_host() {
+        let tenant_router = Router::new().route(
+            "/",
+            axum::routing::get(|matched: MatchedHost| async move {
+                format!("{}:{}", matched.subdomain, matched.pattern)
+            }),
+        );
+
+        let hr = HostRouter::new().host("*.acme.com", tenant_router);
+
+        let router: axum::Router = hr.into();
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "tenant1.acme.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(response_body(resp).await, "tenant1:*.acme.com");
+    }
+
+    #[tokio::test]
+    async fn dispatch_exact_wins_over_wildcard() {
+        let hr = HostRouter::new()
+            .host("app.acme.com", router_with_body("admin"))
+            .host("*.acme.com", router_with_body("tenant"));
+
+        let router: axum::Router = hr.into();
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "app.acme.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(response_body(resp).await, "admin");
+    }
+
+    #[tokio::test]
+    async fn dispatch_fallback() {
+        let hr = HostRouter::new()
+            .host("acme.com", router_with_body("landing"))
+            .fallback(router_with_body("fallback"));
+
+        let router: axum::Router = hr.into();
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "unknown.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(response_body(resp).await, "fallback");
+    }
+
+    #[tokio::test]
+    async fn dispatch_404_no_match_no_fallback() {
+        let hr = HostRouter::new().host("acme.com", router_with_body("landing"));
+
+        let router: axum::Router = hr.into();
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "unknown.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn dispatch_400_missing_host() {
+        let hr = HostRouter::new().host("acme.com", router_with_body("landing"));
+
+        let router: axum::Router = hr.into();
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn dispatch_via_x_forwarded_host() {
+        let hr = HostRouter::new().host("acme.com", router_with_body("landing"));
+
+        let router: axum::Router = hr.into();
+        let req = Request::builder()
+            .uri("/")
+            .header("host", "proxy.internal")
+            .header("x-forwarded-host", "acme.com")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(response_body(resp).await, "landing");
     }
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -57,7 +57,24 @@ impl Task for HttpServer {
 ///     modo::run!(server).await
 /// }
 /// ```
-pub async fn http(router: axum::Router, config: &Config) -> Result<HttpServer> {
+///
+/// With a [`HostRouter`](super::HostRouter):
+///
+/// ```no_run
+/// use modo::server::{self, Config, HostRouter};
+///
+/// #[tokio::main]
+/// async fn main() -> modo::Result<()> {
+///     let config = Config::default();
+///     let app = HostRouter::new()
+///         .host("acme.com", modo::axum::Router::new())
+///         .host("*.acme.com", modo::axum::Router::new());
+///     let server = server::http(app, &config).await?;
+///     modo::run!(server).await
+/// }
+/// ```
+pub async fn http(router: impl Into<axum::Router>, config: &Config) -> Result<HttpServer> {
+    let router = router.into();
     let addr = format!("{}:{}", config.host, config.port);
     let listener = tokio::net::TcpListener::bind(&addr)
         .await

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides:
 //!
 //! - [`Config`] — bind address and shutdown timeout, loaded from YAML.
-//! - [`http`] — starts a TCP listener and returns an [`HttpServer`] handle.
+//! - [`http()`] — starts a TCP listener and returns an [`HttpServer`] handle.
 //! - [`HttpServer`] — opaque server handle that implements
 //!   [`crate::runtime::Task`] for use with the [`crate::run!`] macro.
 //! - [`HostRouter`] — host-based request routing to different axum routers.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,6 +6,8 @@
 //! - [`http`] — starts a TCP listener and returns an [`HttpServer`] handle.
 //! - [`HttpServer`] — opaque server handle that implements
 //!   [`crate::runtime::Task`] for use with the [`crate::run!`] macro.
+//! - [`HostRouter`] — host-based request routing to different axum routers.
+//! - [`MatchedHost`] — extractor for the subdomain matched by a wildcard pattern.
 //!
 //! # Example
 //!
@@ -26,4 +28,5 @@ mod host_router;
 mod http;
 
 pub use config::Config;
+pub use host_router::{HostRouter, MatchedHost};
 pub use http::{HttpServer, http};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -22,6 +22,7 @@
 //! ```
 
 mod config;
+mod host_router;
 mod http;
 
 pub use config::Config;


### PR DESCRIPTION
## Summary

- Add `HostRouter` — a routing primitive that dispatches requests to different axum `Router`s based on the `Host` header, supporting exact matches, single-level wildcard subdomains (`*.acme.com`), and optional fallback
- Add `MatchedHost` extractor for handlers to access the matched subdomain and pattern on wildcard routes
- Make `server::http()` generic over `impl Into<axum::Router>` so both plain `Router` and `HostRouter` can be passed directly

## Test Plan

- [x] 9 unit tests for host resolution (Forwarded, X-Forwarded-Host, Host header priority, port stripping, lowercasing)
- [x] 12 unit tests for builder and matching (exact, wildcard, fallback, NotFound, panic on invalid patterns)
- [x] 4 unit tests for MatchedHost extractor (FromRequestParts, OptionalFromRequestParts)
- [x] 8 integration tests via `tower::ServiceExt::oneshot` (full dispatch through Service impl)
- [x] `cargo clippy --all-features --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --doc` passes
- [x] Full `cargo test` suite passes (no regressions)