### PR TITLE
Improve generated justfile and templates with better defaults

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "modo",
       "source": "./",
       "description": "Development reference and project scaffolding for modo v2",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "author": { "name": "Dmytro Momot" },
       "repository": "https://github.com/dmitrymomot/modo",
       "license": "Apache-2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "modo",
   "description": "Skills for building applications with the modo Rust web framework",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": { "name": "Dmytro Momot" },
   "repository": "https://github.com/dmitrymomot/modo",
   "license": "Apache-2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-rs"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Rust web framework for small monolithic apps"
 license = "Apache-2.0"

--- a/skills/init/references/files.md
+++ b/skills/init/references/files.md
@@ -152,7 +152,7 @@ seed:
 
 # --- Migrations ---
 
-# Apply pending migrations (runs on app startup)
+# Apply pending migrations (starts app; press Ctrl+C after "Listening")
 migrate:
     cargo run
 
@@ -183,7 +183,7 @@ assets-download:
     curl -sL https://unpkg.com/htmx.org@2/dist/htmx.min.js -o assets/static/js/htmx.min.js
     curl -sL https://unpkg.com/htmx-ext-sse@2/sse.js -o assets/static/js/htmx-sse.js
     curl -sL https://unpkg.com/alpinejs@3/dist/cdn.min.js -o assets/static/js/alpine.min.js
-    curl -sL https://unpkg.com/@tailwindplus/elements@1/dist/index.js -o assets/static/js/elements.min.js
+    curl -sL https://unpkg.com/@tailwindplus/elements@1/dist/index.js -o assets/static/js/elements.js
     @echo "Assets downloaded to assets/static/js/"
 
 # Compile Tailwind CSS
@@ -432,7 +432,7 @@ just clean            # Remove build artifacts and databases
 just deps             # Update dependencies
 just db-reset         # Remove all database files
 just seed             # Seed the database with dev data
-just migrate          # Apply pending migrations (runs app)
+just migrate          # Apply pending migrations (Ctrl+C after startup)
 just migrate-create name  # Create new migration file
 ```
 

--- a/skills/init/references/files.md
+++ b/skills/init/references/files.md
@@ -141,27 +141,6 @@ deps:
 # Remove all database files
 db-reset:
     rm -rf data/*.db data/*.db-*
-
-# Seed the database with development data
-seed:
-    @echo "No seed data configured. Edit this recipe in justfile to add seed logic."
-
-# Create a new migration file
-migrate-create name:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    dir="migrations/app"
-    mkdir -p "$dir"
-    last=$(ls -1 "$dir"/*.sql 2>/dev/null | sort | tail -n1 || true)
-    if [ -n "$last" ]; then
-        num=$(basename "$last" | cut -d_ -f1 | sed 's/^0*//')
-    else
-        num=0
-    fi
-    next=$(printf "%03d" $((num + 1)))
-    file="${dir}/${next}_{{ name }}.sql"
-    touch "$file"
-    echo "Created $file"
 ```
 
 ### Conditional: Templates (add when Templates is selected)
@@ -421,8 +400,6 @@ just fmt              # Format code
 just clean            # Remove build artifacts and databases
 just deps             # Update dependencies
 just db-reset         # Remove all database files
-just seed             # Seed the database with dev data
-just migrate-create name  # Create new migration file
 ```
 
 <!-- CONDITIONAL_COMMANDS -->

--- a/skills/init/references/files.md
+++ b/skills/init/references/files.md
@@ -127,10 +127,6 @@ lint:
 fmt:
     cargo fmt
 
-# Check formatting
-fmt-check:
-    cargo fmt --check
-
 # --- Maintenance ---
 
 # Remove build artifacts and databases
@@ -149,12 +145,6 @@ db-reset:
 # Seed the database with development data
 seed:
     @echo "No seed data configured. Edit this recipe in justfile to add seed logic."
-
-# --- Migrations ---
-
-# Apply pending migrations (starts app; press Ctrl+C after "Listening")
-migrate:
-    cargo run
 
 # Create a new migration file
 migrate-create name:
@@ -432,7 +422,6 @@ just clean            # Remove build artifacts and databases
 just deps             # Update dependencies
 just db-reset         # Remove all database files
 just seed             # Seed the database with dev data
-just migrate          # Apply pending migrations (Ctrl+C after startup)
 just migrate-create name  # Create new migration file
 ```
 

--- a/skills/init/references/files.md
+++ b/skills/init/references/files.md
@@ -89,10 +89,6 @@ dev:
     @command -v cargo-watch >/dev/null 2>&1 || { echo "Error: cargo-watch not found. Install: cargo install cargo-watch"; exit 1; }
     cargo watch -w src -w templates -w config -x run
 
-# Run without auto-reload
-run *ARGS:
-    cargo run {{ ARGS }}
-
 # Build release binary
 build:
     cargo build --release
@@ -391,7 +387,6 @@ Generate dynamically using `Write`. Replace `{{project_name}}` with the actual p
 
 ```bash
 just dev              # Run with auto-reload (cargo-watch)
-just run              # Run without auto-reload
 just build            # Build release binary
 just check            # Format, lint, and test (parallel)
 just test             # Run tests

--- a/skills/init/references/files.md
+++ b/skills/init/references/files.md
@@ -89,14 +89,31 @@ dev:
     @command -v cargo-watch >/dev/null 2>&1 || { echo "Error: cargo-watch not found. Install: cargo install cargo-watch"; exit 1; }
     cargo watch -w src -w templates -w config -x run
 
+# Run without auto-reload
+run *ARGS:
+    cargo run {{ ARGS }}
+
 # Build release binary
 build:
     cargo build --release
 
 # --- Quality ---
 
-# Run all checks: format, lint, test
-check: fmt-check lint test
+# Run all checks in parallel: format, lint, test
+check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo fmt --check &
+    pid_fmt=$!
+    cargo clippy -- -D warnings &
+    pid_lint=$!
+    cargo test &
+    pid_test=$!
+    fail=0
+    wait $pid_fmt  || { echo "fmt-check failed"; fail=1; }
+    wait $pid_lint || { echo "lint failed"; fail=1; }
+    wait $pid_test || { echo "test failed"; fail=1; }
+    exit $fail
 
 # Run tests
 test:
@@ -128,17 +145,45 @@ deps:
 # Remove all database files
 db-reset:
     rm -rf data/*.db data/*.db-*
+
+# Seed the database with development data
+seed:
+    @echo "No seed data configured. Edit this recipe in justfile to add seed logic."
+
+# --- Migrations ---
+
+# Apply pending migrations (runs on app startup)
+migrate:
+    cargo run
+
+# Create a new migration file
+migrate-create name:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    dir="migrations/app"
+    mkdir -p "$dir"
+    last=$(ls -1 "$dir"/*.sql 2>/dev/null | sort | tail -n1 || true)
+    if [ -n "$last" ]; then
+        num=$(basename "$last" | cut -d_ -f1 | sed 's/^0*//')
+    else
+        num=0
+    fi
+    next=$(printf "%03d" $((num + 1)))
+    file="${dir}/${next}_{{ name }}.sql"
+    touch "$file"
+    echo "Created $file"
 ```
 
 ### Conditional: Templates (add when Templates is selected)
 
 ```makefile
-# Download vendored JS assets (htmx, alpine)
+# Download vendored JS assets (htmx, alpine, elements)
 assets-download:
     mkdir -p assets/static/js
     curl -sL https://unpkg.com/htmx.org@2/dist/htmx.min.js -o assets/static/js/htmx.min.js
     curl -sL https://unpkg.com/htmx-ext-sse@2/sse.js -o assets/static/js/htmx-sse.js
     curl -sL https://unpkg.com/alpinejs@3/dist/cdn.min.js -o assets/static/js/alpine.min.js
+    curl -sL https://unpkg.com/@tailwindplus/elements@1/dist/index.js -o assets/static/js/elements.min.js
     @echo "Assets downloaded to assets/static/js/"
 
 # Compile Tailwind CSS
@@ -156,6 +201,23 @@ When Templates is selected, also add to the `setup` recipe body:
 ```makefile
     just assets-download
     just css
+```
+
+When Templates is selected, replace the base `dev` recipe with:
+```makefile
+# Run with auto-reload (app + CSS)
+dev:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cargo-watch >/dev/null 2>&1 || { echo "Error: cargo-watch not found. Install: cargo install cargo-watch"; exit 1; }
+    css_pid=""
+    cleanup() { if [ -n "$css_pid" ]; then kill "$css_pid" 2>/dev/null; fi; }
+    trap cleanup EXIT
+    if command -v tailwindcss >/dev/null 2>&1; then
+        tailwindcss -i assets/src/app.css -o assets/static/css/app.css --watch &
+        css_pid=$!
+    fi
+    cargo watch -w src -w templates -w config -x run
 ```
 
 ### Conditional: Geolocation (add when Geolocation is selected)
@@ -359,15 +421,19 @@ Generate dynamically using `Write`. Replace `{{project_name}}` with the actual p
 ## Commands
 
 ```bash
-just dev          # Run with auto-reload (cargo-watch)
-just build        # Build release binary
-just check        # Format, lint, and test
-just test         # Run tests
-just lint         # Run clippy
-just fmt          # Format code
-just clean        # Remove build artifacts and databases
-just deps         # Update dependencies
-just db-reset     # Remove all database files
+just dev              # Run with auto-reload (cargo-watch)
+just run              # Run without auto-reload
+just build            # Build release binary
+just check            # Format, lint, and test (parallel)
+just test             # Run tests
+just lint             # Run clippy
+just fmt              # Format code
+just clean            # Remove build artifacts and databases
+just deps             # Update dependencies
+just db-reset         # Remove all database files
+just seed             # Seed the database with dev data
+just migrate          # Apply pending migrations (runs app)
+just migrate-create name  # Create new migration file
 ```
 
 <!-- CONDITIONAL_COMMANDS -->
@@ -406,7 +472,7 @@ just db-reset     # Remove all database files
 If Templates:
 ````
 ```bash
-just assets-download  # Download vendored JS (htmx, alpine)
+just assets-download  # Download vendored JS (htmx, alpine, elements)
 just css              # Compile Tailwind CSS
 just css-watch        # Watch and recompile CSS
 ```

--- a/skills/init/scripts/download_assets.sh
+++ b/skills/init/scripts/download_assets.sh
@@ -2,7 +2,7 @@
 # Downloads vendored JS assets for a modo project with templates.
 # Usage: download_assets.sh <project_dir>
 #
-# Downloads: htmx.min.js, htmx-sse.js, alpine.min.js, elements.min.js
+# Downloads: htmx.min.js, htmx-sse.js, alpine.min.js, elements.js
 
 set -euo pipefail
 
@@ -19,7 +19,7 @@ curl -sL https://unpkg.com/htmx-ext-sse@2/sse.js -o "$PROJECT_DIR/assets/static/
 echo "Downloading alpine.min.js..."
 curl -sL https://unpkg.com/alpinejs@3/dist/cdn.min.js -o "$PROJECT_DIR/assets/static/js/alpine.min.js"
 
-echo "Downloading elements.min.js..."
-curl -sL https://unpkg.com/@tailwindplus/elements@1/dist/index.js -o "$PROJECT_DIR/assets/static/js/elements.min.js"
+echo "Downloading elements.js..."
+curl -sL https://unpkg.com/@tailwindplus/elements@1/dist/index.js -o "$PROJECT_DIR/assets/static/js/elements.js"
 
 echo "Static JS assets downloaded to $PROJECT_DIR/assets/static/js/"

--- a/skills/init/scripts/download_assets.sh
+++ b/skills/init/scripts/download_assets.sh
@@ -2,7 +2,7 @@
 # Downloads vendored JS assets for a modo project with templates.
 # Usage: download_assets.sh <project_dir>
 #
-# Downloads: htmx.min.js, htmx-sse.js, alpine.min.js
+# Downloads: htmx.min.js, htmx-sse.js, alpine.min.js, elements.min.js
 
 set -euo pipefail
 
@@ -18,5 +18,8 @@ curl -sL https://unpkg.com/htmx-ext-sse@2/sse.js -o "$PROJECT_DIR/assets/static/
 
 echo "Downloading alpine.min.js..."
 curl -sL https://unpkg.com/alpinejs@3/dist/cdn.min.js -o "$PROJECT_DIR/assets/static/js/alpine.min.js"
+
+echo "Downloading elements.min.js..."
+curl -sL https://unpkg.com/@tailwindplus/elements@1/dist/index.js -o "$PROJECT_DIR/assets/static/js/elements.min.js"
 
 echo "Static JS assets downloaded to $PROJECT_DIR/assets/static/js/"

--- a/skills/init/scripts/init_templates.sh
+++ b/skills/init/scripts/init_templates.sh
@@ -24,7 +24,7 @@ cat > "$PROJECT_DIR/templates/base.html" << 'HTML'
   <title>{% block title %}App{% endblock %}</title>
   <link rel="stylesheet" href="{{ static_url('css/app.css') }}">
   <script defer src="{{ static_url('js/alpine.min.js') }}"></script>
-  <script defer src="{{ static_url('js/elements.min.js') }}"></script>
+  <script defer src="{{ static_url('js/elements.js') }}"></script>
   {% block head %}{% endblock %}
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-900 antialiased">

--- a/skills/init/scripts/init_templates.sh
+++ b/skills/init/scripts/init_templates.sh
@@ -24,6 +24,7 @@ cat > "$PROJECT_DIR/templates/base.html" << 'HTML'
   <title>{% block title %}App{% endblock %}</title>
   <link rel="stylesheet" href="{{ static_url('css/app.css') }}">
   <script defer src="{{ static_url('js/alpine.min.js') }}"></script>
+  <script defer src="{{ static_url('js/elements.min.js') }}"></script>
   {% block head %}{% endblock %}
 </head>
 <body class="min-h-screen bg-gray-50 text-gray-900 antialiased">


### PR DESCRIPTION
## Summary

Closes #59

- **Tailwind Plus Elements**: added to `assets-download` recipe, `download_assets.sh`, and `base.html` `<script defer>` tag
- **`run` recipe**: `cargo run` with optional args for one-off runs
- **`seed` recipe**: no-op placeholder to set the convention early
- **`migrate` / `migrate-create`**: apply migrations (via app startup) and scaffold numbered `.sql` files
- **Parallel `check`**: fmt, clippy, and test run concurrently via background processes with proper error aggregation
- **CSS watch in `dev`**: when Templates is selected, `dev` recipe spawns `tailwindcss --watch` alongside `cargo watch` with trap cleanup
- **CLAUDE.md template**: updated with all new commands
- Item 5 (config-aware `db-reset`) was already satisfied — existing template uses `data/*.db` globs

## Test plan

- [x] `download_assets.sh` downloads all 4 JS files (htmx, htmx-sse, alpine, elements) with valid content
- [x] `init_templates.sh` produces `base.html` with `elements.min.js` deferred script tag in head
- [x] `migrate-create` numbering tested: empty dir → 001, sequential → 002/003, gap (010→011)
- [x] Parallel `check` tested: all-pass → exit 0, partial/all-fail → exit 1 with all errors reported
- [x] `dev` cleanup trap tested: no crash when tailwindcss absent (unset `css_pid`), kills background process on exit
- [x] All justfile recipes cross-checked against CLAUDE.md template commands