### PR TITLE
chore: upgrade css-inline, raise MSRV to 1.95, bump to 0.10.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "modo",
       "source": "./",
       "description": "Development reference and project scaffolding for modo v2",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "author": { "name": "Dmytro Momot" },
       "repository": "https://github.com/dmitrymomot/modo",
       "license": "Apache-2.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "modo",
   "description": "Skills for building applications with the modo Rust web framework",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "author": { "name": "Dmytro Momot" },
   "repository": "https://github.com/dmitrymomot/modo",
   "license": "Apache-2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modo-rs"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 description = "Rust web framework for small monolithic apps"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/dmitrymomot/modo"
 readme = "README.md"
 keywords = ["web", "framework", "axum", "sqlite"]
 categories = ["web-programming::http-server"]
-rust-version = "1.92"
+rust-version = "1.95"
 exclude = [".claude", ".claude-plugin", "skills", "docs", ".github", "examples", "CLAUDE.md", "justfile", "tests"]
 
 [lib]
@@ -94,7 +94,7 @@ lettre = { version = "0.11", default-features = false, features = [
   "webpki-roots",
 ] }
 pulldown-cmark = "0.13"
-css-inline = { version = "0.16", default-features = false }
+css-inline = { version = "0.20", default-features = false }
 # Templates
 minijinja = { version = "2", features = ["loader"] }
 minijinja-contrib = "2"


### PR DESCRIPTION
## Summary
- Upgrade `css-inline` 0.16 → 0.20 (the only outdated root dependency); builder API is unchanged, no code edits needed
- Raise MSRV from 1.92 to 1.95 to track current stable
- Bump modo version 0.10.3 → 0.10.4 and sync across `Cargo.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`

## Notes
- `generic-array` (0.14.7) and `matchit` (0.8.4) remain pinned upstream: `crypto-common = "=0.14.7"` and `axum = "=0.8.4"` respectively. Not actionable here.

## Test plan
- [x] `cargo check --features test-helpers`
- [x] `cargo test --features test-helpers` — 108 passed, 25 ignored
- [x] `cargo clippy --features test-helpers --tests -- -D warnings` — clean
- [x] `cargo fmt --check`