### PR TITLE
fix(middleware): stabilize CSRF token across exempt GETs (#75)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "modo",
       "source": "./",
       "description": "Development reference and project scaffolding for modo v2",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "author": { "name": "Dmytro Momot" },
       "repository": "https://github.com/dmitrymomot/modo",
       "license": "Apache-2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "modo",
   "description": "Skills for building applications with the modo Rust web framework",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": { "name": "Dmytro Momot" },
   "repository": "https://github.com/dmitrymomot/modo",
   "license": "Apache-2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-rs"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 description = "Rust web framework for small monolithic apps"
 license = "Apache-2.0"

--- a/src/middleware/csrf.rs
+++ b/src/middleware/csrf.rs
@@ -184,17 +184,32 @@ where
         let is_exempt = self.is_exempt(request.method());
 
         if is_exempt {
-            // Generate a new token, sign it, set cookie, inject into extensions
-            let token = crate::id::ulid();
-            let signed_value = self.sign_token(&token);
-            let set_cookie_value = self.build_set_cookie(&signed_value);
+            // Reuse the existing token when the cookie verifies; only mint +
+            // Set-Cookie on first visit or signature failure. Rotating on every
+            // GET would invalidate tokens already rendered into open tabs and
+            // long-lived pages, breaking the next state-changing request.
+            let existing = self
+                .extract_cookie_value(&request)
+                .and_then(|signed| self.verify_token(&signed));
+
+            let (token, set_cookie_value) = match existing {
+                Some(t) => (t, None),
+                None => {
+                    let t = crate::id::ulid();
+                    let signed = self.sign_token(&t);
+                    let sc = self.build_set_cookie(&signed);
+                    (t, Some(sc))
+                }
+            };
 
             request.extensions_mut().insert(CsrfToken(token.clone()));
 
             Box::pin(async move {
                 let mut response = inner.call(request).await?;
 
-                if let Ok(header_value) = HeaderValue::from_str(&set_cookie_value) {
+                if let Some(sc) = set_cookie_value
+                    && let Ok(header_value) = HeaderValue::from_str(&sc)
+                {
                     response
                         .headers_mut()
                         .append(http::header::SET_COOKIE, header_value);

--- a/src/middleware/csrf.rs
+++ b/src/middleware/csrf.rs
@@ -75,9 +75,12 @@ impl<S> Layer<S> for CsrfLayer {
 
 /// The [`Service`] produced by `CsrfLayer`.
 ///
-/// For exempt methods (GET, HEAD, OPTIONS by default), generates a new CSRF
-/// token, sets a signed cookie, and injects [`CsrfToken`] into both request
-/// and response extensions.
+/// For exempt methods (GET, HEAD, OPTIONS by default), reuses the token from
+/// the request cookie when its signature verifies — only minting a new token
+/// and emitting `Set-Cookie` on first visit or signature failure. In every
+/// case, [`CsrfToken`] is injected into both request and response extensions.
+/// Keeping the token stable across GETs is required for the double-submit
+/// pattern to survive multi-tab sessions and long-lived pages.
 ///
 /// For unsafe methods (POST, PUT, DELETE, PATCH, etc.), reads the signed
 /// cookie, compares the plain token with the value of the configured header,

--- a/tests/middleware_test.rs
+++ b/tests/middleware_test.rs
@@ -595,6 +595,169 @@ async fn test_csrf_skips_exempt_methods() {
     assert_ne!(response.status(), StatusCode::FORBIDDEN);
 }
 
+#[tokio::test]
+async fn test_csrf_reuses_valid_cookie_across_gets() {
+    async fn handler() -> &'static str {
+        "ok"
+    }
+
+    let config = test_csrf_config();
+    let key = test_cookie_key();
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(modo::middleware::csrf(&config, &key))
+        .with_state(Registry::new().into_state());
+
+    let first = app
+        .clone()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let set_cookie = first
+        .headers()
+        .get("set-cookie")
+        .expect("first GET sets cookie")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let cookie_value = set_cookie.split(';').next().unwrap().to_string();
+    let first_token = first
+        .extensions()
+        .get::<modo::middleware::CsrfToken>()
+        .expect("first GET exposes token")
+        .0
+        .clone();
+
+    let second = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("cookie", &cookie_value)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        second.headers().get("set-cookie").is_none(),
+        "second GET with a valid cookie must not rotate the token"
+    );
+    let second_token = second
+        .extensions()
+        .get::<modo::middleware::CsrfToken>()
+        .expect("second GET exposes token")
+        .0
+        .clone();
+    assert_eq!(first_token, second_token);
+}
+
+#[tokio::test]
+async fn test_csrf_mints_new_token_when_cookie_tampered() {
+    async fn handler() -> &'static str {
+        "ok"
+    }
+
+    let config = test_csrf_config();
+    let key = test_cookie_key();
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(modo::middleware::csrf(&config, &key))
+        .with_state(Registry::new().into_state());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("cookie", "_csrf=not-a-valid-signed-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.headers().get("set-cookie").is_some(),
+        "tampered cookie must trigger a fresh Set-Cookie"
+    );
+    let token = response
+        .extensions()
+        .get::<modo::middleware::CsrfToken>()
+        .expect("token injected into extensions")
+        .0
+        .clone();
+    assert_ne!(token, "not-a-valid-signed-token");
+}
+
+#[tokio::test]
+async fn test_csrf_multi_tab_post_succeeds_after_second_get() {
+    async fn handler() -> &'static str {
+        "ok"
+    }
+
+    let config = test_csrf_config();
+    let key = test_cookie_key();
+    let app = Router::new()
+        .route("/", get(handler))
+        .route("/submit", axum::routing::post(handler))
+        .layer(modo::middleware::csrf(&config, &key))
+        .with_state(Registry::new().into_state());
+
+    // Tab A loads the page and captures cookie + token.
+    let tab_a = app
+        .clone()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let cookie_value = tab_a
+        .headers()
+        .get("set-cookie")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .split(';')
+        .next()
+        .unwrap()
+        .to_string();
+    let tab_a_token = tab_a
+        .extensions()
+        .get::<modo::middleware::CsrfToken>()
+        .unwrap()
+        .0
+        .clone();
+
+    // Tab B opens the same page with Tab A's cookie. The bug rotated the cookie
+    // here; the fix must leave it unchanged.
+    let tab_b = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("cookie", &cookie_value)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(tab_b.headers().get("set-cookie").is_none());
+
+    // Tab A's cached token still matches the server cookie → POST succeeds.
+    let post = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/submit")
+                .header("cookie", &cookie_value)
+                .header("x-csrf-token", &tab_a_token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(post.status(), StatusCode::OK);
+}
+
 // ---------------------------------------------------------------------------
 // Rate Limiting
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes [#75](https://github.com/dmitrymomot/modo/issues/75).

- `CsrfService` was minting a fresh ULID and emitting `Set-Cookie` on *every* GET/HEAD/OPTIONS. A second GET from any tab silently rotated the cookie, invalidating tokens already rendered into open pages — any later POST got a 403.
- In the exempt branch, the middleware now reuses the token from the request cookie when its signature verifies, and only mints + emits `Set-Cookie` when the cookie is missing or fails verification.
- Rotation on login/logout remains the session layer's responsibility (clearing `_csrf` forces a fresh mint on the next GET). `ttl_secs` now actually controls lifetime instead of being reset on every read.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --features test-helpers --tests -- -D warnings`
- [x] `cargo test --features test-helpers` — full suite green
- [x] New regression tests in `tests/middleware_test.rs`:
  - `test_csrf_reuses_valid_cookie_across_gets` — second GET with a valid cookie does not emit `Set-Cookie` and reuses the same token
  - `test_csrf_mints_new_token_when_cookie_tampered` — garbage cookie triggers a fresh `Set-Cookie`
  - `test_csrf_multi_tab_post_succeeds_after_second_get` — end-to-end regression for the multi-tab repro in the bug report