### PR TITLE
feat(extractor): nested-struct & Vec<Struct> form deserialization via serde_qs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
 serde_urlencoded = "0.7"
+serde_qs = "1.1"
 
 # Error handling
 thiserror = "2"

--- a/docs/superpowers/specs/2026-05-02-nested-form-deserialization-design.md
+++ b/docs/superpowers/specs/2026-05-02-nested-form-deserialization-design.md
@@ -1,0 +1,169 @@
+# Nested form deserialization for `FormRequest`, `Query`, `MultipartRequest`
+
+**Status:** Approved (brainstorming complete, awaiting implementation plan)
+**Date:** 2026-05-02
+**Related issue:** Follow-up to [#78](https://github.com/dmitrymomot/modo/issues/78)
+
+## Context
+
+Issue #78 added `Vec<scalar>` support for repeated form keys (multi-select
+checkboxes, `tag=a&tag=b&tag=c`) by switching `FormRequest<T>`, `Query<T>`,
+and the text-field path of `MultipartRequest<T>` from `serde_urlencoded` to
+`serde_html_form`. That covers two of the three real-world cases in the
+issue; it does **not** cover the third one — per-row dynamic forms with
+multiple fields per row.
+
+Concrete need: a "new client" form with `client_name: String` plus a
+dynamic contacts list where each row has `type`, `value`, and `comment`.
+Today the only viable shape is three parallel `Vec<String>` fields zipped in
+the handler. That works but:
+
+- Misaligned rows (e.g. browser drops one field) silently corrupt the
+  result — the handler can't tell which row lost which field.
+- Per-row validation (`Validate` on each `Contact`) requires the handler
+  to do the zip first, then validate, instead of the framework doing both.
+- Adding/removing a per-row field touches both the HTML and the handler in
+  three places.
+
+The fix: support `contacts[0][type]=email&contacts[0][value]=…&contacts[1][type]=phone&…`
+form bodies and deserialize them into `Vec<Contact>` directly.
+
+## Approach
+
+Replace `serde_html_form` with `serde_qs` 1.1 in the three sanitizing
+extractors (`FormRequest`, `Query`, `MultipartRequest` text-field path).
+
+`serde_qs` is a strict superset of `serde_html_form` for our use cases:
+
+- Flat fields work identically.
+- Repeated keys → `Vec<scalar>` works ("If the deserializer expects a
+  sequence, we'll deserialize all values into the sequence" — serde_qs
+  docs). This preserves issue #78's behavior.
+- Adds nested-struct deserialization (`address[city]=…`).
+- Adds `Vec<Struct>` deserialization via indexed brackets
+  (`contacts[0][type]=…`).
+- Indexed and unindexed array syntax both accepted on input.
+
+Cost: ~50% deserialize overhead vs `serde_urlencoded` (per crate docs,
+still single-digit microseconds in absolute terms), and serde_qs error
+messages differ in wording. Both acceptable.
+
+### Why a single deserializer rather than a sibling extractor
+
+The user's framework rule (`feedback_breaking_changes_ok` memory; pre-1.0
+project) and the explicit decision in issue #78 ("framework should just do
+the right thing") both push toward upgrading the existing extractors
+in-place rather than introducing `NestedFormRequest` /
+`MultiFormRequest`. There is no scenario where a handler would prefer the
+narrower `serde_html_form` deserializer over the broader `serde_qs` one
+for the same input shape.
+
+### Safety re: db filtering and pagination (explicit user constraint)
+
+Both subsystems are untouched and independent of the deserializer choice:
+
+- **`src/db/filter.rs`** — `Filter::from_request_parts` walks the raw
+  query string with a hand-rolled `split('&')` / `urlencoding::decode`
+  loop, building a `HashMap<String, Vec<String>>`. No serde involved. Its
+  syntax (`field.gt=value`, `sort=-name`) uses dots, not brackets, so
+  there's no syntactic collision with bracketed forms either.
+- **`src/db/page.rs`** — `PageRequest` and `CursorRequest` call
+  `axum::extract::Query` (i.e. `serde_urlencoded`) directly, not our
+  `Query<T>`. They have only flat scalar fields, so the deserializer
+  choice would not change behavior even if we did upgrade them. We leave
+  them as-is.
+
+## Architecture
+
+### Per-extractor configuration
+
+Two `serde_qs::Config` instances, picked per surface:
+
+| Extractor | Mode | Reason |
+|---|---|---|
+| `FormRequest<T>` | `use_form_encoding(true)` | Browsers percent-encode `[`/`]` as `%5B`/`%5D` in `application/x-www-form-urlencoded` bodies; this mode decodes both bare and percent-encoded brackets and treats `+` as space. |
+| `MultipartRequest<T>` text fields | `use_form_encoding(true)` | Multipart text fields are equivalent to form fields after the boundary parse. |
+| `Query<T>` | default (`use_form_encoding(false)`) | URL query strings conventionally allow bare `[`/`]`; default mode keeps URL templates readable while still accepting percent-encoded brackets. |
+
+### Array semantics
+
+serde_qs's deserializer accepts **both** indexed and unindexed array
+syntax on input (`array_format` only controls *serialization*):
+
+- `tag=a&tag=b` → `Vec<String>` ✅
+- `tags[0]=a&tags[1]=b` → `Vec<String>` ✅
+- `contacts[0][type]=email&contacts[0][value]=…` → `Vec<Contact>` ✅
+
+For `Vec<Struct>` the **indexed form is required** — without indices the
+deserializer cannot disambiguate which field belongs to which row. This
+must be called out in the README.
+
+### Top-level shape constraint
+
+serde_qs requires the top-level type to be a struct or map. All existing
+handlers already pass structs, and the multi-field form-body model
+inherently fits a struct shape. No behavior change.
+
+## Error handling
+
+Same as today: any deserialize failure becomes
+`crate::Error::bad_request(format!("invalid form data: {e}"))` (or the
+analogous query/multipart message). serde_qs returns structured errors
+for malformed bracketed keys (unclosed `[`, mismatched depth, etc.); the
+formatted message is forwarded verbatim. No new error variants needed.
+
+## Testing
+
+Add to `tests/extractor_test.rs`:
+
+1. `test_form_request_nested_struct` — `client[name]=Acme&client[id]=42`
+   deserializes into a `Client { name, id }` field.
+2. `test_form_request_vec_of_structs` — full real-world body
+   `name=ACME&contacts[0][type]=email&contacts[0][value]=a@b.com&contacts[0][comment]=primary&contacts[1][type]=phone&contacts[1][value]=555-0100&contacts[1][comment]=`
+   deserializes into `Vec<Contact>` of length 2 with the right field
+   values, including the empty-comment case.
+3. `test_form_request_vec_of_structs_percent_encoded_brackets` — same
+   body but with `%5B`/`%5D`, locking in form-encoding mode behavior.
+4. `test_query_extractor_nested_struct` —
+   `?filter[status]=active&filter[role]=admin` via `Query<T>` →
+   `FilterParams { status, role }`.
+5. `test_multipart_request_vec_of_structs` — multipart body with
+   `contacts[0][type]` etc. → `Vec<Contact>`.
+
+All existing tests must continue to pass unchanged, including the four
+issue-#78 tests for repeated keys and parallel-arrays-via-zip.
+
+Verification commands (per `CLAUDE.md`):
+
+```
+cargo fmt --check
+cargo clippy --features test-helpers --tests -- -D warnings
+cargo test --features test-helpers
+cargo test --doc --features test-helpers
+```
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `Cargo.toml` | `+ serde_qs = "1.1"`; `- serde_html_form`. |
+| `src/extractor/form.rs` | Replace `serde_html_form::from_bytes` with `serde_qs::Config::new().use_form_encoding(true).deserialize_bytes(&bytes)`. Keep the existing content-type guard, body-bytes read, and sanitize step. |
+| `src/extractor/query.rs` | Replace `serde_html_form::from_str` with `serde_qs::from_str` (default config). |
+| `src/extractor/multipart.rs` | Replace `serde_html_form::from_str(&encoded)` with `serde_qs::Config::new().use_form_encoding(true).deserialize_str(&encoded)`. Re-encode step stays the same. |
+| `src/extractor/mod.rs` | Update module-level doc comment to mention nested-struct + `Vec<Struct>` support. |
+| `src/extractor/README.md` | Add "Nested structures" and "Vec of structs (dynamic rows)" subsections. The existing "Per-row parallel arrays" subsection from issue #78 stays as a documented alternative for the case where the HTML cannot emit indexed names. |
+| `tests/extractor_test.rs` | Five new tests listed above. |
+
+## Out of scope
+
+- Touching `Filter` (`src/db/filter.rs`) or pagination extractors
+  (`src/db/page.rs`) — explicit user constraint. They already work and
+  use parsers independent of the deserializer choice.
+- Bumping `Cargo.toml` version or running the project's version-sync
+  sweep across READMEs / skill references — release-time chore, not part
+  of this change.
+- Adding a sibling `NestedFormRequest` / `MultiFormRequest` extractor —
+  single-extractor approach approved.
+- Migrating `src/testing/request.rs` (form-body builder) or `db::page`
+  test calls away from `serde_urlencoded` — they only need flat encoding
+  and serde_urlencoded stays a dependency.

--- a/src/extractor/README.md
+++ b/src/extractor/README.md
@@ -80,6 +80,122 @@ async fn login(FormRequest(form): FormRequest<LoginForm>) {
 }
 ```
 
+#### Repeated keys (multi-select checkboxes / dropdowns)
+
+`FormRequest`, `Query`, and the text-field side of `MultipartRequest` deserialize via
+`serde_qs`, so a repeated form key populates a `Vec<…>` field. A 7-checkbox work-day
+picker that posts `work_days=1&work_days=2&work_days=3&work_days=4&work_days=5`
+arrives as `Vec<u8>` with five elements:
+
+```rust
+use modo::extractor::FormRequest;
+use modo::sanitize::Sanitize;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct NewEmployee {
+    name: String,
+    work_days: Vec<u8>,        // multi-select checkbox group
+    policy_ids: Vec<String>,   // multi-select list
+}
+
+impl Sanitize for NewEmployee {
+    fn sanitize(&mut self) {
+        self.name = self.name.trim().to_string();
+    }
+}
+
+async fn create(FormRequest(form): FormRequest<NewEmployee>) {
+    // form.work_days = [1, 2, 3, 4, 5]
+}
+```
+
+#### Nested structs (bracketed keys)
+
+For grouped fields, use bracket notation in the input names:
+
+```html
+<input name="address[city]" />
+<input name="address[postcode]" />
+```
+
+```rust
+#[derive(Deserialize)]
+struct Address { city: String, postcode: String }
+
+#[derive(Deserialize)]
+struct OrderForm { customer_email: String, address: Address }
+
+impl Sanitize for OrderForm {
+    fn sanitize(&mut self) {
+        self.customer_email = self.customer_email.trim().to_lowercase();
+    }
+}
+
+async fn place_order(FormRequest(o): FormRequest<OrderForm>) {
+    // o.address.city, o.address.postcode
+}
+```
+
+#### `Vec<Struct>` for dynamic rows (htmx, JS-added rows)
+
+For per-row dynamic forms — e.g. a contact list where each row has `kind`, `value`,
+and `comment` — use **indexed** bracket notation. The index disambiguates which
+fields belong to which row:
+
+```html
+<!-- Row 0 -->
+<input name="contacts[0][kind]"    value="email" />
+<input name="contacts[0][value]"   value="a@b.com" />
+<input name="contacts[0][comment]" value="primary" />
+<!-- Row 1 -->
+<input name="contacts[1][kind]"    value="phone" />
+<input name="contacts[1][value]"   value="555-0100" />
+<input name="contacts[1][comment]" value="" />
+```
+
+```rust
+#[derive(Deserialize)]
+struct Contact { kind: String, value: String, comment: String }
+
+#[derive(Deserialize)]
+struct NewClient { name: String, contacts: Vec<Contact> }
+
+impl Sanitize for NewClient {
+    fn sanitize(&mut self) { self.name = self.name.trim().to_string(); }
+}
+
+async fn save(FormRequest(c): FormRequest<NewClient>) {
+    // c.contacts is one entry per submitted row, in index order
+}
+```
+
+> **Indexed names are required for `Vec<Struct>`.** Without indices the
+> deserializer cannot tell which fields belong to which row. For top-level
+> `Vec<scalar>` fields (e.g. `tag=a&tag=b`) the indices are optional.
+
+#### Files alongside nested fields (multipart)
+
+`MultipartRequest<T>` returns `(T, Files)`. Nested-struct deserialization applies to
+the text fields in `T`; uploaded files come back through the `Files` map keyed by
+the multipart field name (which can itself use bracket notation):
+
+```rust
+use modo::extractor::{MultipartRequest, Files};
+
+# use serde::Deserialize;
+# use modo::sanitize::Sanitize;
+#[derive(Deserialize)]
+struct Contact { kind: String, value: String }
+#[derive(Deserialize)]
+struct NewClient { name: String, contacts: Vec<Contact> }
+impl Sanitize for NewClient { fn sanitize(&mut self) {} }
+
+async fn save(MultipartRequest(c, mut files): MultipartRequest<NewClient>) {
+    let avatar = files.file("avatar"); // Option<UploadedFile>
+}
+```
+
 ### Query string
 
 ```rust

--- a/src/extractor/form.rs
+++ b/src/extractor/form.rs
@@ -1,4 +1,4 @@
-use axum::body::{Body, to_bytes};
+use axum::body::Body;
 use axum::extract::FromRequest;
 use http::{Request, header};
 use serde::de::DeserializeOwned;
@@ -55,14 +55,14 @@ where
 {
     type Rejection = crate::error::Error;
 
-    async fn from_request(req: Request<Body>, _state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
         if !has_form_content_type(&req) {
             return Err(crate::error::Error::bad_request(
                 "expected `application/x-www-form-urlencoded` content type",
             ));
         }
 
-        let bytes = to_bytes(req.into_body(), usize::MAX)
+        let bytes = axum::body::Bytes::from_request(req, state)
             .await
             .map_err(|e| crate::error::Error::bad_request(format!("failed to read body: {e}")))?;
 

--- a/src/extractor/form.rs
+++ b/src/extractor/form.rs
@@ -64,7 +64,9 @@ where
 
         let bytes = axum::body::Bytes::from_request(req, state)
             .await
-            .map_err(|e| crate::error::Error::bad_request(format!("failed to read body: {e}")))?;
+            .map_err(|e| {
+                crate::error::Error::new(e.status(), format!("failed to read body: {e}"))
+            })?;
 
         let mut value: T = serde_qs::Config::new()
             .use_form_encoding(true)

--- a/src/extractor/form.rs
+++ b/src/extractor/form.rs
@@ -1,5 +1,6 @@
+use axum::body::{Body, to_bytes};
 use axum::extract::FromRequest;
-use http::Request;
+use http::{Request, header};
 use serde::de::DeserializeOwned;
 
 use crate::sanitize::Sanitize;
@@ -7,6 +8,12 @@ use crate::sanitize::Sanitize;
 /// Axum extractor that deserializes a URL-encoded form body into `T` and then sanitizes it.
 ///
 /// `T` must implement both [`serde::de::DeserializeOwned`] and [`crate::sanitize::Sanitize`].
+///
+/// Repeated form keys, nested structs, and `Vec<Struct>` rows all deserialize via `serde_qs`
+/// form-encoding mode. Flat repeats (`tag=a&tag=b`) populate `Vec<scalar>` fields,
+/// `client[name]=…` populates a nested struct, and indexed brackets (`contacts[0][kind]=…`)
+/// populate `Vec<Struct>` rows. For per-row dynamic forms, the indexed form is required so
+/// the deserializer can group fields into the correct row.
 ///
 /// # Errors
 ///
@@ -22,14 +29,21 @@ use crate::sanitize::Sanitize;
 /// use serde::Deserialize;
 ///
 /// #[derive(Deserialize)]
-/// struct LoginForm { username: String, password: String }
+/// struct Contact { kind: String, value: String, comment: String }
 ///
-/// impl Sanitize for LoginForm {
-///     fn sanitize(&mut self) { self.username = self.username.trim().to_lowercase(); }
+/// #[derive(Deserialize)]
+/// struct NewClient {
+///     name: String,
+///     work_days: Vec<u8>,        // multi-select checkbox group
+///     contacts: Vec<Contact>,    // contacts[0][kind]=…&contacts[0][value]=…
 /// }
 ///
-/// async fn login(FormRequest(form): FormRequest<LoginForm>) {
-///     // form.username is already trimmed and lowercased
+/// impl Sanitize for NewClient {
+///     fn sanitize(&mut self) { self.name = self.name.trim().to_string(); }
+/// }
+///
+/// async fn create(FormRequest(form): FormRequest<NewClient>) {
+///     // form.contacts has one entry per submitted row
 /// }
 /// ```
 pub struct FormRequest<T>(pub T);
@@ -41,14 +55,33 @@ where
 {
     type Rejection = crate::error::Error;
 
-    async fn from_request(
-        req: Request<axum::body::Body>,
-        state: &S,
-    ) -> Result<Self, Self::Rejection> {
-        let axum::Form(mut value) = axum::Form::<T>::from_request(req, state)
+    async fn from_request(req: Request<Body>, _state: &S) -> Result<Self, Self::Rejection> {
+        if !has_form_content_type(&req) {
+            return Err(crate::error::Error::bad_request(
+                "expected `application/x-www-form-urlencoded` content type",
+            ));
+        }
+
+        let bytes = to_bytes(req.into_body(), usize::MAX)
             .await
+            .map_err(|e| crate::error::Error::bad_request(format!("failed to read body: {e}")))?;
+
+        let mut value: T = serde_qs::Config::new()
+            .use_form_encoding(true)
+            .deserialize_bytes(&bytes)
             .map_err(|e| crate::error::Error::bad_request(format!("invalid form data: {e}")))?;
         value.sanitize();
         Ok(FormRequest(value))
     }
+}
+
+fn has_form_content_type<B>(req: &Request<B>) -> bool {
+    let Some(value) = req.headers().get(header::CONTENT_TYPE) else {
+        return false;
+    };
+    let Ok(text) = value.to_str() else {
+        return false;
+    };
+    let mime_type = text.split(';').next().unwrap_or("").trim();
+    mime_type.eq_ignore_ascii_case("application/x-www-form-urlencoded")
 }

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -16,9 +16,10 @@
 //! - Indexed brackets (`contacts[0][kind]=…&contacts[0][value]=…`) populate
 //!   `Vec<Struct>` rows — htmx-added dynamic-row groups and per-row contact lists.
 //!
-//! `FormRequest` and `MultipartRequest` use `serde_qs` form-encoding mode so they
-//! accept browser-encoded brackets (`%5B`/`%5D`); `Query<T>` uses default mode so
-//! URL templates can keep bare brackets.
+//! All three extractors use `serde_qs` form-encoding mode, so they accept both bare
+//! brackets (`?filter[status]=active`) and browser-percent-encoded brackets
+//! (`?filter%5Bstatus%5D=active`). `+` decodes as space, matching standard form and
+//! query-string conventions.
 //!
 //! Provides:
 //!

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -7,6 +7,19 @@
 //! normalization happen automatically. Rejections are [`crate::Error`] values with
 //! `400 Bad Request` status, which render through [`crate::Error::into_response`].
 //!
+//! `FormRequest`, `Query`, and the text-field side of `MultipartRequest` deserialize
+//! through `serde_qs`, so HTML forms can map directly into Rust structs:
+//!
+//! - Repeated keys (`tag=a&tag=b`) populate `Vec<scalar>` fields — multi-select
+//!   checkbox groups and dropdown lists.
+//! - Bracketed keys (`address[city]=…`) populate nested struct fields.
+//! - Indexed brackets (`contacts[0][kind]=…&contacts[0][value]=…`) populate
+//!   `Vec<Struct>` rows — htmx-added dynamic-row groups and per-row contact lists.
+//!
+//! `FormRequest` and `MultipartRequest` use `serde_qs` form-encoding mode so they
+//! accept browser-encoded brackets (`%5B`/`%5D`); `Query<T>` uses default mode so
+//! URL templates can keep bare brackets.
+//!
 //! Provides:
 //!
 //! - [`JsonRequest<T>`] — JSON body (`T: DeserializeOwned + Sanitize`)

--- a/src/extractor/multipart.rs
+++ b/src/extractor/multipart.rs
@@ -142,7 +142,8 @@ impl Files {
 /// file fields (collected into a [`Files`] map). The inner tuple is `(T, Files)`.
 ///
 /// Text fields are re-encoded as `application/x-www-form-urlencoded` and deserialized
-/// via `serde_urlencoded` before [`Sanitize::sanitize`] is called on the result. File
+/// via `serde_html_form` before [`Sanitize::sanitize`] is called on the result. Repeated
+/// text fields populate `Vec<…>` fields just like [`crate::extractor::FormRequest`]. File
 /// fields are fully buffered into memory as [`UploadedFile`] values.
 ///
 /// # Errors
@@ -218,9 +219,12 @@ where
         let encoded = serde_urlencoded::to_string(&text_fields).map_err(|e| {
             Error::bad_request(format!("failed to encode multipart text fields: {e}"))
         })?;
-        let mut value: T = serde_urlencoded::from_str(&encoded).map_err(|e| {
-            Error::bad_request(format!("failed to deserialize multipart text fields: {e}"))
-        })?;
+        let mut value: T = serde_qs::Config::new()
+            .use_form_encoding(true)
+            .deserialize_str(&encoded)
+            .map_err(|e| {
+                Error::bad_request(format!("failed to deserialize multipart text fields: {e}"))
+            })?;
         value.sanitize();
 
         Ok(MultipartRequest(value, Files(file_fields)))

--- a/src/extractor/multipart.rs
+++ b/src/extractor/multipart.rs
@@ -142,9 +142,11 @@ impl Files {
 /// file fields (collected into a [`Files`] map). The inner tuple is `(T, Files)`.
 ///
 /// Text fields are re-encoded as `application/x-www-form-urlencoded` and deserialized
-/// via `serde_html_form` before [`Sanitize::sanitize`] is called on the result. Repeated
-/// text fields populate `Vec<…>` fields just like [`crate::extractor::FormRequest`]. File
-/// fields are fully buffered into memory as [`UploadedFile`] values.
+/// via `serde_qs` (form-encoding mode) before [`Sanitize::sanitize`] is called on the
+/// result. Repeated text fields, nested structs (`address[city]=…`), and indexed-bracket
+/// `Vec<Struct>` rows (`contacts[0][kind]=…`) all deserialize naturally — same behavior
+/// as [`crate::extractor::FormRequest`]. File fields are fully buffered into memory as
+/// [`UploadedFile`] values.
 ///
 /// # Errors
 ///

--- a/src/extractor/query.rs
+++ b/src/extractor/query.rs
@@ -8,7 +8,7 @@ use crate::sanitize::Sanitize;
 ///
 /// `T` must implement both [`serde::de::DeserializeOwned`] and [`crate::sanitize::Sanitize`].
 ///
-/// Repeated query keys deserialize into `Vec<…>` fields — for example `?tag=a&tag=b&tag=c`
+/// Repeated query keys deserialize into `Vec<…>` fields — for example `?tags=a&tags=b&tags=c`
 /// populates a `tags: Vec<String>` field with three elements. Nested keys
 /// (`?filter[status]=active`) populate nested struct fields, and indexed brackets
 /// (`?items[0][id]=…`) populate `Vec<Struct>` rows.
@@ -62,7 +62,9 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let query = parts.uri.query().unwrap_or("");
-        let mut value: T = serde_qs::from_str(query)
+        let mut value: T = serde_qs::Config::new()
+            .use_form_encoding(true)
+            .deserialize_str(query)
             .map_err(|e| crate::error::Error::bad_request(format!("invalid query: {e}")))?;
         value.sanitize();
         Ok(Query(value))

--- a/src/extractor/query.rs
+++ b/src/extractor/query.rs
@@ -8,6 +8,9 @@ use crate::sanitize::Sanitize;
 ///
 /// `T` must implement both [`serde::de::DeserializeOwned`] and [`crate::sanitize::Sanitize`].
 ///
+/// Repeated query keys deserialize into `Vec<…>` fields — for example `?tag=a&tag=b&tag=c`
+/// populates a `tags: Vec<String>` field with three elements.
+///
 /// Because this extractor implements [`FromRequestParts`] rather than `FromRequest`, it
 /// can be combined with body extractors on the same handler. To make `Query` optional
 /// (i.e. `Option<Query<T>>`), axum 0.8 requires an explicit `OptionalFromRequestParts`
@@ -28,14 +31,14 @@ use crate::sanitize::Sanitize;
 /// use serde::Deserialize;
 ///
 /// #[derive(Deserialize)]
-/// struct SearchParams { q: String, page: Option<u32> }
+/// struct SearchParams { q: String, page: Option<u32>, tags: Vec<String> }
 ///
 /// impl Sanitize for SearchParams {
 ///     fn sanitize(&mut self) { self.q = self.q.trim().to_lowercase(); }
 /// }
 ///
 /// async fn search(Query(params): Query<SearchParams>) {
-///     // params.q is already trimmed and lowercased
+///     // params.q is trimmed; params.tags collects every `?tags=` repeat
 /// }
 /// ```
 pub struct Query<T>(pub T);
@@ -47,11 +50,10 @@ where
 {
     type Rejection = crate::error::Error;
 
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let axum::extract::Query(mut value) =
-            axum::extract::Query::<T>::from_request_parts(parts, state)
-                .await
-                .map_err(|e| crate::error::Error::bad_request(format!("invalid query: {e}")))?;
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let query = parts.uri.query().unwrap_or("");
+        let mut value: T = serde_qs::from_str(query)
+            .map_err(|e| crate::error::Error::bad_request(format!("invalid query: {e}")))?;
         value.sanitize();
         Ok(Query(value))
     }

--- a/src/extractor/query.rs
+++ b/src/extractor/query.rs
@@ -9,7 +9,9 @@ use crate::sanitize::Sanitize;
 /// `T` must implement both [`serde::de::DeserializeOwned`] and [`crate::sanitize::Sanitize`].
 ///
 /// Repeated query keys deserialize into `Vec<…>` fields — for example `?tag=a&tag=b&tag=c`
-/// populates a `tags: Vec<String>` field with three elements.
+/// populates a `tags: Vec<String>` field with three elements. Nested keys
+/// (`?filter[status]=active`) populate nested struct fields, and indexed brackets
+/// (`?items[0][id]=…`) populate `Vec<Struct>` rows.
 ///
 /// Because this extractor implements [`FromRequestParts`] rather than `FromRequest`, it
 /// can be combined with body extractors on the same handler. To make `Query` optional
@@ -31,14 +33,22 @@ use crate::sanitize::Sanitize;
 /// use serde::Deserialize;
 ///
 /// #[derive(Deserialize)]
-/// struct SearchParams { q: String, page: Option<u32>, tags: Vec<String> }
+/// struct Filter { status: String, role: String }
+///
+/// #[derive(Deserialize)]
+/// struct SearchParams {
+///     q: String,
+///     page: Option<u32>,
+///     tags: Vec<String>,   // ?tags=web&tags=axum
+///     filter: Filter,      // ?filter[status]=active&filter[role]=admin
+/// }
 ///
 /// impl Sanitize for SearchParams {
 ///     fn sanitize(&mut self) { self.q = self.q.trim().to_lowercase(); }
 /// }
 ///
-/// async fn search(Query(params): Query<SearchParams>) {
-///     // params.q is trimmed; params.tags collects every `?tags=` repeat
+/// async fn search(Query(p): Query<SearchParams>) {
+///     // p.filter.status is "active"
 /// }
 /// ```
 pub struct Query<T>(pub T);

--- a/tests/extractor_test.rs
+++ b/tests/extractor_test.rs
@@ -731,6 +731,50 @@ async fn test_multipart_request_vec_of_structs() {
 }
 
 #[tokio::test]
+async fn test_query_extractor_percent_encoded_brackets() {
+    #[derive(Deserialize)]
+    struct EncodedFilterParams {
+        filter: EncodedFilterInner,
+    }
+    #[derive(Deserialize)]
+    struct EncodedFilterInner {
+        status: String,
+        role: String,
+    }
+    impl Sanitize for EncodedFilterParams {
+        fn sanitize(&mut self) {}
+    }
+
+    async fn handler(
+        modo::extractor::Query(p): modo::extractor::Query<EncodedFilterParams>,
+    ) -> String {
+        format!("{}|{}", p.filter.status, p.filter.role)
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", get(handler))
+        .with_state(registry.into_state());
+
+    // %5B = '[', %5D = ']' — what URLSearchParams / axios default emit
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/?filter%5Bstatus%5D=active&filter%5Brole%5D=admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"active|admin");
+}
+
+#[tokio::test]
 async fn test_form_request_vec_of_structs_percent_encoded_brackets() {
     #[derive(Deserialize)]
     struct EncodedContact {

--- a/tests/extractor_test.rs
+++ b/tests/extractor_test.rs
@@ -133,6 +133,206 @@ async fn test_form_request_deserializes_and_sanitizes() {
     assert_eq!(&body[..], b"hello");
 }
 
+#[derive(Deserialize)]
+struct MultiSelectForm {
+    name: String,
+    work_days: Vec<u8>,
+    policy_ids: Vec<String>,
+}
+
+impl Sanitize for MultiSelectForm {
+    fn sanitize(&mut self) {
+        modo::sanitize::trim(&mut self.name);
+    }
+}
+
+#[tokio::test]
+async fn test_form_request_repeated_keys_into_vec() {
+    async fn handler(
+        modo::extractor::FormRequest(form): modo::extractor::FormRequest<MultiSelectForm>,
+    ) -> String {
+        let days = form
+            .work_days
+            .iter()
+            .map(u8::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        format!("{}|{}|{}", form.name, days, form.policy_ids.join(","))
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", axum::routing::post(handler))
+        .with_state(registry.into_state());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "name=Alice&work_days=1&work_days=2&work_days=3&work_days=4&work_days=5\
+                     &policy_ids=pto&policy_ids=sick",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"Alice|1,2,3,4,5|pto,sick");
+}
+
+#[derive(Deserialize)]
+struct ParallelArrayForm {
+    contact_type: Vec<String>,
+    contact_value: Vec<String>,
+}
+
+impl Sanitize for ParallelArrayForm {
+    fn sanitize(&mut self) {}
+}
+
+#[tokio::test]
+async fn test_form_request_parallel_arrays() {
+    async fn handler(
+        modo::extractor::FormRequest(form): modo::extractor::FormRequest<ParallelArrayForm>,
+    ) -> String {
+        form.contact_type
+            .into_iter()
+            .zip(form.contact_value)
+            .map(|(kind, value)| format!("{kind}={value}"))
+            .collect::<Vec<_>>()
+            .join(";")
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", axum::routing::post(handler))
+        .with_state(registry.into_state());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "contact_type=email&contact_value=a%40b.com\
+                     &contact_type=phone&contact_value=555-0100",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"email=a@b.com;phone=555-0100");
+}
+
+#[tokio::test]
+async fn test_query_extractor_repeated_keys_into_vec() {
+    #[derive(Deserialize)]
+    struct TaggedSearch {
+        q: String,
+        tags: Vec<String>,
+    }
+    impl Sanitize for TaggedSearch {
+        fn sanitize(&mut self) {
+            modo::sanitize::trim(&mut self.q);
+        }
+    }
+
+    async fn handler(modo::extractor::Query(p): modo::extractor::Query<TaggedSearch>) -> String {
+        format!("{}|{}", p.q, p.tags.join(","))
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", get(handler))
+        .with_state(registry.into_state());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/?q=rust&tags=web&tags=axum&tags=sqlite")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"rust|web,axum,sqlite");
+}
+
+#[tokio::test]
+async fn test_multipart_request_repeated_text_fields() {
+    #[derive(Deserialize)]
+    struct ChecklistForm {
+        title: String,
+        items: Vec<String>,
+    }
+    impl Sanitize for ChecklistForm {
+        fn sanitize(&mut self) {
+            modo::sanitize::trim(&mut self.title);
+        }
+    }
+
+    async fn handler(
+        modo::extractor::MultipartRequest(form, _): modo::extractor::MultipartRequest<
+            ChecklistForm,
+        >,
+    ) -> String {
+        format!("{}|{}", form.title, form.items.join(","))
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", axum::routing::post(handler))
+        .with_state(registry.into_state());
+
+    let boundary = "----TestRepeatBoundary";
+    let body = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nGroceries\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"items\"\r\n\r\nmilk\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"items\"\r\n\r\neggs\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"items\"\r\n\r\nbread\r\n\
+         --{boundary}--\r\n"
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"Groceries|milk,eggs,bread");
+}
+
 #[tokio::test]
 async fn test_query_extractor_sanitizes() {
     async fn handler(modo::extractor::Query(item): modo::extractor::Query<CreateItem>) -> String {
@@ -307,6 +507,55 @@ async fn test_json_request_rejects_invalid_json() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[derive(Deserialize)]
+struct ClientForm {
+    client: ClientInner,
+}
+
+#[derive(Deserialize)]
+struct ClientInner {
+    name: String,
+    id: u32,
+}
+
+impl Sanitize for ClientForm {
+    fn sanitize(&mut self) {
+        modo::sanitize::trim(&mut self.client.name);
+    }
+}
+
+#[tokio::test]
+async fn test_form_request_nested_struct() {
+    async fn handler(
+        modo::extractor::FormRequest(form): modo::extractor::FormRequest<ClientForm>,
+    ) -> String {
+        format!("{}|{}", form.client.name, form.client.id)
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", axum::routing::post(handler))
+        .with_state(registry.into_state());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("client[name]=Acme&client[id]=42"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"Acme|42");
 }
 
 #[tokio::test]

--- a/tests/extractor_test.rs
+++ b/tests/extractor_test.rs
@@ -729,3 +729,56 @@ async fn test_multipart_request_vec_of_structs() {
         .unwrap();
     assert_eq!(&body[..], b"Acme|email=a@b.com;phone=555-0100");
 }
+
+#[tokio::test]
+async fn test_form_request_vec_of_structs_percent_encoded_brackets() {
+    #[derive(Deserialize)]
+    struct EncodedContact {
+        kind: String,
+        value: String,
+    }
+    #[derive(Deserialize)]
+    struct EncodedClientForm {
+        contacts: Vec<EncodedContact>,
+    }
+    impl Sanitize for EncodedClientForm {
+        fn sanitize(&mut self) {}
+    }
+
+    async fn handler(
+        modo::extractor::FormRequest(form): modo::extractor::FormRequest<EncodedClientForm>,
+    ) -> String {
+        form.contacts
+            .into_iter()
+            .map(|c| format!("{}={}", c.kind, c.value))
+            .collect::<Vec<_>>()
+            .join(";")
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", axum::routing::post(handler))
+        .with_state(registry.into_state());
+
+    // %5B = '[', %5D = ']'  — what real browsers send
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "contacts%5B0%5D%5Bkind%5D=email&contacts%5B0%5D%5Bvalue%5D=a%40b.com\
+                     &contacts%5B1%5D%5Bkind%5D=phone&contacts%5B1%5D%5Bvalue%5D=555-0100",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"email=a@b.com;phone=555-0100");
+}

--- a/tests/extractor_test.rs
+++ b/tests/extractor_test.rs
@@ -619,3 +619,113 @@ async fn test_multipart_request_with_file_upload() {
         format!("Alice|photo.jpg|image/jpeg|{}", file_data.len())
     );
 }
+
+#[tokio::test]
+async fn test_query_extractor_nested_struct() {
+    #[derive(Deserialize)]
+    struct FilterParams {
+        filter: FilterInner,
+    }
+    #[derive(Deserialize)]
+    struct FilterInner {
+        status: String,
+        role: String,
+    }
+    impl Sanitize for FilterParams {
+        fn sanitize(&mut self) {}
+    }
+
+    async fn handler(modo::extractor::Query(p): modo::extractor::Query<FilterParams>) -> String {
+        format!("{}|{}", p.filter.status, p.filter.role)
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", get(handler))
+        .with_state(registry.into_state());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/?filter[status]=active&filter[role]=admin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"active|admin");
+}
+
+#[tokio::test]
+async fn test_multipart_request_vec_of_structs() {
+    #[derive(Deserialize)]
+    struct ContactRow {
+        kind: String,
+        value: String,
+    }
+    #[derive(Deserialize)]
+    struct NewClientForm {
+        name: String,
+        contacts: Vec<ContactRow>,
+    }
+    impl Sanitize for NewClientForm {
+        fn sanitize(&mut self) {
+            modo::sanitize::trim(&mut self.name);
+        }
+    }
+
+    async fn handler(
+        modo::extractor::MultipartRequest(form, _): modo::extractor::MultipartRequest<
+            NewClientForm,
+        >,
+    ) -> String {
+        let rows = form
+            .contacts
+            .into_iter()
+            .map(|c| format!("{}={}", c.kind, c.value))
+            .collect::<Vec<_>>()
+            .join(";");
+        format!("{}|{}", form.name, rows)
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", axum::routing::post(handler))
+        .with_state(registry.into_state());
+
+    let boundary = "----TestNestedBoundary";
+    let body = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\nAcme\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"contacts[0][kind]\"\r\n\r\nemail\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"contacts[0][value]\"\r\n\r\na@b.com\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"contacts[1][kind]\"\r\n\r\nphone\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"contacts[1][value]\"\r\n\r\n555-0100\r\n\
+         --{boundary}--\r\n"
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&body[..], b"Acme|email=a@b.com;phone=555-0100");
+}

--- a/tests/extractor_test.rs
+++ b/tests/extractor_test.rs
@@ -826,3 +826,32 @@ async fn test_form_request_vec_of_structs_percent_encoded_brackets() {
         .unwrap();
     assert_eq!(&body[..], b"email=a@b.com;phone=555-0100");
 }
+
+#[tokio::test]
+async fn test_form_request_respects_body_limit() {
+    async fn handler(
+        modo::extractor::FormRequest(item): modo::extractor::FormRequest<CreateItem>,
+    ) -> String {
+        item.title
+    }
+
+    let registry = Registry::new();
+    let app = Router::new()
+        .route("/", axum::routing::post(handler))
+        .layer(axum::extract::DefaultBodyLimit::max(10))
+        .with_state(registry.into_state());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from("title=this+is+definitely+more+than+ten+bytes"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}


### PR DESCRIPTION
## Summary

Closes the third case from #78: HTML forms with per-row dynamic fields (e.g. `client[name]=…&contacts[0][kind]=email&contacts[0][value]=…&contacts[1][kind]=phone`) now deserialize directly into `Vec<Struct>` via `FormRequest<T>`, `Query<T>`, and the text-field path of `MultipartRequest<T>`.

- Swaps the underlying deserializer from `serde_urlencoded`/`serde_html_form` to `serde_qs` 1.1 (form-encoding mode across all three extractors).
- Preserves every behavior #78 added: flat fields, `Vec<scalar>` from repeated keys, parallel-array zip pattern still works (though the README now points users at indexed brackets, which is strictly better).
- Adds nested-struct deserialization (`address[city]=…`).
- Adds `Vec<Struct>` deserialization via indexed brackets (`contacts[0][kind]=…`).
- Accepts both bare brackets and browser-percent-encoded brackets (`%5B`/`%5D`) on every surface.

## What didn't change

- `db::filter` and `db::page` extractors are untouched. `Filter` uses its own hand-rolled query parser; `PageRequest`/`CursorRequest` call `axum::extract::Query` (i.e. `serde_urlencoded`) directly. Verified by running their unit tests — all green.
- File handling in `MultipartRequest` is unchanged. Files still flow through the `Files` map alongside the deserialized `T` (no files-inside-struct — that would require proc macros, which the project forbids).

## Notable design choices

| Decision | Why |
|---|---|
| Single deserializer (no `MultiFormRequest` sibling, no feature flag) | `serde_qs` is a strict superset of `serde_html_form` for our cases, and the project's "no per-feature flags" rule rules out gating. |
| `use_form_encoding(true)` on all three extractors | Decodes `%5B`/`%5D` correctly, treats `+` as space (conventional for both form bodies and query strings). Avoids the footgun where `?filter%5Bstatus%5D=…` from `URLSearchParams` would silently 400. |
| Indexed brackets required for `Vec<Struct>` | Documented in README. Without indices, serde_qs can't disambiguate which fields belong to which row. |
| `serde_urlencoded` kept as a dep | Still used by `MultipartRequest`'s text-field re-encode step and by `db::page` unit tests. |

## Notable fixes caught in code review

1. `FormRequest` previously read the body via `to_bytes(req.into_body(), usize::MAX)`, which bypassed axum's `DefaultBodyLimit` / `RequestBodyLimitLayer` — now uses `Bytes::from_request(req, state)` and honors body-limit middleware.
2. `Query<T>` was initially shipped in `serde_qs` default mode, which doesn't decode percent-encoded brackets. Most JS clients (`URLSearchParams`, axios default) emit `%5B`/`%5D`, so `?filter%5Bstatus%5D=active` would silently 400. Switched to form-encoding mode and added a regression test.

## Spec & plan

- Design: [docs/superpowers/specs/2026-05-02-nested-form-deserialization-design.md](https://github.com/dmitrymomot/modo/blob/claude/objective-carson-d2ff9e/docs/superpowers/specs/2026-05-02-nested-form-deserialization-design.md)
- Brainstormed and reviewed before implementation — including a discussion of why `serde_qs` over `serde_html_form` and a hard "do not break db filtering/pagination" constraint.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --features test-helpers --tests -- -D warnings`
- [x] `cargo test --features test-helpers` — full suite, 0 failures
- [x] `cargo test --doc --features test-helpers` — 109 doc tests pass
- [x] 20/20 extractor integration tests including 6 new ones covering nested structs, `Vec<Struct>`, percent-encoded brackets, and the body-limit regression
- [x] `db::page` and `db::filter` unit tests untouched and green
- [x] `serde_html_form` no longer in `cargo tree`; `serde_qs v1.1.1` present
- [ ] Reviewer: confirm the README changes match how you want users to think about checkbox / nested / Vec<Struct> forms