### PR TITLE
feat(db): add DatabasePool for multi-database shard management

### DIFF
--- a/skills/dev/references/database.md
+++ b/skills/dev/references/database.md
@@ -1,6 +1,6 @@
 # Database (`modo::db`)
 
-Lightweight libsql (SQLite) database layer. Single connection, no ORM, no pool. One module: `src/db/`.
+Lightweight libsql (SQLite) database layer. Single connection per handle, no ORM. Optional `DatabasePool` for multi-database sharding. One module: `src/db/`.
 
 Feature flag: `db` (default). Dependencies: `libsql`, `urlencoding`.
 
@@ -36,6 +36,16 @@ Derives `Debug`, `Clone`, `Deserialize`. All fields have serde defaults. `impl D
 | `synchronous`  | `SynchronousMode` | `Normal`             |
 | `foreign_keys` | `bool`            | `true`               |
 | `temp_store`   | `TempStore`       | `Memory`             |
+| `pool`         | `Option<PoolConfig>` | `None`            |
+
+### PoolConfig
+
+Derives `Debug`, `Clone`, `Deserialize`. Nested inside `Config` to enable `DatabasePool`.
+
+| Field          | Type     | Default          |
+| -------------- | -------- | ---------------- |
+| `base_path`    | `String` | `"data/shards"`  |
+| `shard_count`  | `usize`  | `16`             |
 
 ### Enum types
 
@@ -370,6 +380,41 @@ pub struct ManagedDatabase(Database);
 pub fn managed(db: Database) -> ManagedDatabase;
 ```
 
+## DatabasePool (Multi-Database Sharding)
+
+`DatabasePool` — manages a default `Database` plus lazily-opened shard databases. Wraps `Arc<Inner>`, cheap to clone. Created by `DatabasePool::new()`.
+
+```rust
+#[derive(Clone)]
+pub struct DatabasePool { /* inner: Arc<Inner> */ }
+
+impl DatabasePool {
+    pub async fn new(config: &Config) -> Result<Self>;
+    pub async fn conn(&self, shard: Option<&str>) -> Result<Database>;
+}
+```
+
+### `new(config: &Config) -> Result<Self>`
+
+Opens the default database immediately. Shard databases are opened lazily on first `conn()` call. Requires `config.pool` to be `Some`. Rejects `shard_count == 0`.
+
+### `conn(&self, shard: Option<&str>) -> Result<Database>`
+
+- `None` — returns the default database (instant, no lock).
+- `Some("name")` — returns the cached shard database, opening it on first access at `{base_path}/{name}.db`.
+
+Rejects empty shard names and names containing `/` or `\` (path traversal prevention). Concurrent first-access to the same shard may open duplicate connections; last writer wins (benign — `connect` is idempotent).
+
+### `ManagedDatabasePool`
+
+Implements `Task`. Wraps a `DatabasePool` for use with `run!` macro. On shutdown, drops the pool handle.
+
+```rust
+pub struct ManagedDatabasePool(DatabasePool);
+
+pub fn managed_pool(pool: DatabasePool) -> ManagedDatabasePool;
+```
+
 ## libsql Error Conversion
 
 `libsql::Error` converts into `modo::Error` via `From`:
@@ -476,7 +521,9 @@ impl FromRow for User {
 
 ## Gotchas
 
-- **Single connection**: `Database` wraps one `libsql::Connection` in `Arc`. No pool. All clones share the same connection.
+- **Single connection per handle**: `Database` wraps one `libsql::Connection` in `Arc`. All clones share the same connection. `DatabasePool` manages multiple `Database` handles (one per shard).
+
+- **Pool memory at scale**: Each shard connection uses its own SQLite page cache (default 16 MB `cache_size`) and mmap region (default 256 MB virtual). At 100 shards: ~1.6 GB page cache. Consider lowering `cache_size` for large shard counts.
 
 - **999 bind params limit**: SQLite limits a single statement to 999 bound parameters. Batch operations must chunk accordingly.
 

--- a/skills/dev/references/database.md
+++ b/skills/dev/references/database.md
@@ -45,7 +45,7 @@ Derives `Debug`, `Clone`, `Deserialize`. Nested inside `Config` to enable `Datab
 | Field          | Type     | Default          |
 | -------------- | -------- | ---------------- |
 | `base_path`    | `String` | `"data/shards"`  |
-| `shard_count`  | `usize`  | `16`             |
+| `lock_shards`  | `usize`  | `16`             |
 
 ### Enum types
 
@@ -396,7 +396,7 @@ impl DatabasePool {
 
 ### `new(config: &Config) -> Result<Self>`
 
-Opens the default database immediately. Shard databases are opened lazily on first `conn()` call. Requires `config.pool` to be `Some`. Rejects `shard_count == 0`.
+Opens the default database immediately. Shard databases are opened lazily on first `conn()` call. Requires `config.pool` to be `Some`. Rejects `lock_shards == 0`.
 
 ### `conn(&self, shard: Option<&str>) -> Result<Database>`
 

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -19,7 +19,7 @@ modo = { version = "...", features = ["db"] }
 | `ManagedDatabase`  | Wrapper for graceful shutdown via `modo::run!`                           |
 | `managed`          | Wraps a `Database` into a `ManagedDatabase`                              |
 | `DatabasePool`     | Multi-database pool with lazy shard opening for tenant isolation         |
-| `PoolConfig`       | Configuration for database sharding (base_path, shard_count)             |
+| `PoolConfig`       | Configuration for database sharding (base_path, lock_shards)             |
 | `ManagedDatabasePool` | Wrapper for graceful pool shutdown via `modo::run!`                   |
 | `managed_pool`     | Wraps a `DatabasePool` into a `ManagedDatabasePool`                      |
 | `ConnExt`          | Low-level `query_raw`/`execute_raw` trait for Connection and Transaction |
@@ -83,7 +83,7 @@ let config = db::Config {
     migrations: Some("migrations".to_string()),
     pool: Some(db::PoolConfig {
         base_path: "data/shards".to_string(),
-        shard_count: 16,
+        lock_shards: 16,
     }),
     ..Default::default()
 };
@@ -256,7 +256,7 @@ database:
     temp_store: memory # default | file | memory
     pool: # optional — enables DatabasePool
         base_path: "data/shards" # directory for shard .db files
-        shard_count: 16 # number of lock shards for the connection map
+        lock_shards: 16 # number of lock shards for the connection map
 ```
 
 ## Filter query string syntax

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -18,6 +18,10 @@ modo = { version = "...", features = ["db"] }
 | `migrate`          | Runs `*.sql` migrations with checksum tracking                           |
 | `ManagedDatabase`  | Wrapper for graceful shutdown via `modo::run!`                           |
 | `managed`          | Wraps a `Database` into a `ManagedDatabase`                              |
+| `DatabasePool`     | Multi-database pool with lazy shard opening for tenant isolation         |
+| `PoolConfig`       | Configuration for database sharding (base_path, shard_count)             |
+| `ManagedDatabasePool` | Wrapper for graceful pool shutdown via `modo::run!`                   |
+| `managed_pool`     | Wraps a `DatabasePool` into a `ManagedDatabasePool`                      |
 | `ConnExt`          | Low-level `query_raw`/`execute_raw` trait for Connection and Transaction |
 | `ConnQueryExt`     | High-level `query_one`/`query_all`/`query_optional` + `_map` variants    |
 | `SelectBuilder`    | Composable query builder with filter + sort + pagination                 |
@@ -64,6 +68,50 @@ let db = db::connect(&db::Config::default()).await?;
 let task = db::managed(db.clone());
 // Register `task` with modo::run!() for graceful shutdown
 ```
+
+### DatabasePool (multi-database sharding)
+
+`DatabasePool` manages a default database plus lazily-opened shard databases.
+Use `conn(None)` for the default database and `conn(Some("shard_name"))` for
+a tenant shard.
+
+```rust,no_run
+use modo::db::{self, ConnExt, DatabasePool};
+
+let config = db::Config {
+    path: "data/app.db".to_string(),
+    migrations: Some("migrations".to_string()),
+    pool: Some(db::PoolConfig {
+        base_path: "data/shards".to_string(),
+        shard_count: 16,
+    }),
+    ..Default::default()
+};
+
+let pool = DatabasePool::new(&config).await?;
+
+// Default database
+let db = pool.conn(None).await?;
+db.conn().execute_raw("SELECT 1", ()).await?;
+
+// Tenant shard (lazy open + cache)
+let shard = pool.conn(Some("tenant_abc")).await?;
+shard.conn().execute_raw("SELECT 1", ()).await?;
+
+// Graceful shutdown
+let task = db::managed_pool(pool.clone());
+// Register `task` with modo::run!()
+```
+
+Shard databases are created at `{base_path}/{shard_name}.db` and inherit all
+PRAGMAs and migrations from the parent config. Connections are cached after
+first open.
+
+**Memory note:** Each shard connection uses its own SQLite page cache
+(default `cache_size` = 16 MB) and mmap region (default `mmap_size` = 256 MB
+virtual). At 100 shards this means up to ~1.6 GB of page cache memory. For
+large shard counts, consider lowering `cache_size` in the config to reduce
+per-connection memory.
 
 ### Implementing FromRow
 
@@ -206,6 +254,9 @@ database:
     synchronous: normal # off | normal | full | extra
     foreign_keys: true
     temp_store: memory # default | file | memory
+    pool: # optional — enables DatabasePool
+        base_path: "data/shards" # directory for shard .db files
+        shard_count: 16 # number of lock shards for the connection map
 ```
 
 ## Filter query string syntax

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -44,6 +44,12 @@ pub struct Config {
     /// Temp store location.
     #[serde(default = "defaults::temp_store")]
     pub temp_store: TempStore,
+
+    /// Optional pool configuration for multi-database sharding.
+    /// When set, [`DatabasePool::new`](super::DatabasePool::new) can be used
+    /// to manage shard databases that share this config's PRAGMAs and migrations.
+    #[serde(default)]
+    pub pool: Option<PoolConfig>,
 }
 
 impl Default for Config {
@@ -58,6 +64,7 @@ impl Default for Config {
             synchronous: defaults::synchronous(),
             foreign_keys: defaults::foreign_keys(),
             temp_store: defaults::temp_store(),
+            pool: None,
         }
     }
 }
@@ -139,6 +146,23 @@ impl TempStore {
     }
 }
 
+/// Pool configuration for multi-database sharding.
+///
+/// When nested inside [`Config`], enables [`DatabasePool`](super::DatabasePool)
+/// to manage lazily-opened shard databases that share the parent config's
+/// PRAGMAs and migrations.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PoolConfig {
+    /// Directory where shard databases are stored.
+    /// Each shard creates `{base_path}/{shard_name}.db`.
+    #[serde(default = "defaults::base_path")]
+    pub base_path: String,
+
+    /// Number of lock shards for the connection map.
+    #[serde(default = "defaults::shard_count")]
+    pub shard_count: usize,
+}
+
 mod defaults {
     use super::*;
 
@@ -172,5 +196,13 @@ mod defaults {
 
     pub fn temp_store() -> TempStore {
         TempStore::Memory
+    }
+
+    pub fn base_path() -> String {
+        "data/shards".to_string()
+    }
+
+    pub fn shard_count() -> usize {
+        16
     }
 }

--- a/src/db/config.rs
+++ b/src/db/config.rs
@@ -158,9 +158,19 @@ pub struct PoolConfig {
     #[serde(default = "defaults::base_path")]
     pub base_path: String,
 
-    /// Number of lock shards for the connection map.
-    #[serde(default = "defaults::shard_count")]
-    pub shard_count: usize,
+    /// Number of internal lock shards for the connection map.
+    /// Controls lock contention parallelism, not the number of tenant databases.
+    #[serde(default = "defaults::lock_shards")]
+    pub lock_shards: usize,
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        Self {
+            base_path: defaults::base_path(),
+            lock_shards: defaults::lock_shards(),
+        }
+    }
 }
 
 mod defaults {
@@ -202,7 +212,7 @@ mod defaults {
         "data/shards".to_string()
     }
 
-    pub fn shard_count() -> usize {
+    pub fn lock_shards() -> usize {
         16
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -104,7 +104,7 @@ mod managed;
 pub use managed::{ManagedDatabase, managed};
 
 mod pool;
-pub use pool::DatabasePool;
+pub use pool::{DatabasePool, ManagedDatabasePool, managed_pool};
 
 mod migrate;
 pub use migrate::migrate;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -103,6 +103,8 @@ pub use conn::{ConnExt, ConnQueryExt};
 mod managed;
 pub use managed::{ManagedDatabase, managed};
 
+mod pool;
+
 mod migrate;
 pub use migrate::migrate;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -86,7 +86,7 @@
 mod error;
 
 mod config;
-pub use config::{Config, JournalMode, SynchronousMode, TempStore};
+pub use config::{Config, JournalMode, PoolConfig, SynchronousMode, TempStore};
 
 mod database;
 pub use database::Database;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -104,6 +104,7 @@ mod managed;
 pub use managed::{ManagedDatabase, managed};
 
 mod pool;
+pub use pool::DatabasePool;
 
 mod migrate;
 pub use migrate::migrate;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -13,6 +13,10 @@
 //! | [`Config`] | YAML-deserializable database configuration with PRAGMA defaults |
 //! | [`ManagedDatabase`] | Wrapper for graceful shutdown via [`crate::run!`] |
 //! | [`managed`] | Wraps a [`Database`] into a [`ManagedDatabase`] |
+//! | [`DatabasePool`] | Multi-database pool with lazy shard opening for tenant isolation |
+//! | [`PoolConfig`] | Configuration for database sharding (base path, shard count) |
+//! | [`ManagedDatabasePool`] | Wrapper for graceful pool shutdown via [`crate::run!`] |
+//! | [`managed_pool`] | Wraps a [`DatabasePool`] into a [`ManagedDatabasePool`] |
 //!
 //! ## Connection & querying
 //!

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,14 +1,16 @@
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
+use crate::error::{Error, Result};
+
+use super::config::{Config, PoolConfig};
+use super::connect::connect;
 use super::database::Database;
 
 // ---------------------------------------------------------------------------
 // Sharded map
 // ---------------------------------------------------------------------------
-
-const DEFAULT_SHARDS: usize = 16;
 
 struct ShardedMap {
     shards: Vec<RwLock<HashMap<String, Database>>>,
@@ -45,6 +47,114 @@ impl ShardedMap {
         let shard = &self.shards[idx];
         let mut write = shard.write().expect("pool shard lock poisoned");
         write.insert(key, db);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DatabasePool
+// ---------------------------------------------------------------------------
+
+/// Multi-database connection pool with lazy shard opening.
+///
+/// Wraps a default [`Database`] (the main database) plus a sharded cache of
+/// lazily-opened shard databases. All shards share the same PRAGMAs and
+/// migrations from the parent [`Config`].
+///
+/// Cloning is cheap (reference count increment via `Arc`).
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use modo::db::{self, ConnExt, ConnQueryExt, DatabasePool};
+///
+/// let pool = DatabasePool::new(&config).await?;
+///
+/// // Default database:
+/// let user: User = pool.conn(None).await?
+///     .conn()
+///     .query_one("SELECT id, name FROM users WHERE id = ?1", libsql::params!["u1"])
+///     .await?;
+///
+/// // Tenant shard (lazy open + cache):
+/// let user: User = pool.conn(tenant.db_shard.as_deref()).await?
+///     .conn()
+///     .query_one("SELECT id, name FROM users WHERE id = ?1", libsql::params!["u1"])
+///     .await?;
+/// ```
+#[derive(Clone)]
+pub struct DatabasePool {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    default: Database,
+    config: Config,
+    pool_config: PoolConfig,
+    shards: ShardedMap,
+}
+
+impl DatabasePool {
+    /// Create a new pool from the given config.
+    ///
+    /// Opens the default database immediately. Shard databases are opened
+    /// lazily on first [`conn`](Self::conn) call.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `config.pool` is `None` or the default database
+    /// fails to open.
+    pub async fn new(config: &Config) -> Result<Self> {
+        let pool_config = config
+            .pool
+            .clone()
+            .ok_or_else(|| Error::internal("database pool config is required"))?;
+
+        let default = connect(config).await?;
+        let shards = ShardedMap::new(pool_config.shard_count);
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                default,
+                config: config.clone(),
+                pool_config,
+                shards,
+            }),
+        })
+    }
+
+    /// Get a database connection by shard name.
+    ///
+    /// - `None` — returns the default database (instant, no lock).
+    /// - `Some("name")` — returns the cached shard database, opening it on
+    ///   first access at `{base_path}/{name}.db`.
+    pub async fn conn(&self, shard: Option<&str>) -> Result<Database> {
+        let Some(name) = shard else {
+            return Ok(self.inner.default.clone());
+        };
+
+        // Fast path: read-lock lookup
+        if let Some(db) = self.inner.shards.get(name) {
+            return Ok(db);
+        }
+
+        // Slow path: open new connection, then insert
+        let shard_path = if self.inner.pool_config.base_path == ":memory:" {
+            ":memory:".to_string()
+        } else {
+            format!("{}/{}.db", self.inner.pool_config.base_path, name)
+        };
+        let shard_config = Config {
+            path: shard_path,
+            pool: None, // shards don't nest pools
+            ..self.inner.config.clone()
+        };
+
+        let db = connect(&shard_config).await.map_err(|e| {
+            Error::internal(format!("failed to open shard database: {name}")).chain(e)
+        })?;
+
+        self.inner.shards.insert(name.to_string(), db.clone());
+        Ok(db)
     }
 }
 

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -158,6 +158,45 @@ impl DatabasePool {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Graceful shutdown
+// ---------------------------------------------------------------------------
+
+/// Wrapper for graceful shutdown integration with [`crate::run!`].
+///
+/// Wraps a [`DatabasePool`] so it can be registered as a [`Task`](crate::runtime::Task)
+/// with the modo runtime. On shutdown all database handles (default and shards)
+/// are dropped.
+///
+/// Created by [`managed_pool`].
+pub struct ManagedDatabasePool(DatabasePool);
+
+impl crate::runtime::Task for ManagedDatabasePool {
+    async fn shutdown(self) -> Result<()> {
+        drop(self.0);
+        Ok(())
+    }
+}
+
+/// Wrap a [`DatabasePool`] for use with [`crate::run!`].
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use modo::db;
+///
+/// # async fn example() -> modo::Result<()> {
+/// let config = db::Config::default();
+/// let pool = db::DatabasePool::new(&config).await?;
+/// let task = db::managed_pool(pool.clone());
+/// // Register `task` with modo::run!() for graceful shutdown
+/// # Ok(())
+/// # }
+/// ```
+pub fn managed_pool(pool: DatabasePool) -> ManagedDatabasePool {
+    ManagedDatabasePool(pool)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::RwLock;
+
+use super::database::Database;
+
+// ---------------------------------------------------------------------------
+// Sharded map
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SHARDS: usize = 16;
+
+struct ShardedMap {
+    shards: Vec<RwLock<HashMap<String, Database>>>,
+}
+
+impl ShardedMap {
+    fn new(num_shards: usize) -> Self {
+        let mut shards = Vec::with_capacity(num_shards);
+        for _ in 0..num_shards {
+            shards.push(RwLock::new(HashMap::new()));
+        }
+        Self { shards }
+    }
+
+    fn shard_index(&self, key: &str) -> usize {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        hasher.finish() as usize % self.shards.len()
+    }
+
+    /// Look up a cached `Database` by key. Returns a clone (cheap Arc bump)
+    /// or `None` if the key is not present.
+    fn get(&self, key: &str) -> Option<Database> {
+        let idx = self.shard_index(key);
+        let shard = &self.shards[idx];
+        let read = shard.read().expect("pool shard lock poisoned");
+        read.get(key).cloned()
+    }
+
+    /// Insert a `Database` under `key`. If the key already exists the old
+    /// value is replaced (last writer wins).
+    fn insert(&self, key: String, db: Database) {
+        let idx = self.shard_index(&key);
+        let shard = &self.shards[idx];
+        let mut write = shard.write().expect("pool shard lock poisoned");
+        write.insert(key, db);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_db() -> Database {
+        // Directly construct a Database for unit testing the map.
+        // We only need it as a value in the map — no real queries.
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let config = super::super::config::Config {
+                path: ":memory:".to_string(),
+                ..Default::default()
+            };
+            super::super::connect::connect(&config).await.unwrap()
+        })
+    }
+
+    #[test]
+    fn sharded_map_get_returns_none_for_missing_key() {
+        let map = ShardedMap::new(4);
+        assert!(map.get("missing").is_none());
+    }
+
+    #[test]
+    fn sharded_map_insert_and_get() {
+        let map = ShardedMap::new(4);
+        let db = make_test_db();
+        map.insert("tenant_a".to_string(), db);
+        assert!(map.get("tenant_a").is_some());
+    }
+
+    #[test]
+    fn sharded_map_different_keys_independent() {
+        let map = ShardedMap::new(4);
+        let db = make_test_db();
+        map.insert("tenant_a".to_string(), db);
+        assert!(map.get("tenant_a").is_some());
+        assert!(map.get("tenant_b").is_none());
+    }
+
+    #[test]
+    fn sharded_map_insert_idempotent() {
+        let map = ShardedMap::new(4);
+        let db1 = make_test_db();
+        let db2 = make_test_db();
+        map.insert("key".to_string(), db1);
+        map.insert("key".to_string(), db2);
+        assert!(map.get("key").is_some());
+    }
+}

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use crate::error::{Error, Result};
@@ -7,10 +8,6 @@ use crate::error::{Error, Result};
 use super::config::{Config, PoolConfig};
 use super::connect::connect;
 use super::database::Database;
-
-// ---------------------------------------------------------------------------
-// Sharded map
-// ---------------------------------------------------------------------------
 
 struct ShardedMap {
     shards: Vec<RwLock<HashMap<String, Database>>>,
@@ -49,10 +46,6 @@ impl ShardedMap {
         write.insert(key, db);
     }
 }
-
-// ---------------------------------------------------------------------------
-// DatabasePool
-// ---------------------------------------------------------------------------
 
 /// Multi-database connection pool with lazy shard opening.
 ///
@@ -127,25 +120,31 @@ impl DatabasePool {
     /// - `None` — returns the default database (instant, no lock).
     /// - `Some("name")` — returns the cached shard database, opening it on
     ///   first access at `{base_path}/{name}.db`.
+    ///
+    /// Concurrent first-access to the same shard may open duplicate
+    /// connections; the last writer wins and the extra connection is dropped.
+    /// This is benign because `connect` is idempotent (PRAGMAs are
+    /// re-applied, migrations use checksum tracking).
     pub async fn conn(&self, shard: Option<&str>) -> Result<Database> {
         let Some(name) = shard else {
             return Ok(self.inner.default.clone());
         };
 
-        // Fast path: read-lock lookup
         if let Some(db) = self.inner.shards.get(name) {
             return Ok(db);
         }
 
-        // Slow path: open new connection, then insert
         let shard_path = if self.inner.pool_config.base_path == ":memory:" {
             ":memory:".to_string()
         } else {
-            format!("{}/{}.db", self.inner.pool_config.base_path, name)
+            Path::new(&self.inner.pool_config.base_path)
+                .join(format!("{name}.db"))
+                .to_string_lossy()
+                .into_owned()
         };
         let shard_config = Config {
             path: shard_path,
-            pool: None, // shards don't nest pools
+            pool: None,
             ..self.inner.config.clone()
         };
 
@@ -157,10 +156,6 @@ impl DatabasePool {
         Ok(db)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Graceful shutdown
-// ---------------------------------------------------------------------------
 
 /// Wrapper for graceful shutdown integration with [`crate::run!`].
 ///
@@ -201,16 +196,12 @@ pub fn managed_pool(pool: DatabasePool) -> ManagedDatabasePool {
 mod tests {
     use super::*;
 
-    fn make_test_db() -> Database {
-        // Directly construct a Database for unit testing the map.
-        // We only need it as a value in the map — no real queries.
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let config = super::super::config::Config {
-                path: ":memory:".to_string(),
-                ..Default::default()
-            };
-            super::super::connect::connect(&config).await.unwrap()
-        })
+    async fn make_test_db() -> Database {
+        let config = super::super::config::Config {
+            path: ":memory:".to_string(),
+            ..Default::default()
+        };
+        super::super::connect::connect(&config).await.unwrap()
     }
 
     #[test]
@@ -219,28 +210,28 @@ mod tests {
         assert!(map.get("missing").is_none());
     }
 
-    #[test]
-    fn sharded_map_insert_and_get() {
+    #[tokio::test]
+    async fn sharded_map_insert_and_get() {
         let map = ShardedMap::new(4);
-        let db = make_test_db();
+        let db = make_test_db().await;
         map.insert("tenant_a".to_string(), db);
         assert!(map.get("tenant_a").is_some());
     }
 
-    #[test]
-    fn sharded_map_different_keys_independent() {
+    #[tokio::test]
+    async fn sharded_map_different_keys_independent() {
         let map = ShardedMap::new(4);
-        let db = make_test_db();
+        let db = make_test_db().await;
         map.insert("tenant_a".to_string(), db);
         assert!(map.get("tenant_a").is_some());
         assert!(map.get("tenant_b").is_none());
     }
 
-    #[test]
-    fn sharded_map_insert_idempotent() {
+    #[tokio::test]
+    async fn sharded_map_insert_idempotent() {
         let map = ShardedMap::new(4);
-        let db1 = make_test_db();
-        let db2 = make_test_db();
+        let db1 = make_test_db().await;
+        let db2 = make_test_db().await;
         map.insert("key".to_string(), db1);
         map.insert("key".to_string(), db2);
         assert!(map.get("key").is_some());

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::error::{Error, Result};
 
-use super::config::{Config, PoolConfig};
+use super::config::Config;
 use super::connect::connect;
 use super::database::Database;
 
@@ -82,7 +82,6 @@ pub struct DatabasePool {
 struct Inner {
     default: Database,
     config: Config,
-    pool_config: PoolConfig,
     shards: ShardedMap,
 }
 
@@ -99,8 +98,12 @@ impl DatabasePool {
     pub async fn new(config: &Config) -> Result<Self> {
         let pool_config = config
             .pool
-            .clone()
+            .as_ref()
             .ok_or_else(|| Error::internal("database pool config is required"))?;
+
+        if pool_config.shard_count == 0 {
+            return Err(Error::internal("pool shard_count must be greater than 0"));
+        }
 
         let default = connect(config).await?;
         let shards = ShardedMap::new(pool_config.shard_count);
@@ -109,7 +112,6 @@ impl DatabasePool {
             inner: Arc::new(Inner {
                 default,
                 config: config.clone(),
-                pool_config,
                 shards,
             }),
         })
@@ -130,14 +132,20 @@ impl DatabasePool {
             return Ok(self.inner.default.clone());
         };
 
+        if name.is_empty() || name.contains('/') || name.contains('\\') {
+            return Err(Error::bad_request(format!("invalid shard name: {name:?}")));
+        }
+
         if let Some(db) = self.inner.shards.get(name) {
             return Ok(db);
         }
 
-        let shard_path = if self.inner.pool_config.base_path == ":memory:" {
+        // Safety: pool config is validated as Some in new()
+        let pool_config = self.inner.config.pool.as_ref().unwrap();
+        let shard_path = if pool_config.base_path == ":memory:" {
             ":memory:".to_string()
         } else {
-            Path::new(&self.inner.pool_config.base_path)
+            Path::new(&pool_config.base_path)
                 .join(format!("{name}.db"))
                 .to_string_lossy()
                 .into_owned()

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -101,12 +101,12 @@ impl DatabasePool {
             .as_ref()
             .ok_or_else(|| Error::internal("database pool config is required"))?;
 
-        if pool_config.shard_count == 0 {
-            return Err(Error::internal("pool shard_count must be greater than 0"));
+        if pool_config.lock_shards == 0 {
+            return Err(Error::internal("pool lock_shards must be greater than 0"));
         }
 
         let default = connect(config).await?;
-        let shards = ShardedMap::new(pool_config.shard_count);
+        let shards = ShardedMap::new(pool_config.lock_shards);
 
         Ok(Self {
             inner: Arc::new(Inner {
@@ -132,7 +132,12 @@ impl DatabasePool {
             return Ok(self.inner.default.clone());
         };
 
-        if name.is_empty() || name.contains('/') || name.contains('\\') {
+        if name.is_empty()
+            || name.starts_with('.')
+            || name.contains('/')
+            || name.contains('\\')
+            || name.contains('\0')
+        {
             return Err(Error::bad_request(format!("invalid shard name: {name:?}")));
         }
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -10,6 +10,8 @@
 //!   services, and middleware; send requests via HTTP-method helpers.
 //! - [`TestDb`] — in-memory libsql database with chainable `exec` / `migrate`
 //!   setup; exposes a [`Database`](crate::db::Database) handle via [`db()`](TestDb::db).
+//! - [`TestPool`] — in-memory [`DatabasePool`](crate::db::DatabasePool) with chainable
+//!   `exec` setup; both default and shard databases use `:memory:`.
 //! - [`TestRequestBuilder`] — fluent builder for a single in-process HTTP request
 //!   with JSON, form, and raw-body support.
 //! - [`TestResponse`] — captured response with status, header, and body accessors.

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -47,12 +47,14 @@
 
 mod app;
 mod db;
+mod pool;
 mod request;
 mod response;
 mod session;
 
 pub use app::{TestApp, TestAppBuilder};
 pub use db::TestDb;
+pub use pool::TestPool;
 pub use request::TestRequestBuilder;
 pub use response::TestResponse;
 pub use session::TestSession;

--- a/src/testing/pool.rs
+++ b/src/testing/pool.rs
@@ -1,0 +1,79 @@
+use crate::db::{Config, Database, DatabasePool, PoolConfig};
+use crate::error::Result;
+
+/// An in-memory database pool for use in tests.
+///
+/// Both the default database and all shards use `:memory:` — no file I/O.
+/// The builder-style [`exec`](TestPool::exec) method returns `Self` for
+/// chaining.
+///
+/// ```rust,no_run
+/// # #[cfg(feature = "test-helpers")]
+/// # async fn example() {
+/// use modo::testing::TestPool;
+///
+/// let pool = TestPool::new()
+///     .await
+///     .exec(None, "CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT NOT NULL)")
+///     .await;
+///
+/// let db = pool.conn(None).await.unwrap();
+/// # }
+/// ```
+pub struct TestPool {
+    pool: DatabasePool,
+}
+
+impl TestPool {
+    /// Create a new in-memory database pool.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the pool cannot be created.
+    pub async fn new() -> Self {
+        let config = Config {
+            path: ":memory:".to_string(),
+            pool: Some(PoolConfig {
+                base_path: ":memory:".to_string(),
+                shard_count: 4,
+            }),
+            ..Default::default()
+        };
+        let pool = DatabasePool::new(&config)
+            .await
+            .expect("failed to create test pool");
+        Self { pool }
+    }
+
+    /// Execute a raw SQL statement on the given shard (or default) and return
+    /// `self` for chaining.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the statement fails.
+    pub async fn exec(self, shard: Option<&str>, sql: &str) -> Self {
+        use crate::db::ConnExt;
+        let db = self
+            .pool
+            .conn(shard)
+            .await
+            .unwrap_or_else(|e| panic!("failed to get connection for shard {shard:?}: {e}"));
+        db.conn()
+            .execute_raw(sql, ())
+            .await
+            .unwrap_or_else(|e| panic!("failed to execute SQL: {e}\nSQL: {sql}"));
+        self
+    }
+
+    /// Get a database connection by shard name.
+    ///
+    /// See [`DatabasePool::conn`] for details.
+    pub async fn conn(&self, shard: Option<&str>) -> Result<Database> {
+        self.pool.conn(shard).await
+    }
+
+    /// Return a cloned [`DatabasePool`] handle.
+    pub fn pool(&self) -> DatabasePool {
+        self.pool.clone()
+    }
+}

--- a/src/testing/pool.rs
+++ b/src/testing/pool.rs
@@ -35,7 +35,7 @@ impl TestPool {
             path: ":memory:".to_string(),
             pool: Some(PoolConfig {
                 base_path: ":memory:".to_string(),
-                shard_count: 4,
+                lock_shards: 4,
             }),
             ..Default::default()
         };

--- a/tests/db_pool_test.rs
+++ b/tests/db_pool_test.rs
@@ -33,3 +33,163 @@ pool: {}
     assert_eq!(pool.base_path, "data/shards");
     assert_eq!(pool.shard_count, 16);
 }
+
+#[tokio::test]
+async fn pool_new_fails_without_pool_config() {
+    let config = db::Config::default(); // pool is None
+    let result = db::DatabasePool::new(&config).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn pool_conn_none_returns_default() {
+    let config = db::Config {
+        path: ":memory:".to_string(),
+        pool: Some(db::PoolConfig {
+            base_path: "data/test_shards".to_string(),
+            shard_count: 4,
+        }),
+        ..Default::default()
+    };
+    let pool = db::DatabasePool::new(&config).await.unwrap();
+
+    // conn(None) returns the default database — verify it works
+    let db = pool.conn(None).await.unwrap();
+    use modo::db::ConnExt;
+    let result: u64 = db
+        .conn()
+        .execute_raw("CREATE TABLE test_default (id TEXT PRIMARY KEY)", ())
+        .await
+        .unwrap();
+    assert_eq!(result, 0);
+}
+
+#[tokio::test]
+async fn pool_conn_shard_opens_new_database() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = db::Config {
+        path: ":memory:".to_string(),
+        pool: Some(db::PoolConfig {
+            base_path: dir.path().to_str().unwrap().to_string(),
+            shard_count: 4,
+        }),
+        ..Default::default()
+    };
+    let pool = db::DatabasePool::new(&config).await.unwrap();
+
+    // First call to a shard creates the database
+    let shard_db = pool.conn(Some("tenant_abc")).await.unwrap();
+    use modo::db::ConnExt;
+    shard_db
+        .conn()
+        .execute_raw("CREATE TABLE shard_test (id TEXT PRIMARY KEY)", ())
+        .await
+        .unwrap();
+
+    // Second call returns the cached connection — table should exist
+    let shard_db2 = pool.conn(Some("tenant_abc")).await.unwrap();
+    shard_db2
+        .conn()
+        .execute_raw("INSERT INTO shard_test (id) VALUES ('hello')", ())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn pool_shards_are_independent() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = db::Config {
+        path: ":memory:".to_string(),
+        pool: Some(db::PoolConfig {
+            base_path: dir.path().to_str().unwrap().to_string(),
+            shard_count: 4,
+        }),
+        ..Default::default()
+    };
+    let pool = db::DatabasePool::new(&config).await.unwrap();
+
+    // Create a table in shard A
+    use modo::db::ConnExt;
+    let shard_a = pool.conn(Some("shard_a")).await.unwrap();
+    shard_a
+        .conn()
+        .execute_raw("CREATE TABLE only_in_a (id TEXT PRIMARY KEY)", ())
+        .await
+        .unwrap();
+
+    // Shard B should NOT have that table
+    let shard_b = pool.conn(Some("shard_b")).await.unwrap();
+    let err = shard_b
+        .conn()
+        .execute_raw("INSERT INTO only_in_a (id) VALUES ('x')", ())
+        .await;
+    assert!(err.is_err());
+}
+
+#[tokio::test]
+async fn pool_is_clone() {
+    let config = db::Config {
+        path: ":memory:".to_string(),
+        pool: Some(db::PoolConfig {
+            base_path: "data/test_shards".to_string(),
+            shard_count: 4,
+        }),
+        ..Default::default()
+    };
+    let pool = db::DatabasePool::new(&config).await.unwrap();
+    let pool2 = pool.clone();
+
+    // Both clones access the same default database
+    use modo::db::ConnExt;
+    pool.conn(None)
+        .await
+        .unwrap()
+        .conn()
+        .execute_raw("CREATE TABLE clone_test (id TEXT PRIMARY KEY)", ())
+        .await
+        .unwrap();
+
+    pool2
+        .conn(None)
+        .await
+        .unwrap()
+        .conn()
+        .execute_raw("INSERT INTO clone_test (id) VALUES ('from_clone2')", ())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn pool_shard_runs_migrations() {
+    let dir = tempfile::tempdir().unwrap();
+    let migrations_dir = dir.path().join("migrations");
+    std::fs::create_dir_all(&migrations_dir).unwrap();
+    std::fs::write(
+        migrations_dir.join("001_create_users.sql"),
+        "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT NOT NULL);",
+    )
+    .unwrap();
+
+    let config = db::Config {
+        path: dir.path().join("main.db").to_str().unwrap().to_string(),
+        migrations: Some(migrations_dir.to_str().unwrap().to_string()),
+        pool: Some(db::PoolConfig {
+            base_path: dir.path().join("shards").to_str().unwrap().to_string(),
+            shard_count: 4,
+        }),
+        ..Default::default()
+    };
+    let pool = db::DatabasePool::new(&config).await.unwrap();
+
+    // Shard should have the users table from migrations
+    use modo::db::ConnExt;
+    let shard = pool.conn(Some("tenant_xyz")).await.unwrap();
+    shard
+        .conn()
+        .execute_raw(
+            "INSERT INTO users (id, name) VALUES ('u1', 'Alice')",
+            (),
+        )
+        .await
+        .unwrap();
+}

--- a/tests/db_pool_test.rs
+++ b/tests/db_pool_test.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "db")]
 
-use modo::db;
+use modo::db::{self, ConnExt};
 
 #[test]
 fn config_pool_defaults_to_none() {
@@ -55,7 +55,6 @@ async fn pool_conn_none_returns_default() {
 
     // conn(None) returns the default database — verify it works
     let db = pool.conn(None).await.unwrap();
-    use modo::db::ConnExt;
     let result: u64 = db
         .conn()
         .execute_raw("CREATE TABLE test_default (id TEXT PRIMARY KEY)", ())
@@ -79,7 +78,6 @@ async fn pool_conn_shard_opens_new_database() {
 
     // First call to a shard creates the database
     let shard_db = pool.conn(Some("tenant_abc")).await.unwrap();
-    use modo::db::ConnExt;
     shard_db
         .conn()
         .execute_raw("CREATE TABLE shard_test (id TEXT PRIMARY KEY)", ())
@@ -109,7 +107,6 @@ async fn pool_shards_are_independent() {
     let pool = db::DatabasePool::new(&config).await.unwrap();
 
     // Create a table in shard A
-    use modo::db::ConnExt;
     let shard_a = pool.conn(Some("shard_a")).await.unwrap();
     shard_a
         .conn()
@@ -140,7 +137,6 @@ async fn pool_is_clone() {
     let pool2 = pool.clone();
 
     // Both clones access the same default database
-    use modo::db::ConnExt;
     pool.conn(None)
         .await
         .unwrap()
@@ -182,7 +178,6 @@ async fn pool_shard_runs_migrations() {
     let pool = db::DatabasePool::new(&config).await.unwrap();
 
     // Shard should have the users table from migrations
-    use modo::db::ConnExt;
     let shard = pool.conn(Some("tenant_xyz")).await.unwrap();
     shard
         .conn()
@@ -206,4 +201,35 @@ async fn managed_pool_can_shutdown() {
     // Verify it implements Task by calling shutdown
     use modo::runtime::Task;
     managed.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn pool_rejects_zero_shard_count() {
+    let config = db::Config {
+        path: ":memory:".to_string(),
+        pool: Some(db::PoolConfig {
+            base_path: ":memory:".to_string(),
+            shard_count: 0,
+        }),
+        ..Default::default()
+    };
+    assert!(db::DatabasePool::new(&config).await.is_err());
+}
+
+#[tokio::test]
+async fn pool_rejects_invalid_shard_names() {
+    let config = db::Config {
+        path: ":memory:".to_string(),
+        pool: Some(db::PoolConfig {
+            base_path: ":memory:".to_string(),
+            shard_count: 4,
+        }),
+        ..Default::default()
+    };
+    let pool = db::DatabasePool::new(&config).await.unwrap();
+
+    assert!(pool.conn(Some("")).await.is_err());
+    assert!(pool.conn(Some("../escape")).await.is_err());
+    assert!(pool.conn(Some("back\\slash")).await.is_err());
+    assert!(pool.conn(Some("valid_name")).await.is_ok());
 }

--- a/tests/db_pool_test.rs
+++ b/tests/db_pool_test.rs
@@ -186,10 +186,7 @@ async fn pool_shard_runs_migrations() {
     let shard = pool.conn(Some("tenant_xyz")).await.unwrap();
     shard
         .conn()
-        .execute_raw(
-            "INSERT INTO users (id, name) VALUES ('u1', 'Alice')",
-            (),
-        )
+        .execute_raw("INSERT INTO users (id, name) VALUES ('u1', 'Alice')", ())
         .await
         .unwrap();
 }

--- a/tests/db_pool_test.rs
+++ b/tests/db_pool_test.rs
@@ -14,12 +14,12 @@ fn config_pool_deserializes_from_yaml() {
 path: "data/app.db"
 pool:
   base_path: "data/shards"
-  shard_count: 8
+  lock_shards: 8
 "#;
     let config: db::Config = serde_yaml_ng::from_str(yaml).unwrap();
     let pool = config.pool.unwrap();
     assert_eq!(pool.base_path, "data/shards");
-    assert_eq!(pool.shard_count, 8);
+    assert_eq!(pool.lock_shards, 8);
 }
 
 #[test]
@@ -31,7 +31,7 @@ pool: {}
     let config: db::Config = serde_yaml_ng::from_str(yaml).unwrap();
     let pool = config.pool.unwrap();
     assert_eq!(pool.base_path, "data/shards");
-    assert_eq!(pool.shard_count, 16);
+    assert_eq!(pool.lock_shards, 16);
 }
 
 #[tokio::test]
@@ -47,7 +47,7 @@ async fn pool_conn_none_returns_default() {
         path: ":memory:".to_string(),
         pool: Some(db::PoolConfig {
             base_path: "data/test_shards".to_string(),
-            shard_count: 4,
+            lock_shards: 4,
         }),
         ..Default::default()
     };
@@ -70,7 +70,7 @@ async fn pool_conn_shard_opens_new_database() {
         path: ":memory:".to_string(),
         pool: Some(db::PoolConfig {
             base_path: dir.path().to_str().unwrap().to_string(),
-            shard_count: 4,
+            lock_shards: 4,
         }),
         ..Default::default()
     };
@@ -100,7 +100,7 @@ async fn pool_shards_are_independent() {
         path: ":memory:".to_string(),
         pool: Some(db::PoolConfig {
             base_path: dir.path().to_str().unwrap().to_string(),
-            shard_count: 4,
+            lock_shards: 4,
         }),
         ..Default::default()
     };
@@ -129,7 +129,7 @@ async fn pool_is_clone() {
         path: ":memory:".to_string(),
         pool: Some(db::PoolConfig {
             base_path: "data/test_shards".to_string(),
-            shard_count: 4,
+            lock_shards: 4,
         }),
         ..Default::default()
     };
@@ -171,7 +171,7 @@ async fn pool_shard_runs_migrations() {
         migrations: Some(migrations_dir.to_str().unwrap().to_string()),
         pool: Some(db::PoolConfig {
             base_path: dir.path().join("shards").to_str().unwrap().to_string(),
-            shard_count: 4,
+            lock_shards: 4,
         }),
         ..Default::default()
     };
@@ -192,7 +192,7 @@ async fn managed_pool_can_shutdown() {
         path: ":memory:".to_string(),
         pool: Some(db::PoolConfig {
             base_path: "data/test_shards".to_string(),
-            shard_count: 4,
+            lock_shards: 4,
         }),
         ..Default::default()
     };
@@ -204,12 +204,12 @@ async fn managed_pool_can_shutdown() {
 }
 
 #[tokio::test]
-async fn pool_rejects_zero_shard_count() {
+async fn pool_rejects_zero_lock_shards() {
     let config = db::Config {
         path: ":memory:".to_string(),
         pool: Some(db::PoolConfig {
             base_path: ":memory:".to_string(),
-            shard_count: 0,
+            lock_shards: 0,
         }),
         ..Default::default()
     };
@@ -222,7 +222,7 @@ async fn pool_rejects_invalid_shard_names() {
         path: ":memory:".to_string(),
         pool: Some(db::PoolConfig {
             base_path: ":memory:".to_string(),
-            shard_count: 4,
+            lock_shards: 4,
         }),
         ..Default::default()
     };
@@ -231,5 +231,7 @@ async fn pool_rejects_invalid_shard_names() {
     assert!(pool.conn(Some("")).await.is_err());
     assert!(pool.conn(Some("../escape")).await.is_err());
     assert!(pool.conn(Some("back\\slash")).await.is_err());
+    assert!(pool.conn(Some(".hidden")).await.is_err());
+    assert!(pool.conn(Some("null\0byte")).await.is_err());
     assert!(pool.conn(Some("valid_name")).await.is_ok());
 }

--- a/tests/db_pool_test.rs
+++ b/tests/db_pool_test.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "db")]
+
+use modo::db;
+
+#[test]
+fn config_pool_defaults_to_none() {
+    let config = db::Config::default();
+    assert!(config.pool.is_none());
+}
+
+#[test]
+fn config_pool_deserializes_from_yaml() {
+    let yaml = r#"
+path: "data/app.db"
+pool:
+  base_path: "data/shards"
+  shard_count: 8
+"#;
+    let config: db::Config = serde_yaml_ng::from_str(yaml).unwrap();
+    let pool = config.pool.unwrap();
+    assert_eq!(pool.base_path, "data/shards");
+    assert_eq!(pool.shard_count, 8);
+}
+
+#[test]
+fn pool_config_defaults() {
+    let yaml = r#"
+path: "data/app.db"
+pool: {}
+"#;
+    let config: db::Config = serde_yaml_ng::from_str(yaml).unwrap();
+    let pool = config.pool.unwrap();
+    assert_eq!(pool.base_path, "data/shards");
+    assert_eq!(pool.shard_count, 16);
+}

--- a/tests/db_pool_test.rs
+++ b/tests/db_pool_test.rs
@@ -193,3 +193,20 @@ async fn pool_shard_runs_migrations() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn managed_pool_can_shutdown() {
+    let config = db::Config {
+        path: ":memory:".to_string(),
+        pool: Some(db::PoolConfig {
+            base_path: "data/test_shards".to_string(),
+            shard_count: 4,
+        }),
+        ..Default::default()
+    };
+    let pool = db::DatabasePool::new(&config).await.unwrap();
+    let managed = db::managed_pool(pool);
+    // Verify it implements Task by calling shutdown
+    use modo::runtime::Task;
+    managed.shutdown().await.unwrap();
+}

--- a/tests/testing_pool_test.rs
+++ b/tests/testing_pool_test.rs
@@ -30,15 +30,15 @@ async fn test_pool_default_works() {
         .await
         .unwrap();
     db.conn()
-        .execute_raw(
-            "INSERT INTO items (id, name) VALUES ('i1', 'Widget')",
-            (),
-        )
+        .execute_raw("INSERT INTO items (id, name) VALUES ('i1', 'Widget')", ())
         .await
         .unwrap();
     let item: Item = db
         .conn()
-        .query_one("SELECT id, name FROM items WHERE id = ?1", libsql::params!["i1"])
+        .query_one(
+            "SELECT id, name FROM items WHERE id = ?1",
+            libsql::params!["i1"],
+        )
         .await
         .unwrap();
     assert_eq!(item.id, "i1");

--- a/tests/testing_pool_test.rs
+++ b/tests/testing_pool_test.rs
@@ -1,0 +1,117 @@
+#![cfg(feature = "test-helpers")]
+
+use modo::db::{ConnExt, ConnQueryExt, FromRow};
+use modo::testing::TestPool;
+
+#[derive(Debug)]
+struct Item {
+    id: String,
+    name: String,
+}
+
+impl FromRow for Item {
+    fn from_row(row: &libsql::Row) -> modo::Result<Self> {
+        Ok(Self {
+            id: row.get::<String>(0).map_err(modo::Error::from)?,
+            name: row.get::<String>(1).map_err(modo::Error::from)?,
+        })
+    }
+}
+
+#[tokio::test]
+async fn test_pool_default_works() {
+    let pool = TestPool::new().await;
+    let db = pool.conn(None).await.unwrap();
+    db.conn()
+        .execute_raw(
+            "CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT NOT NULL)",
+            (),
+        )
+        .await
+        .unwrap();
+    db.conn()
+        .execute_raw(
+            "INSERT INTO items (id, name) VALUES ('i1', 'Widget')",
+            (),
+        )
+        .await
+        .unwrap();
+    let item: Item = db
+        .conn()
+        .query_one("SELECT id, name FROM items WHERE id = ?1", libsql::params!["i1"])
+        .await
+        .unwrap();
+    assert_eq!(item.id, "i1");
+    assert_eq!(item.name, "Widget");
+}
+
+#[tokio::test]
+async fn test_pool_shard_is_independent() {
+    let pool = TestPool::new().await;
+
+    // Create table in default
+    pool.conn(None)
+        .await
+        .unwrap()
+        .conn()
+        .execute_raw("CREATE TABLE t (id TEXT PRIMARY KEY)", ())
+        .await
+        .unwrap();
+
+    // Shard should NOT have it (independent in-memory DB)
+    let shard = pool.conn(Some("tenant_a")).await.unwrap();
+    let err = shard
+        .conn()
+        .execute_raw("INSERT INTO t (id) VALUES ('x')", ())
+        .await;
+    assert!(err.is_err());
+}
+
+#[tokio::test]
+async fn test_pool_shard_is_cached() {
+    let pool = TestPool::new().await;
+
+    // First access creates, second reuses
+    let shard1 = pool.conn(Some("tenant_b")).await.unwrap();
+    shard1
+        .conn()
+        .execute_raw("CREATE TABLE cached (id TEXT PRIMARY KEY)", ())
+        .await
+        .unwrap();
+
+    let shard2 = pool.conn(Some("tenant_b")).await.unwrap();
+    shard2
+        .conn()
+        .execute_raw("INSERT INTO cached (id) VALUES ('yes')", ())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_pool_exec_chaining() {
+    let pool = TestPool::new()
+        .await
+        .exec(None, "CREATE TABLE chained (id TEXT PRIMARY KEY)")
+        .await
+        .exec(
+            Some("shard_x"),
+            "CREATE TABLE chained (id TEXT PRIMARY KEY)",
+        )
+        .await;
+
+    pool.conn(None)
+        .await
+        .unwrap()
+        .conn()
+        .execute_raw("INSERT INTO chained (id) VALUES ('a')", ())
+        .await
+        .unwrap();
+
+    pool.conn(Some("shard_x"))
+        .await
+        .unwrap()
+        .conn()
+        .execute_raw("INSERT INTO chained (id) VALUES ('b')", ())
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

- Add `DatabasePool` type that manages a default database plus lazily-opened shard databases, enabling tenant isolation with a unified `conn(shard: Option<&str>)` API
- Add `PoolConfig` (nested in `Config`), `ShardedMap` (sharded `RwLock<HashMap>` for connection caching), `ManagedDatabasePool` (graceful shutdown wrapper)
- Add `TestPool` in `src/testing/pool.rs` for in-memory shard testing, following the existing `TestDb` pattern

## Test Plan

- [x] 10 integration tests in `tests/db_pool_test.rs` — config defaults, YAML deserialization, pool creation, default conn, shard opening, shard independence, clone sharing, migration propagation, managed shutdown
- [x] 4 integration tests in `tests/testing_pool_test.rs` — default works, shard independence, shard caching, exec chaining
- [x] 4 unit tests for `ShardedMap` in `src/db/pool.rs`
- [x] Full test suite passes (`cargo test --features test-helpers`)
- [x] Clippy clean (`cargo clippy --features db --tests -- -D warnings` and `--features test-helpers`)
- [x] `cargo fmt --check` clean