### PR TITLE
fix(email): polish base layout — flat body, sized logo/OTP, dark-mode fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "modo",
       "source": "./",
       "description": "Development reference and project scaffolding for modo v2",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "author": { "name": "Dmytro Momot" },
       "repository": "https://github.com/dmitrymomot/modo",
       "license": "Apache-2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "modo",
   "description": "Skills for building applications with the modo Rust web framework",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": { "name": "Dmytro Momot" },
   "repository": "https://github.com/dmitrymomot/modo",
   "license": "Apache-2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-rs"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 description = "Rust web framework for small monolithic apps"
 license = "Apache-2.0"

--- a/src/email/layout.rs
+++ b/src/email/layout.rs
@@ -67,10 +67,10 @@ body { margin: 0 !important; padding: 0 !important; width: 100% !important; }
 </html>"##;
 
 /// Logo row when `logo_url` is present but `app_url` is not — bare `<img>`.
-const LOGO_SECTION_BARE: &str = r#"<tr><td align="left" style="padding-bottom:24px;"><img src="{{logo_url}}" alt="" style="max-width:96px;height:auto;display:block;border:0;" /></td></tr>"#;
+const LOGO_SECTION_BARE: &str = r#"<tr><td align="left" style="padding-bottom:24px;"><img src="{{logo_url}}" alt="" style="max-width:96px;max-height:48px;height:auto;width:auto;display:block;border:0;" /></td></tr>"#;
 
 /// Logo row when both `logo_url` and `app_url` are present — linked `<img>`.
-const LOGO_SECTION_LINKED: &str = r#"<tr><td align="left" style="padding-bottom:24px;"><a href="{{app_url}}" style="text-decoration:none;border:0;"><img src="{{logo_url}}" alt="" style="max-width:96px;height:auto;display:block;border:0;" /></a></td></tr>"#;
+const LOGO_SECTION_LINKED: &str = r#"<tr><td align="left" style="padding-bottom:24px;"><a href="{{app_url}}" style="text-decoration:none;border:0;"><img src="{{logo_url}}" alt="" style="max-width:96px;max-height:48px;height:auto;width:auto;display:block;border:0;" /></a></td></tr>"#;
 
 const FOOTER_SECTION: &str = concat!(
     r#"<tr><td style="padding-top:40px;font-size:0;line-height:0;">&nbsp;</td></tr>"#,

--- a/src/email/layout.rs
+++ b/src/email/layout.rs
@@ -31,10 +31,11 @@ img { -ms-interpolation-mode: bicubic; max-width: 100%; }
 body { margin: 0 !important; padding: 0 !important; width: 100% !important; }
 @media (prefers-color-scheme: dark) {
   .email-body { background-color: #1a1a1a !important; }
-  .email-card { background-color: #2a2a2a !important; }
+  .email-card { background-color: #1a1a1a !important; }
   .email-content, .email-content * { color: #e4e4e7 !important; }
   .email-footer { color: #a1a1aa !important; }
   .email-divider { border-color: #3f3f46 !important; }
+  .email-otp-bg { background-color: #27272a !important; color: #e4e4e7 !important; }
 }
 @media only screen and (max-width: 620px) {
   .email-outer { padding: 16px 8px !important; }
@@ -42,19 +43,21 @@ body { margin: 0 !important; padding: 0 !important; width: 100% !important; }
 }
 </style>
 </head>
-<body class="email-body" style="margin:0;padding:0;width:100%;background-color:#f4f4f5;-webkit-font-smoothing:antialiased;">
-<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" class="email-body" style="background-color:#f4f4f5;">
+<body class="email-body" style="margin:0;padding:0;width:100%;background-color:#ffffff;-webkit-font-smoothing:antialiased;">
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" class="email-body" style="background-color:#ffffff;">
 <tr>
 <td class="email-outer" align="center" style="padding:24px 16px;">
 <!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
 <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="width:100%;max-width:600px;">
-{{logo_section}}
 <tr>
-<td class="email-card email-content" style="background-color:#ffffff;padding:32px;border-radius:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;line-height:1.6;color:#18181b;">
-{{content}}
+<td class="email-card email-content" style="background-color:#ffffff;padding:32px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;line-height:1.6;color:#18181b;">
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+{{logo_section}}
+<tr><td>{{content}}</td></tr>
+{{footer_section}}
+</table>
 </td>
 </tr>
-{{footer_section}}
 </table>
 <!--[if mso]></td></tr></table><![endif]-->
 </td>
@@ -64,12 +67,15 @@ body { margin: 0 !important; padding: 0 !important; width: 100% !important; }
 </html>"##;
 
 /// Logo row when `logo_url` is present but `app_url` is not — bare `<img>`.
-const LOGO_SECTION_BARE: &str = r#"<tr><td align="center" style="padding-bottom:24px;"><img src="{{logo_url}}" alt="" style="max-width:150px;height:auto;display:block;border:0;" /></td></tr>"#;
+const LOGO_SECTION_BARE: &str = r#"<tr><td align="left" style="padding-bottom:24px;"><img src="{{logo_url}}" alt="" style="max-width:96px;height:auto;display:block;border:0;" /></td></tr>"#;
 
 /// Logo row when both `logo_url` and `app_url` are present — linked `<img>`.
-const LOGO_SECTION_LINKED: &str = r#"<tr><td align="center" style="padding-bottom:24px;"><a href="{{app_url}}" style="text-decoration:none;border:0;"><img src="{{logo_url}}" alt="" style="max-width:150px;height:auto;display:block;border:0;" /></a></td></tr>"#;
+const LOGO_SECTION_LINKED: &str = r#"<tr><td align="left" style="padding-bottom:24px;"><a href="{{app_url}}" style="text-decoration:none;border:0;"><img src="{{logo_url}}" alt="" style="max-width:96px;height:auto;display:block;border:0;" /></a></td></tr>"#;
 
-const FOOTER_SECTION: &str = r#"<tr><td class="email-footer" align="center" style="padding-top:24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#71717a;">{{footer_text}}</td></tr>"#;
+const FOOTER_SECTION: &str = concat!(
+    r#"<tr><td style="padding-top:40px;font-size:0;line-height:0;">&nbsp;</td></tr>"#,
+    r#"<tr><td class="email-footer email-divider" align="left" style="border-top:1px solid #e4e4e7;padding-top:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#71717a;">{{footer_text}}</td></tr>"#,
+);
 
 /// Load custom layouts from the given directory.
 ///
@@ -296,11 +302,35 @@ mod tests {
 
     #[test]
     fn base_layout_has_inline_light_styles() {
-        // Body background inline on <body>
+        // Body background inline on <body> — flat white in light mode
         assert!(
-            BASE_LAYOUT.contains(r#"background-color:#f4f4f5"#)
-                || BASE_LAYOUT.contains(r#"background-color: #f4f4f5"#)
+            BASE_LAYOUT.contains(r#"background-color:#ffffff"#)
+                || BASE_LAYOUT.contains(r#"background-color: #ffffff"#)
         );
+    }
+
+    #[test]
+    fn base_layout_has_otp_dark_override() {
+        // OTP pill gets dark-mode override via .email-otp-bg class
+        assert!(BASE_LAYOUT.contains(".email-otp-bg"));
+    }
+
+    #[test]
+    fn apply_layout_logo_is_left_aligned() {
+        let mut vars = HashMap::new();
+        vars.insert("logo_url".into(), "https://cdn.example.com/logo.png".into());
+        let result = apply_layout(BASE_LAYOUT, "<p>x</p>", &vars);
+        assert!(result.contains(r#"align="left""#));
+        assert!(result.contains("max-width:96px") || result.contains("max-width: 96px"));
+    }
+
+    #[test]
+    fn apply_layout_footer_has_divider() {
+        let mut vars = HashMap::new();
+        vars.insert("footer_text".into(), "© 2026".into());
+        let result = apply_layout(BASE_LAYOUT, "<p>x</p>", &vars);
+        assert!(result.contains("email-divider"));
+        assert!(result.contains("border-top:1px solid"));
     }
 
     #[test]

--- a/src/email/otp.rs
+++ b/src/email/otp.rs
@@ -16,7 +16,7 @@ pub(crate) fn is_valid_code(s: &str) -> bool {
 pub fn render_otp_html(code: &str) -> String {
     let escaped = render::escape_html(code);
     format!(
-        r#"<table role="presentation" border="0" cellpadding="0" cellspacing="0" style="margin:8px 0 24px 0;"><tr><td style="font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:28px;font-weight:700;letter-spacing:6px;color:#18181b;background-color:#f4f4f5;padding:14px 20px;border-radius:8px;">{escaped}</td></tr></table>"#
+        r#"<table role="presentation" border="0" cellpadding="0" cellspacing="0" style="margin:8px 0 24px 0;"><tr><td class="email-otp-bg" style="font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:22px;font-weight:700;letter-spacing:4px;color:#18181b;background-color:#f4f4f5;padding:12px 16px;border-radius:8px;">{escaped}</td></tr></table>"#
     )
 }
 
@@ -74,7 +74,7 @@ mod tests {
         assert!(html.contains(">123456<"));
         assert!(html.contains("role=\"presentation\""));
         assert!(html.contains("font-family:ui-monospace"));
-        assert!(html.contains("letter-spacing:6px"));
+        assert!(html.contains("letter-spacing:4px"));
     }
 
     #[test]
@@ -87,5 +87,12 @@ mod tests {
     #[test]
     fn render_text_format() {
         assert_eq!(render_otp_text("123456"), "\n\n123456\n\n");
+    }
+
+    #[test]
+    fn render_html_has_dark_class() {
+        // .email-otp-bg lets the layout's dark-mode @media rule target the pill
+        let html = render_otp_html("123456");
+        assert!(html.contains(r#"class="email-otp-bg""#));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up polish on the table-based base email layout landed yesterday ([#71](https://github.com/dmitrymomot/modo/issues/71)). Real-inbox testing of a Stafferly sign-in email surfaced four issues this PR fixes:

- **OTP pill inverted in dark mode** — hardcoded light colors with no `@media` override. Added `.email-otp-bg` class and a dark-mode rule (`#27272a` bg, `#e4e4e7` text).
- **Card-on-gray aesthetic** — body was `#f4f4f5`, card was `#ffffff`. Flattened to `#ffffff` throughout in light mode and `#1a1a1a` throughout in dark mode. Dropped `border-radius` since there's no contrast to round.
- **Logo too large, centered** — now left-aligned, `max-width:96px` + `max-height:48px` so tall-aspect logos don't blow up vertically.
- **No separator above footer** — introduced a spacer row for the gap above the line, plus `border-top` on the footer cell itself so the gap between the line and the footer text stays tight. Footer is also left-aligned now. The `email-divider` class still drives the dark-mode border color.

Structurally, logo / content / footer now share the same `email-card` cell via a nested presentation table, so the email reads as a single body rather than three stacked blocks.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --features test-helpers --tests -- -D warnings` clean
- [x] `cargo test --features test-helpers` — 1751 pass, 0 fail
- [x] Rendered against local MailPit via a new (gitignored) `experiments/email-preview` crate; verified in both light and dark MailPit preview modes
- [x] Smoke-test in a real client (Gmail + Apple Mail) before merging

Closes part of the follow-up work on [#71](https://github.com/dmitrymomot/modo/issues/71).