### PR TITLE
feat(db): add maintenance module with health check and vacuum support

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pre-commit hook: detect formatting and lint errors before commit.
+# Does NOT auto-format — just fails fast so CI won't reject the commit.
+#
+# Install: git config core.hooksPath .githooks
+
+set -e
+
+echo "pre-commit: checking formatting..."
+if ! cargo fmt --check 2>&1; then
+    echo ""
+    echo "ERROR: cargo fmt --check failed. Run 'cargo fmt' to fix."
+    exit 1
+fi
+
+echo "pre-commit: running clippy..."
+if ! cargo clippy --all-features --tests -- -D warnings 2>&1; then
+    echo ""
+    echo "ERROR: cargo clippy found warnings. Fix them before committing."
+    exit 1
+fi
+
+echo "pre-commit: all checks passed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,22 +1,30 @@
 #!/usr/bin/env bash
-# Pre-commit hook: detect formatting and lint errors before commit.
-# Does NOT auto-format — just fails fast so CI won't reject the commit.
+# Pre-commit hook: format + lint + compile check — mirrors CI's fmt, lint,
+# and check jobs. Does NOT auto-format or run tests.
 #
-# Install: git config core.hooksPath .githooks
+# Install: just setup  (or: git config core.hooksPath .githooks)
+# Skip once: git commit --no-verify
 
 set -e
 
-echo "pre-commit: checking formatting..."
+echo "pre-commit [1/3]: cargo fmt --check"
 if ! cargo fmt --check 2>&1; then
     echo ""
-    echo "ERROR: cargo fmt --check failed. Run 'cargo fmt' to fix."
+    echo "ERROR: formatting check failed. Run 'cargo fmt' to fix."
     exit 1
 fi
 
-echo "pre-commit: running clippy..."
-if ! cargo clippy --all-features --tests -- -D warnings 2>&1; then
+echo "pre-commit [2/3]: cargo clippy --features full,test-helpers --tests -- -D warnings"
+if ! cargo clippy --features full,test-helpers --tests -- -D warnings 2>&1; then
     echo ""
-    echo "ERROR: cargo clippy found warnings. Fix them before committing."
+    echo "ERROR: clippy found warnings. Fix them before committing."
+    exit 1
+fi
+
+echo "pre-commit [3/3]: cargo check"
+if ! cargo check 2>&1; then
+    echo ""
+    echo "ERROR: cargo check (default features) failed."
     exit 1
 fi
 

--- a/docs/superpowers/plans/2026-04-04-db-maintenance.md
+++ b/docs/superpowers/plans/2026-04-04-db-maintenance.md
@@ -1,0 +1,580 @@
+# Database Maintenance Module Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `db::maintenance` module with health check metrics, threshold-guarded VACUUM, and a cron handler factory.
+
+**Architecture:** Single file `src/db/maintenance.rs` under the existing `db` feature flag. Library functions take `&libsql::Connection`. A `VacuumHandler` struct implements `CronHandler` for cron scheduling. Core functions log at `debug`, cron handler at `info`.
+
+**Tech Stack:** libsql (PRAGMA queries, VACUUM), tracing, modo's cron system (`CronHandler`, `FromCronContext`, `Service<T>`)
+
+**Spec:** `docs/superpowers/specs/2026-04-04-db-maintenance-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/db/maintenance.rs` | Create | All types (`DbHealth`, `VacuumOptions`, `VacuumResult`, `VacuumHandler`) and functions (`run_vacuum`, `vacuum_if_needed`, `vacuum_handler`) |
+| `src/db/mod.rs` | Modify | Add `mod maintenance` + re-exports, update module doc table |
+
+---
+
+### Task 1: `DbHealth` struct and `collect`
+
+**Files:**
+- Create: `src/db/maintenance.rs`
+- Modify: `src/db/mod.rs`
+
+- [ ] **Step 1: Create `maintenance.rs` with `DbHealth` struct, `collect`, `needs_vacuum`, and a test**
+
+Create `src/db/maintenance.rs`:
+
+```rust
+use crate::error::{Error, Result};
+
+/// Database health metrics from PRAGMA introspection.
+///
+/// Contains page-level statistics useful for deciding whether to run
+/// `VACUUM`. Does **not** derive `Serialize` — these are internal
+/// infrastructure metrics that must not be exposed on unauthenticated
+/// endpoints.
+#[derive(Debug, Clone)]
+pub struct DbHealth {
+    /// Total number of pages in the database.
+    pub page_count: u64,
+    /// Number of pages on the freelist (reclaimable by VACUUM).
+    pub freelist_count: u64,
+    /// Size of each page in bytes.
+    pub page_size: u64,
+    /// Percentage of pages on the freelist (0.0–100.0).
+    pub free_percent: f64,
+    /// Total database file size in bytes (`page_count * page_size`).
+    pub total_size_bytes: u64,
+    /// Wasted space in bytes (`freelist_count * page_size`).
+    pub wasted_bytes: u64,
+}
+
+impl DbHealth {
+    /// Collect health metrics via `PRAGMA page_count`, `freelist_count`,
+    /// `page_size`. Computes derived fields from those three values.
+    pub async fn collect(conn: &libsql::Connection) -> Result<Self> {
+        let page_count = Self::pragma_u64(conn, "page_count").await?;
+        let freelist_count = Self::pragma_u64(conn, "freelist_count").await?;
+        let page_size = Self::pragma_u64(conn, "page_size").await?;
+
+        let free_percent = if page_count > 0 {
+            (freelist_count as f64 / page_count as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        Ok(Self {
+            page_count,
+            freelist_count,
+            page_size,
+            free_percent,
+            total_size_bytes: page_count * page_size,
+            wasted_bytes: freelist_count * page_size,
+        })
+    }
+
+    /// Returns `true` if `free_percent >= threshold_percent`.
+    pub fn needs_vacuum(&self, threshold_percent: f64) -> bool {
+        self.free_percent >= threshold_percent
+    }
+
+    async fn pragma_u64(conn: &libsql::Connection, name: &str) -> Result<u64> {
+        let mut rows = conn
+            .query(&format!("PRAGMA {name}"), ())
+            .await
+            .map_err(Error::from)?;
+        let row = rows
+            .next()
+            .await
+            .map_err(Error::from)?
+            .ok_or_else(|| Error::internal(format!("PRAGMA {name} returned no rows")))?;
+        let val: i64 = row.get(0).map_err(Error::from)?;
+        Ok(val as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_conn() -> libsql::Connection {
+        let db = libsql::Builder::new_local(":memory:")
+            .build()
+            .await
+            .unwrap();
+        db.connect().unwrap()
+    }
+
+    #[tokio::test]
+    async fn collect_returns_metrics_for_fresh_db() {
+        let conn = test_conn().await;
+        let health = DbHealth::collect(&conn).await.unwrap();
+
+        assert!(health.page_count > 0);
+        assert_eq!(health.freelist_count, 0);
+        assert_eq!(health.page_size, 4096);
+        assert_eq!(health.free_percent, 0.0);
+        assert_eq!(health.total_size_bytes, health.page_count * 4096);
+        assert_eq!(health.wasted_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn needs_vacuum_threshold_logic() {
+        let health = DbHealth {
+            page_count: 100,
+            freelist_count: 25,
+            page_size: 4096,
+            free_percent: 25.0,
+            total_size_bytes: 100 * 4096,
+            wasted_bytes: 25 * 4096,
+        };
+
+        assert!(health.needs_vacuum(20.0));
+        assert!(health.needs_vacuum(25.0));
+        assert!(!health.needs_vacuum(30.0));
+    }
+}
+```
+
+- [ ] **Step 2: Wire module in `src/db/mod.rs`**
+
+Add after the `select` import at the bottom of `src/db/mod.rs` (before the `pub use libsql` line):
+
+```rust
+mod maintenance;
+pub use maintenance::{DbHealth, run_vacuum, vacuum_handler, vacuum_if_needed, VacuumOptions, VacuumResult};
+```
+
+Note: `run_vacuum`, `VacuumOptions`, `VacuumResult`, `vacuum_handler` don't exist yet — the module will fail to compile until Task 2 and Task 3 add them. That's fine; we run tests scoped to what exists.
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cargo test --features db db::maintenance --lib`
+
+Expected: 2 tests pass (`collect_returns_metrics_for_fresh_db`, `needs_vacuum_threshold_logic`).
+
+Note: The `pub use` line in `mod.rs` references symbols that don't exist yet. If the compiler blocks the test run, temporarily comment out the not-yet-existing re-exports (`run_vacuum`, `vacuum_handler`, `vacuum_if_needed`, `VacuumOptions`, `VacuumResult`) and only re-export `DbHealth`. Restore them in Task 2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/maintenance.rs src/db/mod.rs
+git commit -m "feat(db): add DbHealth struct with collect and needs_vacuum"
+```
+
+---
+
+### Task 2: `VacuumOptions`, `VacuumResult`, `run_vacuum`, `vacuum_if_needed`
+
+**Files:**
+- Modify: `src/db/maintenance.rs`
+- Modify: `src/db/mod.rs` (restore re-exports if commented)
+
+- [ ] **Step 1: Add types and functions with tests**
+
+Add the following to `src/db/maintenance.rs`, above the `#[cfg(test)]` block:
+
+```rust
+/// Options for [`run_vacuum`].
+pub struct VacuumOptions {
+    /// Only vacuum if freelist exceeds this percentage. Default: `20.0`.
+    pub threshold_percent: f64,
+    /// Log-only mode — report health without running VACUUM. Default: `false`.
+    pub dry_run: bool,
+}
+
+impl Default for VacuumOptions {
+    fn default() -> Self {
+        Self {
+            threshold_percent: 20.0,
+            dry_run: false,
+        }
+    }
+}
+
+/// Result of a [`run_vacuum`] call.
+pub struct VacuumResult {
+    /// Health snapshot taken before the vacuum decision.
+    pub health_before: DbHealth,
+    /// Health snapshot taken after VACUUM. `None` if skipped or dry_run.
+    pub health_after: Option<DbHealth>,
+    /// Whether VACUUM actually executed.
+    pub vacuumed: bool,
+    /// Wall-clock duration of the full operation.
+    pub duration: std::time::Duration,
+}
+
+/// Run VACUUM with safety checks.
+///
+/// 1. Collects health metrics.
+/// 2. If `free_percent < threshold` or `dry_run`, returns early.
+/// 3. Executes `VACUUM`.
+/// 4. Collects health metrics again.
+///
+/// Logs before/after metrics at `debug` level.
+pub async fn run_vacuum(
+    conn: &libsql::Connection,
+    opts: VacuumOptions,
+) -> Result<VacuumResult> {
+    let start = std::time::Instant::now();
+    let health_before = DbHealth::collect(conn).await?;
+
+    tracing::debug!(
+        page_count = health_before.page_count,
+        freelist_count = health_before.freelist_count,
+        free_pct = health_before.free_percent,
+        wasted_bytes = health_before.wasted_bytes,
+        "vacuum: health before"
+    );
+
+    if opts.dry_run || !health_before.needs_vacuum(opts.threshold_percent) {
+        tracing::debug!(
+            free_pct = health_before.free_percent,
+            threshold = opts.threshold_percent,
+            dry_run = opts.dry_run,
+            "vacuum: skipped"
+        );
+        return Ok(VacuumResult {
+            health_before,
+            health_after: None,
+            vacuumed: false,
+            duration: start.elapsed(),
+        });
+    }
+
+    conn.execute("VACUUM", ())
+        .await
+        .map_err(|e| Error::internal("VACUUM failed").chain(e))?;
+
+    let health_after = DbHealth::collect(conn).await?;
+
+    tracing::debug!(
+        page_count = health_after.page_count,
+        freelist_count = health_after.freelist_count,
+        free_pct = health_after.free_percent,
+        wasted_bytes = health_after.wasted_bytes,
+        "vacuum: health after"
+    );
+
+    Ok(VacuumResult {
+        health_before,
+        health_after: Some(health_after),
+        vacuumed: true,
+        duration: start.elapsed(),
+    })
+}
+
+/// Shorthand: run [`run_vacuum`] with the given threshold and default options.
+pub async fn vacuum_if_needed(
+    conn: &libsql::Connection,
+    threshold_percent: f64,
+) -> Result<VacuumResult> {
+    run_vacuum(
+        conn,
+        VacuumOptions {
+            threshold_percent,
+            ..Default::default()
+        },
+    )
+    .await
+}
+```
+
+Add the following tests inside the `mod tests` block:
+
+```rust
+    #[tokio::test]
+    async fn run_vacuum_skips_when_below_threshold() {
+        let conn = test_conn().await;
+
+        let result = run_vacuum(
+            &conn,
+            VacuumOptions {
+                threshold_percent: 20.0,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.vacuumed);
+        assert!(result.health_after.is_none());
+        assert_eq!(result.health_before.freelist_count, 0);
+    }
+
+    #[tokio::test]
+    async fn run_vacuum_skips_in_dry_run() {
+        let conn = test_conn().await;
+
+        let result = run_vacuum(
+            &conn,
+            VacuumOptions {
+                threshold_percent: 0.0, // would trigger on any freelist
+                dry_run: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.vacuumed);
+        assert!(result.health_after.is_none());
+    }
+
+    #[tokio::test]
+    async fn run_vacuum_executes_when_threshold_met() {
+        let conn = test_conn().await;
+
+        // Create a table, insert rows, delete them to produce freelist pages
+        conn.execute(
+            "CREATE TABLE bloat (id INTEGER PRIMARY KEY, data TEXT)",
+            (),
+        )
+        .await
+        .unwrap();
+
+        // Insert enough data to create multiple pages
+        for i in 0..500 {
+            conn.execute(
+                "INSERT INTO bloat (id, data) VALUES (?1, ?2)",
+                libsql::params![i, "x".repeat(200)],
+            )
+            .await
+            .unwrap();
+        }
+
+        // Delete all rows — pages go to freelist
+        conn.execute("DELETE FROM bloat", ()).await.unwrap();
+
+        let health = DbHealth::collect(&conn).await.unwrap();
+        assert!(health.freelist_count > 0, "expected freelist pages after bulk delete");
+
+        // Run vacuum with a very low threshold so it triggers
+        let result = run_vacuum(
+            &conn,
+            VacuumOptions {
+                threshold_percent: 0.0,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.vacuumed);
+        let after = result.health_after.unwrap();
+        assert!(
+            after.freelist_count < health.freelist_count,
+            "freelist should shrink after vacuum"
+        );
+    }
+
+    #[tokio::test]
+    async fn vacuum_if_needed_delegates_correctly() {
+        let conn = test_conn().await;
+
+        // Fresh DB, 0% free — should skip with threshold 20
+        let result = vacuum_if_needed(&conn, 20.0).await.unwrap();
+        assert!(!result.vacuumed);
+    }
+```
+
+- [ ] **Step 2: Restore full re-exports in `src/db/mod.rs`**
+
+If you commented out re-exports in Task 1 Step 3, restore them now. The full line should be:
+
+```rust
+pub use maintenance::{DbHealth, VacuumOptions, VacuumResult, run_vacuum, vacuum_handler, vacuum_if_needed};
+```
+
+Note: `vacuum_handler` still doesn't exist — if the compiler blocks, temporarily exclude it from the re-export. Restore it in Task 3.
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cargo test --features db db::maintenance --lib`
+
+Expected: 6 tests pass (2 from Task 1 + 4 new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/maintenance.rs src/db/mod.rs
+git commit -m "feat(db): add run_vacuum and vacuum_if_needed with threshold guard"
+```
+
+---
+
+### Task 3: `VacuumHandler` cron handler factory
+
+**Files:**
+- Modify: `src/db/maintenance.rs`
+- Modify: `src/db/mod.rs` (restore `vacuum_handler` re-export if commented)
+
+- [ ] **Step 1: Add `VacuumHandler` and `vacuum_handler` factory**
+
+Add the following to `src/db/maintenance.rs`, after the `vacuum_if_needed` function and before the `#[cfg(test)]` block:
+
+```rust
+use crate::cron::context::{CronContext, FromCronContext};
+use crate::cron::handler::CronHandler;
+use crate::extractor::Service;
+
+use super::Database;
+
+/// Cron handler that checks database health and vacuums if the freelist
+/// ratio exceeds the configured threshold. Logs results at `info` level.
+///
+/// Created by [`vacuum_handler`].
+#[derive(Clone)]
+pub struct VacuumHandler {
+    threshold_percent: f64,
+}
+
+impl CronHandler<(Service<Database>,)> for VacuumHandler {
+    async fn call(self, ctx: CronContext) -> Result<()> {
+        let Service(db) = Service::<Database>::from_cron_context(&ctx)?;
+
+        let result = run_vacuum(
+            db.conn(),
+            VacuumOptions {
+                threshold_percent: self.threshold_percent,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        if result.vacuumed {
+            let after = result.health_after.as_ref().unwrap();
+            tracing::info!(
+                before_free_pct = result.health_before.free_percent,
+                after_free_pct = after.free_percent,
+                reclaimed_bytes = result.health_before.wasted_bytes - after.wasted_bytes,
+                duration_ms = result.duration.as_millis(),
+                "vacuum completed"
+            );
+        } else {
+            tracing::info!(
+                free_pct = result.health_before.free_percent,
+                threshold = self.threshold_percent,
+                "vacuum skipped, below threshold"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns a cron handler that checks DB health and vacuums if needed.
+///
+/// The handler extracts [`Service<Database>`] from the cron context.
+/// Register the `Database` in the service registry before building the
+/// scheduler.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use modo::cron::Scheduler;
+/// use modo::db::maintenance;
+/// use modo::service::Registry;
+///
+/// # async fn example() -> modo::Result<()> {
+/// let mut registry = Registry::new();
+/// // registry.add(db.clone());
+///
+/// let scheduler = Scheduler::builder(&registry)
+///     .job("0 3 * * 0", maintenance::vacuum_handler(20.0))?
+///     .start()
+///     .await;
+/// # Ok(())
+/// # }
+/// ```
+pub fn vacuum_handler(threshold_percent: f64) -> VacuumHandler {
+    VacuumHandler { threshold_percent }
+}
+```
+
+Note on imports: the `use` statements for cron types and `Service` should be placed at the top of the file with the other imports. The `CronHandler` trait uses RPITIT (`impl Future` in return position), so the manual impl above uses the same pattern — this compiles because `VacuumHandler` is a concrete type, not behind `dyn`.
+
+- [ ] **Step 2: Restore `vacuum_handler` in `src/db/mod.rs` re-exports**
+
+The full re-export line should now be:
+
+```rust
+pub use maintenance::{
+    DbHealth, VacuumOptions, VacuumResult, run_vacuum, vacuum_handler, vacuum_if_needed,
+};
+```
+
+- [ ] **Step 3: Run `cargo check --features db` to verify compilation**
+
+Run: `cargo check --features db`
+
+Expected: compiles with no errors. The `VacuumHandler` impl of `CronHandler` requires `Clone + Send + 'static` — all satisfied.
+
+- [ ] **Step 4: Run all maintenance tests**
+
+Run: `cargo test --features db db::maintenance --lib`
+
+Expected: 6 tests pass (no new tests — `VacuumHandler` is tested indirectly through the existing `run_vacuum` tests and will be exercised end-to-end by the app developer).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db/maintenance.rs src/db/mod.rs
+git commit -m "feat(db): add vacuum_handler cron handler factory"
+```
+
+---
+
+### Task 4: Module docs and clippy
+
+**Files:**
+- Modify: `src/db/mod.rs` (doc comment table)
+- Modify: `src/db/maintenance.rs` (if clippy issues)
+
+- [ ] **Step 1: Update `src/db/mod.rs` doc comment**
+
+Add a new `## Maintenance` section to the module doc comment in `src/db/mod.rs`. Insert it after the `## Configuration enums` table and before the `## Re-exports` section:
+
+```rust
+//! ## Maintenance
+//!
+//! | Item | Purpose |
+//! |------|---------|
+//! | [`DbHealth`] | Page-level health metrics from PRAGMA introspection |
+//! | [`VacuumOptions`] | Configuration for [`run_vacuum`] (threshold, dry_run) |
+//! | [`VacuumResult`] | Before/after health snapshots with timing |
+//! | [`run_vacuum`] | VACUUM with threshold guard and health snapshots |
+//! | [`vacuum_if_needed`] | Shorthand for `run_vacuum` with threshold only |
+//! | [`vacuum_handler`] | Cron handler factory for scheduled maintenance |
+```
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy --features db --tests -- -D warnings`
+
+Expected: no warnings. Fix any clippy issues in `src/db/maintenance.rs` if they appear.
+
+- [ ] **Step 3: Run fmt**
+
+Run: `cargo fmt`
+
+Expected: no changes (or auto-formats if needed).
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cargo test --features db`
+
+Expected: all tests pass, including the 6 maintenance tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db/mod.rs src/db/maintenance.rs
+git commit -m "docs(db): add maintenance section to module docs"
+```

--- a/docs/superpowers/specs/2026-04-04-db-maintenance-design.md
+++ b/docs/superpowers/specs/2026-04-04-db-maintenance-design.md
@@ -160,16 +160,11 @@ let scheduler = Scheduler::builder(&registry)
     .await;
 ```
 
-### Health check endpoint
+## Security
 
-```rust
-use modo::db::maintenance::DbHealth;
+`DbHealth` exposes internal infrastructure metrics (page counts, file sizes, freelist ratios). **Do not serialize `DbHealth` on unauthenticated endpoints** like `/_ready` or `/_live`. The existing `/_ready` returns only a status code — keep it that way. If an app needs a health dashboard with vacuum metrics, gate it behind authentication.
 
-async fn health_handler(Service(db): Service<Database>) -> Result<Json<DbHealth>> {
-    let health = DbHealth::collect(db.conn()).await?;
-    Ok(Json(health))
-}
-```
+`DbHealth` intentionally does **not** derive `Serialize` to prevent accidental exposure. Callers who need JSON output can map the fields explicitly into their own response type.
 
 ## Testing Strategy
 

--- a/docs/superpowers/specs/2026-04-04-db-maintenance-design.md
+++ b/docs/superpowers/specs/2026-04-04-db-maintenance-design.md
@@ -1,0 +1,211 @@
+# Database Maintenance Module
+
+**Module:** `db::maintenance`
+**File:** `src/db/maintenance.rs`
+**Feature flag:** `db` (existing, no new flag)
+**Date:** 2026-04-04
+
+---
+
+## Problem
+
+Bulk data deletions (tenant removal, expired data purges) leave SQLite/libsql databases with unreclaimable dead pages. Without periodic maintenance the database file grows monotonically, fragmentation increases, and sequential read performance degrades.
+
+modo currently has no built-in way to assess database health (freelist ratio, file bloat) or safely run `VACUUM` with pre-checks.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Consumer model | Library functions + cron handler factory; end-app wires it | Matches modo's explicit-wiring philosophy |
+| Feature flag | Existing `db` flag | Zero new dependencies, just PRAGMA queries and VACUUM |
+| Connection type | `&libsql::Connection` | Consistent with `ConnExt`/`ConnQueryExt` pattern |
+| File structure | Single flat file `src/db/maintenance.rs` | ~150 lines, YAGNI on sub-modules |
+| Health scope | Page/freelist metrics only | `integrity_check` is a separate concern (expensive) |
+| Logging | `debug` in core functions, `info` in cron handler | Composable for library callers, visible for operators |
+
+## Public API
+
+### `DbHealth`
+
+```rust
+/// Database health metrics from PRAGMA introspection.
+#[derive(Debug, Clone)]
+pub struct DbHealth {
+    /// Total number of pages in the database.
+    pub page_count: u64,
+    /// Number of pages on the freelist (reclaimable by VACUUM).
+    pub freelist_count: u64,
+    /// Size of each page in bytes.
+    pub page_size: u64,
+    /// Percentage of pages on the freelist (0.0–100.0).
+    pub free_percent: f64,
+    /// Total database file size in bytes (page_count * page_size).
+    pub total_size_bytes: u64,
+    /// Wasted space in bytes (freelist_count * page_size).
+    pub wasted_bytes: u64,
+}
+```
+
+**Methods:**
+
+- `async fn collect(conn: &libsql::Connection) -> Result<Self>` — runs `PRAGMA page_count`, `PRAGMA freelist_count`, `PRAGMA page_size`, computes derived fields.
+- `fn needs_vacuum(&self, threshold_percent: f64) -> bool` — returns `true` if `free_percent >= threshold_percent`.
+
+### `VacuumOptions`
+
+```rust
+pub struct VacuumOptions {
+    /// Only vacuum if freelist exceeds this percentage. Default: 20.0
+    pub threshold_percent: f64,
+    /// Log-only mode — report health without running VACUUM. Default: false
+    pub dry_run: bool,
+}
+```
+
+`Default` impl: `threshold_percent: 20.0`, `dry_run: false`.
+
+### `VacuumResult`
+
+```rust
+pub struct VacuumResult {
+    /// Health snapshot taken before the vacuum decision.
+    pub health_before: DbHealth,
+    /// Health snapshot taken after VACUUM. `None` if skipped or dry_run.
+    pub health_after: Option<DbHealth>,
+    /// Whether VACUUM actually executed.
+    pub vacuumed: bool,
+    /// Wall-clock duration of the full operation.
+    pub duration: std::time::Duration,
+}
+```
+
+### Core Functions
+
+```rust
+/// Run VACUUM with safety checks.
+///
+/// 1. Collects health metrics.
+/// 2. If free_percent < threshold or dry_run, returns early.
+/// 3. Executes VACUUM.
+/// 4. Collects health metrics again.
+///
+/// Logs before/after metrics at debug level.
+pub async fn run_vacuum(
+    conn: &libsql::Connection,
+    opts: VacuumOptions,
+) -> Result<VacuumResult>;
+
+/// Shorthand: run_vacuum with the given threshold and defaults.
+pub async fn vacuum_if_needed(
+    conn: &libsql::Connection,
+    threshold_percent: f64,
+) -> Result<VacuumResult>;
+```
+
+### Cron Handler Factory
+
+```rust
+/// Returns a cron handler that checks DB health and vacuums if needed.
+///
+/// Extracts `Service<Database>` from the cron context. Logs at info level.
+pub fn vacuum_handler(threshold_percent: f64) -> VacuumHandler;
+```
+
+Implementation: `VacuumHandler` is a private-fields, `#[derive(Clone)]` struct that implements `CronHandler<(Service<Database>,)>` manually. It calls `run_vacuum` with the captured threshold and logs results at `info` level.
+
+## Module Wiring
+
+**`src/db/mod.rs`** adds:
+
+```rust
+mod maintenance;
+pub use maintenance::{
+    DbHealth, VacuumOptions, VacuumResult,
+    run_vacuum, vacuum_if_needed, vacuum_handler,
+};
+```
+
+## End-App Usage
+
+### On-demand after bulk deletes
+
+```rust
+use modo::db::maintenance;
+
+// After tenant data deletion in a background job
+let result = maintenance::vacuum_if_needed(db.conn(), 25.0).await?;
+if result.vacuumed {
+    tracing::info!(
+        before_pct = result.health_before.free_percent,
+        after_pct = result.health_after.as_ref().unwrap().free_percent,
+        duration_ms = result.duration.as_millis(),
+        "post-deletion vacuum completed"
+    );
+}
+```
+
+### Scheduled via cron
+
+```rust
+use modo::db::maintenance;
+use modo::cron::Scheduler;
+
+// Database must be registered in the service registry
+registry.register(db.clone());
+
+let scheduler = Scheduler::builder(&registry)
+    .job("0 3 * * 0", maintenance::vacuum_handler(20.0))? // Weekly Sunday 3am
+    .start()
+    .await;
+```
+
+### Health check endpoint
+
+```rust
+use modo::db::maintenance::DbHealth;
+
+async fn health_handler(Service(db): Service<Database>) -> Result<Json<DbHealth>> {
+    let health = DbHealth::collect(db.conn()).await?;
+    Ok(Json(health))
+}
+```
+
+## Testing Strategy
+
+Unit tests in `src/db/maintenance.rs` using in-memory libsql databases:
+
+1. **`DbHealth::collect`** — create in-memory DB, verify page_count > 0, freelist_count == 0 on fresh DB, page_size == 4096 (default).
+2. **`needs_vacuum`** — construct `DbHealth` manually, assert threshold logic.
+3. **`run_vacuum` below threshold** — fresh DB has 0% free; verify `vacuumed == false`, `health_after == None`.
+4. **`run_vacuum` dry_run** — even if threshold met, verify `vacuumed == false`.
+5. **`run_vacuum` executes** — insert rows, delete them, verify freelist grows, run vacuum, verify freelist shrinks.
+6. **`vacuum_if_needed`** — verify it delegates correctly (threshold pass-through).
+
+The `VacuumHandler` struct is tested indirectly — it's a thin wrapper over `run_vacuum` with `Service<Database>` extraction.
+
+## Operational Considerations
+
+### Litestream
+
+`VACUUM` rewrites the entire database file, forcing Litestream to re-replicate in full. A weekly schedule keeps this manageable. End-app operators should be aware of this trade-off.
+
+### WAL Mode
+
+`VACUUM` in WAL mode checkpoints first, then rewrites. This temporarily blocks writers. For single-server deployments with low traffic at maintenance time, this is a non-issue.
+
+### libsql Compatibility
+
+The implementation relies on:
+- `PRAGMA page_count` — standard SQLite, expected to work in libsql.
+- `PRAGMA freelist_count` — standard SQLite, expected to work in libsql.
+- `PRAGMA page_size` — standard SQLite, expected to work in libsql.
+- `VACUUM` — standard SQLite, expected to work in libsql embedded mode.
+
+These should be verified against the actual libsql version during implementation.
+
+### What This Doesn't Solve
+
+- **Index fragmentation** — `REINDEX` is cheaper if only indexes are degraded.
+- **WAL file growth** — managed by checkpoint policy, not vacuum.
+- **Query performance** — likely missing indexes, not fragmentation.

--- a/justfile
+++ b/justfile
@@ -24,3 +24,7 @@ test-all:
 
 # Run all checks (fmt + lint + test-all) — use in CI or pre-push
 check: fmt-check lint test-all
+
+# Install git hooks (run once after clone)
+setup:
+    git config core.hooksPath .githooks

--- a/skills/dev/references/database.md
+++ b/skills/dev/references/database.md
@@ -519,6 +519,76 @@ impl FromRow for User {
 }
 ```
 
+## Maintenance (Health Check & VACUUM)
+
+### `DbHealth`
+
+Page-level health metrics from PRAGMA introspection. Derives `Debug, Clone`. Does **not** derive `Serialize` — internal metrics that must not be exposed on unauthenticated endpoints.
+
+```rust
+pub struct DbHealth {
+    pub page_count: u64,
+    pub freelist_count: u64,
+    pub page_size: u64,
+    pub free_percent: f64,       // 0.0–100.0
+    pub total_size_bytes: u64,   // page_count * page_size
+    pub wasted_bytes: u64,       // freelist_count * page_size
+}
+
+impl DbHealth {
+    pub async fn collect(conn: &libsql::Connection) -> Result<Self>;
+    pub fn needs_vacuum(&self, threshold_percent: f64) -> bool;
+}
+```
+
+`collect` runs `PRAGMA page_count`, `PRAGMA freelist_count`, `PRAGMA page_size` and computes derived fields. `needs_vacuum` returns `true` if `free_percent >= threshold_percent`.
+
+### `VacuumOptions`
+
+Derives `Debug, Clone`. Implements `Default` (threshold: `20.0`, dry_run: `false`).
+
+```rust
+pub struct VacuumOptions {
+    pub threshold_percent: f64,  // default: 20.0
+    pub dry_run: bool,           // default: false
+}
+```
+
+### `VacuumResult`
+
+Derives `Debug, Clone`.
+
+```rust
+pub struct VacuumResult {
+    pub health_before: DbHealth,
+    pub health_after: Option<DbHealth>,  // None if skipped or dry_run
+    pub vacuumed: bool,
+    pub duration: std::time::Duration,
+}
+```
+
+### `async run_vacuum(conn: &libsql::Connection, opts: VacuumOptions) -> Result<VacuumResult>`
+
+Run VACUUM with safety checks: collects health, checks threshold, executes `VACUUM` if needed, collects health again. Logs before/after metrics at `debug` level. Skips if `dry_run` or below threshold (returns `vacuumed: false`, `health_after: None`).
+
+### `async vacuum_if_needed(conn: &libsql::Connection, threshold_percent: f64) -> Result<VacuumResult>`
+
+Shorthand for `run_vacuum` with the given threshold and default options.
+
+### `vacuum_handler(threshold_percent: f64) -> VacuumHandler`
+
+Returns a cron handler implementing `CronHandler<(Service<Database>,)>`. Extracts `Service<Database>` from the cron context, calls `run_vacuum`, logs results at `info` level. `VacuumHandler` is public (as return type) but has private fields — construct via `vacuum_handler()` only.
+
+```rust
+use modo::cron::Scheduler;
+use modo::db;
+
+let scheduler = Scheduler::builder(&registry)
+    .job("0 3 * * 0", db::vacuum_handler(20.0))?
+    .start()
+    .await;
+```
+
 ## Gotchas
 
 - **Single connection per handle**: `Database` wraps one `libsql::Connection` in `Arc`. All clones share the same connection. `DatabasePool` manages multiple `Database` handles (one per shard).

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -262,7 +262,7 @@ println!("free pages: {}%", health.free_percent);
 let result = vacuum_if_needed(db.conn(), 20.0).await?;
 if result.vacuumed {
     let after = result.health_after.unwrap();
-    println!("reclaimed {} bytes", result.health_before.wasted_bytes - after.wasted_bytes);
+    println!("reclaimed {} bytes", result.health_before.wasted_bytes.saturating_sub(after.wasted_bytes));
 }
 
 // Full options: dry_run mode, custom threshold

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -7,7 +7,7 @@ Requires feature `"db"` (enabled by default).
 
 ```toml
 [dependencies]
-modo = { version = "0.6", features = ["db"] }
+modo-rs = { version = "0.6.2", features = ["db"] }
 ```
 
 ## Key types
@@ -42,6 +42,12 @@ modo = { version = "0.6", features = ["db"] }
 | `JournalMode`      | SQLite journal mode enum (WAL, Delete, Truncate, Memory, Off)            |
 | `SynchronousMode`  | SQLite synchronous mode enum (Off, Normal, Full, Extra)                  |
 | `TempStore`        | SQLite temp store location enum (Default, File, Memory)                  |
+| `DbHealth`         | Page-level health metrics from PRAGMA introspection                      |
+| `VacuumOptions`    | Configuration for `run_vacuum` (threshold, dry_run)                      |
+| `VacuumResult`     | Before/after health snapshots with timing                                |
+| `run_vacuum`       | VACUUM with threshold guard and health snapshots                         |
+| `vacuum_if_needed` | Shorthand for `run_vacuum` with threshold only                           |
+| `vacuum_handler`   | Cron handler factory for scheduled maintenance                           |
 
 The `libsql` crate is also re-exported for direct access to low-level types
 like `libsql::params!`, `libsql::Value`, `libsql::Connection`, and
@@ -242,6 +248,45 @@ db::migrate(db.conn(), "migrations").await?;
 Migration files are `*.sql` files in the directory, sorted by filename.
 Each migration is tracked in a `_migrations` table with a checksum.
 Modified files after application produce an error.
+
+### Database maintenance (VACUUM)
+
+```rust,no_run
+use modo::db::{self, DbHealth, VacuumOptions, run_vacuum, vacuum_if_needed};
+
+// Check database health
+let health = DbHealth::collect(db.conn()).await?;
+println!("free pages: {}%", health.free_percent);
+
+// Run vacuum only if freelist exceeds 20%
+let result = vacuum_if_needed(db.conn(), 20.0).await?;
+if result.vacuumed {
+    let after = result.health_after.unwrap();
+    println!("reclaimed {} bytes", result.health_before.wasted_bytes - after.wasted_bytes);
+}
+
+// Full options: dry_run mode, custom threshold
+let result = run_vacuum(db.conn(), VacuumOptions {
+    threshold_percent: 10.0,
+    dry_run: true,
+}).await?;
+```
+
+Schedule automatic maintenance with the cron handler:
+
+```rust,no_run
+use modo::cron::Scheduler;
+use modo::db;
+use modo::service::Registry;
+
+let mut registry = Registry::new();
+// registry.add(db.clone());
+
+let scheduler = Scheduler::builder(&registry)
+    .job("0 3 * * 0", db::vacuum_handler(20.0))? // weekly at 3am Sunday
+    .start()
+    .await;
+```
 
 ## Configuration
 

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -66,7 +66,8 @@ impl DbHealth {
             .map_err(Error::from)?
             .ok_or_else(|| Error::internal(format!("PRAGMA {name} returned no rows")))?;
         let val: i64 = row.get(0).map_err(Error::from)?;
-        Ok(val as u64)
+        u64::try_from(val)
+            .map_err(|_| Error::internal(format!("PRAGMA {name} returned negative value: {val}")))
     }
 }
 
@@ -229,7 +230,7 @@ impl CronHandler<(Service<Database>,)> for VacuumHandler {
 ///
 /// ```rust,no_run
 /// use modo::cron::Scheduler;
-/// use modo::db::maintenance;
+/// use modo::db;
 /// use modo::service::Registry;
 ///
 /// # async fn example() -> modo::Result<()> {
@@ -237,7 +238,7 @@ impl CronHandler<(Service<Database>,)> for VacuumHandler {
 /// // registry.add(db.clone());
 ///
 /// let scheduler = Scheduler::builder(&registry)
-///     .job("0 3 * * 0", maintenance::vacuum_handler(20.0))?
+///     .job("0 3 * * 0", db::vacuum_handler(20.0))?
 ///     .start()
 ///     .await;
 /// # Ok(())

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -1,4 +1,8 @@
+use crate::cron::{CronContext, CronHandler, FromCronContext};
 use crate::error::{Error, Result};
+use crate::extractor::Service;
+
+use super::Database;
 
 /// Database health metrics from PRAGMA introspection.
 ///
@@ -170,6 +174,77 @@ pub async fn vacuum_if_needed(
         },
     )
     .await
+}
+
+/// Cron handler that checks database health and vacuums if the freelist
+/// ratio exceeds the configured threshold. Logs results at `info` level.
+///
+/// Created by [`vacuum_handler`].
+#[derive(Clone)]
+pub struct VacuumHandler {
+    threshold_percent: f64,
+}
+
+impl CronHandler<(Service<Database>,)> for VacuumHandler {
+    async fn call(self, ctx: CronContext) -> Result<()> {
+        let Service(db) = Service::<Database>::from_cron_context(&ctx)?;
+
+        let result = run_vacuum(
+            db.conn(),
+            VacuumOptions {
+                threshold_percent: self.threshold_percent,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        if result.vacuumed {
+            let after = result.health_after.as_ref().unwrap();
+            tracing::info!(
+                before_free_pct = result.health_before.free_percent,
+                after_free_pct = after.free_percent,
+                reclaimed_bytes = result.health_before.wasted_bytes - after.wasted_bytes,
+                duration_ms = result.duration.as_millis(),
+                "vacuum completed"
+            );
+        } else {
+            tracing::info!(
+                free_pct = result.health_before.free_percent,
+                threshold = self.threshold_percent,
+                "vacuum skipped, below threshold"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns a cron handler that checks DB health and vacuums if needed.
+///
+/// The handler extracts [`Service<Database>`] from the cron context.
+/// Register the `Database` in the service registry before building the
+/// scheduler.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use modo::cron::Scheduler;
+/// use modo::db::maintenance;
+/// use modo::service::Registry;
+///
+/// # async fn example() -> modo::Result<()> {
+/// let mut registry = Registry::new();
+/// // registry.add(db.clone());
+///
+/// let scheduler = Scheduler::builder(&registry)
+///     .job("0 3 * * 0", maintenance::vacuum_handler(20.0))?
+///     .start()
+///     .await;
+/// # Ok(())
+/// # }
+/// ```
+pub fn vacuum_handler(threshold_percent: f64) -> VacuumHandler {
+    VacuumHandler { threshold_percent }
 }
 
 #[cfg(test)]

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -284,7 +284,10 @@ mod tests {
         assert_eq!(health.freelist_count, 0);
         assert!(health.page_size > 0);
         assert_eq!(health.free_percent, 0.0);
-        assert_eq!(health.total_size_bytes, health.page_count * health.page_size);
+        assert_eq!(
+            health.total_size_bytes,
+            health.page_count * health.page_size
+        );
         assert_eq!(health.wasted_bytes, 0);
     }
 

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -67,6 +67,7 @@ impl DbHealth {
 }
 
 /// Options for [`run_vacuum`].
+#[derive(Debug, Clone)]
 pub struct VacuumOptions {
     /// Only vacuum if freelist exceeds this percentage. Default: `20.0`.
     pub threshold_percent: f64,
@@ -84,6 +85,7 @@ impl Default for VacuumOptions {
 }
 
 /// Result of a [`run_vacuum`] call.
+#[derive(Debug, Clone)]
 pub struct VacuumResult {
     /// Health snapshot taken before the vacuum decision.
     pub health_before: DbHealth,

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -203,7 +203,7 @@ impl CronHandler<(Service<Database>,)> for VacuumHandler {
             tracing::info!(
                 before_free_pct = result.health_before.free_percent,
                 after_free_pct = after.free_percent,
-                reclaimed_bytes = result.health_before.wasted_bytes - after.wasted_bytes,
+                reclaimed_bytes = result.health_before.wasted_bytes.saturating_sub(after.wasted_bytes),
                 duration_ms = result.duration.as_millis(),
                 "vacuum completed"
             );

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -208,8 +208,7 @@ impl CronHandler<(Service<Database>,)> for VacuumHandler {
         )
         .await?;
 
-        if result.vacuumed {
-            let after = result.health_after.as_ref().unwrap();
+        if let Some(after) = result.health_after.as_ref() {
             tracing::info!(
                 before_free_pct = result.health_before.free_percent,
                 after_free_pct = after.free_percent,
@@ -283,9 +282,9 @@ mod tests {
 
         assert!(health.page_count > 0);
         assert_eq!(health.freelist_count, 0);
-        assert_eq!(health.page_size, 4096);
+        assert!(health.page_size > 0);
         assert_eq!(health.free_percent, 0.0);
-        assert_eq!(health.total_size_bytes, health.page_count * 4096);
+        assert_eq!(health.total_size_bytes, health.page_count * health.page_size);
         assert_eq!(health.wasted_bytes, 0);
     }
 

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -1,0 +1,113 @@
+use crate::error::{Error, Result};
+
+/// Database health metrics from PRAGMA introspection.
+///
+/// Contains page-level statistics useful for deciding whether to run
+/// `VACUUM`. Does **not** derive `Serialize` — these are internal
+/// infrastructure metrics that must not be exposed on unauthenticated
+/// endpoints.
+#[derive(Debug, Clone)]
+pub struct DbHealth {
+    /// Total number of pages in the database.
+    pub page_count: u64,
+    /// Number of pages on the freelist (reclaimable by VACUUM).
+    pub freelist_count: u64,
+    /// Size of each page in bytes.
+    pub page_size: u64,
+    /// Percentage of pages on the freelist (0.0–100.0).
+    pub free_percent: f64,
+    /// Total database file size in bytes (`page_count * page_size`).
+    pub total_size_bytes: u64,
+    /// Wasted space in bytes (`freelist_count * page_size`).
+    pub wasted_bytes: u64,
+}
+
+impl DbHealth {
+    /// Collect health metrics via `PRAGMA page_count`, `freelist_count`,
+    /// `page_size`. Computes derived fields from those three values.
+    pub async fn collect(conn: &libsql::Connection) -> Result<Self> {
+        let page_count = Self::pragma_u64(conn, "page_count").await?;
+        let freelist_count = Self::pragma_u64(conn, "freelist_count").await?;
+        let page_size = Self::pragma_u64(conn, "page_size").await?;
+
+        let free_percent = if page_count > 0 {
+            (freelist_count as f64 / page_count as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        Ok(Self {
+            page_count,
+            freelist_count,
+            page_size,
+            free_percent,
+            total_size_bytes: page_count * page_size,
+            wasted_bytes: freelist_count * page_size,
+        })
+    }
+
+    /// Returns `true` if `free_percent >= threshold_percent`.
+    pub fn needs_vacuum(&self, threshold_percent: f64) -> bool {
+        self.free_percent >= threshold_percent
+    }
+
+    async fn pragma_u64(conn: &libsql::Connection, name: &str) -> Result<u64> {
+        let mut rows = conn
+            .query(&format!("PRAGMA {name}"), ())
+            .await
+            .map_err(Error::from)?;
+        let row = rows
+            .next()
+            .await
+            .map_err(Error::from)?
+            .ok_or_else(|| Error::internal(format!("PRAGMA {name} returned no rows")))?;
+        let val: i64 = row.get(0).map_err(Error::from)?;
+        Ok(val as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn test_conn() -> libsql::Connection {
+        let db = libsql::Builder::new_local(":memory:")
+            .build()
+            .await
+            .unwrap();
+        db.connect().unwrap()
+    }
+
+    #[tokio::test]
+    async fn collect_returns_metrics_for_fresh_db() {
+        let conn = test_conn().await;
+        // Create a table to force page allocation in the in-memory database.
+        conn.execute("CREATE TABLE _health_probe (id INTEGER PRIMARY KEY)", ())
+            .await
+            .unwrap();
+        let health = DbHealth::collect(&conn).await.unwrap();
+
+        assert!(health.page_count > 0);
+        assert_eq!(health.freelist_count, 0);
+        assert_eq!(health.page_size, 4096);
+        assert_eq!(health.free_percent, 0.0);
+        assert_eq!(health.total_size_bytes, health.page_count * 4096);
+        assert_eq!(health.wasted_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn needs_vacuum_threshold_logic() {
+        let health = DbHealth {
+            page_count: 100,
+            freelist_count: 25,
+            page_size: 4096,
+            free_percent: 25.0,
+            total_size_bytes: 100 * 4096,
+            wasted_bytes: 25 * 4096,
+        };
+
+        assert!(health.needs_vacuum(20.0));
+        assert!(health.needs_vacuum(25.0));
+        assert!(!health.needs_vacuum(30.0));
+    }
+}

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -29,6 +29,10 @@ pub struct DbHealth {
 impl DbHealth {
     /// Collect health metrics via `PRAGMA page_count`, `freelist_count`,
     /// `page_size`. Computes derived fields from those three values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any PRAGMA query fails or returns an unexpected value.
     pub async fn collect(conn: &libsql::Connection) -> Result<Self> {
         let page_count = Self::pragma_u64(conn, "page_count").await?;
         let freelist_count = Self::pragma_u64(conn, "freelist_count").await?;
@@ -110,6 +114,10 @@ pub struct VacuumResult {
 /// 4. Collects health metrics again.
 ///
 /// Logs before/after metrics at `debug` level.
+///
+/// # Errors
+///
+/// Returns an error if health collection or the `VACUUM` statement fails.
 pub async fn run_vacuum(conn: &libsql::Connection, opts: VacuumOptions) -> Result<VacuumResult> {
     let start = std::time::Instant::now();
     let health_before = DbHealth::collect(conn).await?;
@@ -160,6 +168,10 @@ pub async fn run_vacuum(conn: &libsql::Connection, opts: VacuumOptions) -> Resul
 }
 
 /// Shorthand: run [`run_vacuum`] with the given threshold and default options.
+///
+/// # Errors
+///
+/// Returns an error if health collection or the `VACUUM` statement fails.
 pub async fn vacuum_if_needed(
     conn: &libsql::Connection,
     threshold_percent: f64,

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -66,6 +66,110 @@ impl DbHealth {
     }
 }
 
+/// Options for [`run_vacuum`].
+pub struct VacuumOptions {
+    /// Only vacuum if freelist exceeds this percentage. Default: `20.0`.
+    pub threshold_percent: f64,
+    /// Log-only mode — report health without running VACUUM. Default: `false`.
+    pub dry_run: bool,
+}
+
+impl Default for VacuumOptions {
+    fn default() -> Self {
+        Self {
+            threshold_percent: 20.0,
+            dry_run: false,
+        }
+    }
+}
+
+/// Result of a [`run_vacuum`] call.
+pub struct VacuumResult {
+    /// Health snapshot taken before the vacuum decision.
+    pub health_before: DbHealth,
+    /// Health snapshot taken after VACUUM. `None` if skipped or dry_run.
+    pub health_after: Option<DbHealth>,
+    /// Whether VACUUM actually executed.
+    pub vacuumed: bool,
+    /// Wall-clock duration of the full operation.
+    pub duration: std::time::Duration,
+}
+
+/// Run VACUUM with safety checks.
+///
+/// 1. Collects health metrics.
+/// 2. If `free_percent < threshold` or `dry_run`, returns early.
+/// 3. Executes `VACUUM`.
+/// 4. Collects health metrics again.
+///
+/// Logs before/after metrics at `debug` level.
+pub async fn run_vacuum(
+    conn: &libsql::Connection,
+    opts: VacuumOptions,
+) -> Result<VacuumResult> {
+    let start = std::time::Instant::now();
+    let health_before = DbHealth::collect(conn).await?;
+
+    tracing::debug!(
+        page_count = health_before.page_count,
+        freelist_count = health_before.freelist_count,
+        free_pct = health_before.free_percent,
+        wasted_bytes = health_before.wasted_bytes,
+        "vacuum: health before"
+    );
+
+    if opts.dry_run || !health_before.needs_vacuum(opts.threshold_percent) {
+        tracing::debug!(
+            free_pct = health_before.free_percent,
+            threshold = opts.threshold_percent,
+            dry_run = opts.dry_run,
+            "vacuum: skipped"
+        );
+        return Ok(VacuumResult {
+            health_before,
+            health_after: None,
+            vacuumed: false,
+            duration: start.elapsed(),
+        });
+    }
+
+    conn.execute("VACUUM", ())
+        .await
+        .map_err(|e| Error::internal("VACUUM failed").chain(e))?;
+
+    let health_after = DbHealth::collect(conn).await?;
+
+    tracing::debug!(
+        page_count = health_after.page_count,
+        freelist_count = health_after.freelist_count,
+        free_pct = health_after.free_percent,
+        wasted_bytes = health_after.wasted_bytes,
+        "vacuum: health after"
+    );
+
+    Ok(VacuumResult {
+        health_before,
+        health_after: Some(health_after),
+        vacuumed: true,
+        duration: start.elapsed(),
+    })
+}
+
+/// Shorthand: run [`run_vacuum`] with the given threshold and default options.
+pub async fn vacuum_if_needed(
+    conn: &libsql::Connection,
+    threshold_percent: f64,
+) -> Result<VacuumResult> {
+    run_vacuum(
+        conn,
+        VacuumOptions {
+            threshold_percent,
+            ..Default::default()
+        },
+    )
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,5 +213,98 @@ mod tests {
         assert!(health.needs_vacuum(20.0));
         assert!(health.needs_vacuum(25.0));
         assert!(!health.needs_vacuum(30.0));
+    }
+
+    #[tokio::test]
+    async fn run_vacuum_skips_when_below_threshold() {
+        let conn = test_conn().await;
+
+        let result = run_vacuum(
+            &conn,
+            VacuumOptions {
+                threshold_percent: 20.0,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.vacuumed);
+        assert!(result.health_after.is_none());
+        assert_eq!(result.health_before.freelist_count, 0);
+    }
+
+    #[tokio::test]
+    async fn run_vacuum_skips_in_dry_run() {
+        let conn = test_conn().await;
+
+        let result = run_vacuum(
+            &conn,
+            VacuumOptions {
+                threshold_percent: 0.0, // would trigger on any freelist
+                dry_run: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.vacuumed);
+        assert!(result.health_after.is_none());
+    }
+
+    #[tokio::test]
+    async fn run_vacuum_executes_when_threshold_met() {
+        let conn = test_conn().await;
+
+        // Create a table, insert rows, delete them to produce freelist pages
+        conn.execute(
+            "CREATE TABLE bloat (id INTEGER PRIMARY KEY, data TEXT)",
+            (),
+        )
+        .await
+        .unwrap();
+
+        // Insert enough data to create multiple pages
+        for i in 0..500 {
+            conn.execute(
+                "INSERT INTO bloat (id, data) VALUES (?1, ?2)",
+                libsql::params![i, "x".repeat(200)],
+            )
+            .await
+            .unwrap();
+        }
+
+        // Delete all rows — pages go to freelist
+        conn.execute("DELETE FROM bloat", ()).await.unwrap();
+
+        let health = DbHealth::collect(&conn).await.unwrap();
+        assert!(health.freelist_count > 0, "expected freelist pages after bulk delete");
+
+        // Run vacuum with a very low threshold so it triggers
+        let result = run_vacuum(
+            &conn,
+            VacuumOptions {
+                threshold_percent: 0.0,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(result.vacuumed);
+        let after = result.health_after.unwrap();
+        assert!(
+            after.freelist_count < health.freelist_count,
+            "freelist should shrink after vacuum"
+        );
+    }
+
+    #[tokio::test]
+    async fn vacuum_if_needed_delegates_correctly() {
+        let conn = test_conn().await;
+
+        // Fresh DB, 0% free — should skip with threshold 20
+        let result = vacuum_if_needed(&conn, 20.0).await.unwrap();
+        assert!(!result.vacuumed);
     }
 }

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -109,10 +109,7 @@ pub struct VacuumResult {
 /// 4. Collects health metrics again.
 ///
 /// Logs before/after metrics at `debug` level.
-pub async fn run_vacuum(
-    conn: &libsql::Connection,
-    opts: VacuumOptions,
-) -> Result<VacuumResult> {
+pub async fn run_vacuum(conn: &libsql::Connection, opts: VacuumOptions) -> Result<VacuumResult> {
     let start = std::time::Instant::now();
     let health_before = DbHealth::collect(conn).await?;
 
@@ -203,7 +200,10 @@ impl CronHandler<(Service<Database>,)> for VacuumHandler {
             tracing::info!(
                 before_free_pct = result.health_before.free_percent,
                 after_free_pct = after.free_percent,
-                reclaimed_bytes = result.health_before.wasted_bytes.saturating_sub(after.wasted_bytes),
+                reclaimed_bytes = result
+                    .health_before
+                    .wasted_bytes
+                    .saturating_sub(after.wasted_bytes),
                 duration_ms = result.duration.as_millis(),
                 "vacuum completed"
             );
@@ -334,12 +334,9 @@ mod tests {
         let conn = test_conn().await;
 
         // Create a table, insert rows, delete them to produce freelist pages
-        conn.execute(
-            "CREATE TABLE bloat (id INTEGER PRIMARY KEY, data TEXT)",
-            (),
-        )
-        .await
-        .unwrap();
+        conn.execute("CREATE TABLE bloat (id INTEGER PRIMARY KEY, data TEXT)", ())
+            .await
+            .unwrap();
 
         // Insert enough data to create multiple pages
         for i in 0..500 {
@@ -355,7 +352,10 @@ mod tests {
         conn.execute("DELETE FROM bloat", ()).await.unwrap();
 
         let health = DbHealth::collect(&conn).await.unwrap();
-        assert!(health.freelist_count > 0, "expected freelist pages after bulk delete");
+        assert!(
+            health.freelist_count > 0,
+            "expected freelist pages after bulk delete"
+        );
 
         // Run vacuum with a very low threshold so it triggers
         let result = run_vacuum(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -123,7 +123,10 @@ mod select;
 pub use select::SelectBuilder;
 
 mod maintenance;
-pub use maintenance::{DbHealth, VacuumOptions, VacuumResult, run_vacuum, vacuum_if_needed};
+pub use maintenance::{
+    DbHealth, VacuumOptions, VacuumResult, VacuumHandler, run_vacuum, vacuum_handler,
+    vacuum_if_needed,
+};
 
 // Re-export libsql for direct access
 pub use libsql;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -135,8 +135,7 @@ pub use select::SelectBuilder;
 
 mod maintenance;
 pub use maintenance::{
-    DbHealth, VacuumHandler, VacuumOptions, VacuumResult, run_vacuum, vacuum_handler,
-    vacuum_if_needed,
+    DbHealth, VacuumOptions, VacuumResult, run_vacuum, vacuum_handler, vacuum_if_needed,
 };
 
 // Re-export libsql for direct access

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -123,7 +123,7 @@ mod select;
 pub use select::SelectBuilder;
 
 mod maintenance;
-pub use maintenance::DbHealth;
+pub use maintenance::{DbHealth, VacuumOptions, VacuumResult, run_vacuum, vacuum_if_needed};
 
 // Re-export libsql for direct access
 pub use libsql;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -122,5 +122,8 @@ pub use filter::{FieldType, Filter, FilterSchema, ValidatedFilter};
 mod select;
 pub use select::SelectBuilder;
 
+mod maintenance;
+pub use maintenance::DbHealth;
+
 // Re-export libsql for direct access
 pub use libsql;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -58,6 +58,17 @@
 //! | [`SynchronousMode`] | SQLite synchronous mode (Off, Normal, Full, Extra) |
 //! | [`TempStore`] | SQLite temp store location (Default, File, Memory) |
 //!
+//! ## Maintenance
+//!
+//! | Item | Purpose |
+//! |------|---------|
+//! | [`DbHealth`] | Page-level health metrics from PRAGMA introspection |
+//! | [`VacuumOptions`] | Configuration for [`run_vacuum`] (threshold, dry_run) |
+//! | [`VacuumResult`] | Before/after health snapshots with timing |
+//! | [`run_vacuum`] | VACUUM with threshold guard and health snapshots |
+//! | [`vacuum_if_needed`] | Shorthand for `run_vacuum` with threshold only |
+//! | [`vacuum_handler`] | Cron handler factory for scheduled maintenance |
+//!
 //! ## Re-exports
 //!
 //! The [`libsql`] crate is re-exported for direct access to low-level types
@@ -124,7 +135,7 @@ pub use select::SelectBuilder;
 
 mod maintenance;
 pub use maintenance::{
-    DbHealth, VacuumOptions, VacuumResult, VacuumHandler, run_vacuum, vacuum_handler,
+    DbHealth, VacuumHandler, VacuumOptions, VacuumResult, run_vacuum, vacuum_handler,
     vacuum_if_needed,
 };
 


### PR DESCRIPTION
## Summary

- Add `db::maintenance` module with `DbHealth` struct for page-level health metrics via PRAGMA introspection
- Add `run_vacuum` with threshold guard, dry-run mode, and before/after health snapshots
- Add `vacuum_handler` cron handler factory for scheduled maintenance via `modo::cron::Scheduler`

## Design

- Single file `src/db/maintenance.rs` under existing `db` feature flag
- Core functions take `&libsql::Connection` (consistent with `ConnExt` pattern)
- `DbHealth` intentionally does not derive `Serialize` to prevent accidental exposure on public endpoints
- Core functions log at `debug`, cron handler logs at `info`
- Spec: `docs/superpowers/specs/2026-04-04-db-maintenance-design.md`

## Test plan

- [x] `DbHealth::collect` returns correct metrics for fresh in-memory DB
- [x] `needs_vacuum` threshold logic (above, at, below)
- [x] `run_vacuum` skips when below threshold
- [x] `run_vacuum` skips in dry_run mode
- [x] `run_vacuum` executes when threshold met (bulk insert/delete/vacuum cycle)
- [x] `vacuum_if_needed` delegates correctly
- [x] clippy clean, fmt clean, all doc-tests pass