### PR TITLE
feat: implement Clone for Mailer via Arc<Inner>

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "modo",
       "source": "./",
       "description": "Development reference and project scaffolding for modo v2",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "author": { "name": "Dmytro Momot" },
       "repository": "https://github.com/dmitrymomot/modo",
       "license": "Apache-2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "modo",
   "description": "Skills for building applications with the modo Rust web framework",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": { "name": "Dmytro Momot" },
   "repository": "https://github.com/dmitrymomot/modo",
   "license": "Apache-2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-rs"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 description = "Rust web framework for small monolithic apps"
 license = "Apache-2.0"

--- a/skills/dev/references/email.md
+++ b/skills/dev/references/email.md
@@ -140,7 +140,7 @@ LRU-cached wrapper around any `TemplateSource`. Implements `TemplateSource`. Cac
 
 ## Mailer
 
-`Mailer` is the primary entry point. It holds the template source, SMTP transport, config, and preloaded layouts.
+`Mailer` is the primary entry point. It holds the template source, SMTP transport, config, and preloaded layouts. Cloning is cheap (`Arc`-based) and shares the SMTP connection, template source, and preloaded layouts.
 
 ### Construction
 
@@ -206,7 +206,7 @@ Errors: empty recipient list, malformed addresses, SMTP delivery failures.
 
 | Type                              | Description                                                                                            |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `Mailer`                          | Renders templates and sends email over SMTP                                                            |
+| `Mailer`                          | Renders templates and sends email over SMTP. Cheap `Clone` via `Arc`.                                  |
 | `SendEmail`                       | Builder for composing an email to send                                                                 |
 | `RenderedEmail`                   | Result of rendering: `subject`, `html`, `text`                                                         |
 | `SenderProfile`                   | Per-email From/Reply-To override                                                                       |

--- a/src/email/README.md
+++ b/src/email/README.md
@@ -15,7 +15,7 @@ modo = { version = "0.6", features = ["email"] }
 
 | Type | Description |
 | -------------------------------- | -------------------------------------------------- |
-| `Mailer` | Renders templates and delivers email over SMTP |
+| `Mailer` | Renders templates and delivers email over SMTP (cheap `Clone` via `Arc`) |
 | `EmailConfig` | Top-level configuration (deserializes from YAML) |
 | `SmtpConfig` / `SmtpSecurity` | SMTP connection settings and TLS mode |
 | `SendEmail` | Builder for composing an outgoing email |

--- a/src/email/mailer.rs
+++ b/src/email/mailer.rs
@@ -41,16 +41,9 @@ struct Inner {
 /// - [`Mailer::with_source`] — accepts any custom [`TemplateSource`].
 /// - `Mailer::with_stub_transport` — in-memory stub for tests
 ///   (requires feature `"test-helpers"` or `#[cfg(test)]`).
+#[derive(Clone)]
 pub struct Mailer {
     inner: Arc<Inner>,
-}
-
-impl Clone for Mailer {
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
-    }
 }
 
 impl Mailer {

--- a/src/email/mailer.rs
+++ b/src/email/mailer.rs
@@ -18,11 +18,21 @@ enum Transport {
     Stub(lettre::transport::stub::AsyncStubTransport),
 }
 
+struct Inner {
+    source: Arc<dyn TemplateSource>,
+    transport: Transport,
+    config: EmailConfig,
+    layouts: HashMap<String, String>,
+}
+
 /// The primary entry point for sending transactional email.
 ///
 /// `Mailer` loads Markdown templates, performs variable substitution, renders
 /// HTML and plain-text bodies, applies a layout, and delivers the resulting
 /// message over SMTP.
+///
+/// Cloning is cheap (`Arc`-based) and shares the SMTP connection, template
+/// source, and preloaded layouts.
 ///
 /// # Construction
 ///
@@ -32,10 +42,15 @@ enum Transport {
 /// - `Mailer::with_stub_transport` — in-memory stub for tests
 ///   (requires feature `"test-helpers"` or `#[cfg(test)]`).
 pub struct Mailer {
-    source: Arc<dyn TemplateSource>,
-    transport: Transport,
-    config: EmailConfig,
-    layouts: HashMap<String, String>,
+    inner: Arc<Inner>,
+}
+
+impl Clone for Mailer {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 impl Mailer {
@@ -61,10 +76,12 @@ impl Mailer {
         let layouts = layout::load_layouts(&config.layouts_path)?;
 
         Ok(Self {
-            source,
-            transport: Transport::Smtp(transport),
-            config: config.clone(),
-            layouts,
+            inner: Arc::new(Inner {
+                source,
+                transport: Transport::Smtp(transport),
+                config: config.clone(),
+                layouts,
+            }),
         })
     }
 
@@ -82,10 +99,12 @@ impl Mailer {
         let layouts = layout::load_layouts(&config.layouts_path)?;
 
         Ok(Self {
-            source,
-            transport: Transport::Smtp(transport),
-            config: config.clone(),
-            layouts,
+            inner: Arc::new(Inner {
+                source,
+                transport: Transport::Smtp(transport),
+                config: config.clone(),
+                layouts,
+            }),
         })
     }
 
@@ -111,10 +130,12 @@ impl Mailer {
         let layouts = layout::load_layouts(&config.layouts_path)?;
 
         Ok(Self {
-            source,
-            transport: Transport::Stub(stub),
-            config: config.clone(),
-            layouts,
+            inner: Arc::new(Inner {
+                source,
+                transport: Transport::Stub(stub),
+                config: config.clone(),
+                layouts,
+            }),
         })
     }
 
@@ -173,12 +194,13 @@ impl Mailer {
         let locale = email
             .locale
             .as_deref()
-            .unwrap_or(&self.config.default_locale);
+            .unwrap_or(&self.inner.config.default_locale);
 
         // Load raw template
-        let raw = self
-            .source
-            .load(&email.template, locale, &self.config.default_locale)?;
+        let raw =
+            self.inner
+                .source
+                .load(&email.template, locale, &self.inner.config.default_locale)?;
 
         // Stage 1: Substitute variables
         let substituted = render::substitute(&raw, &email.vars);
@@ -191,7 +213,7 @@ impl Mailer {
         let html_body = markdown::markdown_to_html(&body, brand_color);
 
         // Stage 4: Apply layout
-        let layout_html = layout::resolve_layout(&frontmatter.layout, &self.layouts)?;
+        let layout_html = layout::resolve_layout(&frontmatter.layout, &self.inner.layouts)?;
         let html = layout::apply_layout(&layout_html, &html_body, &email.vars);
 
         // Stage 5: Plain text
@@ -227,17 +249,17 @@ impl Mailer {
             .sender
             .as_ref()
             .map(|s| &s.from_name)
-            .unwrap_or(&self.config.default_from_name);
+            .unwrap_or(&self.inner.config.default_from_name);
         let from_email = email
             .sender
             .as_ref()
             .map(|s| &s.from_email)
-            .unwrap_or(&self.config.default_from_email);
+            .unwrap_or(&self.inner.config.default_from_email);
         let reply_to = email
             .sender
             .as_ref()
             .and_then(|s| s.reply_to.as_deref())
-            .or(self.config.default_reply_to.as_deref());
+            .or(self.inner.config.default_reply_to.as_deref());
 
         let from = if from_name.is_empty() {
             from_email.parse()
@@ -290,7 +312,7 @@ impl Mailer {
             )
             .map_err(|e| Error::internal(format!("failed to build email message: {e}")))?;
 
-        match &self.transport {
+        match &self.inner.transport {
             Transport::Smtp(transport) => {
                 transport
                     .send(message)

--- a/tests/email_test.rs
+++ b/tests/email_test.rs
@@ -250,3 +250,42 @@ async fn send_with_custom_sender_profile() {
     let (_envelope, raw) = &msgs[0];
     assert!(raw.contains("custom@example.com"));
 }
+
+#[tokio::test]
+async fn mailer_is_clone() {
+    let dir = tempfile::tempdir().unwrap();
+    write_template(
+        dir.path(),
+        "en",
+        "hello",
+        "---\nsubject: Hello!\n---\nHi there",
+    );
+
+    let config = test_config(dir.path());
+    let stub = lettre::transport::stub::AsyncStubTransport::new_ok();
+    let mailer = Mailer::with_stub_transport(&config, stub.clone()).unwrap();
+    let mailer2 = mailer.clone();
+
+    // Both clones can render
+    let r1 = mailer
+        .render(&SendEmail::new("hello", "a@example.com"))
+        .unwrap();
+    let r2 = mailer2
+        .render(&SendEmail::new("hello", "b@example.com"))
+        .unwrap();
+    assert_eq!(r1.subject, r2.subject);
+    assert_eq!(r1.html, r2.html);
+
+    // Both clones can send (shared transport)
+    mailer
+        .send(SendEmail::new("hello", "a@example.com"))
+        .await
+        .unwrap();
+    mailer2
+        .send(SendEmail::new("hello", "b@example.com"))
+        .await
+        .unwrap();
+
+    let msgs = stub.messages().await;
+    assert_eq!(msgs.len(), 2);
+}


### PR DESCRIPTION
## Summary

- Wrap `Mailer` internal state in `Arc<Inner>` so cloning is cheap and shares the SMTP connection, template source, and preloaded layouts
- Add `mailer_is_clone` integration test verifying both clones can render and send
- Update docs (`src/email/README.md`, `skills/dev/references/email.md`, struct doc comment)
- Bump version `0.6.1` → `0.6.2`

Closes #61

## Why `HealthChecks` is not included

Issue #61 also requested `Clone` for `HealthChecks`. After discussion, this was intentionally excluded:

`HealthChecks` are purpose-built for a specific endpoint (e.g., `/healthz`) and mounted once. Cloning them across multiple routers would duplicate the same health handlers at different paths, which isn't a real use case. Each set of checks should be constructed independently for its specific purpose.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo check --features email` — compiles
- [x] `cargo clippy --features email,test-helpers --tests -- -D warnings` — no warnings
- [x] `cargo test --features email,test-helpers` — 10/10 email tests pass (including new `mailer_is_clone`)
- [x] Full test suite — 348 tests + 64 doctests, 0 failures