### PR TITLE
refactor(auth): dedup helpers and tighten per-request hot paths

### DIFF
--- a/src/auth/apikey/middleware.rs
+++ b/src/auth/apikey/middleware.rs
@@ -115,19 +115,16 @@ where
         Box::pin(async move {
             let (mut parts, body) = request.into_parts();
 
-            // Extract raw token from header
             let raw_token = match extract_token(&parts, &header) {
                 Ok(token) => token,
                 Err(e) => return Ok(e.into_response()),
             };
 
-            // Verify
             let meta = match store.verify(raw_token).await {
                 Ok(m) => m,
                 Err(e) => return Ok(e.into_response()),
             };
 
-            // Insert into extensions
             parts.extensions.insert(meta);
 
             let request = Request::from_parts(parts, body);

--- a/src/auth/apikey/store.rs
+++ b/src/auth/apikey/store.rs
@@ -136,6 +136,8 @@ impl ApiKeyStore {
     pub async fn verify(&self, raw_token: &str) -> Result<ApiKeyMeta> {
         // Run hash compare against a dummy for missing/revoked/expired paths
         // so timing doesn't distinguish between "key id unknown" and "wrong secret".
+        // Note: malformed tokens (parse_token failure) still skip the DB round-trip
+        // and so remain timing-distinguishable from valid-format-but-unknown ids.
         const DUMMY_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 
         let parsed = token::parse_token(raw_token, &self.0.config.prefix);

--- a/src/auth/apikey/store.rs
+++ b/src/auth/apikey/store.rs
@@ -134,38 +134,39 @@ impl ApiKeyStore {
     /// Returns `unauthorized` if the token is malformed, not found, revoked,
     /// expired, or the hash does not match. Propagates backend lookup errors.
     pub async fn verify(&self, raw_token: &str) -> Result<ApiKeyMeta> {
-        let parsed = token::parse_token(raw_token, &self.0.config.prefix)
-            .ok_or_else(|| Error::unauthorized("invalid API key"))?;
+        // Run hash compare against a dummy for missing/revoked/expired paths
+        // so timing doesn't distinguish between "key id unknown" and "wrong secret".
+        const DUMMY_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
 
-        let record = self
-            .0
-            .backend
-            .lookup(parsed.id)
-            .await?
-            .ok_or_else(|| Error::unauthorized("invalid API key"))?;
+        let parsed = token::parse_token(raw_token, &self.0.config.prefix);
+        let record = match parsed.as_ref() {
+            Some(p) => self.0.backend.lookup(p.id).await?,
+            None => None,
+        };
 
-        // Revoked?
-        if record.revoked_at.is_some() {
+        let unusable = record
+            .as_ref()
+            .map(|r| {
+                r.revoked_at.is_some()
+                    || r.expires_at
+                        .as_deref()
+                        .map(expires_at_passed)
+                        .unwrap_or(false)
+            })
+            .unwrap_or(true);
+
+        let secret = parsed.as_ref().map(|p| p.secret).unwrap_or("");
+        let stored_hash = record
+            .as_ref()
+            .map(|r| r.key_hash.as_str())
+            .unwrap_or(DUMMY_HASH);
+        let hash_ok = token::verify_hash(secret, stored_hash);
+
+        if unusable || !hash_ok {
             return Err(Error::unauthorized("invalid API key"));
         }
+        let record = record.expect("hash_ok implies record");
 
-        // Expired?
-        if let Some(ref exp) = record.expires_at {
-            if let Ok(exp_dt) = chrono::DateTime::parse_from_rfc3339(exp) {
-                if exp_dt <= Utc::now() {
-                    return Err(Error::unauthorized("invalid API key"));
-                }
-            } else {
-                return Err(Error::unauthorized("invalid API key"));
-            }
-        }
-
-        // Constant-time hash verification
-        if !token::verify_hash(parsed.secret, &record.key_hash) {
-            return Err(Error::unauthorized("invalid API key"));
-        }
-
-        // Touch throttling — fire-and-forget if threshold elapsed
         self.maybe_touch(&record);
 
         Ok(record.into_meta())
@@ -247,4 +248,10 @@ impl ApiKeyStore {
             });
         }
     }
+}
+
+fn expires_at_passed(rfc3339: &str) -> bool {
+    chrono::DateTime::parse_from_rfc3339(rfc3339)
+        .map(|dt| dt <= Utc::now())
+        .unwrap_or(true)
 }

--- a/src/auth/apikey/token.rs
+++ b/src/auth/apikey/token.rs
@@ -1,7 +1,7 @@
+use crate::auth::internal::{random_string, verify_sha256_hex};
 use crate::encoding::hex;
-use subtle::ConstantTimeEq;
 
-const BASE62: &[u8; 62] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+const BASE62: &[u8] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 const ULID_LEN: usize = 26;
 
 /// Result of parsing a raw API key token.
@@ -12,24 +12,9 @@ pub(crate) struct ParsedToken<'a> {
     pub secret: &'a str,
 }
 
-/// Maximum byte value that avoids modulo bias for base62 (62 * 4 = 248).
-const BIAS_LIMIT: u8 = 248;
-
 /// Generate a random base62 secret of `len` characters.
-///
-/// Uses rejection sampling to avoid modulo bias: bytes >= 248 are
-/// discarded so every base62 character has equal probability.
 pub(crate) fn generate_secret(len: usize) -> String {
-    let mut result = String::with_capacity(len);
-    let mut buf = [0u8; 1];
-    while result.len() < len {
-        rand::fill(&mut buf[..]);
-        let b = buf[0];
-        if b < BIAS_LIMIT {
-            result.push(BASE62[(b as usize) % 62] as char);
-        }
-    }
-    result
+    random_string(BASE62, len)
 }
 
 /// Format a full token: `{prefix}_{ulid}{secret}`.
@@ -59,8 +44,7 @@ pub(crate) fn hash_secret(secret: &str) -> String {
 
 /// Constant-time comparison of a secret against a stored hash.
 pub(crate) fn verify_hash(secret: &str, stored_hash: &str) -> bool {
-    let computed = hash_secret(secret);
-    computed.as_bytes().ct_eq(stored_hash.as_bytes()).into()
+    verify_sha256_hex(secret, stored_hash)
 }
 
 #[cfg(test)]

--- a/src/auth/backup.rs
+++ b/src/auth/backup.rs
@@ -1,4 +1,4 @@
-use subtle::ConstantTimeEq;
+use super::internal::{random_string, verify_sha256_hex};
 
 const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
 
@@ -24,38 +24,16 @@ pub fn generate(count: usize) -> Vec<(String, String)> {
 ///
 /// Requires feature `"auth"`.
 pub fn verify(code: &str, hash: &str) -> bool {
-    let normalized = normalize(code);
-    let computed = sha256_hex(&normalized);
-    computed.as_bytes().ct_eq(hash.as_bytes()).into()
+    verify_sha256_hex(normalize(code), hash)
 }
 
 fn generate_one() -> (String, String) {
-    let mut chars = Vec::with_capacity(8);
-    for _ in 0..8 {
-        let mut byte = [0u8; 1];
-        loop {
-            rand::fill(&mut byte);
-            // Rejection sampling: ALPHABET.len()=36, accept <252 to avoid modulo bias (252 = 36*7)
-            if byte[0] < 252 {
-                chars.push(ALPHABET[(byte[0] as usize) % ALPHABET.len()] as char);
-                break;
-            }
-        }
-    }
-
-    let plaintext = format!(
-        "{}-{}",
-        chars[..4].iter().collect::<String>(),
-        chars[4..].iter().collect::<String>(),
-    );
-    let hash = sha256_hex(&normalize(&plaintext));
+    let raw = random_string(ALPHABET, 8);
+    let plaintext = format!("{}-{}", &raw[..4], &raw[4..]);
+    let hash = crate::encoding::hex::sha256(normalize(&plaintext));
     (plaintext, hash)
 }
 
 fn normalize(code: &str) -> String {
     code.replace('-', "").to_lowercase()
-}
-
-fn sha256_hex(input: &str) -> String {
-    crate::encoding::hex::sha256(input)
 }

--- a/src/auth/internal.rs
+++ b/src/auth/internal.rs
@@ -15,14 +15,16 @@ pub(crate) fn verify_sha256_hex(plain: impl AsRef<[u8]>, stored_hex: &str) -> bo
 pub(crate) fn random_string(alphabet: &[u8], len: usize) -> String {
     assert!(!alphabet.is_empty(), "alphabet must not be empty");
     let n = alphabet.len();
-    let bias_limit = ((256 / n) * n) as u8;
+    // Keep the comparison in usize: when n divides 256 evenly the limit is 256,
+    // which would wrap to 0 if cast to u8 and hang the loop forever.
+    let bias_limit: usize = (256 / n) * n;
     let mut out = String::with_capacity(len);
     let mut buf = [0u8; 1];
     while out.len() < len {
         rand::fill(&mut buf[..]);
-        let b = buf[0];
+        let b = buf[0] as usize;
         if b < bias_limit {
-            out.push(alphabet[(b as usize) % n] as char);
+            out.push(alphabet[b % n] as char);
         }
     }
     out

--- a/src/auth/internal.rs
+++ b/src/auth/internal.rs
@@ -1,0 +1,29 @@
+//! Crate-private helpers shared across `auth` submodules.
+
+use subtle::ConstantTimeEq;
+
+/// Constant-time SHA-256 hex comparison: `sha256_hex(plain) == stored_hex`.
+pub(crate) fn verify_sha256_hex(plain: impl AsRef<[u8]>, stored_hex: &str) -> bool {
+    let computed = crate::encoding::hex::sha256(plain.as_ref());
+    computed.as_bytes().ct_eq(stored_hex.as_bytes()).into()
+}
+
+/// Generate a random string by sampling `len` characters from `alphabet` using
+/// rejection sampling to avoid modulo bias.
+///
+/// Panics if `alphabet` is empty.
+pub(crate) fn random_string(alphabet: &[u8], len: usize) -> String {
+    assert!(!alphabet.is_empty(), "alphabet must not be empty");
+    let n = alphabet.len();
+    let bias_limit = ((256 / n) * n) as u8;
+    let mut out = String::with_capacity(len);
+    let mut buf = [0u8; 1];
+    while out.len() < len {
+        rand::fill(&mut buf[..]);
+        let b = buf[0];
+        if b < bias_limit {
+            out.push(alphabet[(b as usize) % n] as char);
+        }
+    }
+    out
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -55,6 +55,8 @@ pub mod totp;
 
 pub mod oauth;
 
+mod internal;
+
 // Back-compat re-export — jwt now lives at `auth::session::jwt`.
 // This alias keeps `modo::auth::jwt::*` working without breakage.
 pub use crate::auth::session::jwt;

--- a/src/auth/oauth/github.rs
+++ b/src/auth/oauth/github.rs
@@ -156,20 +156,3 @@ impl OAuthProvider for GitHub {
         })
     }
 }
-
-mod urlencoding {
-    pub fn encode(s: &str) -> String {
-        let mut result = String::with_capacity(s.len());
-        for b in s.bytes() {
-            match b {
-                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                    result.push(b as char);
-                }
-                _ => {
-                    result.push_str(&format!("%{b:02X}"));
-                }
-            }
-        }
-        result
-    }
-}

--- a/src/auth/oauth/google.rs
+++ b/src/auth/oauth/google.rs
@@ -140,20 +140,3 @@ impl OAuthProvider for Google {
         })
     }
 }
-
-mod urlencoding {
-    pub fn encode(s: &str) -> String {
-        let mut result = String::with_capacity(s.len());
-        for b in s.bytes() {
-            match b {
-                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                    result.push(b as char);
-                }
-                _ => {
-                    result.push_str(&format!("%{b:02X}"));
-                }
-            }
-        }
-        result
-    }
-}

--- a/src/auth/otp.rs
+++ b/src/auth/otp.rs
@@ -1,4 +1,6 @@
-use subtle::ConstantTimeEq;
+use super::internal::{random_string, verify_sha256_hex};
+
+const DIGITS: &[u8] = b"0123456789";
 
 /// Generates a numeric one-time password of `length` digits.
 ///
@@ -8,19 +10,8 @@ use subtle::ConstantTimeEq;
 ///
 /// Requires feature `"auth"`.
 pub fn generate(length: usize) -> (String, String) {
-    let mut code = String::with_capacity(length);
-    for _ in 0..length {
-        let mut byte = [0u8; 1];
-        loop {
-            rand::fill(&mut byte);
-            // Rejection sampling: only accept values 0-249 to avoid modulo bias
-            if byte[0] < 250 {
-                code.push((b'0' + (byte[0] % 10)) as char);
-                break;
-            }
-        }
-    }
-    let hash = sha256_hex(&code);
+    let code = random_string(DIGITS, length);
+    let hash = crate::encoding::hex::sha256(&code);
     (code, hash)
 }
 
@@ -30,10 +21,5 @@ pub fn generate(length: usize) -> (String, String) {
 ///
 /// Requires feature `"auth"`.
 pub fn verify(code: &str, hash: &str) -> bool {
-    let computed = sha256_hex(code);
-    computed.as_bytes().ct_eq(hash.as_bytes()).into()
-}
-
-fn sha256_hex(input: &str) -> String {
-    crate::encoding::hex::sha256(input)
+    verify_sha256_hex(code, hash)
 }

--- a/src/auth/role/middleware.rs
+++ b/src/auth/role/middleware.rs
@@ -100,13 +100,11 @@ where
         Box::pin(async move {
             let (mut parts, body) = request.into_parts();
 
-            // Extract role
             let role = match extractor.extract(&mut parts).await {
                 Ok(r) => r,
                 Err(e) => return Ok(e.into_response()),
             };
 
-            // Insert into extensions
             parts.extensions.insert(Role(role));
 
             let request = Request::from_parts(parts, body);

--- a/src/auth/session/cookie/middleware.rs
+++ b/src/auth/session/cookie/middleware.rs
@@ -92,13 +92,11 @@ where
             let key = svc.cookie_key();
             let cookie_config = svc.config().cookie.clone();
 
-            // 1. Extract client IP
             let ip = request
                 .extensions()
                 .get::<ClientIp>()
                 .map(|c| c.0.to_string())
                 .unwrap_or_else(|| {
-                    // Fallback: no ClientIpLayer applied — use ConnectInfo directly
                     request
                         .extensions()
                         .get::<ConnectInfo<std::net::SocketAddr>>()
@@ -107,17 +105,14 @@ where
                 });
             let headers = request.headers();
 
-            // 2. Build SessionMeta
             let ua = header_str(headers, "user-agent");
             let accept_lang = header_str(headers, "accept-language");
             let accept_enc = header_str(headers, "accept-encoding");
             let meta = SessionMeta::from_headers(ip, ua, accept_lang, accept_enc);
 
-            // 3. Read signed session cookie
             let session_token = read_signed_cookie(request.headers(), cookie_name, key);
             let had_cookie = session_token.is_some();
 
-            // 4. Load session from DB
             let (current_session, read_failed) = if let Some(ref token) = session_token {
                 match store.read_by_token(token).await {
                     Ok(session) => (session, false),
@@ -130,7 +125,6 @@ where
                 (None, false)
             };
 
-            // 5/6. Validate fingerprint
             let current_session = if let Some(session) = current_session {
                 if config.validate_fingerprint && meta.fingerprint != session.fingerprint {
                     tracing::warn!(
@@ -147,19 +141,16 @@ where
                 None
             };
 
-            // Check if touch interval elapsed
             let should_touch = current_session.as_ref().is_some_and(|s| {
                 let elapsed = chrono::Utc::now() - s.last_active_at;
                 elapsed >= chrono::Duration::seconds(config.touch_interval_secs as i64)
             });
 
-            // 7. Insert Session data view for the data extractor
             if let Some(raw) = current_session.as_ref() {
                 let session_data = Session::from(raw.clone());
                 request.extensions_mut().insert(session_data);
             }
 
-            // 8. Build SessionState and insert for CookieSession extractor
             let session_state = Arc::new(SessionState {
                 service: svc.clone(),
                 meta,
@@ -170,10 +161,7 @@ where
 
             request.extensions_mut().insert(session_state.clone());
 
-            // Run inner service
             let mut response = inner.call(request).await?;
-
-            // --- Response path ---
 
             let action = {
                 let guard = session_state.action.lock().expect("session mutex poisoned");
@@ -227,7 +215,6 @@ where
                             );
                         }
 
-                        // Refresh cookie if we did a flush or touch
                         if (is_dirty || should_touch)
                             && let Some(ref token) = session_token
                         {
@@ -242,7 +229,6 @@ where
                         }
                     }
 
-                    // Stale cookie cleanup
                     if had_cookie && current_session.is_none() && !read_failed {
                         remove_signed_cookie(&mut response, cookie_name, &cookie_config, key);
                     }
@@ -269,7 +255,6 @@ fn read_signed_cookie(
         if let Some((name, value)) = pair.split_once('=')
             && name.trim() == cookie_name
         {
-            // Verify signature using cookie crate's signed jar
             let mut jar = CookieJar::new();
             jar.add_original(Cookie::new(
                 cookie_name.to_string(),
@@ -301,7 +286,6 @@ fn set_signed_cookie(
         .value()
         .to_string();
 
-    // Build Set-Cookie header with attributes
     let same_site = match config.same_site.as_str() {
         "strict" => SameSite::Strict,
         "none" => SameSite::None,

--- a/src/auth/session/jwt/decoder.rs
+++ b/src/auth/session/jwt/decoder.rs
@@ -24,12 +24,18 @@ struct JwtDecoderInner {
     validation: ValidationConfig,
 }
 
-fn jwt_err(kind: JwtError) -> Error {
+pub(super) fn jwt_err(kind: JwtError) -> Error {
     let status_fn = match kind {
         JwtError::SigningFailed | JwtError::SerializationFailed => Error::internal,
         _ => Error::unauthorized,
     };
     status_fn("unauthorized").chain(kind).with_code(kind.code())
+}
+
+/// Build an `Error::unauthorized` carrying a stable error code string.
+/// Used by middleware/extractors for `auth:*` codes that don't have a typed source.
+pub(super) fn auth_err(code: &'static str) -> Error {
+    Error::unauthorized("unauthorized").with_code(code)
 }
 
 impl JwtDecoder {
@@ -103,14 +109,13 @@ impl JwtDecoder {
     /// expired tokens, not-yet-valid tokens, issuer mismatch, or audience mismatch.
     /// Missing `exp` is treated as expired.
     pub fn decode<T: DeserializeOwned>(&self, token: &str) -> Result<T> {
-        let parts: Vec<&str> = token.splitn(4, '.').collect();
-        if parts.len() != 3 {
+        let mut iter = token.splitn(4, '.');
+        let (Some(header_b64), Some(payload_b64), Some(signature_b64), None) =
+            (iter.next(), iter.next(), iter.next(), iter.next())
+        else {
             return Err(jwt_err(JwtError::MalformedToken));
-        }
+        };
 
-        let (header_b64, payload_b64, signature_b64) = (parts[0], parts[1], parts[2]);
-
-        // Decode and verify header
         let header_bytes =
             base64url::decode(header_b64).map_err(|_| jwt_err(JwtError::InvalidHeader))?;
         let header: serde_json::Value =
@@ -123,21 +128,19 @@ impl JwtDecoder {
             return Err(jwt_err(JwtError::AlgorithmMismatch));
         }
 
-        // Verify signature
         let signature =
             base64url::decode(signature_b64).map_err(|_| jwt_err(JwtError::MalformedToken))?;
-        let header_payload = format!("{header_b64}.{payload_b64}");
-        self.inner
-            .verifier
-            .verify(header_payload.as_bytes(), &signature)?;
+        let mut header_payload = Vec::with_capacity(header_b64.len() + 1 + payload_b64.len());
+        header_payload.extend_from_slice(header_b64.as_bytes());
+        header_payload.push(b'.');
+        header_payload.extend_from_slice(payload_b64.as_bytes());
+        self.inner.verifier.verify(&header_payload, &signature)?;
 
-        // Decode payload into a JSON value for validation
         let payload_bytes =
             base64url::decode(payload_b64).map_err(|_| jwt_err(JwtError::MalformedToken))?;
         let payload: serde_json::Value = serde_json::from_slice(&payload_bytes)
             .map_err(|_| jwt_err(JwtError::DeserializationFailed))?;
 
-        // Validate exp (always required)
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock before UNIX epoch")
@@ -152,14 +155,12 @@ impl JwtDecoder {
             return Err(jwt_err(JwtError::Expired));
         }
 
-        // Validate nbf (if present)
         if let Some(nbf) = payload.get("nbf").and_then(|v| v.as_u64())
             && now + leeway < nbf
         {
             return Err(jwt_err(JwtError::NotYetValid));
         }
 
-        // Validate iss (if policy requires it)
         if let Some(ref required_iss) = self.inner.validation.require_issuer {
             match payload.get("iss").and_then(|v| v.as_str()) {
                 Some(iss) if iss == required_iss => {}
@@ -167,7 +168,6 @@ impl JwtDecoder {
             }
         }
 
-        // Validate aud (if policy requires it)
         if let Some(ref required_aud) = self.inner.validation.require_audience {
             match payload.get("aud").and_then(|v| v.as_str()) {
                 Some(aud) if aud == required_aud => {}
@@ -175,7 +175,6 @@ impl JwtDecoder {
             }
         }
 
-        // Deserialize into the requested type
         serde_json::from_value(payload).map_err(|_| jwt_err(JwtError::DeserializationFailed))
     }
 }

--- a/src/auth/session/jwt/encoder.rs
+++ b/src/auth/session/jwt/encoder.rs
@@ -76,14 +76,12 @@ impl JwtEncoder {
     /// [`JwtError::SigningFailed`](super::JwtError::SigningFailed) if the HMAC signing
     /// operation fails.
     pub fn encode<T: Serialize>(&self, claims: &T) -> Result<String> {
-        // Auto-fill exp if missing and default_expiry is configured
         let claims_json = if let Some(default_exp) = self.inner.default_expiry {
             let mut value = serde_json::to_value(claims).map_err(|_| {
                 Error::internal("failed to serialize token")
                     .chain(JwtError::SerializationFailed)
                     .with_code(JwtError::SerializationFailed.code())
             })?;
-            // Only inject exp when the payload has no exp field already
             if value.get("exp").is_none() {
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)

--- a/src/auth/session/jwt/middleware.rs
+++ b/src/auth/session/jwt/middleware.rs
@@ -8,11 +8,10 @@ use axum::response::IntoResponse;
 use http::Request;
 use tower::{Layer, Service};
 
-use crate::Error;
 use crate::auth::session::Session;
 
 use super::claims::Claims;
-use super::decoder::JwtDecoder;
+use super::decoder::{JwtDecoder, auth_err, jwt_err};
 use super::error::JwtError;
 use super::service::JwtSessionService;
 use super::source::{BearerSource, TokenSource};
@@ -139,63 +138,34 @@ where
         Box::pin(async move {
             let (mut parts, body) = request.into_parts();
 
-            // Try each token source in order
-            let token = sources.iter().find_map(|s| s.extract(&parts));
-            let token = match token {
+            let token = match sources.iter().find_map(|s| s.extract(&parts)) {
                 Some(t) => t,
-                None => {
-                    let err = Error::unauthorized("unauthorized")
-                        .chain(JwtError::MissingToken)
-                        .with_code(JwtError::MissingToken.code());
-                    return Ok(err.into_response());
-                }
+                None => return Ok(jwt_err(JwtError::MissingToken).into_response()),
             };
 
-            // Decode and validate (sync)
             let claims: Claims = match decoder.decode(&token) {
                 Ok(c) => c,
                 Err(e) => return Ok(e.into_response()),
             };
 
-            // Stateful validation: when backed by a JwtSessionService and
-            // stateful_validation is enabled, hash the jti claim, load the session
-            // row, and insert the transport-agnostic Session into extensions.
-            // Returns 401 when the row is absent; propagates DB errors as 5xx.
             if let Some(svc) = service {
-                // Fix #1: reject non-access audience tokens before any DB lookup.
                 if claims.aud.as_deref() != Some("access") {
-                    let err = Error::unauthorized("unauthorized").with_code("auth:aud_mismatch");
-                    return Ok(err.into_response());
+                    return Ok(auth_err("auth:aud_mismatch").into_response());
                 }
 
-                // Fix #2: honor stateful_validation flag.
                 if svc.config().stateful_validation {
-                    let jti = match claims.jti.as_deref() {
-                        Some(j) => j,
-                        None => {
-                            let err = Error::unauthorized("unauthorized")
-                                .with_code("auth:session_not_found");
-                            return Ok(err.into_response());
-                        }
-                    };
-
-                    let session_token = match SessionToken::from_raw(jti) {
+                    let session_token = match claims.jti.as_deref().and_then(SessionToken::from_raw)
+                    {
                         Some(t) => t,
                         None => {
-                            let err = Error::unauthorized("unauthorized")
-                                .with_code("auth:session_not_found");
-                            return Ok(err.into_response());
+                            return Ok(auth_err("auth:session_not_found").into_response());
                         }
                     };
 
-                    // Fix #5: propagate DB errors as 5xx; 401 only for missing row.
-                    let lookup = svc.store().read_by_token_hash(&session_token.hash()).await;
-                    let raw = match lookup {
+                    let raw = match svc.store().read_by_token_hash(&session_token.hash()).await {
                         Err(e) => return Ok(e.into_response()),
                         Ok(None) => {
-                            let err = Error::unauthorized("unauthorized")
-                                .with_code("auth:session_not_found");
-                            return Ok(err.into_response());
+                            return Ok(auth_err("auth:session_not_found").into_response());
                         }
                         Ok(Some(row)) => row,
                     };
@@ -204,7 +174,6 @@ where
                 }
             }
 
-            // Insert claims into extensions
             parts.extensions.insert(claims);
 
             let request = Request::from_parts(parts, body);

--- a/src/auth/session/jwt/signer.rs
+++ b/src/auth/session/jwt/signer.rs
@@ -48,16 +48,18 @@ pub struct HmacSigner {
 }
 
 struct HmacSignerInner {
-    secret: Vec<u8>,
+    // Pre-initialized HMAC template; cloned per call so the key block is
+    // expanded once at construction instead of on every sign/verify.
+    mac: HmacSha256,
 }
 
 impl HmacSigner {
     /// Creates a new `HmacSigner` with the given secret.
     pub fn new(secret: impl AsRef<[u8]>) -> Self {
+        let mac = HmacSha256::new_from_slice(secret.as_ref())
+            .expect("HMAC-SHA256 accepts keys of any length");
         Self {
-            inner: Arc::new(HmacSignerInner {
-                secret: secret.as_ref().to_vec(),
-            }),
+            inner: Arc::new(HmacSignerInner { mac }),
         }
     }
 }
@@ -72,8 +74,7 @@ impl Clone for HmacSigner {
 
 impl TokenVerifier for HmacSigner {
     fn verify(&self, header_payload: &[u8], signature: &[u8]) -> Result<()> {
-        let mut mac = HmacSha256::new_from_slice(&self.inner.secret)
-            .map_err(|_| Error::internal("invalid HMAC key").chain(JwtError::InvalidSignature))?;
+        let mut mac = self.inner.mac.clone();
         mac.update(header_payload);
         mac.verify_slice(signature).map_err(|_| {
             Error::unauthorized("unauthorized")
@@ -89,8 +90,7 @@ impl TokenVerifier for HmacSigner {
 
 impl TokenSigner for HmacSigner {
     fn sign(&self, header_payload: &[u8]) -> Result<Vec<u8>> {
-        let mut mac = HmacSha256::new_from_slice(&self.inner.secret)
-            .map_err(|_| Error::internal("invalid HMAC key").chain(JwtError::SigningFailed))?;
+        let mut mac = self.inner.mac.clone();
         mac.update(header_payload);
         Ok(mac.finalize().into_bytes().to_vec())
     }

--- a/src/auth/session/jwt/source.rs
+++ b/src/auth/session/jwt/source.rs
@@ -44,16 +44,7 @@ pub struct QuerySource(pub &'static str);
 
 impl TokenSource for QuerySource {
     fn extract(&self, parts: &Parts) -> Option<String> {
-        let query = parts.uri.query()?;
-        for pair in query.split('&') {
-            if let Some((key, value)) = pair.split_once('=')
-                && key == self.0
-                && !value.is_empty()
-            {
-                return Some(value.to_string());
-            }
-        }
-        None
+        extract_query(parts, self.0)
     }
 }
 
@@ -65,17 +56,7 @@ pub struct CookieSource(pub &'static str);
 
 impl TokenSource for CookieSource {
     fn extract(&self, parts: &Parts) -> Option<String> {
-        let cookie_header = parts.headers.get(http::header::COOKIE)?.to_str().ok()?;
-        for cookie in cookie_header.split(';') {
-            let cookie = cookie.trim();
-            if let Some((name, value)) = cookie.split_once('=')
-                && name.trim() == self.0
-                && !value.is_empty()
-            {
-                return Some(value.trim().to_string());
-            }
-        }
-        None
+        extract_cookie(parts, self.0)
     }
 }
 
@@ -86,30 +67,15 @@ pub struct HeaderSource(pub &'static str);
 
 impl TokenSource for HeaderSource {
     fn extract(&self, parts: &Parts) -> Option<String> {
-        let value = parts.headers.get(self.0)?.to_str().ok()?;
-        if value.is_empty() {
-            return None;
-        }
-        Some(value.to_string())
+        extract_header(parts, self.0)
     }
 }
-
-// ── Owned-string variants used internally by TokenSourceConfig::build() ────────
 
 struct OwnedQuerySource(String);
 
 impl TokenSource for OwnedQuerySource {
     fn extract(&self, parts: &Parts) -> Option<String> {
-        let query = parts.uri.query()?;
-        for pair in query.split('&') {
-            if let Some((key, value)) = pair.split_once('=')
-                && key == self.0
-                && !value.is_empty()
-            {
-                return Some(value.to_string());
-            }
-        }
-        None
+        extract_query(parts, &self.0)
     }
 }
 
@@ -117,17 +83,7 @@ struct OwnedCookieSource(String);
 
 impl TokenSource for OwnedCookieSource {
     fn extract(&self, parts: &Parts) -> Option<String> {
-        let cookie_header = parts.headers.get(http::header::COOKIE)?.to_str().ok()?;
-        for cookie in cookie_header.split(';') {
-            let cookie = cookie.trim();
-            if let Some((name, value)) = cookie.split_once('=')
-                && name.trim() == self.0
-                && !value.is_empty()
-            {
-                return Some(value.trim().to_string());
-            }
-        }
-        None
+        extract_cookie(parts, &self.0)
     }
 }
 
@@ -135,12 +91,43 @@ struct OwnedHeaderSource(String);
 
 impl TokenSource for OwnedHeaderSource {
     fn extract(&self, parts: &Parts) -> Option<String> {
-        let value = parts.headers.get(self.0.as_str())?.to_str().ok()?;
-        if value.is_empty() {
-            return None;
-        }
-        Some(value.to_string())
+        extract_header(parts, &self.0)
     }
+}
+
+fn extract_query(parts: &Parts, name: &str) -> Option<String> {
+    let query = parts.uri.query()?;
+    for pair in query.split('&') {
+        if let Some((key, value)) = pair.split_once('=')
+            && key == name
+            && !value.is_empty()
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn extract_cookie(parts: &Parts, name: &str) -> Option<String> {
+    let cookie_header = parts.headers.get(http::header::COOKIE)?.to_str().ok()?;
+    for cookie in cookie_header.split(';') {
+        let cookie = cookie.trim();
+        if let Some((cname, value)) = cookie.split_once('=')
+            && cname.trim() == name
+            && !value.is_empty()
+        {
+            return Some(value.trim().to_string());
+        }
+    }
+    None
+}
+
+fn extract_header(parts: &Parts, name: &str) -> Option<String> {
+    let value = parts.headers.get(name)?.to_str().ok()?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.to_string())
 }
 
 // ── TokenSourceConfig ────────────────────────────────────────────────────────

--- a/src/auth/session/token.rs
+++ b/src/auth/session/token.rs
@@ -4,7 +4,6 @@
 //! signed cookie, and only the SHA-256 hash is stored in the database.
 //! `Debug` and `Display` both redact the value as `"****"`.
 
-use sha2::{Digest, Sha256};
 use std::fmt;
 
 /// A cryptographically random 32-byte session token.
@@ -59,8 +58,7 @@ impl SessionToken {
     /// the hash ensures that a read of the database cannot be used to impersonate
     /// users.
     pub fn hash(&self) -> String {
-        let digest = Sha256::digest(self.0);
-        crate::encoding::hex::encode(&digest)
+        crate::encoding::hex::sha256(self.0)
     }
 
     /// Expose the raw token as a 64-character hex string.

--- a/src/auth/totp.rs
+++ b/src/auth/totp.rs
@@ -132,8 +132,8 @@ impl Totp {
     /// and time period. Authenticator apps scan this URI to provision the key.
     pub fn otpauth_uri(&self, issuer: &str, account: &str) -> String {
         let secret_b32 = crate::encoding::base32::encode(&self.secret);
-        let encoded_account = urlencoding_encode(account);
-        let encoded_issuer = urlencoding_encode(issuer);
+        let encoded_account = urlencoding::encode(account);
+        let encoded_issuer = urlencoding::encode(issuer);
         format!(
             "otpauth://totp/{encoded_issuer}:{encoded_account}?secret={secret_b32}&issuer={encoded_issuer}&digits={}&period={}",
             self.config.digits, self.config.step_secs
@@ -154,19 +154,4 @@ fn hotp(secret: &[u8], counter: u64, digits: u32) -> u32 {
         result[offset + 3],
     ]);
     code % 10u32.pow(digits)
-}
-
-fn urlencoding_encode(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    for b in s.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                result.push(b as char);
-            }
-            _ => {
-                result.push_str(&format!("%{b:02X}"));
-            }
-        }
-    }
-    result
 }


### PR DESCRIPTION
## Summary

Three parallel review passes (reuse / quality / efficiency) on `src/auth` surfaced ~30 findings. This PR applies the high-impact, low-risk fixes — shared helpers, hot-path allocations, and a security nit. Net diff is **−133 lines** with no public API change.

## Reuse

- Removed three byte-identical hand-rolled `urlencoding` modules in [`totp.rs`](src/auth/totp.rs), [`oauth/google.rs`](src/auth/oauth/google.rs), [`oauth/github.rs`](src/auth/oauth/github.rs); the `urlencoding` crate was already in deps.
- New crate-private [`src/auth/internal.rs`](src/auth/internal.rs) with `verify_sha256_hex()` and `random_string()` helpers; `otp.rs`, `backup.rs`, `apikey/token.rs` now share rather than copy the rejection-sampling and constant-time-compare patterns.
- `SessionToken::hash()` collapsed to a single `crate::encoding::hex::sha256()` call.
- `OwnedQuerySource` / `OwnedCookieSource` / `OwnedHeaderSource` and their public `&'static str` siblings now share private `extract_query` / `extract_cookie` / `extract_header` helpers; dropped ~50 lines of duplicated trait bodies.

## Efficiency

- **HMAC key cached at construction** in `HmacSigner`. Previously every JWT request called `Hmac::<Sha256>::new_from_slice(secret)`, which performs the inner-block expansion. Now we expand once and `clone()` the pre-initialized template per call.
- **JWT decoder allocations** trimmed: `splitn(4,'.').collect::<Vec<_>>()` → iterator destructure; `format!(\"{header}.{payload}\")` → preallocated `Vec<u8>` with two `extend_from_slice` calls.
- **ApiKey timing flattened**: `ApiKeyStore::verify()` previously short-circuited on missing / revoked / expired records before reaching the constant-time hash compare. Now always runs `verify_hash` against a fixed dummy on those paths so wall-clock timing doesn't distinguish \"key id unknown\" from \"wrong secret.\"

## Quality

- Made `jwt_err()` `pub(super)` and added `auth_err()` for the `auth:*` codes that don't have a typed source. Middleware now uses both helpers instead of inlining `Error::unauthorized(\"unauthorized\").chain(...).with_code(...)` at every site.
- Stripped numbered/narrative step comments (`// 1. Extract`, `// Try each token source`, `// Decode and validate (sync)`) and PR-reference comments (`// Fix #1`, `// Fix #2`, `// Fix #5`) from cookie middleware, JWT middleware, JWT encoder, JWT decoder, apikey middleware, and role middleware.

## Out of scope

These were flagged but deliberately deferred — each is structural and warrants its own PR:
- Provider-name enum to replace `\"google\"` / `\"github\"` string literals
- Shared `SessionStoreConfig` between cookie and JWT transports (currently JWT borrows cookie's config type)
- `Arc<SessionData>` to eliminate per-request `SessionData::clone()`
- Privatizing `pub` fields on `SessionState` and `ApiKeyRecord`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --features test-helpers --tests -- -D warnings` — clean
- [x] `cargo test --features test-helpers` — 991 lib + all integration tests pass, 0 failures
- [x] `cargo test --features test-helpers --lib auth::` — 134 auth-module tests pass
- [x] Pre-commit hooks pass