### PR TITLE
refactor(i18n): standalone i18n module with Translator extractor (closes #68)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "modo",
       "source": "./",
       "description": "Development reference and project scaffolding for modo v2",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "author": { "name": "Dmytro Momot" },
       "repository": "https://github.com/dmitrymomot/modo",
       "license": "Apache-2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "modo",
   "description": "Skills for building applications with the modo Rust web framework",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "author": { "name": "Dmytro Momot" },
   "repository": "https://github.com/dmitrymomot/modo",
   "license": "Apache-2.0",

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Cargo.lock
 .worktrees/
 .claire/
 experiments/
+*.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,12 +42,7 @@ modo — Rust web framework. Single crate, zero proc macros, plain `async fn` ha
 
 ## Feature Flags
 
-Feature-gated modules: `db` (default), `session`, `job`, `auth`, `templates`, `sse`, `email`, `storage`, `webhooks`, `dns`, `geolocation`, `qrcode`, `sentry`, `apikey`, `text-embedding`, `tier`. Always-available: cache, encoding, flash, ip, tenant, rbac, cron. Test-only: `test-helpers` (gates TestDb, TestApp, TestSession, and all in-memory/stub backends).
-
-- Integration test files need `#![cfg(feature = "X")]`
-- Feature-gated modules for integration tests must use `pub mod` (not `pub(crate) mod`)
-- `test-helpers` gates all in-memory/stub test backends: `#[cfg(any(test, feature = "test-helpers"))]`; dead_code suppression: `#[cfg_attr(not(any(test, feature = "test-helpers")), allow(dead_code))]`
-- `Cargo.lock` is gitignored (library crate)
+All production modules are always compiled — there are no per-module feature flags. The only runtime feature is `test-helpers`, which gates `TestDb`, `TestApp`, `TestSession`, and all in-memory/stub backends used by tests. Integration test files no longer need `#![cfg(feature = "X")]` gates. `Cargo.lock` is gitignored (library crate).
 
 ## Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,8 @@ modo — Rust web framework. Single crate, zero proc macros, plain `async fn` ha
 ## Commands
 
 - `cargo check` — type check
-- `cargo test` — run all tests
-- `cargo test --features X` — test feature-gated module
-- `cargo clippy --features X --tests -- -D warnings` — lint (plain `cargo clippy` skips test code)
+- `cargo test --features test-helpers` — run all tests
+- `cargo clippy --features test-helpers --tests -- -D warnings` — lint (plain `cargo clippy` skips test code)
 - `cargo fmt` / `cargo fmt --check` — format
 
 ## Workflow

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-rs"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 description = "Rust web framework for small monolithic apps"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -190,10 +190,10 @@ only feature is `test-helpers`, enabled in your `[dev-dependencies]`.
 
 ```toml
 [dependencies]
-modo = { package = "modo-rs", version = "0.8" }
+modo = { package = "modo-rs", version = "0.9" }
 
 [dev-dependencies]
-modo = { package = "modo-rs", version = "0.8", features = ["test-helpers"] }
+modo = { package = "modo-rs", version = "0.9", features = ["test-helpers"] }
 ```
 
 > **Trade-off:** modo deliberately keeps every module always-on so the public

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -95,7 +95,7 @@ modo is a single Rust crate with zero proc macros. Everything is explicit:
 - **Middleware** is standard Tower layers applied via `.layer()` on the router.
 - **Config** loads from YAML files with `${VAR}` / `${VAR:default}` env var substitution.
 
-Every module is always compiled — modo 0.8 has a single feature flag,
+Every module is always compiled — modo has a single feature flag,
 `test-helpers`, enabled in `[dev-dependencies]` to expose in-memory backends
 (`TestDb`, `TestApp`, `TestSession`, …) to integration tests.
 

--- a/skills/dev/references/auth.md
+++ b/skills/dev/references/auth.md
@@ -1,7 +1,7 @@
 # Auth Reference (OAuth2, JWT, Password, TOTP, Role-Based Gating, Guards)
 
 All identity and access features live under `modo::auth` and are always
-available — there are no per-module feature flags in modo 0.8. The only
+available — there are no per-module feature flags. The only
 cargo feature is `test-helpers` (dev-only test scaffolding), which does
 not gate any of the modules below.
 
@@ -753,19 +753,19 @@ The JWT module follows this pattern consistently -- all `JwtError` variants prod
 - `OAuthProvider` is RPITIT (not object-safe). Never use `dyn OAuthProvider` or `Arc<dyn OAuthProvider>`.
 - `RoleExtractor` is RPITIT (not object-safe). Never use `dyn RoleExtractor`; pass concrete types into `modo::auth::role::middleware(...)`.
 - `TokenSource` and `TokenVerifier`/`TokenSigner` are object-safe -- use `Arc<dyn TokenSource>`, `Arc<dyn TokenVerifier>`, `Arc<dyn TokenSigner>`.
-- All auth modules are always compiled in modo 0.8 — only `test-helpers` exists as a cargo feature, and it gates none of these modules.
+- All auth modules are always compiled — only `test-helpers` exists as a cargo feature, and it gates none of these modules.
 - The role middleware must apply via `.layer()` on the outer router. `ApiKeyLayer` likewise applies via `.layer()`. Guards (`require_authenticated`, `require_role`, `require_scope`) must apply via `.route_layer()` after route matching.
 - `require_scope` returns **500** (not 401) when `ApiKeyLayer` is missing — missing middleware is a server wiring bug, not a client auth failure. The guard logs the misconfiguration via `tracing::error!`.
 - `Role` extractor returns **500** when `auth::role::middleware()` is not applied — same rationale (server wiring bug, not a client failure).
 - `JwtDecoder::decode()` always requires `exp` -- tokens without `exp` are rejected as expired (`jwt:expired`).
 - `OAuthState` extractor requires `Key` (from `axum_extra::extract::cookie`) registered in `AppState`. Missing-key returns `Error::internal`; missing/tampered cookie returns `Error::bad_request`.
-- `Claims` requires `JwtLayer` to be applied to the route -- the middleware inserts claims into extensions. For the extractor to work: no generic parameter required (`Claims` is non-generic in v0.8).
+- `Claims` requires `JwtLayer` to be applied to the route -- the middleware inserts claims into extensions. For the extractor to work: no generic parameter required (`Claims` is non-generic).
 - `Bearer` extractor is independent of `JwtLayer` -- it only reads the raw token string, no decode/validate.
 - `JwtEncoder`/`JwtDecoder` are cheap to clone (state behind `Arc`).
 - `JwtDecoder::from(&encoder)` shares the signing key and validation policy -- use when encoder and decoder come from the same `JwtSessionsConfig`.
 - `JwtConfig` is a back-compat alias for `JwtSessionsConfig`. Prefer `JwtSessionsConfig` in new code.
-- `Claims` is **non-generic** in v0.8. There is no `Claims<T>`. Custom payload fields: define your own struct and pass it to `encoder.encode(&my_payload)` / `decoder.decode::<MyPayload>(&token)`.
-- `JwtLayer` has no generic parameter in v0.8 (`JwtLayer`, not `JwtLayer<T>`). It always decodes into `Claims`.
+- `Claims` is **non-generic**. There is no `Claims<T>`. Custom payload fields: define your own struct and pass it to `encoder.encode(&my_payload)` / `decoder.decode::<MyPayload>(&token)`.
+- `JwtLayer` has no generic parameter (`JwtLayer`, not `JwtLayer<T>`). It always decodes into `Claims`.
 - The `Revocation` trait and `with_revocation()` no longer exist. Stateful row lookup in `JwtLayer::from_service` replaces revocation: the session row absent = revoked. The `Revoked` and `RevocationCheckFailed` `JwtError` variants no longer exist.
 - `PasswordConfig`, `TotpConfig`, `JwtSessionsConfig`, `ValidationConfig`, `OAuthConfig`, `OAuthProviderConfig`, `CallbackParams`, and `UserProfile` are all `#[non_exhaustive]` -- never construct with struct literals (no `..Default::default()` either). Use the provided constructors (`::new(...)`, `Default::default()`) and override fields by direct assignment.
 - `JwtSessionsConfig` and `OAuthConfig` have `#[serde(default)]` at struct level -- all fields are optional in YAML (fall back to defaults).

--- a/skills/dev/references/config.md
+++ b/skills/dev/references/config.md
@@ -89,7 +89,7 @@ cookie:
 
 ## Config Struct
 
-`modo::Config` — top-level framework config (`#[non_exhaustive]`). All fields use `#[serde(default)]`, so any section can be omitted. Every sub-config is present on every build (modo 0.8 compiles every module unconditionally).
+`modo::Config` — top-level framework config (`#[non_exhaustive]`). All fields use `#[serde(default)]`, so any section can be omitted. Every sub-config is present on every build (modo compiles every module unconditionally).
 
 Source: `src/config/modo.rs`
 
@@ -120,6 +120,7 @@ cfg.server.port = 3000;
 | `oauth`            | `auth::oauth::OAuthConfig`                | `oauth`            | OAuth provider settings                                                     |
 | `email`            | `email::EmailConfig`                      | `email`            | SMTP / email delivery                                                       |
 | `template`         | `template::TemplateConfig`                | `template`         | MiniJinja template engine                                                   |
+| `i18n`             | `i18n::I18nConfig`                        | `i18n`             | Locale resolver chain and translation store                                 |
 | `geolocation`      | `geolocation::GeolocationConfig`          | `geolocation`      | MaxMind GeoIP database                                                      |
 | `storage`          | `storage::BucketConfig`                   | `storage`          | S3-compatible storage bucket                                                |
 | `dns`              | `dns::DnsConfig`                          | `dns`              | DNS verification                                                            |
@@ -302,12 +303,28 @@ cfg.cookie.secret = "a-64-character-or-longer-secret-for-signing-cookies..".to_s
 
 ### `i18n::I18nConfig`
 
+`#[non_exhaustive]`. YAML-deserializable configuration. The top-level YAML key is `i18n`.
+
 | Field                | Type     | Default     | Description                       |
 | -------------------- | -------- | ----------- | --------------------------------- |
 | `locales_path`       | `String` | `"locales"` | Locale YAML directory             |
 | `default_locale`     | `String` | `"en"`      | Fallback locale                   |
 | `locale_cookie`      | `String` | `"lang"`    | Cookie for locale resolution      |
 | `locale_query_param` | `String` | `"lang"`    | Query param for locale resolution |
+
+```yaml
+i18n:
+  locales_path: locales
+  default_locale: en
+  locale_cookie: lang
+  locale_query_param: lang
+```
+
+End-apps construct the shared `I18n` handle from this config:
+
+```rust,ignore
+let i18n = modo::i18n::I18n::new(&config.i18n)?;
+```
 
 ### `geolocation::GeolocationConfig`
 
@@ -391,14 +408,14 @@ jwt:
 
 ## Feature Flags
 
-modo 0.8 has exactly one cargo feature: `test-helpers`. Enable it only under `[dev-dependencies]` to gate the `modo::testing` module and all in-memory/stub backends:
+modo has exactly one cargo feature: `test-helpers`. Enable it only under `[dev-dependencies]` to gate the `modo::testing` module and all in-memory/stub backends:
 
 ```toml
 [dev-dependencies]
-modo = { package = "modo-rs", version = "0.8", features = ["test-helpers"] }
+modo = { package = "modo-rs", version = "0.9", features = ["test-helpers"] }
 ```
 
-Every framework module (`db`, `session`, `job`, `auth`, `email`, `template`, `storage`, `dns`, `geolocation`, `apikey`, `jwt`, `sentry`, `tier`, etc.) is compiled unconditionally. To disable a module, simply leave its YAML config section at defaults and skip wiring it into `main`.
+Every framework module (`db`, `session`, `job`, `auth`, `email`, `template`, `i18n`, `storage`, `dns`, `geolocation`, `apikey`, `jwt`, `sentry`, `tier`, etc.) is compiled unconditionally. To disable a module, simply leave its YAML config section at defaults and skip wiring it into `main`.
 
 ## Gotchas
 
@@ -414,7 +431,7 @@ Every framework module (`db`, `session`, `job`, `auth`, `email`, `template`, `st
 
 6. **`load()` is not async** — it reads the file synchronously with `std::fs::read_to_string`. Call it at startup before entering the async runtime's hot path.
 
-7. **All config sections are always present on `Config`** — modo 0.8 compiles every module unconditionally, so `database`, `session`, `job`, etc. are available on every build. Unknown YAML keys are silently ignored by serde.
+7. **All config sections are always present on `Config`** — modo compiles every module unconditionally, so `database`, `session`, `job`, etc. are available on every build. Unknown YAML keys are silently ignored by serde.
 
 8. **`max_sessions_per_user` must be > 0** — deserialization fails if set to `0` (custom deserializer rejects it to prevent locking out all users).
 

--- a/skills/dev/references/config.md
+++ b/skills/dev/references/config.md
@@ -294,15 +294,20 @@ cfg.cookie.secret = "a-64-character-or-longer-secret-for-signing-cookies..".to_s
 
 ### `template::TemplateConfig`
 
-| Field                | Type     | Default       | Description                       |
-| -------------------- | -------- | ------------- | --------------------------------- |
-| `templates_path`     | `String` | `"templates"` | MiniJinja template directory      |
-| `static_path`        | `String` | `"static"`    | Static asset directory            |
-| `static_url_prefix`  | `String` | `"/assets"`   | URL prefix for static assets      |
-| `locales_path`       | `String` | `"locales"`   | Locale YAML directory             |
-| `default_locale`     | `String` | `"en"`        | Fallback locale                   |
-| `locale_cookie`      | `String` | `"lang"`      | Cookie for locale resolution      |
-| `locale_query_param` | `String` | `"lang"`      | Query param for locale resolution |
+| Field               | Type     | Default       | Description                  |
+| ------------------- | -------- | ------------- | ---------------------------- |
+| `templates_path`    | `String` | `"templates"` | MiniJinja template directory |
+| `static_path`       | `String` | `"static"`    | Static asset directory       |
+| `static_url_prefix` | `String` | `"/assets"`   | URL prefix for static assets |
+
+### `i18n::I18nConfig`
+
+| Field                | Type     | Default     | Description                       |
+| -------------------- | -------- | ----------- | --------------------------------- |
+| `locales_path`       | `String` | `"locales"` | Locale YAML directory             |
+| `default_locale`     | `String` | `"en"`      | Fallback locale                   |
+| `locale_cookie`      | `String` | `"lang"`    | Cookie for locale resolution      |
+| `locale_query_param` | `String` | `"lang"`    | Query param for locale resolution |
 
 ### `geolocation::GeolocationConfig`
 

--- a/skills/dev/references/conventions.md
+++ b/skills/dev/references/conventions.md
@@ -74,9 +74,9 @@ Flat aggregators: `modo::extractors`, `modo::middlewares`, `modo::guards`
 re-export every extractor / Tower Layer / route guard modo ships for ergonomic
 wiring.
 
-## Feature Flags (v0.8)
+## Feature Flags
 
-v0.8 has a single feature flag: **`test-helpers`**. Every production module is
+modo has a single feature flag: **`test-helpers`**. Every production module is
 unconditionally compiled — there are no feature-gated production modules.
 
 | Feature | Purpose |
@@ -87,7 +87,7 @@ Enable in dev-dependencies only:
 
 ```toml
 [dev-dependencies]
-modo = { package = "modo-rs", version = "0.8", features = ["test-helpers"] }
+modo = { package = "modo-rs", version = "0.9", features = ["test-helpers"] }
 ```
 
 ---
@@ -531,7 +531,7 @@ async fn handler(Service(pool): Service<Pool>) {
 ## IDs
 
 **Module:** `src/id/`
-Always available (no feature flag required — all production modules compile unconditionally in v0.8).
+Always available (no feature flag required — all production modules compile unconditionally).
 
 ### `id::ulid() -> String`
 

--- a/skills/dev/references/handlers.md
+++ b/skills/dev/references/handlers.md
@@ -121,7 +121,7 @@ All middleware functions return Tower-compatible layers. Apply them with `.layer
     - `mw::TemplateContext::new(...)` (aliases `template::TemplateContextLayer`)
     - `mw::Tier::new(...)` (aliases `tier::TierLayer`)
 
-> **v0.8 note:** The `session` free function (`mw::session(...)`) was removed. Session middleware is now constructed via `CookieSessionService::layer()` -- see `modo::auth::session::cookie::CookieSessionService`. The session layer is not re-exported from `modo::middlewares`.
+> **Note:** The `session` free function (`mw::session(...)`) is not exposed. Session middleware is constructed via `CookieSessionService::layer()` -- see `modo::auth::session::cookie::CookieSessionService`. The session layer is not re-exported from `modo::middlewares`.
 
 The underlying `modo::middleware` module (singular) ships only the universal always-available layers (CORS, CSRF, compression, request-id, tracing, catch-panic, error-handler, security-headers, rate-limit) along with their configs and supporting types (`CorsConfig`, `CsrfConfig`, `CsrfToken`, `RateLimitConfig`, `RateLimitLayer`, `SecurityHeadersConfig`, `KeyExtractor`, `PeerIpKeyExtractor`, `GlobalKeyExtractor`, predicates `subdomains`/`urls`).
 

--- a/skills/dev/references/sessions.md
+++ b/skills/dev/references/sessions.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-modo provides database-backed HTTP sessions (libsql/SQLite via `authenticated_sessions` table), signed cookie utilities, and cookie-based flash messages. All three are always available in modo 0.8 — no feature flags required.
+modo provides database-backed HTTP sessions (libsql/SQLite via `authenticated_sessions` table), signed cookie utilities, and cookie-based flash messages. All three are always available — no feature flags required.
 
 Two transports are available: cookie-backed (`auth::session::cookie`) and JWT-backed (`auth::session::jwt`). Both share the same SQLite table and the transport-agnostic `Session` data extractor.
 
@@ -924,7 +924,7 @@ use modo::cookie::{CookieConfig, CookieJar, Key, PrivateCookieJar, SignedCookieJ
 
 1. **Raw `cookie::CookieJar`, not `axum_extra`**: The session and flash middleware use the raw `cookie` crate's `CookieJar` and `SignedJar` internally for cookie signing — not `axum_extra::extract::cookie::SignedCookieJar`. The `axum_extra` types are re-exported from `modo::cookie` for use in handlers, but the middleware does its own signing.
 
-2. **Session and cookie are always compiled**: No feature flags in modo 0.8. `auth::session` does require the `db` feature (included in `default`).
+2. **Session and cookie are always compiled**: No per-module feature flags. `auth::session` uses the database layer, which is always available.
 
 3. **`authenticated_sessions` table schema not shipped**: The table schema is not shipped as a migration — end-apps own their DB schema. Column `session_token_hash` (not `token_hash`).
 

--- a/skills/dev/references/templates.md
+++ b/skills/dev/references/templates.md
@@ -12,11 +12,10 @@ use modo::template::{
 The `context!` macro from MiniJinja is also re-exported: `modo::template::context`.
 
 For internationalization (the `t()` template function, `Translator` extractor,
-locale resolvers), see `skills/dev/references/i18n.md` and
-`src/i18n/README.md`. Pass an `I18n` handle to `EngineBuilder::i18n(...)` to
-register `t()` on the engine; install `I18nLayer` upstream of
-`TemplateContextLayer` so the middleware can copy the resolved locale into
-the template context.
+locale resolvers), see the `modo::i18n` rustdocs and `src/i18n/README.md`.
+Pass an `I18n` handle to `EngineBuilder::i18n(...)` to register `t()` on the
+engine; install `I18nLayer` upstream of `TemplateContextLayer` so the
+middleware can copy the resolved locale into the template context.
 
 ---
 

--- a/skills/dev/references/templates.md
+++ b/skills/dev/references/templates.md
@@ -29,8 +29,8 @@ middleware can copy the resolved locale into the template context.
 | `static_path`       | `String` | `"static"`    | Directory with static assets            |
 | `static_url_prefix` | `String` | `"/assets"`   | URL prefix for serving static files     |
 
-Locale knobs moved to `modo::i18n::I18nConfig` in v0.9 (`locales_path`,
-`default_locale`, `locale_cookie`, `locale_query_param`).
+Locale knobs live in `modo::i18n::I18nConfig` (the `i18n:` top-level YAML key):
+`locales_path`, `default_locale`, `locale_cookie`, `locale_query_param`.
 
 ---
 

--- a/skills/dev/references/templates.md
+++ b/skills/dev/references/templates.md
@@ -1,4 +1,4 @@
-# Templates (MiniJinja, i18n, HTMX)
+# Templates (MiniJinja, HTMX)
 
 Always available — import directly from `modo::template`:
 
@@ -9,16 +9,14 @@ use modo::template::{
 };
 ```
 
-Locale resolvers are re-exported from `modo::template`:
-
-```rust
-use modo::template::locale::{
-    AcceptLanguageResolver, CookieResolver, LocaleResolver, QueryParamResolver,
-    SessionResolver,
-};
-```
-
 The `context!` macro from MiniJinja is also re-exported: `modo::template::context`.
+
+For internationalization (the `t()` template function, `Translator` extractor,
+locale resolvers), see `skills/dev/references/i18n.md` and
+`src/i18n/README.md`. Pass an `I18n` handle to `EngineBuilder::i18n(...)` to
+register `t()` on the engine; install `I18nLayer` upstream of
+`TemplateContextLayer` so the middleware can copy the resolved locale into
+the template context.
 
 ---
 
@@ -26,15 +24,14 @@ The `context!` macro from MiniJinja is also re-exported: `modo::template::contex
 
 `#[non_exhaustive]`. Derives `Debug`, `Clone`, `Deserialize`. Has `impl Default` (manual, not derive). YAML-deserializable configuration. All fields have defaults and support `#[serde(default)]`.
 
-| Field                | Type     | Default       | Purpose                                   |
-| -------------------- | -------- | ------------- | ----------------------------------------- |
-| `templates_path`     | `String` | `"templates"` | Directory with MiniJinja template files   |
-| `static_path`        | `String` | `"static"`    | Directory with static assets              |
-| `static_url_prefix`  | `String` | `"/assets"`   | URL prefix for serving static files       |
-| `locales_path`       | `String` | `"locales"`   | Directory with locale YAML subdirectories |
-| `default_locale`     | `String` | `"en"`        | Fallback BCP 47 language tag              |
-| `locale_cookie`      | `String` | `"lang"`      | Cookie name for `CookieResolver`          |
-| `locale_query_param` | `String` | `"lang"`      | Query param name for `QueryParamResolver` |
+| Field               | Type     | Default       | Purpose                                 |
+| ------------------- | -------- | ------------- | --------------------------------------- |
+| `templates_path`    | `String` | `"templates"` | Directory with MiniJinja template files |
+| `static_path`       | `String` | `"static"`    | Directory with static assets            |
+| `static_url_prefix` | `String` | `"/assets"`   | URL prefix for serving static files     |
+
+Locale knobs moved to `modo::i18n::I18nConfig` in v0.9 (`locales_path`,
+`default_locale`, `locale_cookie`, `locale_query_param`).
 
 ---
 
@@ -45,16 +42,25 @@ The `context!` macro from MiniJinja is also re-exported: `modo::template::contex
 ### Building
 
 ```rust
+use modo::i18n::{I18n, I18nConfig};
+use modo::template::{Engine, TemplateConfig};
+
+# fn example() -> modo::Result<()> {
+let i18n = I18n::new(&I18nConfig::default())?;
+
 let engine = Engine::builder()
-    .config(config)                           // TemplateConfig (optional, defaults used otherwise)
+    .config(TemplateConfig::default())
+    .i18n(i18n.clone())                       // optional — registers t() when supplied
     .function("greet", || -> Result<String, minijinja::Error> {
         Ok("Hi!".into())
     })
     .filter("shout", |val: String| -> Result<String, minijinja::Error> {
         Ok(val.to_uppercase())
     })
-    .locale_resolvers(vec![...])              // override default locale chain
     .build()?;
+# let _ = engine;
+# Ok(())
+# }
 ```
 
 `EngineBuilder` is `#[must_use]` and derives `Default`.
@@ -64,14 +70,14 @@ let engine = Engine::builder()
 - `config(TemplateConfig)` -- sets template config; defaults used if omitted.
 - `function(name, f)` -- registers a MiniJinja global function. `f` must implement `minijinja::functions::Function`.
 - `filter(name, f)` -- registers a MiniJinja filter. Same trait bounds as `function`.
-- `locale_resolvers(Vec<Arc<dyn LocaleResolver>>)` -- overrides the default locale resolver chain.
-- `build() -> modo::Result<Engine>` -- constructs the engine. Fails if the locales directory exists but cannot be read, a locale YAML file fails to parse, or static-file hashing hits an I/O error. Templates directory is not validated up front (errors surface on render).
+- `i18n(I18n)` -- provides a shared `modo::i18n::I18n` handle. When supplied, `build()` registers the `t()` template function backed by the handle's `TranslationStore`. Omit to skip `t()` registration.
+- `build() -> modo::Result<Engine>` -- constructs the engine. Fails if static-file hashing hits an I/O error. Templates directory is not validated up front (errors surface on render).
 
 ### What `build()` registers automatically
 
 - **Filesystem loader** from `config.templates_path`.
 - **minijinja-contrib** common filters and functions.
-- **`t()` function** for i18n (only if `locales_path` directory exists).
+- **`t()` function** for i18n (only when `.i18n(...)` was called).
 - **`static_url()` function** for cache-busted asset URLs (SHA-256, 8 hex chars).
 - User-registered functions and filters (applied last, can override built-ins).
 
@@ -79,8 +85,6 @@ let engine = Engine::builder()
 
 - `static_service() -> axum::Router` -- serves static files from `static_path` under `static_url_prefix`. Debug builds use `Cache-Control: no-cache`; release builds use `Cache-Control: public, max-age=31536000, immutable`.
 - `render()` is `pub(crate)` -- handlers use `Renderer` instead.
-- `locale_chain()` is `pub(crate)` -- returns `&[Arc<dyn LocaleResolver>]`.
-- `default_locale()` is `pub(crate)` -- returns `&str`.
 
 ### Hot-reload
 
@@ -130,26 +134,44 @@ Handlers do not manipulate `TemplateContext` directly. The `Renderer` extractor 
 
 ## TemplateContextLayer (middleware)
 
-Derives `Clone`. Tower middleware that populates `TemplateContext` and inserts it into request extensions. Also re-exported as `modo::middlewares::TemplateContext` for wiring sites that prefer the `mw::` prefix style.
+Derives `Clone`, `Default`. Tower middleware that populates `TemplateContext` and inserts it into request extensions. Also re-exported as `modo::middlewares::TemplateContext` for wiring sites that prefer the `mw::` prefix style.
 
 ```rust
+# fn example() -> modo::Result<()> {
+use modo::i18n::{I18n, I18nConfig};
+use modo::template::{Engine, TemplateConfig, TemplateContextLayer};
+
+let i18n = I18n::new(&I18nConfig::default())?;
+let engine = Engine::builder()
+    .config(TemplateConfig::default())
+    .i18n(i18n.clone())
+    .build()?;
+
 let router = axum::Router::new()
     .merge(engine.static_service())
-    .layer(TemplateContextLayer::new(engine.clone()));
+    .layer(TemplateContextLayer::new())
+    .layer(i18n.layer());
+# let _ = router;
+# Ok(())
+# }
 ```
+
+Install `I18nLayer` (from `i18n.layer()`) **as an outer layer** of
+`TemplateContextLayer` so the translator is set on the request before the
+template middleware reads it.
 
 ### Keys injected per request
 
-| Key              | Source                                                              |
-| ---------------- | ------------------------------------------------------------------- |
-| `current_url`    | `request.uri().to_string()`                                         |
-| `is_htmx`        | `HX-Request: true` header                                           |
-| `request_id`     | `X-Request-Id` header (if present)                                  |
-| `locale`         | Locale resolver chain, falls back to `default_locale`               |
-| `csrf_token`     | `CsrfToken` extension (if CSRF middleware installed)                |
-| `flash_messages` | Template function from `FlashState` (if flash middleware installed) |
-| `tier_name`      | Plan name string from `TierInfo` (if `tier` feature enabled and `TierInfo` in extensions) |
-| `tier_has`       | Template function: `tier_has('feature_name')` → `bool` (calls `TierInfo::has_feature`) |
+| Key              | Source                                                                                    |
+| ---------------- | ----------------------------------------------------------------------------------------- |
+| `current_url`    | `request.uri().to_string()`                                                               |
+| `is_htmx`        | `HX-Request: true` header                                                                 |
+| `request_id`     | `X-Request-Id` header (if present)                                                        |
+| `locale`         | `Translator::locale()` read from request extensions (absent when no `I18nLayer` upstream) |
+| `csrf_token`     | `CsrfToken` extension (if CSRF middleware installed)                                      |
+| `flash_messages` | Template function from `FlashState` (if flash middleware installed)                       |
+| `tier_name`      | Plan name string from `TierInfo` (if `TierInfo` in extensions)                            |
+| `tier_has`       | Template function: `tier_has('feature_name')` → `bool` (calls `TierInfo::has_feature`)    |
 | `tier_enabled`   | Template function: `tier_enabled('feature_name')` → `bool` (calls `TierInfo::is_enabled`) |
 | `tier_limit`     | Template function: `tier_limit('feature_name')` → `Option<u64>` (calls `TierInfo::limit`) |
 
@@ -170,72 +192,6 @@ async fn handler(hx: HxRequest) {
 ```
 
 `Renderer` also exposes `is_htmx()` and `html_partial()` for the common pattern of choosing between full page and partial template.
-
----
-
-## i18n (translations)
-
-### File structure
-
-```
-locales/
-  en/
-    common.yaml
-    auth.yaml
-  uk/
-    common.yaml
-```
-
-Each locale is a subdirectory. YAML files (`.yaml` or `.yml`) within are namespaced by filename. Keys are dot-separated: file `auth.yaml` with nested key `login.title` becomes `auth.login.title`.
-
-### `t()` template function
-
-Registered automatically when `locales_path` directory exists.
-
-```jinja
-{{ t('common.greeting') }}
-{{ t('greet.welcome', name="Dmytro", age="30") }}
-{{ t('items.count', count=5) }}
-```
-
-- Reads `locale` from template context (set by middleware).
-- Falls back to `default_locale` if key missing in requested locale.
-- Falls back to the key string itself if missing everywhere.
-- Supports `{placeholder}` interpolation with keyword arguments.
-- Supports pluralization via `count` kwarg.
-
-### Pluralization
-
-YAML format for plural entries (must have `other` key; allowed keys: `zero`, `one`, `two`, `few`, `many`, `other`):
-
-```yaml
-count:
-    one: "{count} item"
-    other: "{count} items"
-```
-
-Uses CLDR plural rules via `intl_pluralrules`. Correct for Slavic languages (Ukrainian `few`/`many` categories), English, and others.
-
-### Locale resolver chain
-
-Default order (first `Some` wins):
-
-1. `QueryParamResolver` -- reads `?lang=uk` from URL query string.
-2. `CookieResolver` -- reads `lang` cookie.
-3. `SessionResolver` -- reads `"locale"` key from session data (requires `SessionLayer`). Always in the chain; returns `None` silently when no session extension is present.
-4. `AcceptLanguageResolver` -- parses `Accept-Language` header, picks highest-quality match.
-
-All resolvers validate against available locales when `available_locales` is non-empty.
-
-Override with `EngineBuilder::locale_resolvers()`.
-
-### LocaleResolver trait
-
-```rust
-pub trait LocaleResolver: Send + Sync {
-    fn resolve(&self, parts: &Parts) -> Option<String>;
-}
-```
 
 ---
 
@@ -277,5 +233,4 @@ The return value uses `Value::from_safe_string()` so it is not HTML-escaped.
 - **Handler context must be a map**: Pass `context! { ... }` to render methods. Non-map values are silently ignored with a warning log.
 - **Hot-reload is debug-only**: Template cache is only cleared per-render in debug builds.
 - **`render()` is `pub(crate)`**: Handlers must use the `Renderer` extractor, not `Engine::render()` directly.
-- **Locale resolvers need `Arc`**: The resolver chain is `Vec<Arc<dyn LocaleResolver>>`, not boxed.
-- **SessionResolver needs SessionLayer**: If `SessionLayer` is not installed, `SessionResolver::resolve()` returns `None` silently.
+- **`t()` requires `I18nLayer` upstream**: The `t()` function reads `locale` from the template context. `TemplateContextLayer` only sets `locale` when `I18nLayer` has already injected a `Translator` into request extensions. Without upstream `I18nLayer`, `t()` falls back to the store's default locale.

--- a/skills/dev/references/testing.md
+++ b/skills/dev/references/testing.md
@@ -7,7 +7,7 @@ your crate's dev-dependencies:
 
 ```toml
 [dev-dependencies]
-modo = { package = "modo-rs", version = "0.8", features = ["test-helpers"] }
+modo = { package = "modo-rs", version = "0.9", features = ["test-helpers"] }
 ```
 
 Source: `src/testing/` module. Re-exported as `modo::testing`.
@@ -466,7 +466,7 @@ async fn test_full_app_with_db_and_session() {
 
 ## Running tests
 
-modo 0.8 ships two feature flags: `default` (empty) and `test-helpers`.
+modo ships two feature flags: `default` (empty) and `test-helpers`.
 `test-helpers` gates the in-memory/stub backends used by tests:
 
 ```bash

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -188,7 +188,7 @@ let app = routes::router(registry)
     .layer(modo::middleware::cors(&config.modo.cors))
     .layer(modo::middleware::csrf(&config.modo.csrf, &cookie_key))
     // Template context (if templates)
-    .layer(modo::template::TemplateContextLayer::new(engine))
+    .layer(modo::template::TemplateContextLayer::new())
     // Session
     .layer(session_svc.layer())
     // Flash

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -131,7 +131,7 @@ These files depend on the selected components — generate each with `Write`. Re
 
 **Required dynamic files:**
 
-1. **`Cargo.toml`** — modo 0.8 ships every module unconditionally, so no per-module feature list is needed. See `references/files.md` for the template.
+1. **`Cargo.toml`** — modo ships every module unconditionally, so no per-module feature list is needed. See `references/files.md` for the template.
 
 2. **`src/main.rs`** — Assemble from component blocks in `references/components.md`:
    - Module declarations and imports

--- a/skills/init/references/components.md
+++ b/skills/init/references/components.md
@@ -298,13 +298,8 @@ Always available — no feature flag.
 
 ```rust
 // i18n handle (owns translation store + locale resolver chain).
-// Build an `I18nConfig` inline for now — a forthcoming task will wire this
-// into the top-level `config.modo.i18n` field so it can come from YAML.
-let i18n = modo::i18n::I18n::new(&modo::i18n::I18nConfig {
-    locales_path: "locales".into(),
-    default_locale: "en".into(),
-    ..modo::i18n::I18nConfig::default()
-})?;
+// Built from the top-level `config.modo.i18n` field (YAML key: `i18n`).
+let i18n = modo::i18n::I18n::new(&config.modo.i18n)?;
 
 // Template engine — wire the i18n handle so `{{ t(...) }}` is available
 let engine = modo::template::Engine::builder()
@@ -335,11 +330,13 @@ template:
   templates_path: templates
   static_path: assets/static
   static_url_prefix: /static
-```
 
-> Note: `I18nConfig` is currently built inline in `main.rs` (see the snippet
-> above). A forthcoming task will add an `i18n:` section to the top-level
-> config so locales can be configured via YAML.
+i18n:
+  locales_path: locales
+  default_locale: en
+  locale_cookie: lang
+  locale_query_param: lang
+```
 
 ### Config YAML (production)
 

--- a/skills/init/references/components.md
+++ b/skills/init/references/components.md
@@ -297,9 +297,13 @@ Always available — no feature flag.
 ### Registry setup
 
 ```rust
-// Template engine
+// i18n handle (owns translation store + locale resolver chain)
+let i18n = modo::i18n::I18n::new(&config.modo.i18n)?;
+
+// Template engine — wire the i18n handle so `{{ t(...) }}` is available
 let engine = modo::template::Engine::builder()
     .config(config.modo.template.clone())
+    .i18n(i18n.clone())
     .build()?;
 registry.add(engine.clone());
 ```
@@ -312,8 +316,10 @@ Insert these at the correct position in the middleware chain:
 // After routes, before error_handler — merge static file service
 .merge(engine.static_service())
 
-// After CSRF, before session layer
-.layer(modo::template::TemplateContextLayer::new(engine))
+// After CSRF, before session layer — inner template context
+.layer(modo::template::TemplateContextLayer::new())
+// Outer i18n layer — must run before TemplateContextLayer sees the request
+.layer(i18n.layer())
 ```
 
 ### Config YAML (development)
@@ -323,7 +329,10 @@ template:
   templates_path: templates
   static_path: assets/static
   static_url_prefix: /static
+
+i18n:
   locales_path: locales
+  default_locale: en
 ```
 
 ### Config YAML (production)

--- a/skills/init/references/components.md
+++ b/skills/init/references/components.md
@@ -297,8 +297,14 @@ Always available — no feature flag.
 ### Registry setup
 
 ```rust
-// i18n handle (owns translation store + locale resolver chain)
-let i18n = modo::i18n::I18n::new(&config.modo.i18n)?;
+// i18n handle (owns translation store + locale resolver chain).
+// Build an `I18nConfig` inline for now — a forthcoming task will wire this
+// into the top-level `config.modo.i18n` field so it can come from YAML.
+let i18n = modo::i18n::I18n::new(&modo::i18n::I18nConfig {
+    locales_path: "locales".into(),
+    default_locale: "en".into(),
+    ..modo::i18n::I18nConfig::default()
+})?;
 
 // Template engine — wire the i18n handle so `{{ t(...) }}` is available
 let engine = modo::template::Engine::builder()
@@ -329,11 +335,11 @@ template:
   templates_path: templates
   static_path: assets/static
   static_url_prefix: /static
-
-i18n:
-  locales_path: locales
-  default_locale: en
 ```
+
+> Note: `I18nConfig` is currently built inline in `main.rs` (see the snippet
+> above). A forthcoming task will add an `i18n:` section to the top-level
+> config so locales can be configured via YAML.
 
 ### Config YAML (production)
 

--- a/skills/init/references/files.md
+++ b/skills/init/references/files.md
@@ -27,18 +27,18 @@ edition = "2024"
 rust-version = "1.92"
 
 [dependencies]
-modo = { package = "modo-rs", version = "0.8" }
+modo = { package = "modo-rs", version = "0.9" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 
 [dev-dependencies]
-modo = { package = "modo-rs", version = "0.8", features = ["test-helpers"] }
+modo = { package = "modo-rs", version = "0.9", features = ["test-helpers"] }
 ```
 
 ### Feature flags
 
-modo 0.8 ships every module unconditionally — there are no per-module feature
+modo ships every module unconditionally — there are no per-module feature
 flags. The only feature is `test-helpers`, enabled in `[dev-dependencies]` to
 expose in-memory backends (`TestDb`, `TestApp`, `TestSession`, …) for
 integration tests.
@@ -359,7 +359,7 @@ Generate dynamically using `Write`. Replace `{{project_name}}` with the actual p
 ````markdown
 # {{project_name}}
 
-**Framework:** [modo](https://github.com/dmitrymomot/modo) v0.8 — Rust web framework with SQLite
+**Framework:** [modo](https://github.com/dmitrymomot/modo) v0.9 — Rust web framework with SQLite
 
 ## Commands
 

--- a/src/auth/session/README.md
+++ b/src/auth/session/README.md
@@ -2,7 +2,7 @@
 
 Transport-agnostic, database-backed session management.
 
-v0.8 splits sessions into two independent transports that share one SQLite table
+Sessions are split into two independent transports that share one SQLite table
 (`authenticated_sessions`) and one public data type (`Session`).
 
 ## Two transports, one data type

--- a/src/auth/session/mod.rs
+++ b/src/auth/session/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Unified session management for cookie and JWT transports.
 //!
-//! v0.8 provides two independent transports that share one SQLite table
+//! Two independent transports share one SQLite table
 //! (`authenticated_sessions`) and one public data type ([`Session`]).
 //!
 //! ## Transports

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -120,27 +120,28 @@ trusted_proxies:
 
 `Config` composes the sub-configs of every built-in module. All fields use
 `#[serde(default)]`, so any section omitted from the YAML file falls back to
-the type's own `Default` implementation. Every module is always compiled in
-v0.8+, so every field is always present.
+the type's own `Default` implementation. Every module is always compiled, so
+every field is always present.
 
-| Field              | Type                                |
-| ------------------ | ----------------------------------- |
-| `server`           | `server::Config`                    |
-| `database`         | `db::Config`                        |
-| `tracing`          | `tracing::Config`                   |
-| `cookie`           | `Option<cookie::CookieConfig>`      |
-| `security_headers` | `middleware::SecurityHeadersConfig` |
-| `cors`             | `middleware::CorsConfig`            |
-| `csrf`             | `middleware::CsrfConfig`            |
-| `rate_limit`       | `middleware::RateLimitConfig`       |
-| `session`          | `auth::session::SessionConfig`      |
-| `job`              | `job::JobConfig`                    |
-| `trusted_proxies`  | `Vec<String>`                       |
-| `oauth`            | `auth::oauth::OAuthConfig`          |
-| `email`            | `email::EmailConfig`                |
-| `template`         | `template::TemplateConfig`          |
-| `geolocation`      | `geolocation::GeolocationConfig`    |
-| `storage`          | `storage::BucketConfig`             |
-| `dns`              | `dns::DnsConfig`                    |
-| `apikey`           | `auth::apikey::ApiKeyConfig`        |
-| `jwt`              | `auth::session::jwt::JwtSessionsConfig`      |
+| Field              | Type                                    |
+| ------------------ | --------------------------------------- |
+| `server`           | `server::Config`                        |
+| `database`         | `db::Config`                            |
+| `tracing`          | `tracing::Config`                       |
+| `cookie`           | `Option<cookie::CookieConfig>`          |
+| `security_headers` | `middleware::SecurityHeadersConfig`     |
+| `cors`             | `middleware::CorsConfig`                |
+| `csrf`             | `middleware::CsrfConfig`                |
+| `rate_limit`       | `middleware::RateLimitConfig`           |
+| `session`          | `auth::session::SessionConfig`          |
+| `job`              | `job::JobConfig`                        |
+| `trusted_proxies`  | `Vec<String>`                           |
+| `oauth`            | `auth::oauth::OAuthConfig`              |
+| `email`            | `email::EmailConfig`                    |
+| `template`         | `template::TemplateConfig`              |
+| `i18n`             | `i18n::I18nConfig`                      |
+| `geolocation`      | `geolocation::GeolocationConfig`        |
+| `storage`          | `storage::BucketConfig`                 |
+| `dns`              | `dns::DnsConfig`                        |
+| `apikey`           | `auth::apikey::ApiKeyConfig`            |
+| `jwt`              | `auth::session::jwt::JwtSessionsConfig` |

--- a/src/config/modo.rs
+++ b/src/config/modo.rs
@@ -51,6 +51,9 @@ pub struct Config {
     /// MiniJinja template engine settings.
     #[serde(default)]
     pub template: crate::template::TemplateConfig,
+    /// i18n locale resolver chain and translation store settings.
+    #[serde(default)]
+    pub i18n: crate::i18n::I18nConfig,
     /// MaxMind GeoIP database path and settings.
     #[serde(default)]
     pub geolocation: crate::geolocation::GeolocationConfig,

--- a/src/config/modo.rs
+++ b/src/config/modo.rs
@@ -51,7 +51,7 @@ pub struct Config {
     /// MiniJinja template engine settings.
     #[serde(default)]
     pub template: crate::template::TemplateConfig,
-    /// i18n locale resolver chain and translation store settings.
+    /// Internationalization locale resolver chain and translation store settings.
     #[serde(default)]
     pub i18n: crate::i18n::I18nConfig,
     /// MaxMind GeoIP database path and settings.

--- a/src/error/core.rs
+++ b/src/error/core.rs
@@ -15,6 +15,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// - an optional structured `details` payload (arbitrary JSON),
 /// - an optional boxed `source` error for causal chaining,
 /// - an optional static `error_code` string that survives the response pipeline,
+/// - an optional static `locale_key` that lets the default error handler translate
+///   the message at response-build time,
 /// - a `lagged` flag used by the SSE broadcaster to signal that a subscriber dropped messages.
 ///
 /// # Conversion to HTTP response
@@ -32,12 +34,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// # Clone behaviour
 ///
 /// Cloning an `Error` drops the `source` field because `Box<dyn Error>` is not `Clone`.
-/// The `error_code`, `details`, and all other fields are preserved.
+/// The `error_code`, `locale_key`, `details`, and all other fields are preserved.
 pub struct Error {
     status: StatusCode,
     message: String,
     source: Option<Box<dyn std::error::Error + Send + Sync>>,
     error_code: Option<&'static str>,
+    locale_key: Option<&'static str>,
     details: Option<serde_json::Value>,
     lagged: bool,
 }
@@ -50,6 +53,7 @@ impl Error {
             message: message.into(),
             source: None,
             error_code: None,
+            locale_key: None,
             details: None,
             lagged: false,
         }
@@ -68,6 +72,35 @@ impl Error {
             message: message.into(),
             source: Some(Box::new(source)),
             error_code: None,
+            locale_key: None,
+            details: None,
+            lagged: false,
+        }
+    }
+
+    /// Create an error whose message is a translation key.
+    ///
+    /// The `key` is stored in the `locale_key` slot and is also used as the raw
+    /// `message`. When the
+    /// [`default_error_handler`](crate::middleware::default_error_handler) runs
+    /// and a [`Translator`](crate::i18n::Translator) is present in the request
+    /// extensions (installed by
+    /// [`I18nLayer`](crate::i18n::I18nLayer)), it resolves `key` into the
+    /// user-facing string at response-build time. Without that middleware (or
+    /// without a `Translator`), the response falls back to the raw key — making
+    /// the behaviour predictable and easy to spot in logs.
+    ///
+    /// This constructor leaves `error_code`, `details`, and `source` unset;
+    /// chain [`with_code`](Error::with_code),
+    /// [`with_details`](Error::with_details), or [`chain`](Error::chain)
+    /// afterwards if needed.
+    pub fn localized(status: StatusCode, key: &'static str) -> Self {
+        Self {
+            status,
+            message: key.to_string(),
+            source: None,
+            error_code: None,
+            locale_key: Some(key),
             details: None,
             lagged: false,
         }
@@ -112,6 +145,26 @@ impl Error {
     /// Returns the error code, if one was set.
     pub fn error_code(&self) -> Option<&str> {
         self.error_code
+    }
+
+    /// Tag an existing error with a translation key (builder-style).
+    ///
+    /// Unlike [`Error::localized`], this preserves the current `message` — use
+    /// it when you already have a descriptive fallback string and want to add a
+    /// translation key alongside it. The
+    /// [`default_error_handler`](crate::middleware::default_error_handler) will
+    /// prefer the translated value whenever a
+    /// [`Translator`](crate::i18n::Translator) is available in the request
+    /// extensions, and otherwise keep the stored `message` untouched.
+    pub fn with_locale_key(mut self, key: &'static str) -> Self {
+        self.locale_key = Some(key);
+        self
+    }
+
+    /// Returns the translation key, if one was set via [`Error::localized`] or
+    /// [`Error::with_locale_key`].
+    pub fn locale_key(&self) -> Option<&'static str> {
+        self.locale_key
     }
 
     /// Downcast the source error to a concrete type.
@@ -186,6 +239,7 @@ impl Error {
             message: format!("SSE subscriber lagged, skipped {skipped} messages"),
             source: None,
             error_code: None,
+            locale_key: None,
             details: None,
             lagged: true,
         }
@@ -199,7 +253,8 @@ impl Error {
 
 /// Clones the error, dropping the `source` field (which is not `Clone`).
 ///
-/// All other fields — `status`, `message`, `error_code`, `details`, and `lagged` — are preserved.
+/// All other fields — `status`, `message`, `error_code`, `locale_key`, `details`, and
+/// `lagged` — are preserved.
 impl Clone for Error {
     fn clone(&self) -> Self {
         Self {
@@ -207,6 +262,7 @@ impl Clone for Error {
             message: self.message.clone(),
             source: None, // source (Box<dyn Error>) can't be cloned
             error_code: self.error_code,
+            locale_key: self.locale_key,
             details: self.details.clone(),
             lagged: self.lagged,
         }
@@ -226,6 +282,7 @@ impl fmt::Debug for Error {
             .field("message", &self.message)
             .field("source", &self.source)
             .field("error_code", &self.error_code)
+            .field("locale_key", &self.locale_key)
             .field("details", &self.details)
             .field("lagged", &self.lagged)
             .finish()
@@ -274,6 +331,7 @@ impl IntoResponse for Error {
             message,
             source: None, // source can't be cloned
             error_code: self.error_code,
+            locale_key: self.locale_key,
             details,
             lagged: self.lagged,
         };
@@ -387,5 +445,45 @@ mod tests {
         let err = Error::gateway_timeout("timed out");
         assert_eq!(err.status(), StatusCode::GATEWAY_TIMEOUT);
         assert_eq!(err.message(), "timed out");
+    }
+
+    #[test]
+    fn localized_sets_key_and_falls_back_to_key_as_message() {
+        let err = Error::localized(StatusCode::NOT_FOUND, "errors.user.not_found");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.locale_key(), Some("errors.user.not_found"));
+        // Fallback message equals the key itself so responses remain predictable
+        // when no error-handler middleware / Translator is installed.
+        assert_eq!(err.message(), "errors.user.not_found");
+        assert!(err.error_code().is_none());
+        assert!(err.details().is_none());
+    }
+
+    #[test]
+    fn with_locale_key_tags_existing_error() {
+        let err = Error::bad_request("boom").with_locale_key("errors.validation.generic");
+        // Builder must preserve the existing message, only attach the key.
+        assert_eq!(err.message(), "boom");
+        assert_eq!(err.locale_key(), Some("errors.validation.generic"));
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn clone_preserves_locale_key() {
+        let err = Error::localized(StatusCode::CONFLICT, "errors.email.in_use");
+        let cloned = err.clone();
+        assert_eq!(cloned.locale_key(), Some("errors.email.in_use"));
+        assert_eq!(cloned.status(), StatusCode::CONFLICT);
+        assert_eq!(cloned.message(), "errors.email.in_use");
+    }
+
+    #[test]
+    fn response_extensions_clone_preserves_locale_key() {
+        use axum::response::IntoResponse;
+        let err = Error::localized(StatusCode::UNAUTHORIZED, "errors.auth.expired");
+        let response = err.into_response();
+        let ext_err = response.extensions().get::<Error>().unwrap();
+        assert_eq!(ext_err.locale_key(), Some("errors.auth.expired"));
+        assert_eq!(ext_err.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/src/error/core.rs
+++ b/src/error/core.rs
@@ -94,6 +94,21 @@ impl Error {
     /// chain [`with_code`](Error::with_code),
     /// [`with_details`](Error::with_details), or [`chain`](Error::chain)
     /// afterwards if needed.
+    ///
+    /// # Kwargs and logging
+    ///
+    /// Translation kwargs (`{count}`, `{name}`, etc.) are not yet supported at
+    /// the `Error` level — the default handler calls `tr.t(key, &[])` with no
+    /// arguments. When you need interpolation, attach a descriptive fallback
+    /// message via [`Error::with_locale_key`] and run translation (with kwargs)
+    /// inside a custom handler passed to
+    /// [`error_handler`](crate::middleware::error_handler).
+    ///
+    /// Also note that [`Debug`] and [`Display`] print the raw key (because the
+    /// fallback message _is_ the key), which makes structured logs look like
+    /// `errors.user.not_found` rather than human text. Prefer
+    /// [`Error::with_locale_key`] when you want log-friendly output alongside
+    /// the translation tag.
     pub fn localized(status: StatusCode, key: &'static str) -> Self {
         Self {
             status,
@@ -137,13 +152,17 @@ impl Error {
     ///
     /// The error code is included in the copy stored in response extensions and can be retrieved
     /// after `into_response()` via [`Error::error_code`].
+    ///
+    /// This is a builder method: the existing `message`, `status`, `locale_key`,
+    /// `details`, and `source` fields are preserved — only `error_code` is
+    /// replaced.
     pub fn with_code(mut self, code: &'static str) -> Self {
         self.error_code = Some(code);
         self
     }
 
     /// Returns the error code, if one was set.
-    pub fn error_code(&self) -> Option<&str> {
+    pub fn error_code(&self) -> Option<&'static str> {
         self.error_code
     }
 
@@ -156,6 +175,10 @@ impl Error {
     /// prefer the translated value whenever a
     /// [`Translator`](crate::i18n::Translator) is available in the request
     /// extensions, and otherwise keep the stored `message` untouched.
+    ///
+    /// This is a builder method: the existing `message`, `status`, `error_code`,
+    /// `details`, and `source` fields are preserved — only `locale_key` is
+    /// replaced.
     pub fn with_locale_key(mut self, key: &'static str) -> Self {
         self.locale_key = Some(key);
         self
@@ -297,6 +320,29 @@ impl std::error::Error for Error {
     }
 }
 
+/// Builds the JSON body shared by [`Error::into_response`] and
+/// [`default_error_handler`](crate::middleware::default_error_handler).
+///
+/// Produces `{"error": {"status", "message"}}`, with a nested
+/// `"details"` key only when `details` is `Some`. Keeping this in one place
+/// ensures the two code paths stay byte-identical.
+pub(crate) fn render_error_body(
+    status: StatusCode,
+    message: &str,
+    details: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "error": {
+            "status": status.as_u16(),
+            "message": message,
+        }
+    });
+    if let Some(d) = details {
+        body["error"]["details"] = d.clone();
+    }
+    body
+}
+
 /// Converts `Error` into an axum [`Response`].
 ///
 /// Produces a JSON body of the form:
@@ -315,15 +361,7 @@ impl IntoResponse for Error {
         let message = self.message.clone();
         let details = self.details.clone();
 
-        let mut body = serde_json::json!({
-            "error": {
-                "status": status.as_u16(),
-                "message": &message
-            }
-        });
-        if let Some(ref d) = details {
-            body["error"]["details"] = d.clone();
-        }
+        let body = render_error_body(status, &message, details.as_ref());
 
         // Store a copy in extensions so error_handler middleware can read it
         let ext_error = Error {
@@ -485,5 +523,35 @@ mod tests {
         let ext_err = response.extensions().get::<Error>().unwrap();
         assert_eq!(ext_err.locale_key(), Some("errors.auth.expired"));
         assert_eq!(ext_err.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn render_error_body_without_details() {
+        let body = render_error_body(StatusCode::NOT_FOUND, "user not found", None);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "error": {
+                    "status": 404,
+                    "message": "user not found",
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn render_error_body_with_details() {
+        let details = serde_json::json!({"field": "email"});
+        let body = render_error_body(StatusCode::UNPROCESSABLE_ENTITY, "invalid", Some(&details));
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "error": {
+                    "status": 422,
+                    "message": "invalid",
+                    "details": {"field": "email"},
+                }
+            })
+        );
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -47,5 +47,6 @@ mod convert;
 mod core;
 mod http_error;
 
+pub(crate) use core::render_error_body;
 pub use core::{Error, Result};
 pub use http_error::HttpError;

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -19,6 +19,7 @@ pub use crate::auth::session::Session;
 pub use crate::auth::session::jwt::{Bearer, Claims};
 
 pub use crate::flash::Flash;
+pub use crate::i18n::Translator;
 pub use crate::ip::{ClientInfo, ClientIp};
 pub use crate::service::AppState;
 pub use crate::sse::LastEventId;

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -106,11 +106,16 @@ chain continues.
 
 ## YAML config
 
+`I18nConfig` lives under the top-level `i18n:` key and is exposed on
+`modo::Config` as `config.i18n`. End-apps build the shared handle with
+`modo::i18n::I18n::new(&config.i18n)`.
+
 ```yaml
-locales_path: "locales"       # directory of locale subdirectories
-default_locale: "en"          # fallback when no resolver matches
-locale_cookie: "lang"         # cookie name read by CookieResolver
-locale_query_param: "lang"    # query param read by QueryParamResolver
+i18n:
+  locales_path: "locales"       # directory of locale subdirectories
+  default_locale: "en"          # fallback when no resolver matches
+  locale_cookie: "lang"         # cookie name read by CookieResolver
+  locale_query_param: "lang"    # query param read by QueryParamResolver
 ```
 
 All fields are optional and fall back to the defaults shown above.

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -1,0 +1,205 @@
+# modo::i18n
+
+Internationalization primitives for the modo web framework.
+
+Loads YAML translation files from disk, resolves the active locale from the
+request through a pluggable chain (query param, cookie, session,
+`Accept-Language`), exposes a `Translator` axum extractor for handlers, and
+powers the MiniJinja `t()` function used by `modo::template`.
+
+## Key types
+
+| Type / Trait             | Purpose                                                                     |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `I18n`                   | Factory that owns the store, resolver chain, and default locale             |
+| `I18nConfig`             | Configuration for locales path, default locale, cookie/query-param names   |
+| `I18nLayer`              | Tower middleware that resolves the locale and injects a `Translator`        |
+| `Translator`             | Axum extractor with `t(key, kwargs)` / `t_plural(key, count, kwargs)`        |
+| `TranslationStore`       | Cheap `Arc`-wrapped store; cloneable across threads                         |
+| `LocaleResolver` (trait) | Pluggable interface for per-request locale detection                        |
+| `QueryParamResolver`     | Resolves locale from a URL query parameter                                  |
+| `CookieResolver`         | Resolves locale from a cookie                                               |
+| `SessionResolver`        | Resolves locale from the current session                                    |
+| `AcceptLanguageResolver` | Resolves locale from the `Accept-Language` header                           |
+| `make_t_function`        | Builds a MiniJinja-compatible `t()` function from a `TranslationStore`       |
+
+## Three ways to translate
+
+### 1. Inside an axum handler — `Translator` extractor
+
+```rust,no_run
+use modo::i18n::Translator;
+
+async fn greet(t: Translator) -> String {
+    t.t("common.greeting", &[("name", "World")])
+}
+```
+
+The `I18nLayer` must be installed on the router — otherwise extraction returns
+`Error::internal("I18nLayer not installed")` and the handler gets a 500.
+
+### 2. Outside a request — `I18n::translator`
+
+```rust,no_run
+use modo::i18n::{I18n, I18nConfig};
+
+# fn example() -> modo::Result<()> {
+let i18n = I18n::new(&I18nConfig::default())?;
+let t = i18n.translator("uk");
+let msg = t.t_plural("items.count", 5, &[]);
+# let _ = msg;
+# Ok(())
+# }
+```
+
+Useful in background jobs, CLI commands, and tests, where there is no incoming
+request to resolve the locale from.
+
+### 3. Inside MiniJinja templates — `t()` function
+
+`modo::template::Engine` wires up a `t()` function through
+`make_t_function(store)`. Templates call it directly:
+
+```jinja
+{{ t("common.greeting", name="World") }}
+{{ t("items.count", count=5) }}
+```
+
+The function reads the `locale` variable from the template context; it falls
+back to the store's default locale when no locale is set.
+
+## Wiring
+
+```rust,no_run
+use modo::i18n::{I18n, I18nConfig};
+
+# fn example() -> modo::Result<()> {
+let i18n = I18n::new(&I18nConfig::default())?;
+let router: axum::Router = axum::Router::new()
+    // ... routes ...
+    .layer(i18n.layer());
+# let _ = router;
+# Ok(())
+# }
+```
+
+`I18n::new` loads translations from `config.locales_path`. If the directory
+does not exist the store is initialised empty (useful in scaffolds / tests);
+only an unreadable directory or malformed YAML surfaces as an error.
+
+## Locale resolution chain
+
+By default the chain runs in order:
+
+1. `QueryParamResolver` — `?lang=...`
+2. `CookieResolver` — `Cookie: lang=...`
+3. `SessionResolver` — `session.data["locale"]`
+4. `AcceptLanguageResolver` — `Accept-Language` header
+
+Each resolver is constrained to locales discovered on disk. The first
+resolver that returns `Some` wins; if all return `None`, the request falls back
+to `I18nConfig::default_locale`.
+
+`SessionResolver` needs [`auth::session::SessionLayer`](../auth/session/)
+installed earlier in the stack; without it the resolver returns `None` and the
+chain continues.
+
+## YAML config
+
+```yaml
+locales_path: "locales"       # directory of locale subdirectories
+default_locale: "en"          # fallback when no resolver matches
+locale_cookie: "lang"         # cookie name read by CookieResolver
+locale_query_param: "lang"    # query param read by QueryParamResolver
+```
+
+All fields are optional and fall back to the defaults shown above.
+
+## Translation files
+
+```
+locales/
+├── en/
+│   ├── common.yaml
+│   └── auth.yaml
+└── uk/
+    ├── common.yaml
+    └── auth.yaml
+```
+
+Each subdirectory is a locale. YAML/YML files inside become namespaces — the
+file's basename is used as the key prefix. Nested keys are flattened with `.`
+separators.
+
+```yaml
+# locales/en/common.yaml
+greeting: "Hello, {name}!"
+auth:
+  login: "Log in"
+  logout: "Log out"
+```
+
+Gives keys `common.greeting`, `common.auth.login`, `common.auth.logout`.
+
+## Plural rules
+
+A mapping with an `other` key (plus any subset of `zero`, `one`, `two`, `few`,
+`many`) is treated as a plural entry:
+
+```yaml
+# locales/en/items.yaml
+count:
+    one: "{count} item"
+    other: "{count} items"
+```
+
+Plural category selection uses [`intl_pluralrules`](https://docs.rs/intl-pluralrules)
+and covers CLDR categories. Missing categories fall back to `other`. The
+`count` argument is automatically available as the `{count}` placeholder.
+
+```rust,no_run
+# use modo::i18n::Translator;
+# fn example(t: &Translator) {
+t.t_plural("items.count", 1, &[]);   // "1 item"
+t.t_plural("items.count", 5, &[]);   // "5 items"
+# }
+```
+
+Ukrainian (and other Slavic languages) cover `one`, `few`, `many`, `other`:
+
+```yaml
+# locales/uk/items.yaml
+count:
+    one: "{count} елемент"
+    few: "{count} елементи"
+    many: "{count} елементів"
+    other: "{count} елементів"
+```
+
+## Placeholder syntax
+
+Placeholders use `{name}` syntax. Unmatched placeholders are left in place so
+missing kwargs are easy to spot in output:
+
+```rust,no_run
+# use modo::i18n::Translator;
+# fn example(t: &Translator) {
+// "welcome: Hello, {name}!"  →  "Hello, World!"
+t.t("welcome", &[("name", "World")]);
+
+// "welcome: Hello, {name}!"  →  "Hello, {name}!"
+t.t("welcome", &[]);
+# }
+```
+
+Placeholders do not support type coercion — all values go in as `&str`. For
+non-string values, format them before passing in.
+
+## Fallback behaviour
+
+1. Look up the key in the requested locale.
+2. Fall back to the default locale.
+3. Fall back to the key itself.
+
+`Translator::t` and `Translator::t_plural` never panic — failures in the
+underlying store return the key unchanged.

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -87,6 +87,26 @@ let router: axum::Router = axum::Router::new()
 does not exist the store is initialised empty (useful in scaffolds / tests);
 only an unreadable directory or malformed YAML surfaces as an error.
 
+### Layer ordering with `error_handler`
+
+When combining `I18nLayer` with
+[`modo::middleware::error_handler`](../middleware/error_handler.rs) (e.g. for
+translating `Error::localized(...)` messages in error responses), install
+`I18nLayer` **outside** `error_handler` so the `Translator` is inserted into
+request extensions *before* `error_handler` clones the request parts:
+
+```rust,ignore
+let router = axum::Router::new()
+    // routes ...
+    .layer(modo::middleware::error_handler(
+        modo::middleware::default_error_handler,
+    ))          // inner
+    .layer(i18n.layer()); // outer — must run before error_handler
+```
+
+Reversing the order silently falls back to the raw translation key because
+`error_handler`'s cloned parts never see the `Translator`.
+
 ## Locale resolution chain
 
 By default the chain runs in order:

--- a/src/i18n/config.rs
+++ b/src/i18n/config.rs
@@ -1,0 +1,80 @@
+use serde::Deserialize;
+
+/// Configuration for the i18n module.
+///
+/// All fields have sensible defaults and can be overridden via YAML config.
+/// Paths are relative to the working directory of the running process.
+///
+/// # Defaults
+///
+/// | Field                | Default     |
+/// |----------------------|-------------|
+/// | `locales_path`       | `"locales"` |
+/// | `default_locale`     | `"en"`      |
+/// | `locale_cookie`      | `"lang"`    |
+/// | `locale_query_param` | `"lang"`    |
+#[non_exhaustive]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct I18nConfig {
+    /// Directory that contains locale subdirectories with YAML translation files.
+    pub locales_path: String,
+    /// BCP 47 language tag used when no locale can be resolved from the request.
+    pub default_locale: String,
+    /// Cookie name read by [`CookieResolver`](super::CookieResolver) to determine the active locale.
+    pub locale_cookie: String,
+    /// Query-string parameter name read by [`QueryParamResolver`](super::QueryParamResolver).
+    pub locale_query_param: String,
+}
+
+impl Default for I18nConfig {
+    fn default() -> Self {
+        Self {
+            locales_path: "locales".into(),
+            default_locale: "en".into(),
+            locale_cookie: "lang".into(),
+            locale_query_param: "lang".into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_sensible_values() {
+        let config = I18nConfig::default();
+        assert_eq!(config.locales_path, "locales");
+        assert_eq!(config.default_locale, "en");
+        assert_eq!(config.locale_cookie, "lang");
+        assert_eq!(config.locale_query_param, "lang");
+    }
+
+    #[test]
+    fn config_deserializes_from_yaml() {
+        let yaml = r#"
+            locales_path: "i18n"
+            default_locale: "uk"
+            locale_cookie: "locale"
+            locale_query_param: "locale"
+        "#;
+        let config: I18nConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.locales_path, "i18n");
+        assert_eq!(config.default_locale, "uk");
+        assert_eq!(config.locale_cookie, "locale");
+        assert_eq!(config.locale_query_param, "locale");
+    }
+
+    #[test]
+    fn config_uses_defaults_for_missing_fields() {
+        let yaml = r#"
+            default_locale: "uk"
+        "#;
+        let config: I18nConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.default_locale, "uk");
+        assert_eq!(config.locales_path, "locales");
+        assert_eq!(config.locale_cookie, "lang");
+        assert_eq!(config.locale_query_param, "lang");
+    }
+}

--- a/src/i18n/extractor.rs
+++ b/src/i18n/extractor.rs
@@ -63,7 +63,9 @@ impl<S: Send + Sync> FromRequestParts<S> for Translator {
             .extensions
             .get::<Translator>()
             .cloned()
-            .ok_or_else(|| crate::Error::internal("I18nLayer not installed"))
+            .ok_or_else(|| {
+                crate::Error::internal("I18nLayer not installed").with_code("i18n:layer_missing")
+            })
     }
 }
 

--- a/src/i18n/extractor.rs
+++ b/src/i18n/extractor.rs
@@ -1,0 +1,121 @@
+use axum::extract::FromRequestParts;
+use http::request::Parts;
+
+use super::store::TranslationStore;
+
+/// Per-request translator handle.
+///
+/// Holds the resolved request locale and a handle to the shared
+/// [`TranslationStore`]. Produced by [`I18nLayer`](super::I18nLayer) and
+/// extracted by handlers through the axum extractor impl below, or built
+/// directly via [`I18n::translator`](super::I18n::translator) for non-request
+/// contexts.
+///
+/// Cheaply cloneable — `TranslationStore` is an `Arc` internally and `locale`
+/// is a short `String`.
+#[derive(Clone, Debug)]
+pub struct Translator {
+    locale: String,
+    store: TranslationStore,
+}
+
+impl Translator {
+    /// Constructs a new translator for `locale` backed by `store`.
+    pub(super) fn new(locale: String, store: TranslationStore) -> Self {
+        Self { locale, store }
+    }
+
+    /// Translates `key`, interpolating any `{placeholder}` values from `kwargs`.
+    ///
+    /// Falls back to the default locale and then to the key itself if no entry
+    /// is found. Never panics.
+    pub fn t(&self, key: &str, kwargs: &[(&str, &str)]) -> String {
+        self.store
+            .translate(&self.locale, key, kwargs)
+            .unwrap_or_else(|_| key.to_string())
+    }
+
+    /// Translates `key` with plural-rule selection based on `count`.
+    ///
+    /// `count` is also injected into `kwargs` under the name `count`.
+    pub fn t_plural(&self, key: &str, count: i64, kwargs: &[(&str, &str)]) -> String {
+        self.store
+            .translate_plural(&self.locale, key, count, kwargs)
+            .unwrap_or_else(|_| key.to_string())
+    }
+
+    /// Returns the resolved locale for this request.
+    pub fn locale(&self) -> &str {
+        &self.locale
+    }
+
+    /// Returns the shared [`TranslationStore`] this translator reads from.
+    pub fn store(&self) -> &TranslationStore {
+        &self.store
+    }
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for Translator {
+    type Rejection = crate::Error;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<Translator>()
+            .cloned()
+            .ok_or_else(|| crate::Error::internal("I18nLayer not installed"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::i18n::config::I18nConfig;
+    use crate::i18n::factory::I18n;
+    use axum::extract::FromRequestParts;
+    use http::{Request, StatusCode};
+
+    fn test_i18n() -> I18n {
+        let dir = tempfile::tempdir().unwrap();
+        let en_dir = dir.path().join("en");
+        std::fs::create_dir_all(&en_dir).unwrap();
+        std::fs::write(en_dir.join("common.yaml"), "greeting: Hello").unwrap();
+
+        let config = I18nConfig {
+            locales_path: dir.path().to_str().unwrap().to_string(),
+            default_locale: "en".into(),
+            ..I18nConfig::default()
+        };
+        I18n::new(&config).unwrap()
+    }
+
+    #[tokio::test]
+    async fn missing_extension_returns_internal_error() {
+        let req = Request::builder().body(()).unwrap();
+        let (mut parts, _) = req.into_parts();
+        let err = Translator::from_request_parts(&mut parts, &())
+            .await
+            .expect_err("should return Err when extension missing");
+        // Error::internal maps to 500.
+        let resp = axum::response::IntoResponse::into_response(err);
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn present_extension_returns_translator() {
+        let i18n = test_i18n();
+        let translator = i18n.translator("en");
+
+        let req = Request::builder().body(()).unwrap();
+        let (mut parts, _) = req.into_parts();
+        parts.extensions.insert(translator);
+
+        let extracted = Translator::from_request_parts(&mut parts, &())
+            .await
+            .expect("extraction should succeed");
+
+        assert_eq!(extracted.locale(), "en");
+        assert_eq!(extracted.t("common.greeting", &[]), "Hello");
+        assert_eq!(extracted.store().default_locale(), "en");
+    }
+}

--- a/src/i18n/factory.rs
+++ b/src/i18n/factory.rs
@@ -9,7 +9,7 @@ use super::store::TranslationStore;
 
 struct I18nInner {
     store: TranslationStore,
-    chain: Vec<Arc<dyn LocaleResolver>>,
+    chain: Arc<[Arc<dyn LocaleResolver>]>,
     default_locale: String,
 }
 
@@ -45,7 +45,8 @@ impl I18n {
         };
 
         let available_locales = store.available_locales();
-        let chain = locale::default_chain(config, &available_locales);
+        let chain: Arc<[Arc<dyn LocaleResolver>]> =
+            locale::default_chain(config, &available_locales).into();
 
         Ok(Self {
             inner: Arc::new(I18nInner {
@@ -60,7 +61,7 @@ impl I18n {
     /// [`Translator`] into the request extensions.
     pub fn layer(&self) -> I18nLayer {
         I18nLayer::new(
-            self.inner.chain.clone(),
+            Arc::clone(&self.inner.chain),
             self.inner.store.clone(),
             self.inner.default_locale.clone(),
         )

--- a/src/i18n/factory.rs
+++ b/src/i18n/factory.rs
@@ -1,0 +1,149 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use super::config::I18nConfig;
+use super::extractor::Translator;
+use super::layer::I18nLayer;
+use super::locale::{self, LocaleResolver};
+use super::store::TranslationStore;
+
+struct I18nInner {
+    store: TranslationStore,
+    chain: Vec<Arc<dyn LocaleResolver>>,
+    default_locale: String,
+}
+
+/// Top-level i18n factory.
+///
+/// `I18n` owns the loaded [`TranslationStore`], the built locale-resolver chain,
+/// and the configured default locale. It hands out a cheap Tower [`I18nLayer`]
+/// for per-request locale resolution, and [`Translator`] instances for use
+/// outside the request lifecycle (jobs, CLI commands, tests).
+///
+/// `I18n` is cheaply cloneable — it wraps an `Arc` internally.
+pub struct I18n {
+    inner: Arc<I18nInner>,
+}
+
+impl I18n {
+    /// Builds an [`I18n`] from an [`I18nConfig`].
+    ///
+    /// Loads translations from `config.locales_path`. If the directory does not
+    /// exist, the store is initialised empty and only the default locale is
+    /// available; translations fall back to the key itself.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`](crate::Error) if the locales directory exists but is
+    /// unreadable, or a locale YAML file cannot be parsed.
+    pub fn new(config: &I18nConfig) -> crate::Result<Self> {
+        let locales_path = Path::new(&config.locales_path);
+        let store = if locales_path.exists() {
+            TranslationStore::load(locales_path, &config.default_locale)?
+        } else {
+            TranslationStore::empty(&config.default_locale)
+        };
+
+        let available_locales = store.available_locales();
+        let chain = locale::default_chain(config, &available_locales);
+
+        Ok(Self {
+            inner: Arc::new(I18nInner {
+                store,
+                chain,
+                default_locale: config.default_locale.clone(),
+            }),
+        })
+    }
+
+    /// Returns a new Tower layer that resolves the request locale and injects a
+    /// [`Translator`] into the request extensions.
+    pub fn layer(&self) -> I18nLayer {
+        I18nLayer::new(
+            self.inner.chain.clone(),
+            self.inner.store.clone(),
+            self.inner.default_locale.clone(),
+        )
+    }
+
+    /// Returns a [`Translator`] for the given `locale`.
+    ///
+    /// Useful for non-request contexts (background jobs, CLI, tests) where there
+    /// is no request to resolve the locale from.
+    pub fn translator(&self, locale: &str) -> Translator {
+        Translator::new(locale.to_string(), self.inner.store.clone())
+    }
+
+    /// Returns the shared [`TranslationStore`].
+    pub fn store(&self) -> &TranslationStore {
+        &self.inner.store
+    }
+
+    /// Returns the configured default locale.
+    pub fn default_locale(&self) -> &str {
+        &self.inner.default_locale
+    }
+}
+
+impl Clone for I18n {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_without_locales_directory_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = I18nConfig {
+            locales_path: dir.path().join("nonexistent").to_str().unwrap().to_string(),
+            default_locale: "en".into(),
+            ..I18nConfig::default()
+        };
+
+        let i18n = I18n::new(&config).expect("should build empty I18n");
+        assert_eq!(i18n.default_locale(), "en");
+        assert!(i18n.store().available_locales().is_empty());
+        // Translations fall back to the key itself when nothing is loaded.
+        let t = i18n.translator("en");
+        assert_eq!(t.t("missing.key", &[]), "missing.key");
+    }
+
+    #[test]
+    fn new_loads_translations_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let en_dir = dir.path().join("en");
+        std::fs::create_dir_all(&en_dir).unwrap();
+        std::fs::write(en_dir.join("common.yaml"), "greeting: Hello").unwrap();
+
+        let config = I18nConfig {
+            locales_path: dir.path().to_str().unwrap().to_string(),
+            default_locale: "en".into(),
+            ..I18nConfig::default()
+        };
+
+        let i18n = I18n::new(&config).unwrap();
+        let t = i18n.translator("en");
+        assert_eq!(t.t("common.greeting", &[]), "Hello");
+    }
+
+    #[test]
+    fn clone_is_cheap_arc_clone() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = I18nConfig {
+            locales_path: dir.path().to_str().unwrap().to_string(),
+            default_locale: "en".into(),
+            ..I18nConfig::default()
+        };
+
+        let a = I18n::new(&config).unwrap();
+        let b = a.clone();
+        // Same inner Arc.
+        assert!(Arc::ptr_eq(&a.inner, &b.inner));
+    }
+}

--- a/src/i18n/factory.rs
+++ b/src/i18n/factory.rs
@@ -21,6 +21,7 @@ struct I18nInner {
 /// outside the request lifecycle (jobs, CLI commands, tests).
 ///
 /// `I18n` is cheaply cloneable — it wraps an `Arc` internally.
+#[derive(Clone)]
 pub struct I18n {
     inner: Arc<I18nInner>,
 }
@@ -83,14 +84,6 @@ impl I18n {
     /// Returns the configured default locale.
     pub fn default_locale(&self) -> &str {
         &self.inner.default_locale
-    }
-}
-
-impl Clone for I18n {
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
     }
 }
 

--- a/src/i18n/layer.rs
+++ b/src/i18n/layer.rs
@@ -21,14 +21,14 @@ use super::store::TranslationStore;
 /// request extensions for handlers to extract.
 #[derive(Clone)]
 pub struct I18nLayer {
-    chain: Vec<Arc<dyn LocaleResolver>>,
+    chain: Arc<[Arc<dyn LocaleResolver>]>,
     store: TranslationStore,
     default_locale: String,
 }
 
 impl I18nLayer {
     pub(super) fn new(
-        chain: Vec<Arc<dyn LocaleResolver>>,
+        chain: Arc<[Arc<dyn LocaleResolver>]>,
         store: TranslationStore,
         default_locale: String,
     ) -> Self {
@@ -46,7 +46,7 @@ impl<S> Layer<S> for I18nLayer {
     fn layer(&self, inner: S) -> Self::Service {
         I18nMiddleware {
             inner,
-            chain: self.chain.clone(),
+            chain: Arc::clone(&self.chain),
             store: self.store.clone(),
             default_locale: self.default_locale.clone(),
         }
@@ -58,7 +58,7 @@ impl<S> Layer<S> for I18nLayer {
 /// Tower [`Service`] produced by [`I18nLayer`].
 pub struct I18nMiddleware<S> {
     inner: S,
-    chain: Vec<Arc<dyn LocaleResolver>>,
+    chain: Arc<[Arc<dyn LocaleResolver>]>,
     store: TranslationStore,
     default_locale: String,
 }
@@ -67,7 +67,7 @@ impl<S: Clone> Clone for I18nMiddleware<S> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            chain: self.chain.clone(),
+            chain: Arc::clone(&self.chain),
             store: self.store.clone(),
             default_locale: self.default_locale.clone(),
         }
@@ -90,7 +90,7 @@ where
     }
 
     fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
-        let chain = self.chain.clone();
+        let chain = Arc::clone(&self.chain);
         let store = self.store.clone();
         let default_locale = self.default_locale.clone();
         let mut inner = self.inner.clone();

--- a/src/i18n/layer.rs
+++ b/src/i18n/layer.rs
@@ -1,0 +1,179 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use http::{Request, Response};
+use tower::{Layer, Service};
+
+use super::extractor::Translator;
+use super::locale::{self, LocaleResolver};
+use super::store::TranslationStore;
+
+// --- Layer ---
+
+/// Tower middleware layer that injects a [`Translator`] into every request.
+///
+/// Obtain via [`I18n::layer`](super::I18n::layer). The layer runs the locale
+/// resolver chain against the request, falls back to the configured default
+/// locale if nothing matches, and inserts the resulting [`Translator`] into
+/// request extensions for handlers to extract.
+#[derive(Clone)]
+pub struct I18nLayer {
+    chain: Vec<Arc<dyn LocaleResolver>>,
+    store: TranslationStore,
+    default_locale: String,
+}
+
+impl I18nLayer {
+    pub(super) fn new(
+        chain: Vec<Arc<dyn LocaleResolver>>,
+        store: TranslationStore,
+        default_locale: String,
+    ) -> Self {
+        Self {
+            chain,
+            store,
+            default_locale,
+        }
+    }
+}
+
+impl<S> Layer<S> for I18nLayer {
+    type Service = I18nMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        I18nMiddleware {
+            inner,
+            chain: self.chain.clone(),
+            store: self.store.clone(),
+            default_locale: self.default_locale.clone(),
+        }
+    }
+}
+
+// --- Service ---
+
+/// Tower [`Service`] produced by [`I18nLayer`].
+pub struct I18nMiddleware<S> {
+    inner: S,
+    chain: Vec<Arc<dyn LocaleResolver>>,
+    store: TranslationStore,
+    default_locale: String,
+}
+
+impl<S: Clone> Clone for I18nMiddleware<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            chain: self.chain.clone(),
+            store: self.store.clone(),
+            default_locale: self.default_locale.clone(),
+        }
+    }
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for I18nMiddleware<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>> + Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let chain = self.chain.clone();
+        let store = self.store.clone();
+        let default_locale = self.default_locale.clone();
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut self.inner, &mut inner);
+
+        Box::pin(async move {
+            let (mut parts, body) = request.into_parts();
+
+            let resolved = locale::resolve_locale(&chain, &parts).unwrap_or(default_locale);
+            let translator = Translator::new(resolved, store);
+            parts.extensions.insert(translator);
+
+            let request = Request::from_parts(parts, body);
+            inner.call(request).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::i18n::config::I18nConfig;
+    use crate::i18n::factory::I18n;
+    use axum::{Router, routing::get};
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    fn test_i18n() -> (tempfile::TempDir, I18n) {
+        let dir = tempfile::tempdir().unwrap();
+        let en_dir = dir.path().join("en");
+        let uk_dir = dir.path().join("uk");
+        std::fs::create_dir_all(&en_dir).unwrap();
+        std::fs::create_dir_all(&uk_dir).unwrap();
+        std::fs::write(en_dir.join("common.yaml"), "greeting: Hello").unwrap();
+        std::fs::write(uk_dir.join("common.yaml"), "greeting: Привіт").unwrap();
+
+        let config = I18nConfig {
+            locales_path: dir.path().to_str().unwrap().to_string(),
+            default_locale: "en".into(),
+            ..I18nConfig::default()
+        };
+        let i18n = I18n::new(&config).unwrap();
+        (dir, i18n)
+    }
+
+    async fn read_locale(translator: Translator) -> (StatusCode, String) {
+        (StatusCode::OK, translator.locale().to_string())
+    }
+
+    async fn read_greeting(translator: Translator) -> (StatusCode, String) {
+        (StatusCode::OK, translator.t("common.greeting", &[]))
+    }
+
+    #[tokio::test]
+    async fn resolves_default_locale() {
+        let (_dir, i18n) = test_i18n();
+        let app = Router::new()
+            .route("/", get(read_locale))
+            .layer(i18n.layer());
+
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(body, "en");
+    }
+
+    #[tokio::test]
+    async fn resolves_locale_from_query() {
+        let (_dir, i18n) = test_i18n();
+        let app = Router::new()
+            .route("/", get(read_greeting))
+            .layer(i18n.layer());
+
+        let req = Request::builder()
+            .uri("/?lang=uk")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(body, "Привіт");
+    }
+}

--- a/src/i18n/locale.rs
+++ b/src/i18n/locale.rs
@@ -198,7 +198,7 @@ impl LocaleResolver for AcceptLanguageResolver {
 
 // --- Chain helpers ---
 
-pub(crate) fn default_chain(
+pub(super) fn default_chain(
     config: &I18nConfig,
     available_locales: &[String],
 ) -> Vec<Arc<dyn LocaleResolver>> {
@@ -222,7 +222,7 @@ pub(crate) fn default_chain(
     chain
 }
 
-pub(crate) fn resolve_locale(chain: &[Arc<dyn LocaleResolver>], parts: &Parts) -> Option<String> {
+pub(super) fn resolve_locale(chain: &[Arc<dyn LocaleResolver>], parts: &Parts) -> Option<String> {
     chain.iter().find_map(|r| r.resolve(parts))
 }
 

--- a/src/i18n/locale.rs
+++ b/src/i18n/locale.rs
@@ -8,6 +8,19 @@ use super::config::I18nConfig;
 /// Implementations are tried in order within the locale chain built by the
 /// i18n module. The first resolver that returns `Some` wins; if all resolvers
 /// return `None`, [`I18nConfig::default_locale`] is used.
+///
+/// # Empty-allowlist semantics
+///
+/// Built-in resolvers disagree on what an empty `available_locales` slice
+/// means, so pick the constructor inputs deliberately:
+///
+/// - [`QueryParamResolver`] and [`CookieResolver`] treat an empty allowlist as
+///   "accept any value" — whatever the caller supplied is returned verbatim.
+/// - [`AcceptLanguageResolver`] treats an empty allowlist as "match nothing"
+///   because it can only return locales that appear in the list.
+///
+/// [`default_chain`] hands every resolver the same `available_locales`, so
+/// the asymmetry only surfaces when wiring resolvers manually.
 pub trait LocaleResolver: Send + Sync {
     /// Returns a locale string (e.g. `"en"`, `"uk"`) if this resolver can determine
     /// the locale from the request, or `None` to fall through to the next resolver.
@@ -19,7 +32,9 @@ pub trait LocaleResolver: Send + Sync {
 /// Resolves the active locale from a URL query parameter.
 ///
 /// When `available_locales` is non-empty, only values present in that list are
-/// accepted. Pass an empty slice to accept any value.
+/// accepted. An empty slice means "accept any value" — the resolver returns
+/// whatever string the request carried. See [`LocaleResolver`] for how this
+/// differs from [`AcceptLanguageResolver`].
 pub struct QueryParamResolver {
     param_name: String,
     available_locales: Vec<String>,
@@ -59,7 +74,9 @@ impl LocaleResolver for QueryParamResolver {
 /// Resolves the active locale from a cookie.
 ///
 /// When `available_locales` is non-empty, only values present in that list are
-/// accepted.
+/// accepted. An empty slice means "accept any value" — the resolver returns
+/// whatever string the cookie carried. See [`LocaleResolver`] for how this
+/// differs from [`AcceptLanguageResolver`].
 pub struct CookieResolver {
     cookie_name: String,
     available_locales: Vec<String>,
@@ -128,7 +145,10 @@ impl LocaleResolver for SessionResolver {
 /// Resolves the active locale from the `Accept-Language` HTTP header.
 ///
 /// Parses quality values (`q=`), strips region subtags (`en-US` → `en`), and
-/// picks the highest-quality language that matches `available`.
+/// picks the highest-quality language that matches `available`. Unlike
+/// [`QueryParamResolver`] and [`CookieResolver`], an empty `available` list
+/// means "match nothing" — this resolver can only return values that appear
+/// in the list. See [`LocaleResolver`] for the full comparison.
 pub struct AcceptLanguageResolver {
     available: Vec<String>,
 }

--- a/src/i18n/locale.rs
+++ b/src/i18n/locale.rs
@@ -1,17 +1,13 @@
 use http::request::Parts;
 use std::sync::Arc;
 
-use super::config::TemplateConfig;
+use super::config::I18nConfig;
 
 /// Trait for extracting the active locale from a request.
 ///
-/// Implementations are tried in order within the locale chain built by
-/// [`EngineBuilder::locale_resolvers`](super::EngineBuilder::locale_resolvers).
-/// The first resolver that returns `Some` wins; if all resolvers return `None`,
-/// [`TemplateConfig::default_locale`] is used.
-///
-/// The resolved locale is stored in the request's [`TemplateContext`](super::TemplateContext)
-/// under the key `"locale"` and is available in every template as `{{ locale }}`.
+/// Implementations are tried in order within the locale chain built by the
+/// i18n module. The first resolver that returns `Some` wins; if all resolvers
+/// return `None`, [`I18nConfig::default_locale`] is used.
 pub trait LocaleResolver: Send + Sync {
     /// Returns a locale string (e.g. `"en"`, `"uk"`) if this resolver can determine
     /// the locale from the request, or `None` to fall through to the next resolver.
@@ -183,7 +179,7 @@ impl LocaleResolver for AcceptLanguageResolver {
 // --- Chain helpers ---
 
 pub(crate) fn default_chain(
-    config: &TemplateConfig,
+    config: &I18nConfig,
     available_locales: &[String],
 ) -> Vec<Arc<dyn LocaleResolver>> {
     let mut chain: Vec<Arc<dyn LocaleResolver>> = vec![
@@ -368,7 +364,7 @@ mod tests {
 
     #[test]
     fn default_chain_builds_all_resolvers() {
-        let config = TemplateConfig::default();
+        let config = I18nConfig::default();
         let available = vec!["en".into(), "uk".into()];
         let chain = default_chain(&config, &available);
         assert_eq!(chain.len(), 4);

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -24,12 +24,11 @@
 //! # }
 //! ```
 
-pub(crate) mod locale;
-
 mod config;
 mod extractor;
 mod factory;
 mod layer;
+mod locale;
 mod store;
 
 pub use config::I18nConfig;

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -1,0 +1,42 @@
+//! # modo::i18n
+//!
+//! Internationalization primitives for modo.
+//!
+//! Provides a [`TranslationStore`] loaded from YAML files on disk, a pluggable
+//! [`LocaleResolver`] chain, a Tower [`I18nLayer`] that injects a per-request
+//! [`Translator`] into request extensions, and an [`I18n`] factory that ties
+//! the pieces together.
+//!
+//! The same [`TranslationStore`] powers the MiniJinja `t()` function registered
+//! by [`modo::template`](crate::template) via
+//! [`make_t_function`](self::make_t_function).
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use modo::i18n::{I18n, I18nConfig};
+//!
+//! # fn example() -> modo::Result<()> {
+//! let i18n = I18n::new(&I18nConfig::default())?;
+//! let router: axum::Router = axum::Router::new().layer(i18n.layer());
+//! # let _ = router;
+//! # Ok(())
+//! # }
+//! ```
+
+pub(crate) mod locale;
+
+mod config;
+mod extractor;
+mod factory;
+mod layer;
+mod store;
+
+pub use config::I18nConfig;
+pub use extractor::Translator;
+pub use factory::I18n;
+pub use layer::I18nLayer;
+pub use locale::{
+    AcceptLanguageResolver, CookieResolver, LocaleResolver, QueryParamResolver, SessionResolver,
+};
+pub use store::{TranslationStore, make_t_function};

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -8,7 +8,7 @@
 //! the pieces together.
 //!
 //! The same [`TranslationStore`] powers the MiniJinja `t()` function registered
-//! by [`modo::template`](crate::template) via
+//! by [`crate::template`] via
 //! [`make_t_function`](self::make_t_function).
 //!
 //! ## Quick start

--- a/src/i18n/store.rs
+++ b/src/i18n/store.rs
@@ -114,13 +114,24 @@ impl TranslationStore {
         }
 
         let en: LanguageIdentifier = "en".parse().expect("en is a valid language tag");
-        let en_rules = PluralRules::create(en.clone(), PluralRuleType::CARDINAL)
+        let en_rules = PluralRules::create(en, PluralRuleType::CARDINAL)
             .expect("en plural rules creation cannot fail");
         let mut plural_rules = HashMap::new();
         for locale_str in translations.keys() {
-            let lang_id: LanguageIdentifier = locale_str.parse().unwrap_or_else(|_| en.clone());
-            let rules = PluralRules::create(lang_id, PluralRuleType::CARDINAL)
-                .unwrap_or_else(|_| en_rules.clone());
+            let Ok(lang_id) = locale_str.parse::<LanguageIdentifier>() else {
+                tracing::warn!(
+                    locale = %locale_str,
+                    "failed to parse locale as language identifier — plural rules will use English fallback"
+                );
+                continue;
+            };
+            let Ok(rules) = PluralRules::create(lang_id, PluralRuleType::CARDINAL) else {
+                tracing::warn!(
+                    locale = %locale_str,
+                    "failed to create plural rules for locale — plural rules will use English fallback"
+                );
+                continue;
+            };
             plural_rules.insert(locale_str.clone(), rules);
         }
 

--- a/src/i18n/store.rs
+++ b/src/i18n/store.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
 use intl_pluralrules::{PluralCategory, PluralRuleType, PluralRules};
 use unic_langid::LanguageIdentifier;
 
 #[derive(Debug, Clone)]
-pub(crate) enum Entry {
+pub(super) enum Entry {
     Plain(String),
     Plural {
         zero: Option<String>,
@@ -17,27 +18,73 @@ pub(crate) enum Entry {
     },
 }
 
-#[derive(Clone)]
-pub(crate) struct TranslationStore {
+struct Inner {
     translations: HashMap<String, HashMap<String, Entry>>,
     default_locale: String,
     plural_rules: HashMap<String, PluralRules>,
 }
 
+/// In-memory store of translation entries loaded from YAML files on disk.
+///
+/// Cheaply cloneable — wraps an `Arc` internally. Created by [`TranslationStore::load`].
+/// Used by the [`Translator`](super::Translator) extractor and the template
+/// engine's `t()` function (registered by
+/// [`make_t_function`](super::make_t_function)).
+#[derive(Clone)]
+pub struct TranslationStore {
+    inner: Arc<Inner>,
+}
+
 impl std::fmt::Debug for TranslationStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TranslationStore")
-            .field("translations", &self.translations)
-            .field("default_locale", &self.default_locale)
+            .field("translations", &self.inner.translations)
+            .field("default_locale", &self.inner.default_locale)
             .field(
                 "plural_rules",
-                &self.plural_rules.keys().collect::<Vec<_>>(),
+                &self.inner.plural_rules.keys().collect::<Vec<_>>(),
             )
             .finish()
     }
 }
 
 impl TranslationStore {
+    /// Creates an empty store with no translations loaded.
+    ///
+    /// Translations fall back to the key itself when nothing is loaded.
+    /// Plural rules are initialised with the default locale plus English.
+    pub(super) fn empty(default_locale: &str) -> Self {
+        let en: LanguageIdentifier = "en".parse().unwrap();
+        let en_rules = PluralRules::create(en.clone(), PluralRuleType::CARDINAL).unwrap();
+        let mut plural_rules = HashMap::new();
+        // Always register English rules as a fallback.
+        plural_rules.insert("en".to_string(), en_rules.clone());
+        // Also register rules for the configured default locale if different.
+        if default_locale != "en" {
+            let lang_id: LanguageIdentifier = default_locale.parse().unwrap_or_else(|_| en.clone());
+            let rules = PluralRules::create(lang_id, PluralRuleType::CARDINAL)
+                .unwrap_or_else(|_| en_rules.clone());
+            plural_rules.insert(default_locale.to_string(), rules);
+        }
+
+        Self {
+            inner: Arc::new(Inner {
+                translations: HashMap::new(),
+                default_locale: default_locale.to_string(),
+                plural_rules,
+            }),
+        }
+    }
+
+    /// Loads translations from the given directory.
+    ///
+    /// Each subdirectory of `path` is treated as a locale. YAML/YML files inside
+    /// become namespaces whose keys are flattened with `.` separators.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`](crate::Error) if the directory is unreadable or a YAML
+    /// file cannot be parsed.
     pub fn load(path: &Path, default_locale: &str) -> crate::Result<Self> {
         let mut translations: HashMap<String, HashMap<String, Entry>> = HashMap::new();
 
@@ -79,12 +126,19 @@ impl TranslationStore {
         }
 
         Ok(Self {
-            translations,
-            default_locale: default_locale.to_string(),
-            plural_rules,
+            inner: Arc::new(Inner {
+                translations,
+                default_locale: default_locale.to_string(),
+                plural_rules,
+            }),
         })
     }
 
+    /// Translates `key` for the given `locale`, interpolating any `{placeholder}`
+    /// values found in `kwargs`.
+    ///
+    /// Falls back to the default locale and finally to the key itself if no entry
+    /// is found.
     pub fn translate(
         &self,
         locale: &str,
@@ -97,8 +151,8 @@ impl TranslationStore {
         }
 
         // Fall back to default locale
-        if locale != self.default_locale
-            && let Some(entry) = self.lookup(&self.default_locale, key)
+        if locale != self.inner.default_locale
+            && let Some(entry) = self.lookup(&self.inner.default_locale, key)
         {
             return Ok(interpolate(entry_to_string(entry), kwargs));
         }
@@ -107,6 +161,9 @@ impl TranslationStore {
         Ok(key.to_string())
     }
 
+    /// Translates `key` with plural-rule selection based on `count`.
+    ///
+    /// `count` is also injected into `kwargs` under the name `count`.
     pub fn translate_plural(
         &self,
         locale: &str,
@@ -115,8 +172,8 @@ impl TranslationStore {
         kwargs: &[(&str, &str)],
     ) -> crate::Result<String> {
         let entry = self.lookup(locale, key).or_else(|| {
-            if locale != self.default_locale {
-                self.lookup(&self.default_locale, key)
+            if locale != self.inner.default_locale {
+                self.lookup(&self.inner.default_locale, key)
             } else {
                 None
             }
@@ -156,21 +213,23 @@ impl TranslationStore {
         Ok(interpolate(template, &all_kwargs))
     }
 
+    /// Returns the list of locales discovered on disk (unordered).
     pub fn available_locales(&self) -> Vec<String> {
-        self.translations.keys().cloned().collect()
+        self.inner.translations.keys().cloned().collect()
     }
 
+    /// Returns the configured default locale.
     pub fn default_locale(&self) -> &str {
-        &self.default_locale
+        &self.inner.default_locale
     }
 
     fn lookup(&self, locale: &str, key: &str) -> Option<&Entry> {
-        self.translations.get(locale)?.get(key)
+        self.inner.translations.get(locale)?.get(key)
     }
 
     fn plural_category(&self, locale: &str, count: i64) -> PluralCategory {
         let abs_count = count.unsigned_abs() as usize;
-        if let Some(rules) = self.plural_rules.get(locale) {
+        if let Some(rules) = self.inner.plural_rules.get(locale) {
             rules.select(abs_count).unwrap_or(PluralCategory::OTHER)
         } else {
             // Fallback to English rules for unknown locales
@@ -181,14 +240,14 @@ impl TranslationStore {
     }
 }
 
-fn entry_to_string(entry: &Entry) -> &str {
+pub(super) fn entry_to_string(entry: &Entry) -> &str {
     match entry {
         Entry::Plain(s) => s,
         Entry::Plural { other, .. } => other,
     }
 }
 
-pub(crate) fn interpolate(template: &str, kwargs: &[(&str, &str)]) -> String {
+pub(super) fn interpolate(template: &str, kwargs: &[(&str, &str)]) -> String {
     let mut result = String::with_capacity(template.len());
     let mut chars = template.chars().peekable();
 
@@ -227,7 +286,7 @@ pub(crate) fn interpolate(template: &str, kwargs: &[(&str, &str)]) -> String {
     result
 }
 
-fn load_locale_dir(locale_path: &Path) -> crate::Result<HashMap<String, Entry>> {
+pub(super) fn load_locale_dir(locale_path: &Path) -> crate::Result<HashMap<String, Entry>> {
     let mut entries = HashMap::new();
 
     let dir_entries = std::fs::read_dir(locale_path).map_err(|e| {
@@ -263,7 +322,11 @@ fn load_locale_dir(locale_path: &Path) -> crate::Result<HashMap<String, Entry>> 
     Ok(entries)
 }
 
-fn flatten_yaml(prefix: &str, value: &serde_yaml_ng::Value, entries: &mut HashMap<String, Entry>) {
+pub(super) fn flatten_yaml(
+    prefix: &str,
+    value: &serde_yaml_ng::Value,
+    entries: &mut HashMap<String, Entry>,
+) {
     match value {
         serde_yaml_ng::Value::Mapping(map) => {
             // Check if this is a plural entry (has "other" key)
@@ -322,7 +385,7 @@ fn get_str(map: &serde_yaml_ng::Mapping, key: &str) -> Option<String> {
 
 /// Creates a MiniJinja-compatible `t()` function that reads the `locale` variable
 /// from the template context and delegates to the `TranslationStore`.
-pub(crate) fn make_t_function(
+pub fn make_t_function(
     store: TranslationStore,
 ) -> impl Fn(
     &minijinja::State,

--- a/src/i18n/store.rs
+++ b/src/i18n/store.rs
@@ -51,27 +51,15 @@ impl std::fmt::Debug for TranslationStore {
 impl TranslationStore {
     /// Creates an empty store with no translations loaded.
     ///
-    /// Translations fall back to the key itself when nothing is loaded.
-    /// Plural rules are initialised with the default locale plus English.
+    /// Translations fall back to the key itself when nothing is loaded. Plural
+    /// rules are populated lazily as translations are loaded, so an empty
+    /// store holds no plural-rule entries.
     pub(super) fn empty(default_locale: &str) -> Self {
-        let en: LanguageIdentifier = "en".parse().unwrap();
-        let en_rules = PluralRules::create(en.clone(), PluralRuleType::CARDINAL).unwrap();
-        let mut plural_rules = HashMap::new();
-        // Always register English rules as a fallback.
-        plural_rules.insert("en".to_string(), en_rules.clone());
-        // Also register rules for the configured default locale if different.
-        if default_locale != "en" {
-            let lang_id: LanguageIdentifier = default_locale.parse().unwrap_or_else(|_| en.clone());
-            let rules = PluralRules::create(lang_id, PluralRuleType::CARDINAL)
-                .unwrap_or_else(|_| en_rules.clone());
-            plural_rules.insert(default_locale.to_string(), rules);
-        }
-
         Self {
             inner: Arc::new(Inner {
                 translations: HashMap::new(),
                 default_locale: default_locale.to_string(),
-                plural_rules,
+                plural_rules: HashMap::new(),
             }),
         }
     }

--- a/src/i18n/store.rs
+++ b/src/i18n/store.rs
@@ -22,6 +22,11 @@ struct Inner {
     translations: HashMap<String, HashMap<String, Entry>>,
     default_locale: String,
     plural_rules: HashMap<String, PluralRules>,
+    /// English cardinal plural rules used as a fallback when the requested
+    /// locale has no loaded entry in `plural_rules`. Built once during
+    /// construction so `translate_plural` for unknown locales does not
+    /// allocate a new `PluralRules` on every call.
+    fallback_plural_rules: PluralRules,
 }
 
 /// In-memory store of translation entries loaded from YAML files on disk.
@@ -55,11 +60,15 @@ impl TranslationStore {
     /// rules are populated lazily as translations are loaded, so an empty
     /// store holds no plural-rule entries.
     pub(super) fn empty(default_locale: &str) -> Self {
+        let en: LanguageIdentifier = "en".parse().expect("en is a valid language tag");
+        let fallback_plural_rules = PluralRules::create(en, PluralRuleType::CARDINAL)
+            .expect("en plural rules creation cannot fail");
         Self {
             inner: Arc::new(Inner {
                 translations: HashMap::new(),
                 default_locale: default_locale.to_string(),
                 plural_rules: HashMap::new(),
+                fallback_plural_rules,
             }),
         }
     }
@@ -92,19 +101,21 @@ impl TranslationStore {
                 continue;
             }
 
-            let locale = locale_path
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string();
+            let Some(locale) = locale_path.file_name().and_then(|n| n.to_str()) else {
+                tracing::warn!(
+                    path = %locale_path.display(),
+                    "skipping non-UTF-8 locale directory name"
+                );
+                continue;
+            };
 
             let locale_entries = load_locale_dir(&locale_path)?;
-            translations.insert(locale, locale_entries);
+            translations.insert(locale.to_string(), locale_entries);
         }
 
-        let en: LanguageIdentifier = "en".parse().unwrap();
-        let en_rules = PluralRules::create(en.clone(), PluralRuleType::CARDINAL).unwrap();
+        let en: LanguageIdentifier = "en".parse().expect("en is a valid language tag");
+        let en_rules = PluralRules::create(en.clone(), PluralRuleType::CARDINAL)
+            .expect("en plural rules creation cannot fail");
         let mut plural_rules = HashMap::new();
         for locale_str in translations.keys() {
             let lang_id: LanguageIdentifier = locale_str.parse().unwrap_or_else(|_| en.clone());
@@ -118,6 +129,7 @@ impl TranslationStore {
                 translations,
                 default_locale: default_locale.to_string(),
                 plural_rules,
+                fallback_plural_rules: en_rules,
             }),
         })
     }
@@ -152,6 +164,15 @@ impl TranslationStore {
     /// Translates `key` with plural-rule selection based on `count`.
     ///
     /// `count` is also injected into `kwargs` under the name `count`.
+    ///
+    /// # Cross-locale fallback
+    ///
+    /// When an entry is missing in the requested locale, the default locale's
+    /// entry is used. Plural rule selection still uses the **requesting**
+    /// locale's rules (e.g., Ukrainian `FEW` / `MANY` categories applied
+    /// against English `one` / `other` forms map to `other`). This keeps
+    /// grammatical selection consistent with the user's language even though
+    /// the fallback copy is authored for a different one.
     pub fn translate_plural(
         &self,
         locale: &str,
@@ -220,10 +241,11 @@ impl TranslationStore {
         if let Some(rules) = self.inner.plural_rules.get(locale) {
             rules.select(abs_count).unwrap_or(PluralCategory::OTHER)
         } else {
-            // Fallback to English rules for unknown locales
-            let en: LanguageIdentifier = "en".parse().unwrap();
-            let rules = PluralRules::create(en, PluralRuleType::CARDINAL).unwrap();
-            rules.select(abs_count).unwrap_or(PluralCategory::OTHER)
+            // Fallback to cached English rules for unknown locales.
+            self.inner
+                .fallback_plural_rules
+                .select(abs_count)
+                .unwrap_or(PluralCategory::OTHER)
         }
     }
 }
@@ -294,7 +316,14 @@ pub(super) fn load_locale_dir(locale_path: &Path) -> crate::Result<HashMap<Strin
             continue;
         }
 
-        let namespace = path.file_stem().unwrap().to_str().unwrap().to_string();
+        let Some(namespace) = path.file_stem().and_then(|n| n.to_str()) else {
+            tracing::warn!(
+                path = %path.display(),
+                "skipping non-UTF-8 translation file name"
+            );
+            continue;
+        };
+        let namespace = namespace.to_string();
 
         let content = std::fs::read_to_string(&path).map_err(|e| {
             crate::Error::internal(format!("Failed to read {}: {e}", path.display()))
@@ -349,7 +378,13 @@ pub(super) fn flatten_yaml(
         serde_yaml_ng::Value::String(s) => {
             entries.insert(prefix.to_string(), Entry::Plain(s.clone()));
         }
-        _ => {}
+        other => {
+            tracing::warn!(
+                key = %prefix,
+                ?other,
+                "translation value is not a string or mapping — ignored"
+            );
+        }
     }
 }
 
@@ -429,8 +464,12 @@ pub fn make_t_function(
             })?
         };
 
-        // Consume all kwargs to avoid "unexpected keyword argument" errors
-        kwargs.assert_all_used().ok();
+        // Consume all kwargs to avoid "unexpected keyword argument" errors.
+        // Surface unused kwargs via tracing so typos are visible during
+        // development without breaking template rendering.
+        if let Err(e) = kwargs.assert_all_used() {
+            tracing::warn!(key = %key, error = %e, "unused template kwargs in t() call");
+        }
 
         Ok(result)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@
 //!
 //! ```toml
 //! [dependencies]
-//! modo = { package = "modo-rs", version = "0.8" }
+//! modo = { package = "modo-rs", version = "0.9" }
 //!
 //! [dev-dependencies]
-//! modo = { package = "modo-rs", version = "0.8", features = ["test-helpers"] }
+//! modo = { package = "modo-rs", version = "0.9", features = ["test-helpers"] }
 //! ```
 //!
 //! Minimal application:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //!
 //! [`prelude`] bundles the extras a typical handler signature needs on top of
 //! those (`Error`, `Result`, `AppState`, `Session`, `Role`, `Flash`, `ClientIp`,
-//! `Tenant`, `TenantId`, and the `Validate` trio).
+//! `Tenant`, `TenantId`, `I18n`, `Translator`, and the `Validate` trio).
 //!
 //! ## Features
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub mod cron;
 pub mod job;
 
 pub mod email;
+pub mod i18n;
 pub mod qrcode;
 pub mod template;
 pub mod webhook;

--- a/src/middleware/error_handler.rs
+++ b/src/middleware/error_handler.rs
@@ -144,6 +144,11 @@ where
         // Clone parts before consuming the request so the error handler can
         // inspect method, URI, headers, etc.
         let (parts, body) = req.into_parts();
+        // NOTE: parts are cloned on every request so the handler callback can
+        // read headers / extensions on the error path. For 2xx responses this
+        // clone is unused — if this becomes a hot-path bottleneck, wrap parts
+        // in an Arc (copy-on-write) or redesign the handler to take only the
+        // extensions slice that default_error_handler actually reads.
         let saved_parts = parts.clone();
         let req = http::Request::from_parts(parts, body);
 

--- a/src/middleware/error_handler.rs
+++ b/src/middleware/error_handler.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use http::request::Parts;
 use tower::{Layer, Service};
 
@@ -38,6 +38,63 @@ where
     Fut: Future<Output = Response> + Send + 'static,
 {
     ErrorHandlerLayer { handler }
+}
+
+/// Default error responder suitable for passing directly to [`error_handler`].
+///
+/// Produces the same JSON shape as [`crate::Error::into_response`]:
+///
+/// ```json
+/// { "error": { "status": 404, "message": "..." } }
+/// ```
+///
+/// When the error carries a translation key (via
+/// [`Error::localized`](crate::Error::localized) or
+/// [`Error::with_locale_key`](crate::Error::with_locale_key)) **and** the
+/// request has a [`Translator`](crate::i18n::Translator) in its extensions
+/// (typically injected by [`I18nLayer`](crate::i18n::I18nLayer)), the key is
+/// resolved at response-build time and the translated string is used as the
+/// response `message`. Otherwise the error's stored `message` is used
+/// unchanged.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use axum::{Router, routing::get};
+/// use modo::middleware::{default_error_handler, error_handler};
+///
+/// let app: Router = Router::new()
+///     .route("/", get(|| async { "ok" }))
+///     .layer(error_handler(default_error_handler));
+/// ```
+pub fn default_error_handler(
+    err: crate::error::Error,
+    parts: Parts,
+) -> Pin<Box<dyn Future<Output = Response> + Send>> {
+    Box::pin(async move {
+        let status = err.status();
+        let details = err.details().cloned();
+
+        let message = match (
+            err.locale_key(),
+            parts.extensions.get::<crate::i18n::Translator>(),
+        ) {
+            (Some(key), Some(tr)) => tr.t(key, &[]),
+            _ => err.message().to_string(),
+        };
+
+        let mut body = serde_json::json!({
+            "error": {
+                "status": status.as_u16(),
+                "message": message,
+            }
+        });
+        if let Some(d) = details {
+            body["error"]["details"] = d;
+        }
+
+        (status, axum::Json(body)).into_response()
+    })
 }
 
 /// Tower [`Layer`] produced by [`error_handler`].
@@ -105,5 +162,142 @@ where
                 Ok(response)
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error as ModoError;
+    use crate::i18n::{I18n, I18nConfig};
+    use axum::body::Body;
+    use axum::{Router, routing::get};
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    fn test_i18n(dir: &std::path::Path) -> I18n {
+        let en_dir = dir.join("en");
+        let uk_dir = dir.join("uk");
+        std::fs::create_dir_all(&en_dir).unwrap();
+        std::fs::create_dir_all(&uk_dir).unwrap();
+        std::fs::write(
+            en_dir.join("errors.yaml"),
+            "user:\n  not_found: User not found\n",
+        )
+        .unwrap();
+        std::fs::write(
+            uk_dir.join("errors.yaml"),
+            "user:\n  not_found: Користувача не знайдено\n",
+        )
+        .unwrap();
+
+        let config = I18nConfig {
+            locales_path: dir.to_str().unwrap().to_string(),
+            default_locale: "en".into(),
+            ..I18nConfig::default()
+        };
+        I18n::new(&config).unwrap()
+    }
+
+    async fn decode_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn localized_handler() -> Result<&'static str, ModoError> {
+        Err(ModoError::localized(
+            StatusCode::NOT_FOUND,
+            "errors.user.not_found",
+        ))
+    }
+
+    async fn plain_handler() -> Result<&'static str, ModoError> {
+        Err(ModoError::bad_request("boom"))
+    }
+
+    #[tokio::test]
+    async fn default_handler_uses_translator_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let i18n = test_i18n(dir.path());
+
+        let app = Router::new()
+            .route("/", get(localized_handler))
+            .layer(error_handler(default_error_handler))
+            .layer(i18n.layer());
+
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let body = decode_json(resp).await;
+        assert_eq!(body["error"]["status"], 404);
+        assert_eq!(body["error"]["message"], "User not found");
+    }
+
+    #[tokio::test]
+    async fn default_handler_translates_using_resolved_locale() {
+        let dir = tempfile::tempdir().unwrap();
+        let i18n = test_i18n(dir.path());
+
+        let app = Router::new()
+            .route("/", get(localized_handler))
+            .layer(error_handler(default_error_handler))
+            .layer(i18n.layer());
+
+        let req = Request::builder()
+            .uri("/?lang=uk")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let body = decode_json(resp).await;
+        assert_eq!(body["error"]["message"], "Користувача не знайдено");
+    }
+
+    #[tokio::test]
+    async fn default_handler_falls_back_to_key_without_translator() {
+        // No I18nLayer is installed, so no Translator exists in the extensions.
+        let app = Router::new()
+            .route("/", get(localized_handler))
+            .layer(error_handler(default_error_handler));
+
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let body = decode_json(resp).await;
+        // Fallback is the raw translation key.
+        assert_eq!(body["error"]["message"], "errors.user.not_found");
+    }
+
+    #[tokio::test]
+    async fn default_handler_passes_through_plain_errors() {
+        // With a Translator installed.
+        let dir = tempfile::tempdir().unwrap();
+        let i18n = test_i18n(dir.path());
+
+        let app = Router::new()
+            .route("/", get(plain_handler))
+            .layer(error_handler(default_error_handler))
+            .layer(i18n.layer());
+
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = decode_json(resp).await;
+        assert_eq!(body["error"]["message"], "boom");
+
+        // And without one.
+        let app = Router::new()
+            .route("/", get(plain_handler))
+            .layer(error_handler(default_error_handler));
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = decode_json(resp).await;
+        assert_eq!(body["error"]["message"], "boom");
     }
 }

--- a/src/middleware/error_handler.rs
+++ b/src/middleware/error_handler.rs
@@ -59,15 +59,26 @@ where
 /// response `message`. Otherwise the error's stored `message` is used
 /// unchanged.
 ///
+/// # Layer ordering
+///
+/// When pairing with [`I18nLayer`](crate::i18n::I18nLayer), install `I18nLayer`
+/// **outside** [`error_handler`] (apply `i18n.layer()` *after* `error_handler`
+/// in `.layer(...)` calls) so the [`Translator`](crate::i18n::Translator) is
+/// inserted into the request extensions before `error_handler` clones the
+/// request parts. Reversed ordering silently falls back to the raw key.
+///
 /// # Example
 ///
 /// ```rust,no_run
 /// use axum::{Router, routing::get};
 /// use modo::middleware::{default_error_handler, error_handler};
 ///
+/// # fn wire(i18n: modo::i18n::I18n) {
 /// let app: Router = Router::new()
 ///     .route("/", get(|| async { "ok" }))
-///     .layer(error_handler(default_error_handler));
+///     .layer(error_handler(default_error_handler))
+///     .layer(i18n.layer());  // outer — must run before error_handler
+/// # }
 /// ```
 pub async fn default_error_handler(err: crate::error::Error, parts: Parts) -> Response {
     let status = err.status();

--- a/src/middleware/error_handler.rs
+++ b/src/middleware/error_handler.rs
@@ -6,6 +6,8 @@ use axum::response::{IntoResponse, Response};
 use http::request::Parts;
 use tower::{Layer, Service};
 
+use crate::error::render_error_body;
+
 /// Creates an error-handler layer that intercepts responses containing a
 /// [`crate::error::Error`] in their extensions and rewrites them through
 /// the supplied handler function.
@@ -67,34 +69,20 @@ where
 ///     .route("/", get(|| async { "ok" }))
 ///     .layer(error_handler(default_error_handler));
 /// ```
-pub fn default_error_handler(
-    err: crate::error::Error,
-    parts: Parts,
-) -> Pin<Box<dyn Future<Output = Response> + Send>> {
-    Box::pin(async move {
-        let status = err.status();
-        let details = err.details().cloned();
+pub async fn default_error_handler(err: crate::error::Error, parts: Parts) -> Response {
+    let status = err.status();
+    let details = err.details().cloned();
 
-        let message = match (
-            err.locale_key(),
-            parts.extensions.get::<crate::i18n::Translator>(),
-        ) {
-            (Some(key), Some(tr)) => tr.t(key, &[]),
-            _ => err.message().to_string(),
-        };
+    let message = match (
+        err.locale_key(),
+        parts.extensions.get::<crate::i18n::Translator>(),
+    ) {
+        (Some(key), Some(tr)) => tr.t(key, &[]),
+        _ => err.message().to_string(),
+    };
 
-        let mut body = serde_json::json!({
-            "error": {
-                "status": status.as_u16(),
-                "message": message,
-            }
-        });
-        if let Some(d) = details {
-            body["error"]["details"] = d;
-        }
-
-        (status, axum::Json(body)).into_response()
-    })
+    let body = render_error_body(status, &message, details.as_ref());
+    (status, axum::Json(body)).into_response()
 }
 
 /// Tower [`Layer`] produced by [`error_handler`].

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -33,6 +33,7 @@
 //! | [`csrf`] / [`CsrfConfig`] | Double-submit signed-cookie CSRF protection |
 //! | [`CsrfToken`] | CSRF token in request/response extensions |
 //! | [`error_handler`] | Centralised error-response rendering |
+//! | [`default_error_handler`] | Ready-made responder that translates `locale_key` when a [`Translator`](crate::i18n::Translator) is available |
 //! | [`security_headers`] / [`SecurityHeadersConfig`] | Security response headers |
 //! | [`tracing`] | HTTP request/response lifecycle spans |
 //! | [`rate_limit`] / [`rate_limit_with`] | Token-bucket rate limiting |
@@ -76,7 +77,7 @@ pub use catch_panic::catch_panic;
 pub use compression::compression;
 pub use cors::{CorsConfig, cors, cors_with, subdomains, urls};
 pub use csrf::{CsrfConfig, CsrfToken, csrf};
-pub use error_handler::error_handler;
+pub use error_handler::{default_error_handler, error_handler};
 pub use rate_limit::{
     GlobalKeyExtractor, KeyExtractor, PeerIpKeyExtractor, RateLimitConfig, RateLimitLayer,
     rate_limit, rate_limit_with,

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -43,8 +43,10 @@ pub use crate::tenant::middleware as tenant;
 // Layer structs — users call `::new(...)`.
 pub use crate::auth::apikey::ApiKeyLayer as ApiKey;
 pub use crate::auth::session::jwt::JwtLayer as Jwt;
+#[doc(alias = "FlashLayer")]
 pub use crate::flash::FlashLayer as Flash;
 pub use crate::geolocation::GeoLayer as Geo;
+#[doc(alias = "I18nLayer")]
 pub use crate::i18n::I18nLayer as I18n;
 pub use crate::ip::ClientIpLayer as ClientIp;
 pub use crate::template::TemplateContextLayer as TemplateContext;

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -35,6 +35,6 @@ pub use crate::tier::TierLayer as Tier;
 
 // Always-available middleware — free functions.
 pub use crate::middleware::{
-    catch_panic, compression, cors, csrf, error_handler, rate_limit, request_id, security_headers,
-    tracing,
+    catch_panic, compression, cors, csrf, default_error_handler, error_handler, rate_limit,
+    request_id, security_headers, tracing,
 };

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -28,6 +28,7 @@ pub use crate::auth::apikey::ApiKeyLayer as ApiKey;
 pub use crate::auth::session::jwt::JwtLayer as Jwt;
 pub use crate::flash::FlashLayer as Flash;
 pub use crate::geolocation::GeoLayer as Geo;
+pub use crate::i18n::I18nLayer as I18n;
 pub use crate::ip::ClientIpLayer as ClientIp;
 pub use crate::template::TemplateContextLayer as TemplateContext;
 pub use crate::tier::TierLayer as Tier;

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -1,7 +1,7 @@
 //! Flat index of every Tower Layer modo ships.
 //!
 //! Wiring-site ergonomics: `use modo::middlewares as mw;` then
-//! `.layer(mw::session(...))`, `.layer(mw::cors(...))`, etc.
+//! `.layer(mw::cors(cfg))`, `.layer(mw::role(extractor))`, `.layer(mw::Flash::new(cfg))`, etc.
 //!
 //! # Name shadowing with [`crate::prelude`]
 //!
@@ -24,8 +24,8 @@
 //! domain modules construct their layers:
 //!
 //! - **lower_case names are functions** — call them directly:
-//!   `mw::session(store, cookie_cfg, key)`, `mw::role(extractor)`,
-//!   `mw::tenant(strategy, resolver)`, `mw::cors(cors_cfg)`.
+//!   `mw::role(extractor)`, `mw::tenant(strategy, resolver)`,
+//!   `mw::cors(cors_cfg)`, `mw::csrf(csrf_cfg)`.
 //! - **PascalCase names are `Layer` structs** — call `::new(...)`:
 //!   `mw::Jwt::new(cfg)`, `mw::ApiKey::new(store)`,
 //!   `mw::Flash::new(cookie_cfg)`, `mw::ClientIp::new(trusted_proxies)`.

--- a/src/middlewares.rs
+++ b/src/middlewares.rs
@@ -3,6 +3,23 @@
 //! Wiring-site ergonomics: `use modo::middlewares as mw;` then
 //! `.layer(mw::session(...))`, `.layer(mw::cors(...))`, etc.
 //!
+//! # Name shadowing with [`crate::prelude`]
+//!
+//! Some layer names in this module deliberately re-export a type under the
+//! same name used by a factory in [`crate::prelude`]. For example,
+//! [`crate::prelude::I18n`] is the factory ([`crate::i18n::I18n`]) while
+//! [`I18n`] in this module is the Tower layer ([`crate::i18n::I18nLayer`]).
+//! [`Flash`] has the same split ([`crate::flash::Flash`] vs
+//! [`crate::flash::FlashLayer`]).
+//!
+//! A file that does both `use modo::prelude::*;` and
+//! `use modo::middlewares::*;` at once will silently shadow one with the
+//! other — whichever `use` came second wins, with no compiler warning. The
+//! recommended convention is `use modo::middlewares as mw;` so layer names
+//! sit behind the `mw::` prefix and never collide with prelude items.
+//!
+//! # Calling conventions
+//!
 //! Two calling conventions are exported, matching how the underlying
 //! domain modules construct their layers:
 //!

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,6 +11,7 @@
 //! - [`Flash`] — per-request flash messages.
 //! - [`ClientIp`] — resolved client IP extractor.
 //! - [`Tenant`], [`TenantId`] — multi-tenant extractor and identifier.
+//! - [`I18n`], [`Translator`] — i18n factory and per-request translator.
 //! - [`Validate`], [`ValidationError`], [`Validator`] — request-body
 //!   validation trait, error, and fluent helper.
 //!
@@ -26,6 +27,7 @@ pub use crate::auth::role::Role;
 pub use crate::auth::session::Session;
 
 pub use crate::flash::Flash;
+pub use crate::i18n::{I18n, Translator};
 pub use crate::ip::ClientIp;
 pub use crate::tenant::{Tenant, TenantId};
 pub use crate::validate::{Validate, ValidationError, Validator};

--- a/src/template/README.md
+++ b/src/template/README.md
@@ -2,28 +2,26 @@
 
 MiniJinja-based template rendering for the modo web framework.
 
-Filesystem template loading with debug-mode hot-reload, built-in `t()` i18n
-function with plural rules, `static_url()` for cache-busted asset paths, a
-Tower middleware that injects per-request template context, and a `Renderer`
-axum extractor for ergonomic HTML responses (including HTMX partial rendering).
+Filesystem template loading with debug-mode hot-reload, `static_url()` for
+cache-busted asset paths, a Tower middleware that injects per-request template
+context, and a `Renderer` axum extractor for ergonomic HTML responses
+(including HTMX partial rendering).
+
+For internationalization (including the `t()` template function), see
+[`modo::i18n`](../i18n/README.md).
 
 ## Key types
 
-| Type / Trait             | Purpose                                                                    |
-| ------------------------ | -------------------------------------------------------------------------- |
-| `Engine`                 | Holds the MiniJinja environment; cheaply cloneable (internal `Arc`)        |
-| `EngineBuilder`          | Fluent builder for `Engine` — obtain via `Engine::builder()`               |
-| `TemplateConfig`         | Configuration for paths, static URL prefix, and locale knobs               |
-| `TemplateContext`        | Per-request key-value map shared by middleware and handlers                |
-| `TemplateContextLayer`   | Tower middleware that populates `TemplateContext` (also `modo::middlewares::TemplateContext`) |
-| `Renderer`               | axum extractor with `html`, `html_partial`, `string` render methods        |
-| `HxRequest`              | Infallible extractor for `HX-Request: true` (also in `modo::extractors`)   |
-| `context!` (macro)       | Re-export of `minijinja::context!` for building template data              |
-| `LocaleResolver` (trait) | Pluggable interface for per-request locale detection                       |
-| `QueryParamResolver`     | Resolves locale from a URL query parameter                                 |
-| `CookieResolver`         | Resolves locale from a cookie                                              |
-| `SessionResolver`        | Resolves locale from the current session                                   |
-| `AcceptLanguageResolver` | Resolves locale from `Accept-Language` header                              |
+| Type / Trait           | Purpose                                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| `Engine`               | Holds the MiniJinja environment; cheaply cloneable (internal `Arc`)                           |
+| `EngineBuilder`        | Fluent builder for `Engine` — obtain via `Engine::builder()`                                  |
+| `TemplateConfig`       | Configuration for template path, static path, and static URL prefix                           |
+| `TemplateContext`      | Per-request key-value map shared by middleware and handlers                                   |
+| `TemplateContextLayer` | Tower middleware that populates `TemplateContext` (also `modo::middlewares::TemplateContext`) |
+| `Renderer`             | axum extractor with `html`, `html_partial`, `string` render methods                           |
+| `HxRequest`            | Infallible extractor for `HX-Request: true` (also in `modo::extractors`)                      |
+| `context!` (macro)     | Re-export of `minijinja::context!` for building template data                                 |
 
 ## Engine setup
 
@@ -40,7 +38,8 @@ let engine = Engine::builder()
 
 - `.config(TemplateConfig)` — override defaults.
 - `.function(name, f)` / `.filter(name, f)` — register custom globals.
-- `.locale_resolvers(Vec<Arc<dyn LocaleResolver>>)` — replace the default chain.
+- `.i18n(I18n)` — enable the `t()` template function backed by the supplied
+  `modo::i18n::I18n` handle. Omit to skip `t()` registration.
 
 ### Custom functions and filters
 
@@ -62,14 +61,23 @@ let engine = Engine::builder()
 ## Wiring into the router
 
 ```rust,no_run
-use modo::template::{Engine, TemplateContextLayer};
+use modo::i18n::{I18n, I18nConfig};
+use modo::template::{Engine, TemplateConfig, TemplateContextLayer};
 
-fn build_router(engine: Engine) -> axum::Router {
-    axum::Router::new()
-        .merge(engine.static_service())            // serves `static_url_prefix`
-        // ... routes ...
-        .layer(TemplateContextLayer::new(engine))  // inject per-request context
-}
+# fn example() -> modo::Result<()> {
+let i18n = I18n::new(&I18nConfig::default())?;
+let engine = Engine::builder()
+    .config(TemplateConfig::default())
+    .i18n(i18n.clone())
+    .build()?;
+
+let router: axum::Router = axum::Router::new()
+    .merge(engine.static_service())           // serves `static_url_prefix`
+    // ... routes ...
+    .layer(TemplateContextLayer::new())       // inject per-request context
+    .layer(i18n.layer());                     // resolve locale -> Translator
+# Ok(())
+# }
 ```
 
 `Engine::static_service()` returns an `axum::Router` that serves
@@ -141,46 +149,12 @@ async fn handler(hx: HxRequest) {
 }
 ```
 
-## Locales
-
-Place YAML files under `locales/<lang>/<namespace>.yaml` (`.yml` also accepted):
-
-```yaml
-# locales/en/common.yaml
-greeting: "Hello, {name}!"
-items:
-    one: "{count} item"
-    other: "{count} items"
-```
-
-Templates call `t(key, ...)`:
-
-```jinja
-{{ t("common.greeting", name="World") }}
-{{ t("common.items", count=5) }}
-```
-
-The built-in locale chain runs in order: `QueryParamResolver` →
-`CookieResolver` → `SessionResolver` → `AcceptLanguageResolver`, falling
-back to `TemplateConfig::default_locale`. Each resolver only accepts
-locales that were discovered on disk. Override the chain with
-`EngineBuilder::locale_resolvers(...)`.
-
-Plural rules come from [`intl_pluralrules`](https://docs.rs/intl-pluralrules)
-and cover CLDR categories (`zero`, `one`, `two`, `few`, `many`, `other`).
-Missing categories fall back to `other`. Placeholders use `{name}` syntax
-(unmatched placeholders are left in place).
-
 ## Configuration
 
 ```yaml
 templates_path: "templates"   # MiniJinja template files
 static_path: "static"          # static assets (CSS, JS, images)
 static_url_prefix: "/assets"   # URL prefix for static files
-locales_path: "locales"        # locale YAML files
-default_locale: "en"           # fallback locale
-locale_cookie: "lang"          # cookie name read by CookieResolver
-locale_query_param: "lang"     # query param read by QueryParamResolver
 ```
 
 All fields are optional and fall back to the defaults shown above.
@@ -192,7 +166,7 @@ All fields are optional and fall back to the defaults shown above.
 | `current_url`    | Full request URI string                                                |
 | `is_htmx`        | `true` when `HX-Request: true`                                         |
 | `request_id`     | Value of `X-Request-Id` header (if present)                            |
-| `locale`         | Resolved locale string (e.g. `"en"`)                                   |
+| `locale`         | Resolved locale from the `Translator` in request extensions (absent when no `I18nLayer` upstream) |
 | `csrf_token`     | CSRF token string (when `csrf()` middleware is active)                 |
 | `flash_messages` | Callable returning flash entries (when `FlashLayer` is installed)      |
 | `tier_name`      | Name of the active tier (when `TierInfo` extension is present)         |

--- a/src/template/config.rs
+++ b/src/template/config.rs
@@ -12,10 +12,6 @@ use serde::Deserialize;
 /// | `templates_path`     | `"templates"`   |
 /// | `static_path`        | `"static"`      |
 /// | `static_url_prefix`  | `"/assets"`     |
-/// | `locales_path`       | `"locales"`     |
-/// | `default_locale`     | `"en"`          |
-/// | `locale_cookie`      | `"lang"`        |
-/// | `locale_query_param` | `"lang"`        |
 #[non_exhaustive]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
@@ -26,14 +22,6 @@ pub struct TemplateConfig {
     pub static_path: String,
     /// URL prefix under which static assets are served (e.g. `"/assets"`).
     pub static_url_prefix: String,
-    /// Directory that contains locale subdirectories with YAML translation files.
-    pub locales_path: String,
-    /// BCP 47 language tag used when no locale can be resolved from the request.
-    pub default_locale: String,
-    /// Cookie name read by [`CookieResolver`](super::CookieResolver) to determine the active locale.
-    pub locale_cookie: String,
-    /// Query-string parameter name read by [`QueryParamResolver`](super::QueryParamResolver).
-    pub locale_query_param: String,
 }
 
 impl Default for TemplateConfig {
@@ -42,10 +30,6 @@ impl Default for TemplateConfig {
             templates_path: "templates".into(),
             static_path: "static".into(),
             static_url_prefix: "/assets".into(),
-            locales_path: "locales".into(),
-            default_locale: "en".into(),
-            locale_cookie: "lang".into(),
-            locale_query_param: "lang".into(),
         }
     }
 }
@@ -60,10 +44,6 @@ mod tests {
         assert_eq!(config.templates_path, "templates");
         assert_eq!(config.static_path, "static");
         assert_eq!(config.static_url_prefix, "/assets");
-        assert_eq!(config.locales_path, "locales");
-        assert_eq!(config.default_locale, "en");
-        assert_eq!(config.locale_cookie, "lang");
-        assert_eq!(config.locale_query_param, "lang");
     }
 
     #[test]
@@ -72,19 +52,11 @@ mod tests {
             templates_path: "views"
             static_path: "public"
             static_url_prefix: "/static"
-            locales_path: "i18n"
-            default_locale: "uk"
-            locale_cookie: "locale"
-            locale_query_param: "locale"
         "#;
         let config: TemplateConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(config.templates_path, "views");
         assert_eq!(config.static_path, "public");
         assert_eq!(config.static_url_prefix, "/static");
-        assert_eq!(config.locales_path, "i18n");
-        assert_eq!(config.default_locale, "uk");
-        assert_eq!(config.locale_cookie, "locale");
-        assert_eq!(config.locale_query_param, "locale");
     }
 
     #[test]
@@ -95,6 +67,6 @@ mod tests {
         let config: TemplateConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(config.templates_path, "views");
         assert_eq!(config.static_path, "static");
-        assert_eq!(config.default_locale, "en");
+        assert_eq!(config.static_url_prefix, "/assets");
     }
 }

--- a/src/template/engine.rs
+++ b/src/template/engine.rs
@@ -3,12 +3,10 @@ use std::sync::Arc;
 
 use super::config::TemplateConfig;
 use super::static_files;
-use crate::i18n::locale::{self, LocaleResolver};
-use crate::i18n::{I18nConfig, TranslationStore, make_t_function};
+use crate::i18n::{I18n, make_t_function};
 
 struct EngineInner {
     env: std::sync::RwLock<minijinja::Environment<'static>>,
-    locale_chain: Vec<Arc<dyn LocaleResolver>>,
     config: TemplateConfig,
 }
 
@@ -20,8 +18,9 @@ struct EngineInner {
 ///   [`TemplateConfig::templates_path`].
 /// - Automatic registration of [minijinja-contrib](https://docs.rs/minijinja-contrib)
 ///   filters and functions.
-/// - A `t()` function (available in every template) that looks up the `locale`
-///   context variable and delegates to the built-in translation store.
+/// - A `t()` function (registered only when an [`I18n`](crate::i18n::I18n) handle
+///   is supplied via [`EngineBuilder::i18n`]) that looks up the `locale` context
+///   variable and delegates to the shared translation store.
 /// - A `static_url()` function that appends a content-hash query parameter to asset
 ///   paths for cache-busting.
 /// - In debug builds, the template cache is cleared on every render so changes on
@@ -83,14 +82,6 @@ impl Engine {
             &self.inner.config.static_url_prefix,
         )
     }
-
-    pub(crate) fn locale_chain(&self) -> &[Arc<dyn LocaleResolver>] {
-        &self.inner.locale_chain
-    }
-
-    pub(crate) fn default_locale(&self) -> &str {
-        &self.inner.config.default_locale
-    }
 }
 
 type EnvCustomizer = Box<dyn FnOnce(&mut minijinja::Environment<'static>) + Send>;
@@ -104,7 +95,7 @@ type EnvCustomizer = Box<dyn FnOnce(&mut minijinja::Environment<'static>) + Send
 pub struct EngineBuilder {
     config: Option<TemplateConfig>,
     customizers: Vec<EnvCustomizer>,
-    locale_resolvers: Option<Vec<Arc<dyn LocaleResolver>>>,
+    i18n: Option<I18n>,
 }
 
 impl EngineBuilder {
@@ -148,15 +139,12 @@ impl EngineBuilder {
         self
     }
 
-    /// Overrides the locale resolver chain.
+    /// Provide a shared I18n handle so templates can call `{{ t("key") }}`.
     ///
-    /// The resolvers are tried in order; the first one that returns `Some` wins.
-    /// When not called, a default chain of [`QueryParamResolver`](super::QueryParamResolver),
-    /// [`CookieResolver`](super::CookieResolver),
-    /// [`AcceptLanguageResolver`](super::AcceptLanguageResolver), and (when the `session`
-    /// feature is enabled) `SessionResolver` is used.
-    pub fn locale_resolvers(mut self, resolvers: Vec<Arc<dyn LocaleResolver>>) -> Self {
-        self.locale_resolvers = Some(resolvers);
+    /// If omitted, the engine does not register the `t()` function — templates
+    /// that reference it will fail to render.
+    pub fn i18n(mut self, i18n: I18n) -> Self {
+        self.i18n = Some(i18n);
         self
     }
 
@@ -164,8 +152,8 @@ impl EngineBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`Error`](crate::Error) if the locales directory is unreadable or a
-    /// locale YAML file cannot be parsed.
+    /// Returns [`Error`](crate::Error) if the static-assets directory cannot be
+    /// hashed.
     pub fn build(self) -> crate::Result<Engine> {
         let config = self.config.unwrap_or_default();
 
@@ -177,20 +165,9 @@ impl EngineBuilder {
         // Register minijinja-contrib common filters/functions
         minijinja_contrib::add_to_environment(&mut env);
 
-        // Load i18n translations (if locales directory exists)
-        let locales_path = Path::new(&config.locales_path);
-        let i18n = if locales_path.exists() {
-            Some(TranslationStore::load(
-                locales_path,
-                &config.default_locale,
-            )?)
-        } else {
-            None
-        };
-
-        // Register t() function if i18n is loaded
-        if let Some(ref store) = i18n {
-            let t_fn = make_t_function(store.clone());
+        // Register t() function when an I18n handle is supplied.
+        if let Some(ref i18n) = self.i18n {
+            let t_fn = make_t_function(i18n.store().clone());
             env.add_function("t", t_fn);
         }
 
@@ -210,29 +187,8 @@ impl EngineBuilder {
             customizer(&mut env);
         }
 
-        // Build locale resolver chain
-        let available_locales = i18n
-            .as_ref()
-            .map(|s| s.available_locales())
-            .unwrap_or_default();
-
-        let locale_chain = self.locale_resolvers.unwrap_or_else(|| {
-            // TEMPORARY (Task 1): build an I18nConfig shim from the
-            // still-owned-by-template locale fields so the relocated
-            // default_chain can consume the new type. Task 2 removes these
-            // fields from TemplateConfig and deletes this shim.
-            let i18n_cfg = I18nConfig {
-                locales_path: config.locales_path.clone(),
-                default_locale: config.default_locale.clone(),
-                locale_cookie: config.locale_cookie.clone(),
-                locale_query_param: config.locale_query_param.clone(),
-            };
-            locale::default_chain(&i18n_cfg, &available_locales)
-        });
-
         let inner = EngineInner {
             env: std::sync::RwLock::new(env),
-            locale_chain,
             config,
         };
 
@@ -245,13 +201,13 @@ impl EngineBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::i18n::{I18n, I18nConfig};
     use crate::template::TemplateConfig;
 
     fn test_config(dir: &std::path::Path) -> TemplateConfig {
         TemplateConfig {
             templates_path: dir.join("templates").to_str().unwrap().into(),
             static_path: dir.join("static").to_str().unwrap().into(),
-            locales_path: dir.join("locales").to_str().unwrap().into(),
             ..TemplateConfig::default()
         }
     }
@@ -274,11 +230,19 @@ mod tests {
         std::fs::write(static_dir.join("app.css"), "body {}").unwrap();
     }
 
+    fn test_i18n(dir: &std::path::Path) -> I18n {
+        let config = I18nConfig {
+            locales_path: dir.join("locales").to_str().unwrap().into(),
+            default_locale: "en".into(),
+            ..I18nConfig::default()
+        };
+        I18n::new(&config).unwrap()
+    }
+
     #[test]
     fn build_engine_with_templates() {
         let dir = tempfile::tempdir().unwrap();
         setup_templates(dir.path());
-        setup_locales(dir.path());
         setup_static(dir.path());
 
         let config = test_config(dir.path());
@@ -300,7 +264,8 @@ mod tests {
         std::fs::write(tpl_dir.join("i18n.html"), "{{ t('common.greeting') }}").unwrap();
 
         let config = test_config(dir.path());
-        let engine = Engine::builder().config(config).build().unwrap();
+        let i18n = test_i18n(dir.path());
+        let engine = Engine::builder().config(config).i18n(i18n).build().unwrap();
 
         // Render with locale in context
         let result = engine
@@ -310,10 +275,26 @@ mod tests {
     }
 
     #[test]
+    fn engine_without_i18n_does_not_register_t() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_static(dir.path());
+
+        let tpl_dir = dir.path().join("templates");
+        std::fs::create_dir_all(&tpl_dir).unwrap();
+        std::fs::write(tpl_dir.join("i18n.html"), "{{ t('common.greeting') }}").unwrap();
+
+        let config = test_config(dir.path());
+        let engine = Engine::builder().config(config).build().unwrap();
+
+        // `t()` is not registered, so rendering should fail.
+        let result = engine.render("i18n.html", minijinja::context! { locale => "en" });
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn engine_static_url_function_works() {
         let dir = tempfile::tempdir().unwrap();
         setup_templates(dir.path());
-        setup_locales(dir.path());
         setup_static(dir.path());
 
         let tpl_dir = dir.path().join("templates");

--- a/src/template/engine.rs
+++ b/src/template/engine.rs
@@ -218,12 +218,6 @@ mod tests {
         std::fs::write(tpl_dir.join("hello.html"), "Hello, {{ name }}!").unwrap();
     }
 
-    fn setup_locales(dir: &std::path::Path) {
-        let en_dir = dir.join("locales/en");
-        std::fs::create_dir_all(&en_dir).unwrap();
-        std::fs::write(en_dir.join("common.yaml"), "greeting: Hello").unwrap();
-    }
-
     fn setup_static(dir: &std::path::Path) {
         let static_dir = dir.join("static/css");
         std::fs::create_dir_all(&static_dir).unwrap();
@@ -231,6 +225,10 @@ mod tests {
     }
 
     fn test_i18n(dir: &std::path::Path) -> I18n {
+        let en_dir = dir.join("locales/en");
+        std::fs::create_dir_all(&en_dir).unwrap();
+        std::fs::write(en_dir.join("common.yaml"), "greeting: Hello").unwrap();
+
         let config = I18nConfig {
             locales_path: dir.join("locales").to_str().unwrap().into(),
             default_locale: "en".into(),
@@ -256,7 +254,6 @@ mod tests {
     #[test]
     fn engine_t_function_works() {
         let dir = tempfile::tempdir().unwrap();
-        setup_locales(dir.path());
         setup_static(dir.path());
 
         let tpl_dir = dir.path().join("templates");
@@ -312,21 +309,6 @@ mod tests {
             .unwrap();
         assert!(result.starts_with("/assets/css/app.css?v="));
         assert_eq!(result.len(), "/assets/css/app.css?v=".len() + 8);
-    }
-
-    #[test]
-    fn build_engine_without_locales_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        setup_templates(dir.path());
-        setup_static(dir.path());
-        // Do NOT create locales dir — verify build still succeeds
-
-        let config = test_config(dir.path());
-        let engine = Engine::builder().config(config).build().unwrap();
-        let result = engine
-            .render("hello.html", minijinja::context! { name => "World" })
-            .unwrap();
-        assert_eq!(result, "Hello, World!");
     }
 
     #[test]

--- a/src/template/engine.rs
+++ b/src/template/engine.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use super::config::TemplateConfig;
-use super::i18n::{TranslationStore, make_t_function};
-use super::locale::{self, LocaleResolver};
 use super::static_files;
+use crate::i18n::locale::{self, LocaleResolver};
+use crate::i18n::{I18nConfig, TranslationStore, make_t_function};
 
 struct EngineInner {
     env: std::sync::RwLock<minijinja::Environment<'static>>,
@@ -216,9 +216,19 @@ impl EngineBuilder {
             .map(|s| s.available_locales())
             .unwrap_or_default();
 
-        let locale_chain = self
-            .locale_resolvers
-            .unwrap_or_else(|| locale::default_chain(&config, &available_locales));
+        let locale_chain = self.locale_resolvers.unwrap_or_else(|| {
+            // TEMPORARY (Task 1): build an I18nConfig shim from the
+            // still-owned-by-template locale fields so the relocated
+            // default_chain can consume the new type. Task 2 removes these
+            // fields from TemplateConfig and deletes this shim.
+            let i18n_cfg = I18nConfig {
+                locales_path: config.locales_path.clone(),
+                default_locale: config.default_locale.clone(),
+                locale_cookie: config.locale_cookie.clone(),
+                locale_query_param: config.locale_query_param.clone(),
+            };
+            locale::default_chain(&i18n_cfg, &available_locales)
+        });
 
         let inner = EngineInner {
             env: std::sync::RwLock::new(env),

--- a/src/template/middleware.rs
+++ b/src/template/middleware.rs
@@ -8,9 +8,8 @@ use http::{Request, Response};
 use tower::{Layer, Service};
 
 use super::context::TemplateContext;
-use super::engine::Engine;
 use crate::flash::state::FlashState;
-use crate::i18n::locale;
+use crate::i18n::Translator;
 
 // --- Layer ---
 
@@ -25,13 +24,19 @@ use crate::i18n::locale;
 /// | `current_url`     | `request.uri().to_string()`                                         |
 /// | `is_htmx`         | `HX-Request: true` header                                           |
 /// | `request_id`      | `X-Request-Id` header (if present)                                  |
-/// | `locale`          | Locale resolver chain (falls back to [`TemplateConfig::default_locale`](super::TemplateConfig::default_locale)) |
+/// | `locale`          | [`Translator`](crate::i18n::Translator) in extensions (present only when [`I18nLayer`](crate::i18n::I18nLayer) is installed upstream) |
 /// | `csrf_token`      | [`CsrfToken`](crate::middleware::CsrfToken) extension (if present)  |
 /// | `flash_messages`  | Callable returning flash entries; `FlashState` extension must be set by [`FlashLayer`](crate::flash::FlashLayer) |
 /// | `tier_name`       | `TierInfo::name` (when `TierInfo` extension is present)             |
 /// | `tier_has`        | Template function `tier_has(name) -> bool` (when `TierInfo` is present) |
 /// | `tier_enabled`    | Template function `tier_enabled(name) -> bool` (when `TierInfo` is present) |
 /// | `tier_limit`      | Template function `tier_limit(name) -> Option<u64>` (when `TierInfo` is present) |
+///
+/// This layer reads the current request's
+/// [`Translator`](crate::i18n::Translator) (installed by
+/// [`I18nLayer`](crate::i18n::I18nLayer)) and exposes `locale` to templates.
+/// If no `I18nLayer` is upstream, the `locale` variable is simply absent from
+/// the template context.
 ///
 /// This layer is also re-exported as
 /// [`modo::middlewares::TemplateContext`](crate::middlewares::TemplateContext)
@@ -40,23 +45,19 @@ use crate::i18n::locale;
 /// # Example
 ///
 /// ```rust,no_run
-/// use modo::template::{Engine, TemplateContextLayer};
+/// use modo::template::TemplateContextLayer;
 ///
-/// # fn example(engine: Engine) {
 /// let router: axum::Router = axum::Router::new()
 ///     // ... routes ...
-///     .layer(TemplateContextLayer::new(engine));
-/// # }
+///     .layer(TemplateContextLayer::new());
 /// ```
-#[derive(Clone)]
-pub struct TemplateContextLayer {
-    engine: Engine,
-}
+#[derive(Clone, Default)]
+pub struct TemplateContextLayer;
 
 impl TemplateContextLayer {
-    /// Creates a new layer backed by the given [`Engine`].
-    pub fn new(engine: Engine) -> Self {
-        Self { engine }
+    /// Creates a new [`TemplateContextLayer`].
+    pub fn new() -> Self {
+        Self
     }
 }
 
@@ -64,10 +65,7 @@ impl<S> Layer<S> for TemplateContextLayer {
     type Service = TemplateContextMiddleware<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        TemplateContextMiddleware {
-            inner,
-            engine: self.engine.clone(),
-        }
+        TemplateContextMiddleware { inner }
     }
 }
 
@@ -80,7 +78,6 @@ impl<S> Layer<S> for TemplateContextLayer {
 #[derive(Clone)]
 pub struct TemplateContextMiddleware<S> {
     inner: S,
-    engine: Engine,
 }
 
 impl<S, ReqBody> Service<Request<ReqBody>> for TemplateContextMiddleware<S>
@@ -99,7 +96,6 @@ where
     }
 
     fn call(&mut self, mut request: Request<ReqBody>) -> Self::Future {
-        let engine = self.engine.clone();
         let mut inner = self.inner.clone();
         std::mem::swap(&mut self.inner, &mut inner);
 
@@ -130,16 +126,21 @@ where
                 ctx.set("request_id", minijinja::Value::from(req_id.to_string()));
             }
 
-            // locale resolution
+            // Read request extensions for locale, csrf, flash, tier.
             {
-                // We need to extract Parts temporarily for locale resolution
-                // Since we can't split the request here, read the values we need from headers
                 let (mut parts, body) = request.into_parts();
 
-                let resolved_locale = locale::resolve_locale(engine.locale_chain(), &parts);
-                let locale_value =
-                    resolved_locale.unwrap_or_else(|| engine.default_locale().to_string());
-                ctx.set("locale", minijinja::Value::from(locale_value));
+                // locale comes from the Translator installed upstream by I18nLayer.
+                // If no I18nLayer is installed, `locale` is simply absent from
+                // the template context — the template engine's MiniJinja state
+                // then sees `locale` as undefined, which is the correct signal
+                // that `t()` cannot be used.
+                if let Some(translator) = parts.extensions.get::<Translator>() {
+                    ctx.set(
+                        "locale",
+                        minijinja::Value::from(translator.locale().to_string()),
+                    );
+                }
 
                 // csrf_token (if present in extensions)
                 if let Some(csrf) = parts.extensions.get::<crate::middleware::CsrfToken>() {
@@ -205,36 +206,52 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{Router, routing::get};
+    use axum::{Router, body::Body, routing::get};
     use http::{Request, StatusCode};
     use tower::ServiceExt;
 
-    use crate::template::{TemplateConfig, TemplateContext};
+    use crate::i18n::{I18n, I18nConfig};
+    use crate::template::{Engine, TemplateConfig, TemplateContext};
 
     // Return TempDir alongside Engine so files persist for the test's lifetime
     fn test_engine() -> (tempfile::TempDir, Engine) {
         let dir = tempfile::tempdir().unwrap();
         let tpl_dir = dir.path().join("templates");
-        let locales_dir = dir.path().join("locales/en");
         let static_dir = dir.path().join("static");
         std::fs::create_dir_all(&tpl_dir).unwrap();
-        std::fs::create_dir_all(&locales_dir).unwrap();
         std::fs::create_dir_all(&static_dir).unwrap();
-        std::fs::write(locales_dir.join("common.yaml"), "greeting: Hello").unwrap();
-
-        let uk_locales_dir = dir.path().join("locales/uk");
-        std::fs::create_dir_all(&uk_locales_dir).unwrap();
-        std::fs::write(uk_locales_dir.join("common.yaml"), "greeting: Привіт").unwrap();
 
         let config = TemplateConfig {
             templates_path: tpl_dir.to_str().unwrap().into(),
-            locales_path: dir.path().join("locales").to_str().unwrap().into(),
             static_path: static_dir.to_str().unwrap().into(),
             ..TemplateConfig::default()
         };
 
         let engine = Engine::builder().config(config).build().unwrap();
         (dir, engine)
+    }
+
+    fn test_i18n(dir: &std::path::Path) -> I18n {
+        let locales_dir = dir.join("locales");
+        std::fs::create_dir_all(locales_dir.join("en")).unwrap();
+        std::fs::write(
+            locales_dir.join("en").join("common.yaml"),
+            "greeting: Hello",
+        )
+        .unwrap();
+        std::fs::create_dir_all(locales_dir.join("uk")).unwrap();
+        std::fs::write(
+            locales_dir.join("uk").join("common.yaml"),
+            "greeting: Привіт",
+        )
+        .unwrap();
+
+        let config = I18nConfig {
+            locales_path: locales_dir.to_str().unwrap().into(),
+            default_locale: "en".into(),
+            ..I18nConfig::default()
+        };
+        I18n::new(&config).unwrap()
     }
 
     // Handlers must be module-level async fn per CLAUDE.md gotcha
@@ -273,10 +290,10 @@ mod tests {
 
     #[tokio::test]
     async fn injects_current_url_value() {
-        let (_dir, engine) = test_engine();
+        let (_dir, _engine) = test_engine();
         let app = Router::new()
             .route("/test", get(extract_url))
-            .layer(TemplateContextLayer::new(engine));
+            .layer(TemplateContextLayer::new());
 
         let req = Request::builder().uri("/test").body(Body::empty()).unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -289,10 +306,10 @@ mod tests {
 
     #[tokio::test]
     async fn injects_is_htmx_false() {
-        let (_dir, engine) = test_engine();
+        let (_dir, _engine) = test_engine();
         let app = Router::new()
             .route("/test", get(extract_is_htmx))
-            .layer(TemplateContextLayer::new(engine));
+            .layer(TemplateContextLayer::new());
 
         let req = Request::builder().uri("/test").body(Body::empty()).unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -301,10 +318,10 @@ mod tests {
 
     #[tokio::test]
     async fn injects_is_htmx_true() {
-        let (_dir, engine) = test_engine();
+        let (_dir, _engine) = test_engine();
         let app = Router::new()
             .route("/test", get(extract_is_htmx))
-            .layer(TemplateContextLayer::new(engine));
+            .layer(TemplateContextLayer::new());
 
         let req = Request::builder()
             .uri("/test")
@@ -320,10 +337,14 @@ mod tests {
 
     #[tokio::test]
     async fn injects_locale_default() {
-        let (_dir, engine) = test_engine();
+        let (_dir, _engine) = test_engine();
+        let i18n = test_i18n(_dir.path());
+        // I18nLayer must run before TemplateContextLayer sees the request, so
+        // install I18nLayer as an outer layer (outer layers run first in axum).
         let app = Router::new()
             .route("/test", get(extract_locale))
-            .layer(TemplateContextLayer::new(engine));
+            .layer(TemplateContextLayer::new())
+            .layer(i18n.layer());
 
         let req = Request::builder().uri("/test").body(Body::empty()).unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -335,10 +356,12 @@ mod tests {
 
     #[tokio::test]
     async fn injects_locale_from_query() {
-        let (_dir, engine) = test_engine();
+        let (_dir, _engine) = test_engine();
+        let i18n = test_i18n(_dir.path());
         let app = Router::new()
             .route("/test", get(extract_locale))
-            .layer(TemplateContextLayer::new(engine));
+            .layer(TemplateContextLayer::new())
+            .layer(i18n.layer());
 
         let req = Request::builder()
             .uri("/test?lang=uk")
@@ -352,11 +375,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn no_i18n_layer_omits_locale() {
+        let (_dir, _engine) = test_engine();
+        // No I18nLayer installed.
+        let app = Router::new()
+            .route("/test", get(extract_locale))
+            .layer(TemplateContextLayer::new());
+
+        let req = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        // locale not set — returns empty string
+        assert_eq!(body, "");
+    }
+
+    #[tokio::test]
     async fn injects_request_id() {
-        let (_dir, engine) = test_engine();
+        let (_dir, _engine) = test_engine();
         let app = Router::new()
             .route("/test", get(extract_request_id))
-            .layer(TemplateContextLayer::new(engine));
+            .layer(TemplateContextLayer::new());
 
         let req = Request::builder()
             .uri("/test")
@@ -445,10 +485,10 @@ mod tests {
 
         #[tokio::test]
         async fn injects_tier_name() {
-            let (_dir, engine) = test_engine();
+            let (_dir, _engine) = test_engine();
             let app = Router::new()
                 .route("/test", get(extract_tier_name))
-                .layer(TemplateContextLayer::new(engine));
+                .layer(TemplateContextLayer::new());
 
             let mut req = Request::builder().uri("/test").body(Body::empty()).unwrap();
             req.extensions_mut().insert(test_tier());
@@ -536,10 +576,10 @@ mod tests {
 
         #[tokio::test]
         async fn no_tier_info_no_injection() {
-            let (_dir, engine) = test_engine();
+            let (_dir, _engine) = test_engine();
             let app = Router::new()
                 .route("/test", get(extract_tier_name))
-                .layer(TemplateContextLayer::new(engine));
+                .layer(TemplateContextLayer::new());
 
             let req = Request::builder().uri("/test").body(Body::empty()).unwrap();
             let resp = app.oneshot(req).await.unwrap();

--- a/src/template/middleware.rs
+++ b/src/template/middleware.rs
@@ -9,8 +9,8 @@ use tower::{Layer, Service};
 
 use super::context::TemplateContext;
 use super::engine::Engine;
-use super::locale;
 use crate::flash::state::FlashState;
+use crate::i18n::locale;
 
 // --- Layer ---
 

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -4,25 +4,24 @@
 //!
 //! This module provides an opinionated template layer built on top of
 //! [MiniJinja](https://docs.rs/minijinja). It covers engine construction,
-//! per-request context injection, HTMX-aware rendering, i18n with plural
-//! rules, and cache-busted static-asset URLs.
+//! per-request context injection, HTMX-aware rendering, and cache-busted
+//! static-asset URLs.
+//!
+//! For internationalization, see [`modo::i18n`](crate::i18n). Pass an
+//! [`I18n`](crate::i18n::I18n) handle to [`EngineBuilder::i18n`] to register
+//! the `t()` template function.
 //!
 //! ## Provides
 //!
 //! | Type / Trait                | Description |
 //! |-----------------------------|-------------|
-//! | [`Engine`] / [`EngineBuilder`] | Compile and cache templates from disk, register custom functions and filters, and override the locale resolver chain. |
-//! | [`TemplateConfig`]          | Configuration for template paths, static-asset prefix, locale defaults, and cookie/query-param names. |
+//! | [`Engine`] / [`EngineBuilder`] | Compile and cache templates from disk and register custom functions and filters. |
+//! | [`TemplateConfig`]          | Configuration for template paths and static-asset prefix. |
 //! | [`TemplateContext`]         | Per-request key-value map shared between middleware and handlers; handler values override middleware values on key conflicts. |
 //! | [`TemplateContextLayer`]    | Tower middleware that injects per-request data (`current_url`, `is_htmx`, `request_id`, `locale`, `csrf_token`, `flash_messages`, and `tier_*` entries) into every request's extensions. Also re-exported as [`modo::middlewares::TemplateContext`](crate::middlewares::TemplateContext). |
 //! | [`Renderer`]                | Axum extractor that gives handlers a ready-to-use render handle. |
 //! | [`HxRequest`]               | Infallible axum extractor that detects the `HX-Request: true` header. Also re-exported from [`modo::extractors`](crate::extractors). |
 //! | [`context`]                 | Re-export of [`minijinja::context!`] for building template data in handlers. |
-//! | [`LocaleResolver`]          | Trait for pluggable locale detection from a request. |
-//! | [`QueryParamResolver`]      | Resolves the active locale from a URL query parameter. |
-//! | [`CookieResolver`]          | Resolves the active locale from a cookie. |
-//! | [`AcceptLanguageResolver`]  | Resolves the active locale from the `Accept-Language` header. |
-//! | [`SessionResolver`]         | Resolves the active locale from the current session. |
 //!
 //! ## Quick start
 //!
@@ -39,7 +38,7 @@
 //! // `Engine` is cheaply cloneable (internal `Arc`).
 //! let router: axum::Router = axum::Router::new()
 //!     .merge(engine.static_service())
-//!     .layer(TemplateContextLayer::new(engine.clone()));
+//!     .layer(TemplateContextLayer::new());
 //! ```
 
 mod config;
@@ -50,9 +49,6 @@ mod middleware;
 mod renderer;
 mod static_files;
 
-pub use crate::i18n::{
-    AcceptLanguageResolver, CookieResolver, LocaleResolver, QueryParamResolver, SessionResolver,
-};
 pub use config::TemplateConfig;
 pub use context::TemplateContext;
 pub use engine::{Engine, EngineBuilder};

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -46,18 +46,17 @@ mod config;
 mod context;
 mod engine;
 mod htmx;
-mod i18n;
-mod locale;
 mod middleware;
 mod renderer;
 mod static_files;
 
+pub use crate::i18n::{
+    AcceptLanguageResolver, CookieResolver, LocaleResolver, QueryParamResolver, SessionResolver,
+};
 pub use config::TemplateConfig;
 pub use context::TemplateContext;
 pub use engine::{Engine, EngineBuilder};
 pub use htmx::HxRequest;
-pub use locale::SessionResolver;
-pub use locale::{AcceptLanguageResolver, CookieResolver, LocaleResolver, QueryParamResolver};
 pub use middleware::TemplateContextLayer;
 pub use minijinja::context;
 pub use renderer::Renderer;

--- a/src/template/renderer.rs
+++ b/src/template/renderer.rs
@@ -135,18 +135,14 @@ mod tests {
 
     fn setup_engine(dir: &std::path::Path) -> Engine {
         let tpl_dir = dir.join("templates");
-        let locales_dir = dir.join("locales/en");
         let static_dir = dir.join("static");
         std::fs::create_dir_all(&tpl_dir).unwrap();
-        std::fs::create_dir_all(&locales_dir).unwrap();
         std::fs::create_dir_all(&static_dir).unwrap();
         std::fs::write(tpl_dir.join("page.html"), "Hello, {{ name }}!").unwrap();
         std::fs::write(tpl_dir.join("partial.html"), "<div>{{ name }}</div>").unwrap();
-        std::fs::write(locales_dir.join("common.yaml"), "greeting: Hello").unwrap();
 
         let config = TemplateConfig {
             templates_path: tpl_dir.to_str().unwrap().into(),
-            locales_path: dir.join("locales").to_str().unwrap().into(),
             static_path: static_dir.to_str().unwrap().into(),
             ..TemplateConfig::default()
         };

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -6,7 +6,7 @@ Requires the `test-helpers` feature.
 
 ```toml
 [dev-dependencies]
-modo = { package = "modo-rs", version = "0.8", features = ["test-helpers"] }
+modo = { package = "modo-rs", version = "0.9", features = ["test-helpers"] }
 ```
 
 ## Key types

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! modo = { package = "modo-rs", version = "0.8", features = ["test-helpers"] }
+//! modo = { package = "modo-rs", version = "0.9", features = ["test-helpers"] }
 //! ```
 //!
 //! Integration test files that use these helpers should also guard their

--- a/tests/i18n_test.rs
+++ b/tests/i18n_test.rs
@@ -1,0 +1,306 @@
+//! End-to-end integration tests for the `modo::i18n` module.
+//!
+//! These tests drive real axum routers through `tower::ServiceExt::oneshot`
+//! and exercise the public behaviour contract of the `Translator` extractor,
+//! `I18nLayer`, `I18n::translator`, and the interaction with
+//! `Error::localized` + `default_error_handler`. Unit-level behaviour lives in
+//! the module's own `#[cfg(test)] mod tests` blocks; this file locks down the
+//! contract across the module boundary.
+//!
+//! Each test builds its own `tempfile::tempdir()` with YAML locale files, so
+//! tests are independent and the directory is cleaned up via `Drop`.
+
+use std::path::Path;
+
+use axum::extract::FromRequestParts;
+use axum::{Json, Router, body::Body, response::Response, routing::get};
+use http::{Request, StatusCode};
+use modo::i18n::{I18n, I18nConfig, Translator};
+use modo::middleware::{default_error_handler, error_handler};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+// --- helpers ---------------------------------------------------------------
+
+fn write_fixture_locales(dir: &Path) {
+    let en_dir = dir.join("locales/en");
+    let uk_dir = dir.join("locales/uk");
+    std::fs::create_dir_all(&en_dir).unwrap();
+    std::fs::create_dir_all(&uk_dir).unwrap();
+
+    std::fs::write(
+        en_dir.join("errors.yaml"),
+        "user:\n  not_found: User not found\n",
+    )
+    .unwrap();
+    std::fs::write(en_dir.join("common.yaml"), "greeting: 'Hello, {name}!'\n").unwrap();
+
+    std::fs::write(
+        uk_dir.join("errors.yaml"),
+        "user:\n  not_found: Користувача не знайдено\n",
+    )
+    .unwrap();
+    std::fs::write(uk_dir.join("common.yaml"), "greeting: 'Привіт, {name}!'\n").unwrap();
+}
+
+fn test_i18n_config(dir: &Path) -> I18nConfig {
+    // I18nConfig is `#[non_exhaustive]`, so construct by mutating defaults
+    // rather than via a struct literal.
+    let mut cfg = I18nConfig::default();
+    cfg.locales_path = dir.join("locales").to_str().unwrap().to_string();
+    cfg.default_locale = "en".into();
+    cfg
+}
+
+fn test_i18n(dir: &Path) -> I18n {
+    write_fixture_locales(dir);
+    I18n::new(&test_i18n_config(dir)).unwrap()
+}
+
+async fn body_text(resp: Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+async fn body_json(resp: Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+// --- handlers (module-level async fn per CLAUDE.md gotcha) -----------------
+
+async fn greet_json(tr: Translator) -> Json<serde_json::Value> {
+    let greeting = tr.t("common.greeting", &[("name", "Dmytro")]);
+    Json(serde_json::json!({
+        "greeting": greeting,
+        "locale": tr.locale(),
+    }))
+}
+
+async fn localized_not_found() -> Result<&'static str, modo::Error> {
+    Err(modo::Error::localized(
+        StatusCode::NOT_FOUND,
+        "errors.user.not_found",
+    ))
+}
+
+async fn echo_locale(tr: Translator) -> String {
+    tr.locale().to_string()
+}
+
+async fn double_extract(req: Request<Body>) -> Result<String, modo::Error> {
+    // Extract Translator twice from the same request parts, and clone it
+    // in between, to confirm it's cheaply cloneable and the extension entry
+    // survives repeated extraction in a single request pipeline.
+    let (mut parts, _body) = req.into_parts();
+    let first = Translator::from_request_parts(&mut parts, &()).await?;
+    let cloned = first.clone();
+    let second = Translator::from_request_parts(&mut parts, &()).await?;
+
+    assert_eq!(first.locale(), cloned.locale());
+    assert_eq!(first.locale(), second.locale());
+    Ok(first.locale().to_string())
+}
+
+// --- tests -----------------------------------------------------------------
+
+#[tokio::test]
+async fn json_handler_translates_with_translator() {
+    let dir: TempDir = tempfile::tempdir().unwrap();
+    let i18n = test_i18n(dir.path());
+
+    let app = Router::new()
+        .route("/greet", get(greet_json))
+        .layer(i18n.layer());
+
+    let req = Request::builder()
+        .uri("/greet?lang=uk")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["greeting"], "Привіт, Dmytro!");
+    assert_eq!(body["locale"], "uk");
+}
+
+#[tokio::test]
+async fn json_handler_falls_back_to_default_locale() {
+    let dir: TempDir = tempfile::tempdir().unwrap();
+    let i18n = test_i18n(dir.path());
+
+    let app = Router::new()
+        .route("/greet", get(greet_json))
+        .layer(i18n.layer());
+
+    let req = Request::builder()
+        .uri("/greet")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["greeting"], "Hello, Dmytro!");
+    assert_eq!(body["locale"], "en");
+}
+
+#[tokio::test]
+async fn translator_extractor_without_layer_returns_500() {
+    // No I18nLayer — the Translator extractor must fail with 500.
+    let app: Router = Router::new().route("/greet", get(greet_json));
+
+    let req = Request::builder()
+        .uri("/greet")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["error"]["status"], 500);
+    assert_eq!(body["error"]["message"], "I18nLayer not installed");
+}
+
+#[tokio::test]
+async fn non_request_translator_via_i18n_handle() {
+    // No router — exercise the "background jobs" path that builds a
+    // Translator directly from the I18n factory.
+    let dir: TempDir = tempfile::tempdir().unwrap();
+    let i18n = test_i18n(dir.path());
+
+    let tr = i18n.translator("uk");
+    assert_eq!(tr.locale(), "uk");
+    assert_eq!(
+        tr.t("common.greeting", &[("name", "Світ")]),
+        "Привіт, Світ!"
+    );
+
+    // Sanity: default locale still works off the same handle.
+    let tr_en = i18n.translator("en");
+    assert_eq!(
+        tr_en.t("common.greeting", &[("name", "World")]),
+        "Hello, World!"
+    );
+}
+
+#[tokio::test]
+async fn error_localized_resolves_when_translator_present() {
+    let dir: TempDir = tempfile::tempdir().unwrap();
+    let i18n = test_i18n(dir.path());
+
+    let app = Router::new()
+        .route("/user", get(localized_not_found))
+        .layer(error_handler(default_error_handler))
+        .layer(i18n.layer());
+
+    let req = Request::builder()
+        .uri("/user?lang=uk")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["error"]["status"], 404);
+    assert_eq!(body["error"]["message"], "Користувача не знайдено");
+}
+
+#[tokio::test]
+async fn error_localized_falls_back_to_key_without_i18n_layer() {
+    // error_handler still wrapping, but NO I18nLayer upstream — no Translator
+    // in extensions, so default_error_handler must surface the raw key.
+    let app: Router = Router::new()
+        .route("/user", get(localized_not_found))
+        .layer(error_handler(default_error_handler));
+
+    let req = Request::builder().uri("/user").body(Body::empty()).unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["error"]["status"], 404);
+    assert_eq!(body["error"]["message"], "errors.user.not_found");
+}
+
+#[tokio::test]
+async fn error_localized_falls_back_to_key_without_error_handler() {
+    // No error_handler middleware at all — Error::into_response fires directly.
+    // It must produce the raw key as the body message.
+    let app: Router = Router::new().route("/user", get(localized_not_found));
+
+    let req = Request::builder().uri("/user").body(Body::empty()).unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["error"]["status"], 404);
+    assert_eq!(body["error"]["message"], "errors.user.not_found");
+}
+
+#[tokio::test]
+async fn translator_accept_language_chain_picks_uk_when_allowed() {
+    let dir: TempDir = tempfile::tempdir().unwrap();
+    let i18n = test_i18n(dir.path());
+
+    let app = Router::new()
+        .route("/", get(echo_locale))
+        .layer(i18n.layer());
+
+    let req = Request::builder()
+        .uri("/")
+        .header("accept-language", "uk,en;q=0.8")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_text(resp).await, "uk");
+}
+
+#[tokio::test]
+async fn translator_cookie_resolver_wins_over_accept_language() {
+    let dir: TempDir = tempfile::tempdir().unwrap();
+    let i18n = test_i18n(dir.path());
+
+    let app = Router::new()
+        .route("/", get(echo_locale))
+        .layer(i18n.layer());
+
+    // Cookie says uk, Accept-Language says en — cookie resolver sits earlier
+    // in the default chain and must win.
+    let req = Request::builder()
+        .uri("/")
+        .header("cookie", "lang=uk")
+        .header("accept-language", "en")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_text(resp).await, "uk");
+}
+
+#[tokio::test]
+async fn translator_is_clone_and_share_across_extractors() {
+    // Pull Translator twice via FromRequestParts in the same handler to
+    // confirm it's cheaply cloneable and the extension entry survives repeat
+    // extraction.
+    let dir: TempDir = tempfile::tempdir().unwrap();
+    let i18n = test_i18n(dir.path());
+
+    let app = Router::new()
+        .route("/", get(double_extract))
+        .layer(i18n.layer());
+
+    let req = Request::builder()
+        .uri("/?lang=uk")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_text(resp).await, "uk");
+}

--- a/tests/i18n_test.rs
+++ b/tests/i18n_test.rs
@@ -162,9 +162,16 @@ async fn translator_extractor_without_layer_returns_500() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
+    // Check the stable error code via response extensions — avoids coupling
+    // the test to the English error message text.
+    let err = resp
+        .extensions()
+        .get::<modo::Error>()
+        .expect("Error is stored in response extensions");
+    assert_eq!(err.error_code(), Some("i18n:layer_missing"));
+
     let body = body_json(resp).await;
     assert_eq!(body["error"]["status"], 500);
-    assert_eq!(body["error"]["message"], "I18nLayer not installed");
 }
 
 #[tokio::test]

--- a/tests/template_test.rs
+++ b/tests/template_test.rs
@@ -1,5 +1,6 @@
 use axum::{Router, body::Body, routing::get};
 use http::{Request, StatusCode};
+use modo::i18n::{I18n, I18nConfig};
 use modo::service::Registry;
 use modo::template::{Engine, Renderer, TemplateConfig, TemplateContextLayer, context};
 use tempfile::TempDir;
@@ -62,15 +63,27 @@ fn setup() -> (TempDir, Router) {
     std::fs::create_dir_all(&static_dir).unwrap();
     std::fs::write(static_dir.join("app.css"), "body { color: red; }").unwrap();
 
-    // Build engine
+    // Build I18n handle (owns translation store + locale resolver chain).
+    let i18n_config = {
+        let mut c = I18nConfig::default();
+        c.locales_path = dir.path().join("locales").to_str().unwrap().into();
+        c.default_locale = "en".into();
+        c
+    };
+    let i18n = I18n::new(&i18n_config).unwrap();
+
+    // Build engine; pass the I18n handle so `t()` is registered.
     let config = {
         let mut c = TemplateConfig::default();
         c.templates_path = tpl_dir.to_str().unwrap().into();
-        c.locales_path = dir.path().join("locales").to_str().unwrap().into();
         c.static_path = dir.path().join("static").to_str().unwrap().into();
         c
     };
-    let engine = Engine::builder().config(config).build().unwrap();
+    let engine = Engine::builder()
+        .config(config)
+        .i18n(i18n.clone())
+        .build()
+        .unwrap();
 
     // Build router — Engine is Clone (wraps Arc internally), no double-Arc needed
     let mut registry = Registry::new();
@@ -83,7 +96,8 @@ fn setup() -> (TempDir, Router) {
         .route("/string", get(string_handler))
         .route("/missing", get(missing_handler))
         .route("/assets", get(static_url_handler))
-        .layer(TemplateContextLayer::new(engine))
+        .layer(TemplateContextLayer::new())
+        .layer(i18n.layer())
         .with_state(registry.into_state());
 
     (dir, router)


### PR DESCRIPTION
## Summary

- Extracts i18n out of `modo::template` into a new top-level `modo::i18n` module.
- Adds `Translator` axum extractor and `I18nLayer` Tower middleware so handlers, jobs, error responders, and flash messages can translate strings without MiniJinja.
- Adds `Error::localized(status, key)` whose key is resolved at response time by a new `middleware::default_error_handler`.
- Top-level `Config` gains an `i18n: I18nConfig` field.
- Bumps crate to `0.9.0`.
- Closes #68.

## Reuse

- Moves existing `TranslationStore`, locale resolvers, and plural-rule handling — no re-implementation.
- Template engine still registers `t()` via the same `make_t_function`, now driven by a shared `I18n` handle instead of owning the store.
- `default_error_handler` and `Error::into_response` share a `render_error_body` helper to prevent drift.

## Efficiency

- `I18nLayer` runs the locale resolver chain once per request and produces a cheaply-cloneable `Translator` (internal `Arc`).
- Resolver chain is stored as `Arc<[Arc<dyn LocaleResolver>]>`; per-request clone is a single `Arc::clone`, not a `Vec` allocation.
- `TranslationStore` is `pub` with `Arc<Inner>` per the framework's `Arc<Inner>` rule — cheap shared access.

## Quality

- Email module is intentionally **out of scope**: it already resolves locale via per-locale Markdown files (`{path}/{locale}/{name}.md`) and needs no translation store.
- Template module now consumes a shared `I18n` via `EngineBuilder::i18n(i18n)`. `{{ t("...") }}` keeps working.
- `TemplateContextLayer::new()` is zero-arg; it reads `Translator` from request extensions (written by `I18nLayer`).
- `Translator` extractor returns `Error::internal("I18nLayer not installed").with_code("i18n:layer_missing")` if the layer is not installed.
- Layer-ordering requirement (`I18nLayer` outer of `error_handler`) documented in `default_error_handler` rustdoc and `src/i18n/README.md`.
- `CLAUDE.md`'s stale `## Feature Flags` section rewritten; skill docs aligned to the v0.9 API.

## Breaking changes

- `TemplateConfig` drops `locales_path`, `default_locale`, `locale_cookie`, `locale_query_param` — these live on the new `I18nConfig` under the top-level `i18n:` YAML key.
- `EngineBuilder::locale_resolvers(...)` removed; override via `I18n` construction instead.
- `Engine::locale_chain()` and `Engine::default_locale()` removed (were `pub(crate)`).
- `TemplateContextLayer::new(engine)` is now `TemplateContextLayer::new()`.
- `Config` gains `i18n: I18nConfig` with `#[serde(default)]`; programmatic construction via all-field-spread must initialize it, but `Config::default()` is unchanged.

## Out of scope

- Email i18n: already locale-aware via per-locale Markdown file paths.
- A CLI linter that checks templates for missing `t()` keys.
- Kwargs on `Error::localized` — initial cut is key-only; attach a descriptive message via `Error::with_locale_key(...)` when needed.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --features test-helpers --tests -- -D warnings`
- [x] `cargo test --features test-helpers` (1012 lib + 10 `tests/i18n_test.rs` + 10 `tests/template_test.rs` + doctests + all other integration suites, all green)
- [x] `tests/i18n_test.rs` covers: JSON handler translation, fallback to default locale, extractor-without-layer 500 via `i18n:layer_missing`, non-request `I18n::translator(...)`, `Error::localized` with and without `I18nLayer`/`error_handler`, resolver chain ordering (query/cookie/Accept-Language), `Translator::clone` + repeat extraction.
- [x] Manual review pass + two-stage subagent review per task (spec compliance, then code quality), plus a final PR-readiness review.